### PR TITLE
Fix textbox cursor disappearing

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -62,7 +62,8 @@
                                 <Grid x:Name="textFieldGrid"
                                       Margin="{TemplateBinding Padding}"
                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}">
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      MinWidth="1">
                                     <ScrollViewer x:Name="PART_ContentHost" Focusable="false"
                                                   HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden"
                                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"


### PR DESCRIPTION
When the HorizontalContentAlignment="Center" the cursor was not showing up due to the TextBox content being resized down to 0. Added a minimum width to ensure that at least the cursor will be visible.

This was reported by @Aangbaeck from the gitter chat.