### PR TITLE
Remove Header from default context menu in TextBox

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -29,17 +29,17 @@
         <Setter Property="ContextMenu">
             <Setter.Value>
                 <ContextMenu>
-                    <MenuItem Header="_Cut" Command="Cut">
+                    <MenuItem Command="Cut">
                         <MenuItem.Icon>
                             <wpf:PackIcon Kind="ContentCut"/>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="_Copy" Command="Copy">
+                    <MenuItem Command="Copy">
                         <MenuItem.Icon>
                             <wpf:PackIcon Kind="ContentCopy" />
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="_Paste" Command="Paste">
+                    <MenuItem Command="Paste">
                         <MenuItem.Icon>
                             <wpf:PackIcon Kind="ContentPaste"/>
                         </MenuItem.Icon>


### PR DESCRIPTION
If the Header property is set on a MenuItem it has a constant value. By not setting it the (localized) name of the command is used instead.