### PR TITLE
Copy button display fix

### DIFF
--- a/MainDemo.Wpf/App.xaml
+++ b/MainDemo.Wpf/App.xaml
@@ -67,9 +67,7 @@
                                         </materialDesign:PackIcon>
                                     </materialDesign:PopupBox.ToggleContent>
                                     <Border MaxHeight="600" MaxWidth="800">
-                                        <StackPanel>
-                                            <avalonEdit:TextEditor Document="{Binding Xaml, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TextDocumentValueConverter}}" 
-                                                                   Style="{StaticResource AvalonTextEditorXamlDisplay}" />
+                                        <DockPanel>
                                             <Button
                                                 Margin="0 10 0 0"
                                                 Tag="{Binding Xaml, RelativeSource={RelativeSource TemplatedParent}}"
@@ -77,9 +75,12 @@
                                                 Command="Copy"
                                                 CommandParameter="{Binding Xaml, RelativeSource={RelativeSource TemplatedParent}}"
                                                 Content="_COPY"
+                                                DockPanel.Dock="Bottom"
                                                 Style="{StaticResource MaterialDesignRaisedButton}">
                                             </Button>
-                                        </StackPanel>
+                                            <avalonEdit:TextEditor Document="{Binding Xaml, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TextDocumentValueConverter}}" 
+                                                                   Style="{StaticResource AvalonTextEditorXamlDisplay}" />
+                                        </DockPanel>
                                     </Border>
 
                                 </materialDesign:PopupBox>


### PR DESCRIPTION
Fixes #885

The copy button was getting pushed off the bottom of the popup when the XAML was too long.