### PR TITLE
Added OpenMode property for DrawerHost

### DIFF
--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -104,16 +104,18 @@
                     <Button Command="{x:Static materialDesign:DrawerHost.OpenDrawerCommand}"
                         CommandParameter="{x:Static Dock.Bottom}"
                         Grid.Row="2" Grid.Column="1" Margin="4">
-                        <materialDesign:PackIcon Kind="ArrowDown" />
-                    </Button>
-                    <Button Command="{x:Static materialDesign:DrawerHost.OpenDrawerCommand}"
+                    <materialDesign:PackIcon Kind="ArrowDown" />
+                </Button>
+                <Button x:Name="OpenAllDrawerButton" Command="{x:Static materialDesign:DrawerHost.OpenDrawerCommand}"
                         Grid.Row="1" Grid.Column="1" Margin="4" 
                         Style="{DynamicResource MaterialDesignRaisedAccentButton}">
-                        <materialDesign:PackIcon Kind="ArrowAll" />
-                    </Button>
-                <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Row="3" Grid.ColumnSpan="3" Orientation="Horizontal">
-                    <TextBlock>Close on click away</TextBlock>
-                    <CheckBox IsChecked="{Binding ElementName=DrawerHost, Path=CloseOnClickAway}"></CheckBox>
+                    <materialDesign:PackIcon Kind="ArrowAll" />
+                </Button>
+                <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="3">
+                    <TextBlock FontWeight="Bold" Margin="0 8 0 8">Open mode:</TextBlock>
+                    <RadioButton Checked="StandardRadioButton_OnChecked" IsChecked="True">Standard</RadioButton>
+                    <RadioButton Checked="StaysOpenRadioButton_OnChecked">Stays Open</RadioButton>
+                    <RadioButton Checked="PinnedRadioButton_OnChecked">Pinned</RadioButton>
                 </StackPanel>
                 </Grid>
             </Grid>

--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -113,7 +113,7 @@
                     </Button>
                 <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Row="3" Grid.ColumnSpan="3" Orientation="Horizontal">
                     <TextBlock>Stays open </TextBlock>
-                    <CheckBox IsChecked="{Binding ElementName=DrawerHost, Path=StaysOpen}"></CheckBox>
+                    <CheckBox IsChecked="{Binding ElementName=DrawerHost, Path=CloseOnClickAway}"></CheckBox>
                 </StackPanel>
                 </Grid>
             </Grid>

--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -130,7 +130,7 @@
                 <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="3">
                     <TextBlock FontWeight="Bold" Margin="0 8 0 8">Open mode:</TextBlock>
                     <RadioButton Checked="StandardRadioButton_OnChecked" IsChecked="True">Standard</RadioButton>
-                    <RadioButton Checked="StaysOpenRadioButton_OnChecked">Stays Open (it means drawer won't close on click away)</RadioButton>
+                    <RadioButton Checked="StaysOpenRadioButton_OnChecked">Stays Open</RadioButton>
                     <RadioButton Checked="PinnedRadioButton_OnChecked">Pinned</RadioButton>
                 </StackPanel>
                 </Grid>

--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -22,14 +22,30 @@
                     <Button Command="{x:Static materialDesign:DrawerHost.CloseDrawerCommand}"
                         Margin="4" HorizontalAlignment="Center"
                         Style="{DynamicResource MaterialDesignFlatButton}">
-                        CLOSE ALL
-                    </Button>
-                </StackPanel>
-            </materialDesign:DrawerHost.LeftDrawerContent>
-            <materialDesign:DrawerHost.TopDrawerContent>
-                <StackPanel Margin="16" HorizontalAlignment="Center" Orientation="Horizontal">
-                    <TextBlock Margin="4" VerticalAlignment="Center">TOP BANANA</TextBlock>
-                    <Button Command="{x:Static materialDesign:DrawerHost.CloseDrawerCommand}"
+                    CLOSE ALL
+                </Button>
+                <ToggleButton
+                    Command="{x:Static materialDesign:DrawerHost.PinDrawerCommand}"
+                    VerticalAlignment="Center"
+                    Style="{StaticResource MaterialDesignSwitchToggleButton}"
+                    ToolTip="Pin this drawer">
+                    <materialDesign:PackIcon
+                        Kind="Pin"
+                        RenderTransformOrigin=".5,.5">
+                        <materialDesign:PackIcon.RenderTransform>
+                            <RotateTransform Angle="45" />
+                        </materialDesign:PackIcon.RenderTransform>
+                    </materialDesign:PackIcon>
+                    <materialDesign:ToggleButtonAssist.OnContent >
+                        <materialDesign:PackIcon Kind="Pin" />
+                    </materialDesign:ToggleButtonAssist.OnContent>
+                </ToggleButton>
+            </StackPanel>
+        </materialDesign:DrawerHost.LeftDrawerContent>
+        <materialDesign:DrawerHost.TopDrawerContent>
+            <StackPanel Margin="16" HorizontalAlignment="Center" Orientation="Horizontal">
+                <TextBlock Margin="4" VerticalAlignment="Center">TOP BANANA</TextBlock>
+                <Button Command="{x:Static materialDesign:DrawerHost.CloseDrawerCommand}"
                         Style="{DynamicResource MaterialDesignFlatButton}"
                         Margin="4" VerticalAlignment="Center">
                         CLOSE ALL
@@ -114,7 +130,7 @@
                 <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="3">
                     <TextBlock FontWeight="Bold" Margin="0 8 0 8">Open mode:</TextBlock>
                     <RadioButton Checked="StandardRadioButton_OnChecked" IsChecked="True">Standard</RadioButton>
-                    <RadioButton Checked="StaysOpenRadioButton_OnChecked">Stays Open</RadioButton>
+                    <RadioButton Checked="StaysOpenRadioButton_OnChecked">Stays Open (it means drawer won't close on click away)</RadioButton>
                     <RadioButton Checked="PinnedRadioButton_OnChecked">Pinned</RadioButton>
                 </StackPanel>
                 </Grid>

--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -9,26 +9,26 @@
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <smtx:XamlDisplay Key="drawers_1" MaxHeight="{x:Static system:Double.MaxValue}" Margin="5">
-        <materialDesign:DrawerHost Margin="64" HorizontalAlignment="Center" VerticalAlignment="Center" BorderThickness="2" BorderBrush="{DynamicResource MaterialDesignDivider}">
+        <materialDesign:DrawerHost x:Name="DrawerHost" Margin="64" BorderThickness="2" BorderBrush="{DynamicResource MaterialDesignDivider}">
             <materialDesign:DrawerHost.LeftDrawerContent>
                 <StackPanel Margin="16">
                     <TextBlock Margin="4" HorizontalAlignment="Center">LEFT FIELD</TextBlock>
                     <Button Command="{x:Static materialDesign:DrawerHost.CloseDrawerCommand}"
-                        CommandParameter="{x:Static Dock.Left}"
-                        Margin="4" HorizontalAlignment="Center"
-                        Style="{DynamicResource MaterialDesignFlatButton}">
+                            CommandParameter="{x:Static Dock.Left}"
+                            Margin="4" HorizontalAlignment="Center"
+                            Style="{DynamicResource MaterialDesignFlatButton}">
                         CLOSE THIS
                     </Button>
                     <Button Command="{x:Static materialDesign:DrawerHost.CloseDrawerCommand}"
-                        Margin="4" HorizontalAlignment="Center"
-                        Style="{DynamicResource MaterialDesignFlatButton}">
+                            Margin="4" HorizontalAlignment="Center"
+                            Style="{DynamicResource MaterialDesignFlatButton}">
                     CLOSE ALL
                 </Button>
                 <ToggleButton
-                    Command="{x:Static materialDesign:DrawerHost.PinDrawerCommand}"
-                    VerticalAlignment="Center"
-                    Style="{StaticResource MaterialDesignSwitchToggleButton}"
-                    ToolTip="Pin this drawer">
+                        Command="{x:Static materialDesign:DrawerHost.PinDrawerCommand}"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource MaterialDesignSwitchToggleButton}"
+                        ToolTip="Pin this drawer">
                     <materialDesign:PackIcon
                         Kind="Pin"
                         RenderTransformOrigin=".5,.5">
@@ -51,9 +51,9 @@
                         CLOSE ALL
                     </Button>
                     <Button Command="{x:Static materialDesign:DrawerHost.CloseDrawerCommand}"
-                        CommandParameter="{x:Static Dock.Top}"
-                        Style="{DynamicResource MaterialDesignFlatButton}"
-                        Margin="4" VerticalAlignment="Center">
+                            CommandParameter="{x:Static Dock.Top}"
+                            Style="{DynamicResource MaterialDesignFlatButton}"
+                            Margin="4" VerticalAlignment="Center">
                         CLOSE THIS
                     </Button>
                 </StackPanel>
@@ -62,9 +62,9 @@
                 <StackPanel Margin="16">
                     <TextBlock Margin="4" HorizontalAlignment="Center">THE RIGHT STUFF</TextBlock>
                     <Button Command="{x:Static materialDesign:DrawerHost.CloseDrawerCommand}"
-                        CommandParameter="{x:Static Dock.Right}"
-                        Margin="4" HorizontalAlignment="Center"
-                        Style="{DynamicResource MaterialDesignFlatButton}">
+                            CommandParameter="{x:Static Dock.Right}"
+                            Margin="4" HorizontalAlignment="Center"
+                            Style="{DynamicResource MaterialDesignFlatButton}">
                         CLOSE THIS
                     </Button>
                     <Button Command="{x:Static materialDesign:DrawerHost.CloseDrawerCommand}"
@@ -78,14 +78,14 @@
                 <StackPanel Margin="16" HorizontalAlignment="Center" Orientation="Horizontal">
                     <TextBlock Margin="4" VerticalAlignment="Center">BOTTOM BRACKET</TextBlock>
                     <Button Command="{x:Static materialDesign:DrawerHost.CloseDrawerCommand}"
-                        Style="{DynamicResource MaterialDesignFlatButton}"
-                        Margin="4" VerticalAlignment="Center">
+                            Style="{DynamicResource MaterialDesignFlatButton}"
+                            Margin="4" VerticalAlignment="Center">
                         CLOSE ALL
                     </Button>
                     <Button Command="{x:Static materialDesign:DrawerHost.CloseDrawerCommand}"
-                        CommandParameter="{x:Static Dock.Bottom}"
-                        Style="{DynamicResource MaterialDesignFlatButton}"
-                        Margin="4" VerticalAlignment="Center">
+                            CommandParameter="{x:Static Dock.Bottom}"
+                            Style="{DynamicResource MaterialDesignFlatButton}"
+                            Margin="4" VerticalAlignment="Center">
                         CLOSE THIS
                     </Button>
                 </StackPanel>
@@ -96,6 +96,7 @@
                         <RowDefinition />
                         <RowDefinition />
                         <RowDefinition />
+                        <RowDefinition />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition />
@@ -103,36 +104,36 @@
                         <ColumnDefinition />
                     </Grid.ColumnDefinitions>
                     <Button Command="{x:Static materialDesign:DrawerHost.OpenDrawerCommand}"
-                        CommandParameter="{x:Static Dock.Left}"
-                        Grid.Row="1" Grid.Column="0"  Margin="4">
+                            CommandParameter="{x:Static Dock.Left}"
+                            Grid.Row="1" Grid.Column="0"  Margin="4">
                         <materialDesign:PackIcon Kind="ArrowLeft" />
                     </Button>
                     <Button Command="{x:Static materialDesign:DrawerHost.OpenDrawerCommand}"
-                        CommandParameter="{x:Static Dock.Top}"
-                        Grid.Row="0" Grid.Column="1" Margin="4">
+                            CommandParameter="{x:Static Dock.Top}"
+                            Grid.Row="0" Grid.Column="1" Margin="4">
                         <materialDesign:PackIcon Kind="ArrowUp" />
                     </Button>
                     <Button Command="{x:Static materialDesign:DrawerHost.OpenDrawerCommand}"
-                        CommandParameter="{x:Static Dock.Right}"
-                        Grid.Row="1" Grid.Column="2" Margin="4">
+                            CommandParameter="{x:Static Dock.Right}"
+                            Grid.Row="1" Grid.Column="2" Margin="4">
                         <materialDesign:PackIcon Kind="ArrowRight" />
                     </Button>
                     <Button Command="{x:Static materialDesign:DrawerHost.OpenDrawerCommand}"
-                        CommandParameter="{x:Static Dock.Bottom}"
-                        Grid.Row="2" Grid.Column="1" Margin="4">
+                            CommandParameter="{x:Static Dock.Bottom}"
+                            Grid.Row="2" Grid.Column="1" Margin="4">
                     <materialDesign:PackIcon Kind="ArrowDown" />
                 </Button>
-                <Button x:Name="OpenAllDrawerButton" Command="{x:Static materialDesign:DrawerHost.OpenDrawerCommand}"
-                        Grid.Row="1" Grid.Column="1" Margin="4" 
-                        Style="{DynamicResource MaterialDesignRaisedAccentButton}">
-                    <materialDesign:PackIcon Kind="ArrowAll" />
-                </Button>
-                <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="3">
-                    <TextBlock FontWeight="Bold" Margin="0 8 0 8">Open mode:</TextBlock>
-                    <RadioButton Checked="StandardRadioButton_OnChecked" IsChecked="True">Standard</RadioButton>
-                    <RadioButton Checked="StaysOpenRadioButton_OnChecked">Stays Open</RadioButton>
-                    <RadioButton Checked="PinnedRadioButton_OnChecked">Pinned</RadioButton>
-                </StackPanel>
+                    <Button x:Name="OpenAllDrawerButton" Command="{x:Static materialDesign:DrawerHost.OpenDrawerCommand}"
+                            Grid.Row="1" Grid.Column="1" Margin="4" 
+                            Style="{DynamicResource MaterialDesignRaisedAccentButton}">
+                        <materialDesign:PackIcon Kind="ArrowAll" />
+                    </Button>
+                    <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="3">
+                        <TextBlock FontWeight="Bold" Margin="0 8 0 8">Open mode:</TextBlock>
+                        <RadioButton Checked="StandardRadioButton_OnChecked" IsChecked="True">Standard</RadioButton>
+                        <RadioButton Checked="StaysOpenRadioButton_OnChecked">Stays Open</RadioButton>
+                        <RadioButton Checked="PinnedRadioButton_OnChecked">Pinned</RadioButton>
+                    </StackPanel>
                 </Grid>
             </Grid>
         </materialDesign:DrawerHost>

--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -111,8 +111,13 @@
                         Style="{DynamicResource MaterialDesignRaisedAccentButton}">
                         <materialDesign:PackIcon Kind="ArrowAll" />
                     </Button>
+                <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Row="3" Grid.ColumnSpan="3" Orientation="Horizontal">
+                    <TextBlock>Stays open </TextBlock>
+                    <CheckBox IsChecked="{Binding ElementName=DrawerHost, Path=StaysOpen}"></CheckBox>
+                </StackPanel>
                 </Grid>
             </Grid>
         </materialDesign:DrawerHost>
     </smtx:XamlDisplay>
 </UserControl>
+

--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -112,7 +112,7 @@
                         <materialDesign:PackIcon Kind="ArrowAll" />
                     </Button>
                 <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Row="3" Grid.ColumnSpan="3" Orientation="Horizontal">
-                    <TextBlock>Stays open </TextBlock>
+                    <TextBlock>Close on click away</TextBlock>
                     <CheckBox IsChecked="{Binding ElementName=DrawerHost, Path=CloseOnClickAway}"></CheckBox>
                 </StackPanel>
                 </Grid>

--- a/MainDemo.Wpf/Drawers.xaml.cs
+++ b/MainDemo.Wpf/Drawers.xaml.cs
@@ -1,18 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using MaterialDesignThemes.Wpf;
 
 namespace MaterialDesignDemo
@@ -27,18 +14,21 @@ namespace MaterialDesignDemo
             InitializeComponent();
         }
 
-        private void StandardRadioButton_OnChecked(object sender, RoutedEventArgs e) {
-            DrawerHost.OpenMode = DrawerHost.DrawerHostOpenMode.Standard;
+        private void StandardRadioButton_OnChecked(object sender, RoutedEventArgs e)
+        {
+            DrawerHost.OpenMode = DrawerHostOpenMode.Standard;
             OpenAllDrawerButton.IsEnabled = true;
         }
 
-        private void StaysOpenRadioButton_OnChecked(object sender, RoutedEventArgs e) {
-            DrawerHost.OpenMode = DrawerHost.DrawerHostOpenMode.StaysOpen;
+        private void StaysOpenRadioButton_OnChecked(object sender, RoutedEventArgs e)
+        {
+            DrawerHost.OpenMode = DrawerHostOpenMode.StaysOpen;
             OpenAllDrawerButton.IsEnabled = true;
         }
 
-        private void PinnedRadioButton_OnChecked(object sender , RoutedEventArgs e) {
-            DrawerHost.OpenMode = DrawerHost.DrawerHostOpenMode.Pinned;
+        private void PinnedRadioButton_OnChecked(object sender, RoutedEventArgs e)
+        {
+            DrawerHost.OpenMode = DrawerHostOpenMode.Pinned;
             OpenAllDrawerButton.IsEnabled = false;
         }
     }

--- a/MainDemo.Wpf/Drawers.xaml.cs
+++ b/MainDemo.Wpf/Drawers.xaml.cs
@@ -1,4 +1,19 @@
-﻿using System.Windows.Controls;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using MaterialDesignThemes.Wpf;
 
 namespace MaterialDesignDemo
 {
@@ -10,6 +25,21 @@ namespace MaterialDesignDemo
         public Drawers()
         {
             InitializeComponent();
+        }
+
+        private void StandardRadioButton_OnChecked(object sender, RoutedEventArgs e) {
+            DrawerHost.OpenMode = DrawerHost.DrawerHostOpenMode.Standard;
+            OpenAllDrawerButton.IsEnabled = true;
+        }
+
+        private void StaysOpenRadioButton_OnChecked(object sender, RoutedEventArgs e) {
+            DrawerHost.OpenMode = DrawerHost.DrawerHostOpenMode.StaysOpen;
+            OpenAllDrawerButton.IsEnabled = true;
+        }
+
+        private void PinnedRadioButton_OnChecked(object sender , RoutedEventArgs e) {
+            DrawerHost.OpenMode = DrawerHost.DrawerHostOpenMode.Pinned;
+            OpenAllDrawerButton.IsEnabled = false;
         }
     }
 }

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -225,14 +225,6 @@ namespace MaterialDesignThemes.Wpf
             private set { SetValue(TopDrawerZIndexPropertyKey, value); }
         }
 
-        public static readonly DependencyProperty TopDrawerCloseOnClickAwayProperty = DependencyProperty.Register(
-            nameof(TopDrawerCloseOnClickAway), typeof(bool), typeof(DrawerHost), new PropertyMetadata(true));
-
-        public bool TopDrawerCloseOnClickAway
-        {
-            get { return (bool)GetValue(TopDrawerCloseOnClickAwayProperty); }
-            set { SetValue(TopDrawerCloseOnClickAwayProperty, value); }
-        }
         #endregion
 
         #region left drawer
@@ -302,15 +294,6 @@ namespace MaterialDesignThemes.Wpf
         {
             get { return (int)GetValue(LeftDrawerZIndexProperty); }
             private set { SetValue(LeftDrawerZIndexPropertyKey, value); }
-        }
-
-        public static readonly DependencyProperty LeftDrawerCloseOnClickAwayProperty = DependencyProperty.Register(
-            nameof(LeftDrawerCloseOnClickAway), typeof(bool), typeof(DrawerHost), new PropertyMetadata(true));
-
-        public bool LeftDrawerCloseOnClickAway
-        {
-            get { return (bool)GetValue(LeftDrawerCloseOnClickAwayProperty); }
-            set { SetValue(LeftDrawerCloseOnClickAwayProperty, value); }
         }
 
         #endregion
@@ -384,15 +367,6 @@ namespace MaterialDesignThemes.Wpf
             private set { SetValue(RightDrawerZIndexPropertyKey, value); }
         }
 
-        public static readonly DependencyProperty RightDrawerCloseOnClickAwayProperty = DependencyProperty.Register(
-            nameof(RightDrawerCloseOnClickAway), typeof(bool), typeof(DrawerHost), new PropertyMetadata(true));
-
-        public bool RightDrawerCloseOnClickAway
-        {
-            get { return (bool)GetValue(RightDrawerCloseOnClickAwayProperty); }
-            set { SetValue(RightDrawerCloseOnClickAwayProperty, value); }
-        }
-
         #endregion
 
         #region bottom drawer
@@ -462,15 +436,6 @@ namespace MaterialDesignThemes.Wpf
         {
             get { return (int)GetValue(BottomDrawerZIndexProperty); }
             private set { SetValue(BottomDrawerZIndexPropertyKey, value); }
-        }
-
-        public static readonly DependencyProperty BottomDrawerCloseOnClickAwayProperty = DependencyProperty.Register(
-            nameof(BottomDrawerCloseOnClickAway), typeof(bool), typeof(DrawerHost), new PropertyMetadata(true));
-
-        public bool BottomDrawerCloseOnClickAway
-        {
-            get { return (bool)GetValue(BottomDrawerCloseOnClickAwayProperty); }
-            set { SetValue(BottomDrawerCloseOnClickAwayProperty, value); }
         }
 
         #endregion

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -96,44 +96,34 @@ namespace MaterialDesignThemes.Wpf
 
         private static void OnOpenModePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs) {
             var drawerHost = dependencyObject as DrawerHost;
-            var newValue = (DrawerHostOpenMode) dependencyPropertyChangedEventArgs.NewValue;
-            if (newValue == DrawerHostOpenMode.Pinned) {
-                if (drawerHost.MoreThanOneDrawerOpened()) throw new Exception( "Cannot set OpenMode = Pinned when there are more than one drawers are opened.");
-                if (drawerHost.IsLeftDrawerOpen) {
-                    drawerHost._mainContent.Margin = new Thickness(drawerHost._leftDrawerElement.ActualWidth, 0, 0, 0);
-                }
-                if (drawerHost.IsTopDrawerOpen) {
-                    drawerHost._mainContent.Margin = new Thickness(0, drawerHost._topDrawerElement.ActualHeight, 0, 0);
-                }
-                if (drawerHost.IsRightDrawerOpen) {
-                    drawerHost._mainContent.Margin = new Thickness(0, 0, drawerHost._rightDrawerElement.ActualWidth, 0);
-                }
-                if (drawerHost.IsBottomDrawerOpen) {
-                    drawerHost._mainContent.Margin = new Thickness(0, 0, 0, drawerHost._bottomDrawerElement.ActualHeight);
-                }
-            }
-            else {
-                drawerHost._mainContent.Margin = new Thickness(0 , 0 , 0 , 0);
-            }
             drawerHost.UpdateVisualStates();
         }
 
-        private FrameworkElement GetOpeningDrawer() {
-            if (IsLeftDrawerOpen) {
-                return _leftDrawerElement;
+        private void UpdateMainContentMargin() {
+            if (OpenMode == DrawerHostOpenMode.Pinned) {
+                if (MoreThanOneDrawerOpened())
+                    throw new Exception(
+                        "Cannot set OpenMode = Pinned when there are more than one drawers are opened.");
+                if (IsLeftDrawerOpen) {
+                    _mainContent.Margin = new Thickness(_leftDrawerElement.ActualWidth, 0, 0, 0);
+                }
+                else if (IsTopDrawerOpen) {
+                    _mainContent.Margin = new Thickness(0, _topDrawerElement.ActualHeight, 0, 0);
+                }
+                else if (IsRightDrawerOpen) {
+                    _mainContent.Margin = new Thickness(0, 0, _rightDrawerElement.ActualWidth, 0);
+                }
+                else if (IsBottomDrawerOpen) {
+                    _mainContent.Margin = new Thickness(0, 0, 0, _bottomDrawerElement.ActualHeight);
+                }
+                else {
+                    _mainContent.Margin = new Thickness(0, 0, 0, 0);
+                }
             }
-            if (IsTopDrawerOpen) {
-                return _topDrawerElement;
+            else {
+                _mainContent.Margin = new Thickness(0, 0, 0, 0);
             }
-            if (IsRightDrawerOpen) {
-                return _rightDrawerElement;
-            }
-            if (IsBottomDrawerOpen) {
-                return _bottomDrawerElement;
-            }
-            return null;
         }
-
         private bool MoreThanOneDrawerOpened() {
             int numberOfOpenedDrawer = 0;
             if (IsLeftDrawerOpen) numberOfOpenedDrawer++;
@@ -537,16 +527,11 @@ namespace MaterialDesignThemes.Wpf
 
         private void UpdateVisualStates(bool? useTransitions = null)
         {
-            if (OpenMode == DrawerHostOpenMode.Pinned) {
-                VisualStateManager.GoToState(this, TemplateAllDrawersAllClosedStateName,
-                    useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
-                return;
-            }
-
             var anyOpen = IsTopDrawerOpen || IsLeftDrawerOpen || IsBottomDrawerOpen || IsRightDrawerOpen;
-
+            UpdateMainContentMargin();
+            
             VisualStateManager.GoToState(this,
-                !anyOpen ? TemplateAllDrawersAllClosedStateName : TemplateAllDrawersAnyOpenStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
+                !anyOpen || OpenMode==DrawerHostOpenMode.Pinned ? TemplateAllDrawersAllClosedStateName : TemplateAllDrawersAnyOpenStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
 
             VisualStateManager.GoToState(this,
                 IsLeftDrawerOpen ? TemplateLeftOpenStateName : TemplateLeftClosedStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -78,14 +78,27 @@ namespace MaterialDesignThemes.Wpf
             CommandBindings.Add(new CommandBinding(CloseDrawerCommand, CloseDrawerHandler));
         }
 
-        public bool CloseOnClickAway 
+        public enum DrawerHostOpenMode 
         {
-            get { return (bool)GetValue(CloseOnClickAwayProperty); }
-            set { SetValue(CloseOnClickAwayProperty , value); }
+            Standard, StaysOpen, Pinned
+            
         }
 
-        public static readonly DependencyProperty CloseOnClickAwayProperty =
-            DependencyProperty.Register("CloseOnClickAway" , typeof(bool) , typeof(DrawerHost) , new PropertyMetadata(true));
+
+
+        public DrawerHostOpenMode OpenMode {
+            get { return (DrawerHostOpenMode)GetValue(OpenModeProperty); }
+            set { SetValue(OpenModeProperty , value); }
+        }
+
+        // Using a DependencyProperty as the backing store for OpenMode.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty OpenModeProperty =
+            DependencyProperty.Register("OpenMode" , typeof(DrawerHostOpenMode) , typeof(DrawerHost) , new PropertyMetadata(DrawerHostOpenMode.Standard, OnOpenModePropertyChangedCallback));
+
+        private static void OnOpenModePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs) 
+        {
+            throw new NotImplementedException();
+        }
 
         #region top drawer
 
@@ -470,7 +483,7 @@ namespace MaterialDesignThemes.Wpf
 
         private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs) 
         {
-            if (!CloseOnClickAway) return;
+            if (OpenMode == DrawerHostOpenMode.StaysOpen) return;
             SetCurrentValue(IsLeftDrawerOpenProperty, false);
             SetCurrentValue(IsRightDrawerOpenProperty, false);
             SetCurrentValue(IsTopDrawerOpenProperty, false);

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -83,62 +83,69 @@ namespace MaterialDesignThemes.Wpf
             CommandBindings.Add(new CommandBinding(CloseDrawerCommand, CloseDrawerHandler));
             CommandBindings.Add(new CommandBinding(PinDrawerCommand, PinDrawerHanlder));
         }
-        #region openModeProperty
-        public enum DrawerHostOpenMode 
-        {
-            Standard, StaysOpen, Pinned
-        }
 
-        public DrawerHostOpenMode OpenMode {
+        #region OpenMode
+
+        public DrawerHostOpenMode OpenMode
+        {
             get { return (DrawerHostOpenMode)GetValue(OpenModeProperty); }
-            set { SetValue(OpenModeProperty , value); }
+            set { SetValue(OpenModeProperty, value); }
         }
 
         public static readonly DependencyProperty OpenModeProperty =
-            DependencyProperty.Register("OpenMode" , typeof(DrawerHostOpenMode) , typeof(DrawerHost) , new PropertyMetadata(DrawerHostOpenMode.Standard, OnOpenModePropertyChangedCallback));
+            DependencyProperty.Register("OpenMode", typeof(DrawerHostOpenMode), typeof(DrawerHost), new PropertyMetadata(DrawerHostOpenMode.Standard, OnOpenModePropertyChangedCallback));
 
-        private static void OnOpenModePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs) {
+        private static void OnOpenModePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
             var drawerHost = dependencyObject as DrawerHost;
             drawerHost.UpdateVisualStates();
         }
 
-        private void UpdateMainContentMargin() {
+        private void UpdateMainContentMargin()
+        {
             //Unfortunately, the animation code can only be done in CS not in XAML
             //I tried to do it in XAML, but then I found out this : 
             //According to https://docs.microsoft.com/en-us/dotnet/framework/wpf/graphics-multimedia/storyboards-overview,
             //You can't use data binding expressions in Storyboards or animation property value
-            var thicknessAnimation = new ThicknessAnimation()
-            {
-               EasingFunction = new SineEase() { EasingMode = EasingMode.EaseOut},
-               Duration = new Duration(new TimeSpan(0, 0, 0, 0, 400))
+            var thicknessAnimation = new ThicknessAnimation() {
+                EasingFunction = new SineEase() { EasingMode = EasingMode.EaseOut },
+                Duration = new Duration(new TimeSpan(0, 0, 0, 0, 400))
             };
-            if (OpenMode == DrawerHostOpenMode.Pinned) {
+            if (OpenMode == DrawerHostOpenMode.Pinned)
+            {
                 if (MoreThanOneDrawerOpened())
                     throw new Exception(
                         "Cannot set OpenMode = Pinned when there are more than one drawers are opened.");
-                if (IsLeftDrawerOpen) {                    
+                if (IsLeftDrawerOpen)
+                {
                     thicknessAnimation.To = new Thickness(_leftDrawerElement.ActualWidth, 0, 0, 0);
                 }
-                else if (IsTopDrawerOpen) {
+                else if (IsTopDrawerOpen)
+                {
                     thicknessAnimation.To = new Thickness(0, _topDrawerElement.ActualHeight, 0, 0);
                 }
-                else if (IsRightDrawerOpen) {
+                else if (IsRightDrawerOpen)
+                {
                     thicknessAnimation.To = new Thickness(0, 0, _rightDrawerElement.ActualWidth, 0);
                 }
-                else if (IsBottomDrawerOpen) {
+                else if (IsBottomDrawerOpen)
+                {
                     thicknessAnimation.To = new Thickness(0, 0, 0, _bottomDrawerElement.ActualHeight);
                 }
-                else {
+                else
+                {
                     thicknessAnimation.To = new Thickness(0, 0, 0, 0);
                 }
             }
-            else {
+            else
+            {
                 thicknessAnimation.To = new Thickness(0, 0, 0, 0);
             }
             _mainContent.BeginAnimation(MarginProperty, thicknessAnimation);
         }
 
-        private bool MoreThanOneDrawerOpened() {
+        private bool MoreThanOneDrawerOpened()
+        {
             int numberOfOpenedDrawer = 0;
             if (IsLeftDrawerOpen) numberOfOpenedDrawer++;
             if (IsTopDrawerOpen) numberOfOpenedDrawer++;
@@ -530,7 +537,7 @@ namespace MaterialDesignThemes.Wpf
                 PrepareZIndexes(BottomDrawerZIndexPropertyKey);
         }
 
-        private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs) 
+        private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
             if (OpenMode != DrawerHostOpenMode.Standard) return;
             SetCurrentValue(IsLeftDrawerOpenProperty, false);
@@ -546,9 +553,9 @@ namespace MaterialDesignThemes.Wpf
             UpdateMainContentMargin();
 
             var anyOpen = IsTopDrawerOpen || IsLeftDrawerOpen || IsBottomDrawerOpen || IsRightDrawerOpen;
-            
+
             VisualStateManager.GoToState(this,
-                !anyOpen || OpenMode==DrawerHostOpenMode.Pinned ? TemplateAllDrawersAllClosedStateName : TemplateAllDrawersAnyOpenStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
+                !anyOpen || OpenMode == DrawerHostOpenMode.Pinned ? TemplateAllDrawersAllClosedStateName : TemplateAllDrawersAnyOpenStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
 
             VisualStateManager.GoToState(this,
                 IsLeftDrawerOpen ? TemplateLeftOpenStateName : TemplateLeftClosedStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
@@ -642,14 +649,17 @@ namespace MaterialDesignThemes.Wpf
 
         private bool _pinned = false;
         private DrawerHostOpenMode _previousMode;
-        private void PinDrawerHanlder(object sender , ExecutedRoutedEventArgs executedRoutedEventArgs) {
+        private void PinDrawerHanlder(object sender, ExecutedRoutedEventArgs executedRoutedEventArgs)
+        {
             if (executedRoutedEventArgs.Handled) return;
-            if (!_pinned) {
+            if (!_pinned)
+            {
                 _previousMode = OpenMode;
                 SetCurrentValue(OpenModeProperty, DrawerHostOpenMode.Pinned);
                 _pinned = true;
             }
-            else {
+            else
+            {
                 SetCurrentValue(OpenModeProperty, _previousMode);
                 _pinned = false;
             }

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -81,10 +81,7 @@ namespace MaterialDesignThemes.Wpf
         public enum DrawerHostOpenMode 
         {
             Standard, StaysOpen, Pinned
-            
         }
-
-
 
         public DrawerHostOpenMode OpenMode {
             get { return (DrawerHostOpenMode)GetValue(OpenModeProperty); }
@@ -483,7 +480,7 @@ namespace MaterialDesignThemes.Wpf
 
         private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs) 
         {
-            if (OpenMode == DrawerHostOpenMode.StaysOpen) return;
+            if (OpenMode != DrawerHostOpenMode.Standard) return;
             SetCurrentValue(IsLeftDrawerOpenProperty, false);
             SetCurrentValue(IsRightDrawerOpenProperty, false);
             SetCurrentValue(IsTopDrawerOpenProperty, false);

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -78,14 +78,14 @@ namespace MaterialDesignThemes.Wpf
             CommandBindings.Add(new CommandBinding(CloseDrawerCommand, CloseDrawerHandler));
         }
 
-        public bool StaysOpen 
+        public bool CloseOnClickAway 
         {
-            get { return (bool)GetValue(StaysOpenProperty); }
-            set { SetValue(StaysOpenProperty , value); }
+            get { return (bool)GetValue(CloseOnClickAwayProperty); }
+            set { SetValue(CloseOnClickAwayProperty , value); }
         }
 
-        public static readonly DependencyProperty StaysOpenProperty =
-            DependencyProperty.Register("StaysOpen" , typeof(bool) , typeof(DrawerHost) , new PropertyMetadata(false));
+        public static readonly DependencyProperty CloseOnClickAwayProperty =
+            DependencyProperty.Register("CloseOnClickAway" , typeof(bool) , typeof(DrawerHost) , new PropertyMetadata(true));
 
         #region top drawer
 
@@ -470,7 +470,7 @@ namespace MaterialDesignThemes.Wpf
 
         private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs) 
         {
-            if (StaysOpen) return;
+            if (!CloseOnClickAway) return;
             SetCurrentValue(IsLeftDrawerOpenProperty, false);
             SetCurrentValue(IsRightDrawerOpenProperty, false);
             SetCurrentValue(IsTopDrawerOpenProperty, false);

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -19,6 +19,7 @@ namespace MaterialDesignThemes.Wpf
     [TemplateVisualState(GroupName = TemplateRightDrawerGroupName, Name = TemplateRightOpenStateName)]
     [TemplateVisualState(GroupName = TemplateBottomDrawerGroupName, Name = TemplateBottomClosedStateName)]
     [TemplateVisualState(GroupName = TemplateBottomDrawerGroupName, Name = TemplateBottomOpenStateName)]
+    [TemplatePart(Name = TemplateMainContentPartName, Type = typeof(FrameworkElement))]
     [TemplatePart(Name = TemplateContentCoverPartName, Type = typeof(FrameworkElement))]
     [TemplatePart(Name = TemplateLeftDrawerPartName, Type = typeof(FrameworkElement))]
     [TemplatePart(Name = TemplateTopDrawerPartName, Type = typeof(FrameworkElement))]
@@ -42,6 +43,7 @@ namespace MaterialDesignThemes.Wpf
         public const string TemplateBottomClosedStateName = "BottomDrawerClosed";
         public const string TemplateBottomOpenStateName = "BottomDrawerOpen";
 
+        public const string TemplateMainContentPartName = "ContentPresenter";
         public const string TemplateContentCoverPartName = "PART_ContentCover";
         public const string TemplateLeftDrawerPartName = "PART_LeftDrawer";
         public const string TemplateTopDrawerPartName = "PART_TopDrawer";
@@ -51,6 +53,7 @@ namespace MaterialDesignThemes.Wpf
         public static RoutedCommand OpenDrawerCommand = new RoutedCommand();
         public static RoutedCommand CloseDrawerCommand = new RoutedCommand();
 
+        private FrameworkElement _mainContent;
         private FrameworkElement _templateContentCoverElement;
         private FrameworkElement _leftDrawerElement;
         private FrameworkElement _topDrawerElement;
@@ -77,7 +80,7 @@ namespace MaterialDesignThemes.Wpf
             CommandBindings.Add(new CommandBinding(OpenDrawerCommand, OpenDrawerHandler));
             CommandBindings.Add(new CommandBinding(CloseDrawerCommand, CloseDrawerHandler));
         }
-
+        #region openModeProperty
         public enum DrawerHostOpenMode 
         {
             Standard, StaysOpen, Pinned
@@ -88,14 +91,59 @@ namespace MaterialDesignThemes.Wpf
             set { SetValue(OpenModeProperty , value); }
         }
 
-        // Using a DependencyProperty as the backing store for OpenMode.  This enables animation, styling, binding, etc...
         public static readonly DependencyProperty OpenModeProperty =
             DependencyProperty.Register("OpenMode" , typeof(DrawerHostOpenMode) , typeof(DrawerHost) , new PropertyMetadata(DrawerHostOpenMode.Standard, OnOpenModePropertyChangedCallback));
 
-        private static void OnOpenModePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs) 
-        {
-            throw new NotImplementedException();
+        private static void OnOpenModePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs) {
+            var drawerHost = dependencyObject as DrawerHost;
+            var newValue = (DrawerHostOpenMode) dependencyPropertyChangedEventArgs.NewValue;
+            if (newValue == DrawerHostOpenMode.Pinned) {
+                if (drawerHost.MoreThanOneDrawerOpened()) throw new Exception( "Cannot set OpenMode = Pinned when there are more than one drawers are opened.");
+                if (drawerHost.IsLeftDrawerOpen) {
+                    drawerHost._mainContent.Margin = new Thickness(drawerHost._leftDrawerElement.ActualWidth, 0, 0, 0);
+                }
+                if (drawerHost.IsTopDrawerOpen) {
+                    drawerHost._mainContent.Margin = new Thickness(0, drawerHost._topDrawerElement.ActualHeight, 0, 0);
+                }
+                if (drawerHost.IsRightDrawerOpen) {
+                    drawerHost._mainContent.Margin = new Thickness(0, 0, drawerHost._rightDrawerElement.ActualWidth, 0);
+                }
+                if (drawerHost.IsBottomDrawerOpen) {
+                    drawerHost._mainContent.Margin = new Thickness(0, 0, 0, drawerHost._bottomDrawerElement.ActualHeight);
+                }
+            }
+            else {
+                drawerHost._mainContent.Margin = new Thickness(0 , 0 , 0 , 0);
+            }
+            drawerHost.UpdateVisualStates();
         }
+
+        private FrameworkElement GetOpeningDrawer() {
+            if (IsLeftDrawerOpen) {
+                return _leftDrawerElement;
+            }
+            if (IsTopDrawerOpen) {
+                return _topDrawerElement;
+            }
+            if (IsRightDrawerOpen) {
+                return _rightDrawerElement;
+            }
+            if (IsBottomDrawerOpen) {
+                return _bottomDrawerElement;
+            }
+            return null;
+        }
+
+        private bool MoreThanOneDrawerOpened() {
+            int numberOfOpenedDrawer = 0;
+            if (IsLeftDrawerOpen) numberOfOpenedDrawer++;
+            if (IsTopDrawerOpen) numberOfOpenedDrawer++;
+            if (IsRightDrawerOpen) numberOfOpenedDrawer++;
+            if (IsBottomDrawerOpen) numberOfOpenedDrawer++;
+            return numberOfOpenedDrawer > 1;
+        }
+
+        #endregion
 
         #region top drawer
 
@@ -434,7 +482,7 @@ namespace MaterialDesignThemes.Wpf
             _topDrawerElement = WireDrawer(GetTemplateChild(TemplateTopDrawerPartName) as FrameworkElement, false);
             _rightDrawerElement = WireDrawer(GetTemplateChild(TemplateRightDrawerPartName) as FrameworkElement, false);
             _bottomDrawerElement = WireDrawer(GetTemplateChild(TemplateBottomDrawerPartName) as FrameworkElement, false);
-
+            _mainContent = GetTemplateChild(TemplateMainContentPartName) as FrameworkElement;
             UpdateVisualStates(false);
         }
 
@@ -489,6 +537,12 @@ namespace MaterialDesignThemes.Wpf
 
         private void UpdateVisualStates(bool? useTransitions = null)
         {
+            if (OpenMode == DrawerHostOpenMode.Pinned) {
+                VisualStateManager.GoToState(this, TemplateAllDrawersAllClosedStateName,
+                    useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
+                return;
+            }
+
             var anyOpen = IsTopDrawerOpen || IsLeftDrawerOpen || IsBottomDrawerOpen || IsRightDrawerOpen;
 
             VisualStateManager.GoToState(this,

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -56,6 +56,7 @@ namespace MaterialDesignThemes.Wpf
 
         public static RoutedCommand OpenDrawerCommand = new RoutedCommand();
         public static RoutedCommand CloseDrawerCommand = new RoutedCommand();
+        public static RoutedCommand PinDrawerCommand = new RoutedCommand();
 
         private FrameworkElement _mainContent;
         private FrameworkElement _templateContentCoverElement;
@@ -83,6 +84,7 @@ namespace MaterialDesignThemes.Wpf
         {
             CommandBindings.Add(new CommandBinding(OpenDrawerCommand, OpenDrawerHandler));
             CommandBindings.Add(new CommandBinding(CloseDrawerCommand, CloseDrawerHandler));
+            CommandBindings.Add(new CommandBinding(PinDrawerCommand, PinDrawerHanlder));
         }
         #region openModeProperty
         public enum DrawerHostOpenMode 
@@ -639,6 +641,22 @@ namespace MaterialDesignThemes.Wpf
                     _lockZIndexes = false;
                 }
             }
+        }
+
+        private bool _pinned = false;
+        private DrawerHostOpenMode _previousMode;
+        private void PinDrawerHanlder(object sender , ExecutedRoutedEventArgs executedRoutedEventArgs) {
+            if (executedRoutedEventArgs.Handled) return;
+            if (!_pinned) {
+                _previousMode = OpenMode;
+                SetCurrentValue(OpenModeProperty, DrawerHostOpenMode.Pinned);
+                _pinned = true;
+            }
+            else {
+                SetCurrentValue(OpenModeProperty, _previousMode);
+                _pinned = false;
+            }
+            executedRoutedEventArgs.Handled = true;
         }
     }
 }

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -20,7 +20,6 @@ namespace MaterialDesignThemes.Wpf
     [TemplateVisualState(GroupName = TemplateRightDrawerGroupName, Name = TemplateRightOpenStateName)]
     [TemplateVisualState(GroupName = TemplateBottomDrawerGroupName, Name = TemplateBottomClosedStateName)]
     [TemplateVisualState(GroupName = TemplateBottomDrawerGroupName, Name = TemplateBottomOpenStateName)]
-    [TemplateVisualState(GroupName = TemplatePinnedLeftDrawerGroupName, Name = TemplatePinnedLeftOpenStateName)]
     [TemplatePart(Name = TemplateMainContentPartName, Type = typeof(FrameworkElement))]
     [TemplatePart(Name = TemplateContentCoverPartName, Type = typeof(FrameworkElement))]
     [TemplatePart(Name = TemplateLeftDrawerPartName, Type = typeof(FrameworkElement))]
@@ -44,8 +43,6 @@ namespace MaterialDesignThemes.Wpf
         public const string TemplateBottomDrawerGroupName = "BottomDrawer";
         public const string TemplateBottomClosedStateName = "BottomDrawerClosed";
         public const string TemplateBottomOpenStateName = "BottomDrawerOpen";
-        public const string TemplatePinnedLeftDrawerGroupName = "PinnedLeftDrawer";
-        public const string TemplatePinnedLeftOpenStateName = "PinnedLeftDrawerOpen";
 
         public const string TemplateMainContentPartName = "ContentPresenter";
         public const string TemplateContentCoverPartName = "PART_ContentCover";

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -78,6 +78,15 @@ namespace MaterialDesignThemes.Wpf
             CommandBindings.Add(new CommandBinding(CloseDrawerCommand, CloseDrawerHandler));
         }
 
+        public bool StaysOpen 
+        {
+            get { return (bool)GetValue(StaysOpenProperty); }
+            set { SetValue(StaysOpenProperty , value); }
+        }
+
+        public static readonly DependencyProperty StaysOpenProperty =
+            DependencyProperty.Register("StaysOpen" , typeof(bool) , typeof(DrawerHost) , new PropertyMetadata(false));
+
         #region top drawer
 
         public static readonly DependencyProperty TopDrawerContentProperty = DependencyProperty.Register(
@@ -459,16 +468,13 @@ namespace MaterialDesignThemes.Wpf
                 PrepareZIndexes(BottomDrawerZIndexPropertyKey);
         }
 
-        private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs)
+        private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs) 
         {
-            if (LeftDrawerCloseOnClickAway)
-                SetCurrentValue(IsLeftDrawerOpenProperty, false);
-            if (RightDrawerCloseOnClickAway)
-                SetCurrentValue(IsRightDrawerOpenProperty, false);
-            if (TopDrawerCloseOnClickAway)
-                SetCurrentValue(IsTopDrawerOpenProperty, false);
-            if (BottomDrawerCloseOnClickAway)
-                SetCurrentValue(IsBottomDrawerOpenProperty, false);
+            if (StaysOpen) return;
+            SetCurrentValue(IsLeftDrawerOpenProperty, false);
+            SetCurrentValue(IsRightDrawerOpenProperty, false);
+            SetCurrentValue(IsTopDrawerOpenProperty, false);
+            SetCurrentValue(IsBottomDrawerOpenProperty, false);
         }
 
         private void UpdateVisualStates(bool? useTransitions = null)

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -138,6 +138,7 @@ namespace MaterialDesignThemes.Wpf
             }
             _mainContent.BeginAnimation(MarginProperty, thicknessAnimation);
         }
+
         private bool MoreThanOneDrawerOpened() {
             int numberOfOpenedDrawer = 0;
             if (IsLeftDrawerOpen) numberOfOpenedDrawer++;
@@ -541,8 +542,11 @@ namespace MaterialDesignThemes.Wpf
 
         private void UpdateVisualStates(bool? useTransitions = null)
         {
-            var anyOpen = IsTopDrawerOpen || IsLeftDrawerOpen || IsBottomDrawerOpen || IsRightDrawerOpen;
+            if (OpenMode == DrawerHostOpenMode.Pinned && MoreThanOneDrawerOpened()) return;
+
             UpdateMainContentMargin();
+
+            var anyOpen = IsTopDrawerOpen || IsLeftDrawerOpen || IsBottomDrawerOpen || IsRightDrawerOpen;
             
             VisualStateManager.GoToState(this,
                 !anyOpen || OpenMode==DrawerHostOpenMode.Pinned ? TemplateAllDrawersAllClosedStateName : TemplateAllDrawersAnyOpenStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));

--- a/MaterialDesignThemes.Wpf/DrawerHostOpenMode.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHostOpenMode.cs
@@ -1,0 +1,9 @@
+﻿namespace MaterialDesignThemes.Wpf
+{
+    public enum DrawerHostOpenMode
+    {
+        Standard,
+        StaysOpen,
+        Pinned
+    }
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,8 +67,6 @@ steps:
     artifactName: 'DemoApp'
     targetPath: 'MainDemo.Wpf/bin/$(buildConfiguration)'
 
-- powershell: copy .\MaterialDesignThemes.nuspec .\MaterialDesignThemes.Wpf\bin\AppVeyor\
-
 - task: PublishPipelineArtifact@0
   name: "PublishMaterialDesign"
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,8 @@ steps:
     artifactName: 'DemoApp'
     targetPath: 'MainDemo.Wpf/bin/$(buildConfiguration)'
 
+- powershell: copy .\MaterialDesignThemes.nuspec .\MaterialDesignThemes.Wpf\bin\AppVeyor\
+
 - task: PublishPipelineArtifact@0
   name: "PublishMaterialDesign"
   inputs:


### PR DESCRIPTION
@ButchersBoy  I've already implemented the OpenModeProperty for DrawerHost, but I'm not sure if the API looks like what you want. 
Currently, the API looks like this : 
```XAML
<DrawerHost OpenMode="Pinned">
    <!---Content here--->
</DrawerHost>
```
![demodrawerhost](https://user-images.githubusercontent.com/23183656/30017893-6c032914-918d-11e7-873a-a1e71f299af2.gif)


_Issues : If OpenMode is set to Pinned, all the drawers works as expected, however only the BottomDrawer does not push the main content when it is opened. I'm not sure why though._