### PR TITLE
Added IsReadOnly Property to RatingBar

### DIFF
--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -1,8 +1,8 @@
-﻿<UserControl x:Class="MaterialDesignColors.WpfExample.Buttons"
+<UserControl x:Class="MaterialDesignColors.WpfExample.Buttons"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:materialDesignConverters="clr-namespace:MaterialDesignThemes.Wpf.Converters;assembly=MaterialDesignThemes.Wpf"
@@ -596,6 +596,7 @@
                 <materialDesign:RatingBar Value="3" x:Name="BasicRatingBar"  ValueChanged="BasicRatingBar_ValueChanged"/>
             </smtx:XamlDisplay>
             <TextBlock Text="{Binding ElementName=BasicRatingBar, Path=Value, StringFormat=Rating: {0}}" VerticalAlignment="Top" Margin="10,2,0,0" />
+
             <smtx:XamlDisplay Key="buttons_59" Margin="24 0 0 5">
                 <materialDesign:RatingBar x:Name="CustomRatingBar" Max="3" Value="2" Orientation="Vertical">
                     <materialDesign:RatingBar.ValueItemTemplate>
@@ -611,6 +612,11 @@
                 </materialDesign:RatingBar>
             </smtx:XamlDisplay>
             <TextBlock Text="{Binding ElementName=CustomRatingBar, Path=Value, StringFormat=Rating: {0}}" VerticalAlignment="Top" Margin="10,2,0,0" />
+
+            <smtx:XamlDisplay Key="buttons_62" VerticalContentAlignment="Top" Margin="5 0 0 5">
+                <materialDesign:RatingBar Value="4" IsReadOnly="True" x:Name="ReadOnlyRatingBar"/>
+            </smtx:XamlDisplay>
+            <TextBlock Text="{Binding ElementName=ReadOnlyRatingBar, Path=Value, StringFormat=Readonly Rating: {0}}" VerticalAlignment="Top" Margin="10,2,0,0" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/MaterialDesignThemes.Wpf/RatingBar.cs
+++ b/MaterialDesignThemes.Wpf/RatingBar.cs
@@ -17,7 +17,7 @@ namespace MaterialDesignThemes.Wpf
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(RatingBar), new FrameworkPropertyMetadata(typeof(RatingBar)));
         }
-                
+
         private readonly ObservableCollection<RatingBarButton> _ratingButtonsInternal = new ObservableCollection<RatingBarButton>();
         private readonly ReadOnlyObservableCollection<RatingBarButton> _ratingButtons;
 
@@ -29,30 +29,30 @@ namespace MaterialDesignThemes.Wpf
 
         private void SelectItemHandler(object sender, ExecutedRoutedEventArgs executedRoutedEventArgs)
         {
-            if (executedRoutedEventArgs.Parameter is int)
-                Value = (int) executedRoutedEventArgs.Parameter;
+            if (executedRoutedEventArgs.Parameter is int && !IsReadOnly)
+                Value = (int)executedRoutedEventArgs.Parameter;
         }
 
         public static readonly DependencyProperty MinProperty = DependencyProperty.Register(
-            nameof(Min), typeof (int), typeof (RatingBar), new PropertyMetadata(1, MinPropertyChangedCallback));
+            nameof(Min), typeof(int), typeof(RatingBar), new PropertyMetadata(1, MinPropertyChangedCallback));
 
         public int Min
         {
-            get { return (int) GetValue(MinProperty); }
+            get { return (int)GetValue(MinProperty); }
             set { SetValue(MinProperty, value); }
         }
 
         public static readonly DependencyProperty MaxProperty = DependencyProperty.Register(
-            nameof(Max), typeof (int), typeof (RatingBar), new PropertyMetadata(5, MaxPropertyChangedCallback));
+            nameof(Max), typeof(int), typeof(RatingBar), new PropertyMetadata(5, MaxPropertyChangedCallback));
 
         public int Max
         {
-            get { return (int) GetValue(MaxProperty); }
+            get { return (int)GetValue(MaxProperty); }
             set { SetValue(MaxProperty, value); }
         }
 
         public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
-            nameof(Value), typeof (int), typeof (RatingBar), new PropertyMetadata(0, ValuePropertyChangedCallback));
+            nameof(Value), typeof(int), typeof(RatingBar), new PropertyMetadata(0, ValuePropertyChangedCallback));
 
         private static void ValuePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
@@ -64,7 +64,7 @@ namespace MaterialDesignThemes.Wpf
 
         public int Value
         {
-            get { return (int) GetValue(ValueProperty); }
+            get { return (int)GetValue(ValueProperty); }
             set { SetValue(ValueProperty, value); }
         }
 
@@ -95,39 +95,48 @@ namespace MaterialDesignThemes.Wpf
         public ReadOnlyObservableCollection<RatingBarButton> RatingButtons => _ratingButtons;
 
         public static readonly DependencyProperty ValueItemContainerButtonStyleProperty = DependencyProperty.Register(
-            nameof(ValueItemContainerButtonStyle), typeof (Style), typeof (RatingBar), new PropertyMetadata(default(Style)));
+            nameof(ValueItemContainerButtonStyle), typeof(Style), typeof(RatingBar), new PropertyMetadata(default(Style)));
 
         public Style ValueItemContainerButtonStyle
         {
-            get { return (Style) GetValue(ValueItemContainerButtonStyleProperty); }
+            get { return (Style)GetValue(ValueItemContainerButtonStyleProperty); }
             set { SetValue(ValueItemContainerButtonStyleProperty, value); }
         }
 
         public static readonly DependencyProperty ValueItemTemplateProperty = DependencyProperty.Register(
-            nameof(ValueItemTemplate), typeof (DataTemplate), typeof (RatingBar), new PropertyMetadata(default(DataTemplate)));
+            nameof(ValueItemTemplate), typeof(DataTemplate), typeof(RatingBar), new PropertyMetadata(default(DataTemplate)));
 
         public DataTemplate ValueItemTemplate
         {
-            get { return (DataTemplate) GetValue(ValueItemTemplateProperty); }
+            get { return (DataTemplate)GetValue(ValueItemTemplateProperty); }
             set { SetValue(ValueItemTemplateProperty, value); }
         }
 
         public static readonly DependencyProperty ValueItemTemplateSelectorProperty = DependencyProperty.Register(
-            nameof(ValueItemTemplateSelector), typeof (DataTemplateSelector), typeof (RatingBar), new PropertyMetadata(default(DataTemplateSelector)));
+            nameof(ValueItemTemplateSelector), typeof(DataTemplateSelector), typeof(RatingBar), new PropertyMetadata(default(DataTemplateSelector)));
 
         public DataTemplateSelector ValueItemTemplateSelector
         {
-            get { return (DataTemplateSelector) GetValue(ValueItemTemplateSelectorProperty); }
+            get { return (DataTemplateSelector)GetValue(ValueItemTemplateSelectorProperty); }
             set { SetValue(ValueItemTemplateSelectorProperty, value); }
         }
 
         public static readonly DependencyProperty OrientationProperty = DependencyProperty.Register(
-            nameof(Orientation), typeof (Orientation), typeof (RatingBar), new PropertyMetadata(default(Orientation)));
+            nameof(Orientation), typeof(Orientation), typeof(RatingBar), new PropertyMetadata(default(Orientation)));
 
         public Orientation Orientation
         {
-            get { return (Orientation) GetValue(OrientationProperty); }
+            get { return (Orientation)GetValue(OrientationProperty); }
             set { SetValue(OrientationProperty, value); }
+        }
+
+        public static readonly DependencyProperty IsReadOnlyProperty = DependencyProperty.Register(
+            nameof(IsReadOnly), typeof(bool), typeof(RatingBar), new PropertyMetadata(default(bool)));
+
+        public bool IsReadOnly
+        {
+            get { return (bool)GetValue(IsReadOnlyProperty); }
+            set { SetValue(IsReadOnlyProperty, value); }
         }
 
         private static void MaxPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
@@ -141,12 +150,12 @@ namespace MaterialDesignThemes.Wpf
         }
 
         private void RebuildButtons()
-        {                        
-            _ratingButtonsInternal.Clear();            
+        {
+            _ratingButtonsInternal.Clear();
             for (var i = Min; i <= Max; i++)
             {
                 _ratingButtonsInternal.Add(new RatingBarButton
-                {                                        
+                {
                     Content = i,
                     ContentTemplate = ValueItemTemplate,
                     ContentTemplateSelector = ValueItemTemplateSelector,
@@ -162,6 +171,6 @@ namespace MaterialDesignThemes.Wpf
             RebuildButtons();
 
             base.OnApplyTemplate();
-        }        
+        }
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RatingBar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RatingBar.xaml
@@ -31,7 +31,9 @@
                         <Setter Property="Template">
                             <Setter.Value>
                                 <ControlTemplate TargetType="wpf:RatingBarButton">
-                                    <wpf:Ripple Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Focusable="False"
+                                    <wpf:Ripple Content="{TemplateBinding Content}" 
+                                                ContentTemplate="{TemplateBinding ContentTemplate}" 
+                                                Focusable="False"
                                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                                 Padding="{TemplateBinding Padding}"
@@ -71,14 +73,15 @@
                             <Setter Property="Template">
                                 <Setter.Value>
                                     <ControlTemplate TargetType="wpf:RatingBarButton">
-                                        <wpf:Ripple Padding="{TemplateBinding Padding}"
-                                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                Content="{TemplateBinding Content}"
-                                                ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                Focusable="False"
-                                                RenderTransformOrigin=".5, .5"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                                        <wpf:Ripple Content="{TemplateBinding Content}"
+                                                    ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                    Focusable="False"
+                                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                    VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                    Padding="{TemplateBinding Padding}"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                    RenderTransformOrigin=".5, .5"
+                                                    IsEnabled="False">
                                         </wpf:Ripple>
                                     </ControlTemplate>
                                 </Setter.Value>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RatingBar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RatingBar.xaml
@@ -31,10 +31,10 @@
                         <Setter Property="Template">
                             <Setter.Value>
                                 <ControlTemplate TargetType="wpf:RatingBarButton">
-                                    <wpf:Ripple Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Focusable="False"     
-                                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                    <wpf:Ripple Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Focusable="False"
+                                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                Padding="{TemplateBinding Padding}" 
+                                                Padding="{TemplateBinding Padding}"
                                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                 RenderTransformOrigin=".5, .5">
                                         <wpf:Ripple.RenderTransform>
@@ -67,6 +67,23 @@
                         <Trigger Property="IsWithinSelectedValue" Value="False">
                             <Setter Property="Opacity" Value=".26" />
                         </Trigger>
+                        <DataTrigger Binding="{Binding IsReadOnly, RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:RatingBar}}" Value="True">
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="wpf:RatingBarButton">
+                                        <wpf:Ripple Padding="{TemplateBinding Padding}"
+                                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                Content="{TemplateBinding Content}"
+                                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                Focusable="False"
+                                                RenderTransformOrigin=".5, .5"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                                        </wpf:Ripple>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </DataTrigger>
                     </Style.Triggers>
                 </Style>
             </Setter.Value>


### PR DESCRIPTION
Added IsReadOnly Property to RatingBar, which disables updating the Value-Property of the RatingBar, when any of the child RatingBarButtons is clicked. The OnClick spinning animation is disabled by this aswell.

#670