### PR TITLE
Add MaterialDesignThemeResources

### DIFF
--- a/MainDemo.Wpf/App.xaml
+++ b/MainDemo.Wpf/App.xaml
@@ -9,13 +9,8 @@
              xmlns:materialDesignDemo="clr-namespace:MaterialDesignDemo"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-        <ResourceDictionary>
+        <materialDesign:MaterialDesignThemeResources BaseTheme="Light" PrimaryColor="DeepPurple" AccentColor="Lime">
             <ResourceDictionary.MergedDictionaries>
-
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/ShowMeTheXAML.AvalonEdit;component/Themes/xamldisplayer.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
@@ -105,7 +100,7 @@
                     </Setter.Value>
                 </Setter>
             </Style>
-        </ResourceDictionary>
+        </materialDesign:MaterialDesignThemeResources>
     </Application.Resources>
 </Application>
 

--- a/MaterialDesignColors.Wpf/AccentColor.cs
+++ b/MaterialDesignColors.Wpf/AccentColor.cs
@@ -1,0 +1,22 @@
+﻿namespace MaterialDesignColors
+{
+    public enum AccentColor
+    {
+        Amber,
+        Blue,
+        Cyan,
+        DeepOrange,
+        DeepPurple,
+        Green,
+        Indigo,
+        LightBlue,
+        LightGreen,
+        Lime,
+        Orange,
+        Pink,
+        Purple,
+        Red,
+        Teal,
+        Yellow
+    }
+}

--- a/MaterialDesignColors.Wpf/MaterialDesignColors.Wpf.csproj
+++ b/MaterialDesignColors.Wpf/MaterialDesignColors.Wpf.csproj
@@ -57,7 +57,9 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AccentColor.cs" />
     <Compile Include="Hue.cs" />
+    <Compile Include="PrimaryColor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/MaterialDesignColors.Wpf/PrimaryColor.cs
+++ b/MaterialDesignColors.Wpf/PrimaryColor.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MaterialDesignColors
+{
+    public enum PrimaryColor
+    {
+        Amber,
+        Blue,
+        BlueGrey,
+        Brown,
+        Cyan,
+        DeepOrange,
+        DeepPurple,
+        Green,
+        Grey,
+        Indigo,
+        LightBlue,
+        LightGreen,
+        Lime,
+        Orange,
+        Pink,
+        Purple,
+        Red,
+        Teal,
+        Yellow
+    }
+}

--- a/MaterialDesignThemes.Wpf/BaseTheme.cs
+++ b/MaterialDesignThemes.Wpf/BaseTheme.cs
@@ -1,0 +1,8 @@
+﻿namespace MaterialDesignThemes.Wpf
+{
+    public enum BaseTheme
+    {
+        Light,
+        Dark
+    }
+}

--- a/MaterialDesignThemes.Wpf/MaterialDesignThemeResources.cs
+++ b/MaterialDesignThemes.Wpf/MaterialDesignThemeResources.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Windows;
+using MaterialDesignColors;
+
+namespace MaterialDesignThemes.Wpf
+{
+    public class MaterialDesignThemeResources : ResourceDictionary
+    {
+        private const string ColorUriFormat =
+            @"pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/{0}/MaterialDesignColor.{1}.xaml";
+
+        private const string ThemeUriFormat =
+            @"pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.{0}.xaml";
+
+
+        public MaterialDesignThemeResources()
+        {
+            MergedDictionaries.Add(BuildDict(ThemeUriFormat, "Defaults"));
+        }
+
+        private ResourceDictionary baseResourceDictionary;
+        private BaseTheme baseTheme;
+        public BaseTheme BaseTheme
+        {
+            get => baseTheme;
+            set => UpdateResourceDictionary(ref baseResourceDictionary, BuildDict(ThemeUriFormat, (baseTheme = value).ToString()));
+        }
+
+        private ResourceDictionary primaryResourceDictionary;
+        private PrimaryColor primaryColor;
+        public PrimaryColor PrimaryColor
+        {
+            get => primaryColor;
+            set => UpdateResourceDictionary(ref primaryResourceDictionary, BuildDict(ColorUriFormat, "Primary", (primaryColor = value).ToString()));
+        }
+
+        private ResourceDictionary accentResourceDictionary;
+        private AccentColor accentColor;
+        public AccentColor AccentColor
+        {
+            get => accentColor;
+            set => UpdateResourceDictionary(ref accentResourceDictionary, BuildDict(ColorUriFormat, "Accent", (accentColor = value).ToString()));
+        }
+
+        private void UpdateResourceDictionary(ref ResourceDictionary existing, ResourceDictionary replacement)
+        {
+            var index = MergedDictionaries.IndexOf(existing);
+            if (index != -1)
+            {
+                MergedDictionaries.RemoveAt(index);
+                MergedDictionaries.Insert(index, replacement);
+            }
+            else
+            {
+                MergedDictionaries.Add(replacement);
+            }
+
+            existing = replacement;
+        }
+
+        private static ResourceDictionary BuildDict(string uriFormatString, params string[] arguments)
+        {
+            var uri = new Uri(string.Format(uriFormatString, arguments));
+            return new ResourceDictionary {Source = uri};
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
+++ b/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
@@ -257,6 +257,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Badged.cs" />
+    <Compile Include="BaseTheme.cs" />
     <Compile Include="ButtonProgressAssist.cs" />
     <Compile Include="Card.cs" />
     <Compile Include="Chip.cs" />
@@ -324,6 +325,7 @@
     <Compile Include="ISnackbarMessageQueue.cs" />
     <Compile Include="ListBoxAssist.cs" />
     <Compile Include="ListViewAssist.cs" />
+    <Compile Include="MaterialDesignThemeResources.cs" />
     <Compile Include="MessageQueueExtension.cs" />
     <Compile Include="PackIconExtension.cs" />
     <Compile Include="Palette.cs" />


### PR DESCRIPTION
Allows easy setup of MaterialDesignTheme defaults using BaseTheme,
PrimaryColor and AccentColor properties.