### PR TITLE
Added Scale and Offset to the combobox template

### DIFF
--- a/MainDemo.Wpf/TextFields.xaml
+++ b/MainDemo.Wpf/TextFields.xaml
@@ -197,6 +197,21 @@
                         </ComboBox.ItemsPanel>
                     </ComboBox>
                 </smtx:XamlDisplay>
+                <smtx:XamlDisplay Key="fields_27">
+                    <ComboBox materialDesign:HintAssist.Hint="(large float hint)"
+                              materialDesign:HintAssist.FloatingScale="1.5"
+                              materialDesign:HintAssist.FloatingOffset="0, -24"
+                              MinWidth="72"
+                              Margin="16 0 0 0"
+                              ItemsSource="{Binding LongListToTestComboVirtualization}"
+                              Style="{StaticResource MaterialDesignFloatingHintComboBox}">
+                        <ComboBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel />
+                            </ItemsPanelTemplate>
+                        </ComboBox.ItemsPanel>
+                    </ComboBox>
+                </smtx:XamlDisplay>
             </StackPanel>
             <TextBlock Style="{StaticResource MaterialDesignHeadlineTextBlock}" Margin="0 16 0 5">Disabled Controls</TextBlock>
             <StackPanel Orientation="Horizontal">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -437,6 +437,8 @@
                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                        UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
                                        UseFloating="{Binding Path=(wpf:HintAssist.IsFloating), RelativeSource={RelativeSource TemplatedParent}}"
+                                       FloatingScale="{Binding Path=(wpf:HintAssist.FloatingScale), RelativeSource={RelativeSource TemplatedParent}}"
+                                       FloatingOffset="{Binding Path=(wpf:HintAssist.FloatingOffset), RelativeSource={RelativeSource TemplatedParent}}"                                               
                                        HintOpacity="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"
                                        Hint="{TemplateBinding wpf:HintAssist.Hint}" />
                     </Grid>


### PR DESCRIPTION
This allows the attached properties to be put on comboboxes and affect the hint. Currently it has the side effect of the hint being cut off when the combobox is expanded and the hint is too big. Any hints on how I can fix that?