### PR TITLE
Close dialog when window is hidden.

### DIFF
--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -696,9 +696,16 @@ namespace MaterialDesignThemes.Wpf
 
         private void WindowIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            if (!(bool) e.NewValue)
+            if (IsOpen)
             {
-                Close(null);
+                if (!(bool) e.NewValue)
+                {
+                    VisualStateManager.GoToState(this, ClosedStateName, !TransitionAssist.GetDisableTransitions(this));
+                }
+                else if ((bool) e.NewValue)
+                {
+                    VisualStateManager.GoToState(this, OpenStateName, !TransitionAssist.GetDisableTransitions(this));
+                }
             }
         }
 

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -217,6 +217,7 @@ namespace MaterialDesignThemes.Wpf
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
 
+
             CommandBindings.Add(new CommandBinding(CloseDialogCommand, CloseDialogHandler, CloseDialogCanExecute));
             CommandBindings.Add(new CommandBinding(OpenDialogCommand, OpenDialogHandler));
         }
@@ -679,15 +680,25 @@ namespace MaterialDesignThemes.Wpf
             {
                 window.Activated += dialogHost.WindowOnActivated;
                 window.Deactivated += dialogHost.WindowOnDeactivated;
+                window.IsVisibleChanged += dialogHost.WindowIsVisibleChanged;
                 dialogHost._closeCleanUp = () =>
                 {
                     window.Activated -= dialogHost.WindowOnActivated;
                     window.Deactivated -= dialogHost.WindowOnDeactivated;
+                    window.IsVisibleChanged -= dialogHost.WindowIsVisibleChanged;
                 };
             }
             else
             {
                 dialogHost._closeCleanUp = () => { };
+            }
+        }
+
+        private void WindowIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!(bool) e.NewValue)
+            {
+                Close(null);
             }
         }
 


### PR DESCRIPTION
Fixes #644 

When the parent window is hidden, the DialogHost closes its popup.