### PR TITLE
*WIP* Better theming and brush usage

### DIFF
--- a/MahMaterialDragablzMashUp/App.xaml
+++ b/MahMaterialDragablzMashUp/App.xaml
@@ -2,7 +2,6 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:dragablz="clr-namespace:Dragablz;assembly=Dragablz"
-             xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>
@@ -10,19 +9,19 @@
             <ResourceDictionary.MergedDictionaries>
 
                 <!-- MahApps -->
-                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
+                <!--<ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/BaseLight.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/BaseLight.xaml" />-->
 
                 <!-- Material Design -->
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <!--<ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />                
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />-->
 
                 <!-- Material Design: MahApps Compatibility -->
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Defaults.xaml "/>                
+                <!--<ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Defaults.xaml"/>-->
 
                 <!-- Dragablz Material Design -->
                 <ResourceDictionary Source="pack://application:,,,/Dragablz;component/Themes/materialdesign.xaml"/>
@@ -30,7 +29,7 @@
             </ResourceDictionary.MergedDictionaries>
 
             <!-- MahApps Brushes -->
-            <SolidColorBrush x:Key="HighlightBrush" Color="{DynamicResource Primary700}"/>
+            <!--<SolidColorBrush x:Key="HighlightBrush" Color="{DynamicResource Primary700}"/>
             <SolidColorBrush x:Key="AccentColorBrush" Color="{DynamicResource Primary500}"/>
             <SolidColorBrush x:Key="AccentColorBrush2" Color="{DynamicResource Primary400}"/>
             <SolidColorBrush x:Key="AccentColorBrush3" Color="{DynamicResource Primary300}"/>
@@ -44,7 +43,7 @@
             <SolidColorBrush x:Key="CheckmarkFill" Color="{DynamicResource Primary500}"/>
             <SolidColorBrush x:Key="RightArrowFill" Color="{DynamicResource Primary500}"/>
             <SolidColorBrush x:Key="IdealForegroundColorBrush" Color="{DynamicResource Primary500Foreground}"/>
-            <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{DynamicResource Primary500}" Opacity="0.4"/>
+            <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{DynamicResource Primary500}" Opacity="0.4"/>-->
 
             <!-- Dragablz Material Design -->
             <Style TargetType="{x:Type dragablz:TabablzControl}" BasedOn="{StaticResource MaterialDesignTabablzControlStyle}" />

--- a/MahMaterialDragablzMashUp/App.xaml.cs
+++ b/MahMaterialDragablzMashUp/App.xaml.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using MaterialDesignThemes.MahApps;
+using MaterialDesignThemes.Wpf;
 using System.Windows;
 
 namespace MahMaterialDragablzMashUp
@@ -13,5 +9,11 @@ namespace MahMaterialDragablzMashUp
     /// </summary>
     public partial class App : Application
     {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            this.WithMaterialDesign(BaseTheme.Light, PrimaryColor.DeepPurple, AccentColor.Lime)
+                .WithMahApps();
+            base.OnStartup(e);
+        }
     }
 }

--- a/MahMaterialDragablzMashUp/PaletteSelectorViewModel.cs
+++ b/MahMaterialDragablzMashUp/PaletteSelectorViewModel.cs
@@ -37,22 +37,22 @@ namespace MahMaterialDragablzMashUp
             foreach (var tabablzControl in Dragablz.TabablzControl.GetLoadedInstances())
             {
                 tabablzControl.Style = style;
-            }                        
+            }
         }
 
         private static void ApplyBase(bool isDark)
         {
-            new PaletteHelper().SetLightDark(isDark);
+            PaletteHelper.SetLightDark(isDark);
         }
 
         private static void ApplyPrimary(Swatch swatch)
         {
-            new PaletteHelper().ReplacePrimaryColor(swatch);
+            PaletteHelper.ReplacePrimaryColor(swatch);
         }
 
         private static void ApplyAccent(Swatch swatch)
         {
-            new PaletteHelper().ReplaceAccentColor(swatch);
+            PaletteHelper.ReplaceAccentColor(swatch);
         }
 
     }

--- a/MainDemo.Wpf/App.xaml
+++ b/MainDemo.Wpf/App.xaml
@@ -1,7 +1,7 @@
 ﻿<Application x:Class="MaterialDesignColors.WpfExample.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:showMeTheXaml="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
+             xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
              xmlns:smtxAe="clr-namespace:ShowMeTheXAML.AvalonEdit;assembly=ShowMeTheXAML.AvalonEdit"
@@ -9,21 +9,19 @@
              xmlns:materialDesignDemo="clr-namespace:MaterialDesignDemo"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-        <ResourceDictionary>
+        <materialDesign:MaterialDesignResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
+                <!-- This is technically optional and will get added in, however not having it in the tree does break intellisense.  -->
+                <!-- The same also applies to the color resources, but those tend to use dynamic resources anyway. -->
+                <!--<ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />-->
                 <ResourceDictionary Source="pack://application:,,,/ShowMeTheXAML.AvalonEdit;component/Themes/xamldisplayer.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <Style TargetType="showMeTheXaml:XamlDisplay" BasedOn="{StaticResource {x:Type showMeTheXaml:XamlDisplay}}">
+            <Style TargetType="smtx:XamlDisplay" BasedOn="{StaticResource {x:Type smtx:XamlDisplay}}">
                 <Style.Resources>
                     <ResourceDictionary>
                         <ResourceDictionary.MergedDictionaries>
-                            <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ToggleButton.xaml" />
+                            <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Button.xaml" />
                         </ResourceDictionary.MergedDictionaries>
 
                         <smtxAe:TextDocumentValueConverter x:Key="TextDocumentValueConverter"/>
@@ -34,16 +32,16 @@
                 <Setter Property="materialDesignDemo:XamlDisplayEx.ButtonDock" Value="Right" />
                 <Setter Property="Formatter">
                     <Setter.Value>
-                        <showMeTheXaml:XamlFormatter NewLineOnAttributes="True" Indent="  ">
-                            <showMeTheXaml:XamlFormatter.NamespacesToRemove>
+                        <smtx:XamlFormatter NewLineOnAttributes="True" Indent="  ">
+                            <smtx:XamlFormatter.NamespacesToRemove>
                                 <system:String>http://materialdesigninxaml.net/winfx/xaml/themes</system:String>
-                            </showMeTheXaml:XamlFormatter.NamespacesToRemove>
-                        </showMeTheXaml:XamlFormatter>
+                            </smtx:XamlFormatter.NamespacesToRemove>
+                        </smtx:XamlFormatter>
                     </Setter.Value>
                 </Setter>
                 <Setter Property="Template">
                     <Setter.Value>
-                        <ControlTemplate TargetType="showMeTheXaml:XamlDisplay">
+                        <ControlTemplate TargetType="smtx:XamlDisplay">
                             <DockPanel>
                                 <materialDesign:PopupBox DockPanel.Dock="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(materialDesignDemo:XamlDisplayEx.ButtonDock)}"
                                                          Padding="10" StaysOpen="True" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -105,7 +103,8 @@
                     </Setter.Value>
                 </Setter>
             </Style>
-        </ResourceDictionary>
+        </materialDesign:MaterialDesignResourceDictionary>
     </Application.Resources>
 </Application>
+
 

--- a/MainDemo.Wpf/App.xaml.cs
+++ b/MainDemo.Wpf/App.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using ShowMeTheXAML;
 using System.Windows;
+using MaterialDesignThemes.Wpf;
 
 namespace MaterialDesignColors.WpfExample
 {
@@ -10,7 +11,10 @@ namespace MaterialDesignColors.WpfExample
     {
         protected override void OnStartup(StartupEventArgs e)
         {
-            XamlDisplay.Init();
+            //This is an alterate way to initialize MaterialDesignInXAML if you don't use the MaterialDesignResourceDictionary in App.xaml
+            //this.WithMaterialDesign(BaseTheme.Dark, PrimaryColor.Cyan, AccentColor.Lime);
+
+            
             //Illustration of setting culture info fully in WPF:
             /*             
             Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
@@ -18,6 +22,9 @@ namespace MaterialDesignColors.WpfExample
             FrameworkElement.LanguageProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(
                         XmlLanguage.GetLanguage(CultureInfo.CurrentCulture.IetfLanguageTag)));
             */
+            
+
+            XamlDisplay.Init();
 
             base.OnStartup(e);
         }

--- a/MainDemo.Wpf/Domain/DocumentationLink.cs
+++ b/MainDemo.Wpf/Domain/DocumentationLink.cs
@@ -47,7 +47,12 @@ namespace MaterialDesignColors.WpfExample.Domain
 
         public static DocumentationLink ApiLink<TClass>()
         {
-            var typeName = typeof(TClass).Name;
+            return ApiLink(typeof(TClass));
+        }
+
+        public static DocumentationLink ApiLink(Type type)
+        {
+            var typeName = type.Name;
 
             return new DocumentationLink(
                 DocumentationLinkType.ControlSource,

--- a/MainDemo.Wpf/Domain/MainWindowViewModel.cs
+++ b/MainDemo.Wpf/Domain/MainWindowViewModel.cs
@@ -31,7 +31,7 @@ namespace MaterialDesignColors.WpfExample.Domain
                         DocumentationLink.WikiLink("Swatches-and-Recommended-Colors", "Swatches"),
                         DocumentationLink.DemoPageLink<PaletteSelector>("Demo View"),
                         DocumentationLink.DemoPageLink<PaletteSelectorViewModel>("Demo View Model"),
-                        DocumentationLink.ApiLink<PaletteHelper>()
+                        DocumentationLink.ApiLink(typeof(PaletteHelper))
                     }),
                 new DemoItem("Buttons & Toggles", new Buttons { DataContext = new ButtonsViewModel() } ,
                     new []

--- a/MainDemo.Wpf/PaletteSelectorViewModel.cs
+++ b/MainDemo.Wpf/PaletteSelectorViewModel.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Text.RegularExpressions;
-using System.Windows;
-using System.Windows.Input;
-using System.Windows.Media;
-using MaterialDesignColors.WpfExample.Domain;
+﻿using MaterialDesignColors.WpfExample.Domain;
 using MaterialDesignThemes.Wpf;
+using System.Collections.Generic;
+using System.Windows.Input;
 
 namespace MaterialDesignColors.WpfExample
 {
@@ -16,14 +9,14 @@ namespace MaterialDesignColors.WpfExample
     {
         public PaletteSelectorViewModel()
         {
-            Swatches = new SwatchesProvider().Swatches;            
+            Swatches = new SwatchesProvider().Swatches;
         }
 
         public ICommand ToggleBaseCommand { get; } = new AnotherCommandImplementation(o => ApplyBase((bool)o));
 
         private static void ApplyBase(bool isDark)
         {
-            new PaletteHelper().SetLightDark(isDark);
+            PaletteHelper.SetLightDark(isDark);
         }
 
         public IEnumerable<Swatch> Swatches { get; }
@@ -32,14 +25,14 @@ namespace MaterialDesignColors.WpfExample
 
         private static void ApplyPrimary(Swatch swatch)
         {
-            new PaletteHelper().ReplacePrimaryColor(swatch);
+            PaletteHelper.ReplacePrimaryColor(swatch);
         }
 
         public ICommand ApplyAccentCommand { get; } = new AnotherCommandImplementation(o => ApplyAccent((Swatch)o));
 
         private static void ApplyAccent(Swatch swatch)
         {
-            new PaletteHelper().ReplaceAccentColor(swatch);
+            PaletteHelper.ReplaceAccentColor(swatch);
         }
     }
 }

--- a/MaterialDesignColors.Wpf.Tests/MaterialDesignColors.Wpf.Tests.csproj
+++ b/MaterialDesignColors.Wpf.Tests/MaterialDesignColors.Wpf.Tests.csproj
@@ -111,6 +111,9 @@
       <Paket>True</Paket>
     </Analyzer>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2')">
       <ItemGroup>

--- a/MaterialDesignColors.Wpf/MaterialDesignColors.Wpf.csproj
+++ b/MaterialDesignColors.Wpf/MaterialDesignColors.Wpf.csproj
@@ -58,6 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Hue.cs" />
+    <Compile Include="RecommendedThemeProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/MaterialDesignColors.Wpf/RecommendedThemeProvider.cs
+++ b/MaterialDesignColors.Wpf/RecommendedThemeProvider.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Resources;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Media;
+
+namespace MaterialDesignColors
+{
+    public class RecommendedThemeProvider
+    {
+        public RecommendedThemeProvider()
+            : this(Assembly.GetExecutingAssembly())
+        {
+
+        }
+
+        public RecommendedThemeProvider(Assembly assembly)
+        {
+            var resourcesName = assembly.GetName().Name + ".g";
+            var manager = new ResourceManager(resourcesName, assembly);
+            var resourceSet = manager.GetResourceSet(CultureInfo.CurrentUICulture, true, true);
+            var dictionaryEntries = resourceSet.OfType<DictionaryEntry>().ToList();
+            var assemblyName = assembly.GetName().Name;
+
+            var regex = new Regex(@"^themes\/recommended\/(?<type>((primary)|(accent)))\/materialdesigncolor\.(?<name>[a-z]+)\.baml$");
+            
+            var swatchProvider = new SwatchesProvider(assembly);
+
+            RecommendedThemes = (from entry in dictionaryEntries
+                let match = regex.Match(entry.Key.ToString())
+                where match.Success
+                let type = match.Groups["type"].Value
+                let name = match.Groups["name"].Value
+                let resourceDictionary = Read(assemblyName, entry.Key.ToString())
+                where resourceDictionary != null
+                let swatch = swatchProvider.Swatches.FirstOrDefault(s => string.Compare(s.Name, name, StringComparison.InvariantCultureIgnoreCase) == 0)
+                    ?? CreateSwatchFromTheme(name, resourceDictionary)
+                let theme = GetTheme(type, resourceDictionary, swatch)
+                where theme != null
+                select theme).ToArray();
+
+            Theme GetTheme(string type, ResourceDictionary resourceDictionary, Swatch swatch)
+            {
+                switch (type.ToLowerInvariant())
+                {
+                    case "primary":
+                        Color? lightColor = GetBrushColor("PrimaryHueLightBrush", resourceDictionary);
+                        int lightIndex = GetHueIndex(swatch.PrimaryHues, lightColor);
+
+                        Color? midColor = GetBrushColor("PrimaryHueMidBrush", resourceDictionary);
+                        int midIndex = GetHueIndex(swatch.PrimaryHues, midColor);
+
+                        Color? darkColor = GetBrushColor("PrimaryHueDarkBrush", resourceDictionary);
+                        int darkIndex = GetHueIndex(swatch.PrimaryHues, darkColor);
+
+                        return new PrimaryTheme(swatch, lightIndex, midIndex, darkIndex);
+                    case "accent":
+                        Color? accentColor = GetBrushColor("SecondaryAccentBrush", resourceDictionary);
+                        int accentIndex = GetHueIndex(swatch.AccentHues, accentColor);
+                        return new AccentTheme(swatch, accentIndex);
+                }
+
+                return null;
+            }
+
+            Color? GetBrushColor(string brushName, ResourceDictionary resourceDictionary)
+            {
+                if (resourceDictionary[brushName] is SolidColorBrush brush)
+                {
+                    return brush.Color;
+                }
+                return null;
+            }
+
+            int GetHueIndex(IEnumerable<Hue> hues, Color? color)
+            {
+                if (color == null) return -1;
+                int index = 0;
+                foreach (Hue hue in hues)
+                {
+                    if (hue.Color == color)
+                        return index;
+                    index++;
+                }
+                return -1;
+            }
+
+            Swatch CreateSwatchFromTheme(string name, ResourceDictionary themeDictionary)
+            {
+                return new Swatch(name, 
+                    new[] {"PrimaryHueLightBrush", "PrimaryHueMidBrush", "PrimaryHueDarkBrush"}.Select(x => CreateHue(x, themeDictionary)).Where(x => x != null),
+                    new[] {"SecondaryAccentBrush"}.Select(x => CreateHue(x, themeDictionary)).Where(x => x != null));
+            }
+
+            Hue CreateHue(string brushName, ResourceDictionary themeDictionary)
+            {
+                if (themeDictionary[brushName] is SolidColorBrush brush &&
+                    themeDictionary[brushName + "Foreground"] is SolidColorBrush foregroundBrush)
+                {
+                    return new Hue("", brush.Color, foregroundBrush.Color);
+                }
+                return null;
+            }
+        }
+
+        public IEnumerable<Theme> RecommendedThemes { get; }
+
+        private static ResourceDictionary Read(string assemblyName, string path)
+        {
+            if (assemblyName == null || path == null)
+                return null;
+
+            return (ResourceDictionary)Application.LoadComponent(new Uri(
+                $"/{assemblyName};component/{path.Replace(".baml", ".xaml")}",
+                UriKind.RelativeOrAbsolute));
+        }
+
+    }
+
+    public abstract class Theme
+    {
+        public Swatch Swatch { get; }
+
+        protected Theme(Swatch swatch)
+        {
+            Swatch = swatch;
+        }
+    }
+
+    public class PrimaryTheme : Theme
+    {
+        public int LightHueIndex { get; }
+
+        public int MidHueIndex { get; }
+
+        public int DarkHueIndex { get; }
+
+        public PrimaryTheme(Swatch swatch, int lightHueIndex, int midHueIndex, int darkHueIndex) 
+            : base(swatch)
+        {
+            LightHueIndex = lightHueIndex;
+            MidHueIndex = midHueIndex;
+            DarkHueIndex = darkHueIndex;
+        }
+    }
+
+    public class AccentTheme : Theme
+    {
+        public int HueIndex { get; }
+
+        public AccentTheme(Swatch swatch, int hueIndex) : base(swatch)
+        {
+            HueIndex = hueIndex;
+        }
+    }
+}

--- a/MaterialDesignColors.Wpf/Swatch.cs
+++ b/MaterialDesignColors.Wpf/Swatch.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Windows;
 
 namespace MaterialDesignColors
 {
@@ -18,14 +15,14 @@ namespace MaterialDesignColors
             if (primaryHues == null) throw new ArgumentNullException(nameof(primaryHues));
             if (accentHues == null) throw new ArgumentNullException(nameof(accentHues));
 
-            var primaryHuesList = primaryHues.ToList();            
+            var primaryHuesList = primaryHues.ToList();
             if (primaryHuesList.Count == 0) throw new ArgumentException("Non primary hues provided.", nameof(primaryHues));
 
             Name = name;
             PrimaryHues = primaryHuesList;
             var accentHuesList = accentHues.ToList();
             AccentHues = accentHuesList;
-            ExemplarHue = primaryHuesList[Math.Min(5, primaryHuesList.Count-1)];
+            ExemplarHue = primaryHuesList[Math.Min(5, primaryHuesList.Count - 1)];
             if (IsAccented)
                 AccentExemplarHue = accentHuesList[Math.Min(2, accentHuesList.Count - 1)];
         }
@@ -36,9 +33,9 @@ namespace MaterialDesignColors
 
         public Hue AccentExemplarHue { get; }
 
-        public IEnumerable<Hue> PrimaryHues { get; }
+        public IList<Hue> PrimaryHues { get; }
 
-        public IEnumerable<Hue> AccentHues { get; }
+        public IList<Hue> AccentHues { get; }
 
         public bool IsAccented => AccentHues.Any();
 

--- a/MaterialDesignThemes.MahApps/MaterialDesignAssist.cs
+++ b/MaterialDesignThemes.MahApps/MaterialDesignAssist.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Media;
+using MaterialDesignColors;
+using MaterialDesignThemes.Wpf;
+
+namespace MaterialDesignThemes.MahApps
+{
+    public static class MaterialDesignAssist
+    {
+        public static MaterialDesignTheme WithMahApps(this MaterialDesignTheme theme)
+        {
+            var resources = Application.Current.Resources;
+            PaletteHelper.ThemeChanged -= PaletteHelperOnThemeChanged;
+            PaletteHelper.ThemeChanged += PaletteHelperOnThemeChanged;
+            PaletteHelper.PaletteChanged -= PaletteHelperOnPaletteChanged;
+            PaletteHelper.PaletteChanged += PaletteHelperOnPaletteChanged;
+            PaletteHelper.PrimarySwatchChanged -= PaletteHelperOnPrimarySwatchChanged;
+            PaletteHelper.PrimarySwatchChanged += PaletteHelperOnPrimarySwatchChanged;
+
+            CreateIfNotExists(GetControlsUri());
+            CreateIfNotExists(GetFontsUri());
+            CreateIfNotExists(GetColorsUri());
+            CreateIfNotExists(GetThemeUri(theme.BaseTheme));
+            CreateIfNotExists(GetCompatibilityUri());
+
+            foreach (var kvp in GetBrushesFromPalette(theme.Palette))
+            {
+                resources[kvp.Key] = kvp.Value;
+            }
+            
+            return theme;
+
+            void CreateIfNotExists(Uri source)
+            {
+                if (FindDictionary(resources.MergedDictionaries, source) == null)
+                {
+                    resources.MergedDictionaries.Add(new ResourceDictionary { Source = source });
+                }
+            }
+        }
+
+        private static Uri GetCompatibilityUri() =>
+            new Uri("pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Defaults.xaml");
+
+        private static Uri GetControlsUri() =>
+            new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml");
+
+        private static Uri GetFontsUri() => 
+            new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml");
+
+        private static Uri GetColorsUri() =>
+            new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml");
+
+        private static Uri GetThemeUri(BaseTheme theme)
+            => new Uri($"pack://application:,,,/MahApps.Metro;component/Styles/Accents/{(theme == BaseTheme.Dark ? "BaseDark" : "BaseLight")}.xaml");
+
+        private static void PaletteHelperOnPaletteChanged(object sender, PaletteChangedEventArgs e)
+        {
+            foreach (var kvp in GetBrushesFromPalette(e.Palette))
+            {
+                Application.Current.Resources.ReplaceEntry(kvp.Key, kvp.Value);
+            }
+        }
+
+        private static void PaletteHelperOnThemeChanged(object sender, ThemeSetEventArgs e)
+        {
+            var existingMahAppsResourceDictionary = Application.Current.Resources.MergedDictionaries
+                .Where(rd => rd.Source != null)
+                .SingleOrDefault(rd => Regex.Match(rd.Source.OriginalString, @"(\/MahApps.Metro;component\/Styles\/Accents\/)((BaseLight)|(BaseDark))").Success);
+            if (existingMahAppsResourceDictionary == null) return;
+
+            var source =
+                $"pack://application:,,,/MahApps.Metro;component/Styles/Accents/{(e.Theme == BaseTheme.Dark ? "BaseDark" : "BaseLight")}.xaml";
+            var newMahAppsResourceDictionary = new ResourceDictionary { Source = new Uri(source) };
+
+            Application.Current.Resources.MergedDictionaries.Remove(existingMahAppsResourceDictionary);
+            Application.Current.Resources.MergedDictionaries.Add(newMahAppsResourceDictionary);
+        }
+
+        private static void PaletteHelperOnPrimarySwatchChanged(object sender, PrimarySwatchChangedEventArgs e)
+        {
+            foreach (var kvp in GetPrimaryBrushes(e.Dark, e.Mid, e.Light))
+            {
+                Application.Current.Resources.ReplaceEntry(kvp.Key, kvp.Value);
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<string, Brush>> GetBrushesFromPalette(Palette palette)
+        {
+            Hue dark = palette.PrimarySwatch.PrimaryHues[palette.PrimaryDarkHueIndex];
+            Hue mid = palette.PrimarySwatch.PrimaryHues[palette.PrimaryMidHueIndex];
+            Hue light = palette.PrimarySwatch.PrimaryHues[palette.PrimaryLightHueIndex];
+
+            return GetPrimaryBrushes(dark, mid, light);
+        }
+
+        private static IEnumerable<KeyValuePair<string, Brush>> GetPrimaryBrushes(Hue dark, Hue mid, Hue light)
+        {
+            yield return new KeyValuePair<string, Brush>("HighlightBrush", new SolidColorBrush(dark.Color));
+            yield return new KeyValuePair<string, Brush>("AccentColorBrush", new SolidColorBrush(dark.Color));
+            yield return new KeyValuePair<string, Brush>("AccentColorBrush2", new SolidColorBrush(mid.Color));
+            yield return new KeyValuePair<string, Brush>("AccentColorBrush3", new SolidColorBrush(light.Color));
+            yield return new KeyValuePair<string, Brush>("AccentColorBrush4", new SolidColorBrush(light.Color) { Opacity = .82 });
+            yield return new KeyValuePair<string, Brush>("WindowTitleColorBrush", new SolidColorBrush(dark.Color));
+            yield return new KeyValuePair<string, Brush>("AccentSelectedColorBrush", new SolidColorBrush(dark.Foreground));
+            yield return new KeyValuePair<string, Brush>("ProgressBrush", new LinearGradientBrush(dark.Color, mid.Color, 90.0));
+            yield return new KeyValuePair<string, Brush>("CheckmarkFill", new SolidColorBrush(dark.Color));
+            yield return new KeyValuePair<string, Brush>("RightArrowFill", new SolidColorBrush(dark.Color));
+            yield return new KeyValuePair<string, Brush>("IdealForegroundColorBrush", new SolidColorBrush(dark.Foreground));
+            yield return new KeyValuePair<string, Brush>("IdealForegroundDisabledBrush", new SolidColorBrush(dark.Color) { Opacity = .4 });
+        }
+
+        private static ResourceDictionary FindDictionary(IEnumerable<ResourceDictionary> dictionaries, Uri source)
+        {
+            return dictionaries.FirstOrDefault(x => x.Source == source);
+        }
+    }
+}

--- a/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.csproj
+++ b/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.csproj
@@ -78,6 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FlyoutAssist.cs" />
+    <Compile Include="MaterialDesignAssist.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -103,6 +104,10 @@
     <AppDesigner Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\MaterialDesignColors.Wpf\MaterialDesignColors.Wpf.csproj">
+      <Project>{90B53209-C60C-4655-B28D-A1B3E1044BA3}</Project>
+      <Name>MaterialDesignColors.Wpf</Name>
+    </ProjectReference>
     <ProjectReference Include="..\MaterialDesignThemes.Wpf\MaterialDesignThemes.Wpf.csproj">
       <Project>{f079fb0a-a8ed-4216-b6a5-345756751a04}</Project>
       <Name>MaterialDesignThemes.Wpf</Name>

--- a/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
+++ b/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
@@ -157,6 +157,9 @@
       <Paket>True</Paket>
     </Analyzer>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2')">
       <ItemGroup>

--- a/MaterialDesignThemes.Wpf/MaterialDesignAssist.cs
+++ b/MaterialDesignThemes.Wpf/MaterialDesignAssist.cs
@@ -10,6 +10,8 @@ namespace MaterialDesignThemes.Wpf
 {
     public static class MaterialDesignAssist
     {
+        private static readonly Regex _StringFormatParameterReplacement = new Regex(@"{\d+(?<Alignment>,-?\d*)?(?<Format>:.*?)?}", RegexOptions.Compiled);
+
         private const string ColorUriFormat =
             @"pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/{0}/MaterialDesignColor.{1}.xaml";
 
@@ -31,17 +33,6 @@ namespace MaterialDesignThemes.Wpf
             Palette palette = PaletteHelper.ReplacePalette(primaryColor.ToString(), accentColor.ToString());
             return new MaterialDesignTheme(theme, primaryColor, accentColor, palette);
         }
-
-        //public static ResourceDictionary WithMaterialDesign(this ResourceDictionary resourceDictionary, BaseTheme theme, PrimaryColor primaryColor, AccentColor accentColor)
-        //{
-        //    if (resourceDictionary == null) throw new ArgumentNullException(nameof(resourceDictionary));
-        //    resourceDictionary.MergedDictionaries.Add(CreateDefaultThemeDictionary());
-        //
-        //    return resourceDictionary
-        //        .WithTheme(theme)
-        //        .WithPrimaryColor(primaryColor)
-        //        .WithAccentColor(accentColor);
-        //}
 
         private static ResourceDictionary CreateEmptyPaletteDictionary()
         {
@@ -172,35 +163,19 @@ namespace MaterialDesignThemes.Wpf
 
         private static ResourceDictionary FindDictionary<TEnum>(IEnumerable<ResourceDictionary> dictionaries, string formatString) where TEnum : struct
         {
-            var regex = new Regex(StringFormatHelper.GetRegexPatternImpl(formatString, string.Join("|", Enum.GetValues(typeof(TEnum)).Cast<TEnum>())));
+            var regex = new Regex(GetRegexPatternImpl(formatString, string.Join("|", Enum.GetValues(typeof(TEnum)).Cast<TEnum>())));
             return dictionaries.FirstOrDefault(x => regex.IsMatch(x.Source?.OriginalString ?? ""));
         }
 
         private static ResourceDictionary FindDictionary(IEnumerable<ResourceDictionary> dictionaries, string formatString)
         {
-            var regex = new Regex(StringFormatHelper.GetRegexPatternImpl(formatString));
+            var regex = new Regex(GetRegexPatternImpl(formatString));
             return dictionaries.FirstOrDefault(x => regex.IsMatch(x.Source?.OriginalString ?? ""));
         }
 
-        private static class StringFormatHelper
+        private static string GetRegexPatternImpl(string stringFormat, string replacement = ".*")
         {
-            private static readonly Regex _ParameterReplacement = new Regex(@"{\d+(?<Alignment>,-?\d*)?(?<Format>:.*?)?}", RegexOptions.Compiled);
-
-            public static bool MatchesStringFormat(string testString, string stringFormat)
-            {
-                var regexPattern = GetRegexPattern(stringFormat);
-                return Regex.IsMatch(testString ?? "", regexPattern);
-            }
-
-            private static string GetRegexPattern(string stringFormat)
-            {
-                return GetRegexPatternImpl(stringFormat);
-            }
-
-            public static string GetRegexPatternImpl(string stringFormat, string replacement = ".*")
-            {
-                return string.Join(replacement, _ParameterReplacement.Split(stringFormat).Select(Regex.Escape));
-            }
+            return string.Join(replacement, _StringFormatParameterReplacement.Split(stringFormat).Select(Regex.Escape));
         }
     }
 }

--- a/MaterialDesignThemes.Wpf/MaterialDesignAssist.cs
+++ b/MaterialDesignThemes.Wpf/MaterialDesignAssist.cs
@@ -1,0 +1,206 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+
+namespace MaterialDesignThemes.Wpf
+{
+    public static class MaterialDesignAssist
+    {
+        private const string ColorUriFormat =
+            @"pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/{0}/MaterialDesignColor.{1}.xaml";
+
+        private const string ThemeUriFormat =
+            @"pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.{0}.xaml";
+
+
+        public static MaterialDesignTheme WithMaterialDesign(this Application application,
+            BaseTheme theme, PrimaryColor primaryColor, AccentColor accentColor)
+        {
+            //NB: When the palettes are changed it hunts through the merged dictionaries.
+            //Putting this at the beginning to avoid needing to hunt through all of them.
+            application.Resources.MergedDictionaries.Add(CreateEmptyPaletteDictionary());
+            if (FindDictionary(application.Resources.MergedDictionaries, string.Format(ThemeUriFormat, "Defaults")) == null)
+            {
+                application.Resources.MergedDictionaries.Add(CreateDefaultThemeDictionary());
+            }
+            PaletteHelper.SetLightDark(theme == BaseTheme.Dark);
+            Palette palette = PaletteHelper.ReplacePalette(primaryColor.ToString(), accentColor.ToString());
+            return new MaterialDesignTheme(theme, primaryColor, accentColor, palette);
+        }
+
+        //public static ResourceDictionary WithMaterialDesign(this ResourceDictionary resourceDictionary, BaseTheme theme, PrimaryColor primaryColor, AccentColor accentColor)
+        //{
+        //    if (resourceDictionary == null) throw new ArgumentNullException(nameof(resourceDictionary));
+        //    resourceDictionary.MergedDictionaries.Add(CreateDefaultThemeDictionary());
+        //
+        //    return resourceDictionary
+        //        .WithTheme(theme)
+        //        .WithPrimaryColor(primaryColor)
+        //        .WithAccentColor(accentColor);
+        //}
+
+        private static ResourceDictionary CreateEmptyPaletteDictionary()
+        {
+            return new ResourceDictionary
+            {
+                ["PrimaryHueLightBrush"] = new SolidColorBrush(),
+                ["PrimaryHueLightForegroundBrush"] = new SolidColorBrush(),
+                ["PrimaryHueMidBrush"] = new SolidColorBrush(),
+                ["PrimaryHueMidForegroundBrush"] = new SolidColorBrush(),
+                ["PrimaryHueDarkBrush"] = new SolidColorBrush(),
+                ["PrimaryHueDarkForegroundBrush"] = new SolidColorBrush(),
+                ["SecondaryAccentBrush"] = new SolidColorBrush(),
+                ["SecondaryAccentForegroundBrush"] = new SolidColorBrush()
+            };
+        }
+
+        public static ResourceDictionary WithTheme(this ResourceDictionary resourceDictionary, BaseTheme theme)
+        {
+            if (resourceDictionary == null) throw new ArgumentNullException(nameof(resourceDictionary));
+            ResourceDictionary existing = resourceDictionary.FindThemeDictionary(theme);
+            if (existing != null)
+            {
+                resourceDictionary.MergedDictionaries.Remove(existing);
+            }
+            resourceDictionary.MergedDictionaries.Add(CreateThemeDictionary(theme));
+            return resourceDictionary;
+        }
+
+        public static ResourceDictionary WithPrimaryColor(this ResourceDictionary resourceDictionary,
+            PrimaryColor primaryColor)
+        {
+            if (resourceDictionary == null) throw new ArgumentNullException(nameof(resourceDictionary));
+            ResourceDictionary existing = resourceDictionary.FindThemeDictionary(primaryColor);
+            if (existing != null)
+            {
+                resourceDictionary.MergedDictionaries.Remove(existing);
+            }
+            resourceDictionary.MergedDictionaries.Add(CreateColorThemeDictionary(primaryColor));
+            return resourceDictionary;
+        }
+
+        public static ResourceDictionary WithAccentColor(this ResourceDictionary resourceDictionary,
+            AccentColor accentColor)
+        {
+            if (resourceDictionary == null) throw new ArgumentNullException(nameof(resourceDictionary));
+            ResourceDictionary existing = resourceDictionary.FindThemeDictionary(accentColor);
+            if (existing != null)
+            {
+                resourceDictionary.MergedDictionaries.Remove(existing);
+            }
+            resourceDictionary.MergedDictionaries.Add(CreateColorThemeDictionary(accentColor));
+            return resourceDictionary;
+        }
+
+        public static ResourceDictionary FindThemeDictionary(this ResourceDictionary resourceDictionary,
+            BaseTheme theme)
+        {
+            if (resourceDictionary == null) throw new ArgumentNullException(nameof(resourceDictionary));
+            return FindDictionary<BaseTheme>(resourceDictionary.MergedDictionaries, ThemeUriFormat);
+        }
+
+        public static ResourceDictionary FindThemeDictionary(this ResourceDictionary resourceDictionary,
+            PrimaryColor primaryColor)
+        {
+            if (resourceDictionary == null) throw new ArgumentNullException(nameof(resourceDictionary));
+            return FindDictionary<PrimaryColor>(resourceDictionary.MergedDictionaries,
+                string.Format(ColorUriFormat, "Primary", "{0}"));
+        }
+
+        public static ResourceDictionary FindThemeDictionary(this ResourceDictionary resourceDictionary,
+            AccentColor accentColor)
+        {
+            if (resourceDictionary == null) throw new ArgumentNullException(nameof(resourceDictionary));
+            return FindDictionary<PrimaryColor>(resourceDictionary.MergedDictionaries,
+                string.Format(ColorUriFormat, "Accent", "{0}"));
+        }
+
+        /// <summary>
+        /// Replaces a certain entry anywhere in the source dictionary and its merged dictionaries
+        /// </summary>
+        /// <param name="sourceDictionary">The source dictionary to start with</param>
+        /// <param name="name">The entry to replace</param>
+        /// <param name="value">The new entry value</param>
+        public static void ReplaceEntry(this ResourceDictionary sourceDictionary, object name, object value)
+        {
+            if (sourceDictionary.Contains(name))
+            {
+                if (sourceDictionary[name] is SolidColorBrush brush && 
+                    !brush.IsFrozen && value is SolidColorBrush newBrush)
+                {
+                    var animation = new ColorAnimation
+                    {
+                        From = brush.Color,
+                        To = newBrush.Color,
+                        Duration = new Duration(TimeSpan.FromMilliseconds(300))
+                    };
+                    brush.BeginAnimation(SolidColorBrush.ColorProperty, animation);
+                }
+                else
+                {
+                    sourceDictionary[name] = value; //Set value normally
+                }
+            }
+
+            foreach (var dictionary in sourceDictionary.MergedDictionaries)
+            {
+                ReplaceEntry(dictionary, name, value);
+            }
+        }
+
+        private static ResourceDictionary CreateThemeDictionary(BaseTheme theme)
+            => new ResourceDictionary { Source = GetUri(theme) };
+
+        private static ResourceDictionary CreateColorThemeDictionary(PrimaryColor color)
+            => new ResourceDictionary { Source = GetUri(color) };
+
+        private static ResourceDictionary CreateColorThemeDictionary(AccentColor color)
+            => new ResourceDictionary { Source = GetUri(color) };
+
+        private static ResourceDictionary CreateDefaultThemeDictionary()
+            => new ResourceDictionary { Source = new Uri(string.Format(ThemeUriFormat, "Defaults")) };
+
+        private static Uri GetUri(BaseTheme theme) => new Uri(string.Format(ThemeUriFormat, theme));
+
+        private static Uri GetUri(PrimaryColor color) => new Uri(string.Format(ColorUriFormat, "Primary", color));
+
+        private static Uri GetUri(AccentColor color) => new Uri(string.Format(ColorUriFormat, "Accent", color));
+
+        private static ResourceDictionary FindDictionary<TEnum>(IEnumerable<ResourceDictionary> dictionaries, string formatString) where TEnum : struct
+        {
+            var regex = new Regex(StringFormatHelper.GetRegexPatternImpl(formatString, string.Join("|", Enum.GetValues(typeof(TEnum)).Cast<TEnum>())));
+            return dictionaries.FirstOrDefault(x => regex.IsMatch(x.Source?.OriginalString ?? ""));
+        }
+
+        private static ResourceDictionary FindDictionary(IEnumerable<ResourceDictionary> dictionaries, string formatString)
+        {
+            var regex = new Regex(StringFormatHelper.GetRegexPatternImpl(formatString));
+            return dictionaries.FirstOrDefault(x => regex.IsMatch(x.Source?.OriginalString ?? ""));
+        }
+
+        private static class StringFormatHelper
+        {
+            private static readonly Regex _ParameterReplacement = new Regex(@"{\d+(?<Alignment>,-?\d*)?(?<Format>:.*?)?}", RegexOptions.Compiled);
+
+            public static bool MatchesStringFormat(string testString, string stringFormat)
+            {
+                var regexPattern = GetRegexPattern(stringFormat);
+                return Regex.IsMatch(testString ?? "", regexPattern);
+            }
+
+            private static string GetRegexPattern(string stringFormat)
+            {
+                return GetRegexPatternImpl(stringFormat);
+            }
+
+            public static string GetRegexPatternImpl(string stringFormat, string replacement = ".*")
+            {
+                return string.Join(replacement, _ParameterReplacement.Split(stringFormat).Select(Regex.Escape));
+            }
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/MaterialDesignResourceDictionary.cs
+++ b/MaterialDesignThemes.Wpf/MaterialDesignResourceDictionary.cs
@@ -1,0 +1,34 @@
+﻿using System.Windows;
+
+namespace MaterialDesignThemes.Wpf
+{
+    public class MaterialDesignResourceDictionary : ResourceDictionary
+    {
+        public MaterialDesignResourceDictionary()
+        {
+            Application.Current.Resources = this;
+            Application.Current.WithMaterialDesign(Theme, PrimaryColor, AccentColor);
+        }
+
+        private BaseTheme _theme = BaseTheme.Light;
+        public BaseTheme Theme
+        {
+            get => _theme;
+            set => this.WithTheme(_theme = value);
+        }
+
+        private PrimaryColor _primaryColor = PrimaryColor.DeepPurple;
+        public PrimaryColor PrimaryColor
+        {
+            get => _primaryColor;
+            set => this.WithPrimaryColor(_primaryColor = value);
+        }
+
+        private AccentColor _accentColor = AccentColor.Lime;
+        public AccentColor AccentColor
+        {
+            get => _accentColor;
+            set => this.WithAccentColor(_accentColor = value);
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/MaterialDesignTheme.cs
+++ b/MaterialDesignThemes.Wpf/MaterialDesignTheme.cs
@@ -1,0 +1,67 @@
+﻿namespace MaterialDesignThemes.Wpf
+{
+    public class MaterialDesignTheme
+    {
+        public MaterialDesignTheme(BaseTheme theme, PrimaryColor primaryColor, AccentColor accentColor, Palette palette)
+        {
+            BaseTheme = theme;
+            PrimaryColor = primaryColor;
+            AccentColor = accentColor;
+            Palette = palette;
+        }
+
+        public BaseTheme BaseTheme { get; }
+        public PrimaryColor PrimaryColor { get; }
+        public AccentColor AccentColor { get; }
+        public Palette Palette { get; }
+    }
+
+    public enum AccentColor
+    {
+        Amber,
+        Blue,
+        Cyan,
+        DeepOrange,
+        DeepPurple,
+        Green,
+        Indigo,
+        LightBlue,
+        LightGreen,
+        Lime,
+        Orange,
+        Pink,
+        Purple,
+        Red,
+        Teal,
+        Yellow
+    }
+
+    public enum PrimaryColor
+    {
+        Amber,
+        Blue,
+        BlueGrey,
+        Brown,
+        Cyan,
+        DeepOrange,
+        DeepPurple,
+        Green,
+        Grey,
+        Indigo,
+        LightBlue,
+        LightGreen,
+        Lime,
+        Orange,
+        Pink,
+        Purple,
+        Red,
+        Teal,
+        Yellow
+    }
+
+    public enum BaseTheme
+    {
+        Light,
+        Dark
+    }
+}

--- a/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
+++ b/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
@@ -324,10 +324,15 @@
     <Compile Include="ISnackbarMessageQueue.cs" />
     <Compile Include="ListBoxAssist.cs" />
     <Compile Include="ListViewAssist.cs" />
+    <Compile Include="MaterialDesignAssist.cs" />
+    <Compile Include="MaterialDesignResourceDictionary.cs" />
+    <Compile Include="MaterialDesignTheme.cs" />
     <Compile Include="MessageQueueExtension.cs" />
     <Compile Include="PackIconExtension.cs" />
     <Compile Include="Palette.cs" />
+    <Compile Include="PaletteChangedEventArgs.cs" />
     <Compile Include="Plane3D.cs" />
+    <Compile Include="PrimarySwatchChangedEventArgs.cs" />
     <Compile Include="ScaleHost.cs" />
     <Compile Include="ScrollViewerAssist.cs" />
     <Compile Include="Screen.cs" />
@@ -337,6 +342,8 @@
     <Compile Include="SnackbarMessageQueue.cs" />
     <Compile Include="SnackbarMessageQueueItem.cs" />
     <Compile Include="Spelling.cs" />
+    <Compile Include="ThemeAssist.cs" />
+    <Compile Include="ThemeSetEventArgs.cs" />
     <Compile Include="Transitions\CircleWipe.cs" />
     <Compile Include="IHintProxy.cs" />
     <Compile Include="Transitions\FadeWipe.cs" />

--- a/MaterialDesignThemes.Wpf/PaletteChangedEventArgs.cs
+++ b/MaterialDesignThemes.Wpf/PaletteChangedEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace MaterialDesignThemes.Wpf
+{
+    public class PaletteChangedEventArgs : EventArgs
+    {
+        public PaletteChangedEventArgs(Palette palette)
+        {
+            Palette = palette;
+        }
+
+        public Palette Palette { get; }
+    }
+}

--- a/MaterialDesignThemes.Wpf/PaletteHelper.cs
+++ b/MaterialDesignThemes.Wpf/PaletteHelper.cs
@@ -3,68 +3,75 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Media;
-using System.Windows.Media.Animation;
-using System.Runtime.InteropServices;
 namespace MaterialDesignThemes.Wpf
 {
-    public class PaletteHelper
+    public static class PaletteHelper
     {
-        public virtual void SetLightDark(bool isDark)
+        public static event EventHandler<ThemeSetEventArgs> ThemeChanged;
+        public static event EventHandler<PaletteChangedEventArgs> PaletteChanged;
+        public static event EventHandler<PrimarySwatchChangedEventArgs> PrimarySwatchChanged; 
+
+        private static readonly SwatchesProvider _swatchesProvider = new SwatchesProvider();
+        private static readonly RecommendedThemeProvider _themeProvider = new RecommendedThemeProvider();
+
+        public static void SetLightDark(bool isDark)
         {
-            var existingResourceDictionary = Application.Current.Resources.MergedDictionaries
-                .Where(rd => rd.Source != null)
-                .SingleOrDefault(rd => Regex.Match(rd.Source.OriginalString, @"(\/MaterialDesignThemes.Wpf;component\/Themes\/MaterialDesignTheme\.)((Light)|(Dark))").Success);
-            if (existingResourceDictionary == null)
-                throw new ApplicationException("Unable to find Light/Dark base theme in Application resources.");
+            Application.Current.Resources.WithTheme(isDark ? BaseTheme.Dark : BaseTheme.Light);
+            ThemeChanged?.Invoke(null, new ThemeSetEventArgs(isDark ? BaseTheme.Dark : BaseTheme.Light));
+        }
 
-            var source =
-                $"pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.{(isDark ? "Dark" : "Light")}.xaml";
-            var newResourceDictionary = new ResourceDictionary() { Source = new Uri(source) };
+        public static Palette ReplacePalette(string primaryName, string accentName)
+        {
+            if (primaryName == null) throw new ArgumentNullException(nameof(primaryName));
+            if (accentName == null) throw new ArgumentNullException(nameof(accentName));
 
-            Application.Current.Resources.MergedDictionaries.Remove(existingResourceDictionary);
-            Application.Current.Resources.MergedDictionaries.Add(newResourceDictionary);
+            PrimaryTheme primaryTheme = _themeProvider.RecommendedThemes.OfType<PrimaryTheme>().FirstOrDefault(x =>
+                string.Compare(x.Swatch.Name, primaryName, StringComparison.InvariantCultureIgnoreCase) == 0)
+                ?? throw new ArgumentException($"Could not find primary theme for '{primaryName}'", nameof(primaryName));
 
-            var existingMahAppsResourceDictionary = Application.Current.Resources.MergedDictionaries
-                .Where(rd => rd.Source != null)
-                .SingleOrDefault(rd => Regex.Match(rd.Source.OriginalString, @"(\/MahApps.Metro;component\/Styles\/Accents\/)((BaseLight)|(BaseDark))").Success);
-            if (existingMahAppsResourceDictionary == null) return;
+            AccentTheme accentTheme = _themeProvider.RecommendedThemes.OfType<AccentTheme>().FirstOrDefault(x =>
+                string.Compare(x.Swatch.Name, accentName, StringComparison.InvariantCultureIgnoreCase) == 0)
+                ?? throw new ArgumentException($"Could not find accent theme for '{accentName}'", nameof(accentName));
 
-            source =
-                $"pack://application:,,,/MahApps.Metro;component/Styles/Accents/{(isDark ? "BaseDark" : "BaseLight")}.xaml";
-            var newMahAppsResourceDictionary = new ResourceDictionary { Source = new Uri(source) };
-
-            Application.Current.Resources.MergedDictionaries.Remove(existingMahAppsResourceDictionary);
-            Application.Current.Resources.MergedDictionaries.Add(newMahAppsResourceDictionary);
+            var palette = new Palette(
+                primaryTheme.Swatch, 
+                accentTheme.Swatch, 
+                primaryTheme.LightHueIndex,
+                primaryTheme.MidHueIndex, 
+                primaryTheme.DarkHueIndex, 
+                accentTheme.HueIndex);
+            ReplacePalette(palette);
+            return palette;
         }
 
         /// <summary>
         /// Replaces the entire palette
         /// </summary>
-        public virtual void ReplacePalette(Palette palette)
+        public static void ReplacePalette(Palette palette)
         {
             if (palette == null) throw new ArgumentNullException(nameof(palette));
 
             var allHues = palette.PrimarySwatch.PrimaryHues.ToList();
             ReplacePrimaryColor(
-                palette.PrimarySwatch, 
-                allHues[palette.PrimaryLightHueIndex], 
+                palette.PrimarySwatch,
+                allHues[palette.PrimaryLightHueIndex],
                 allHues[palette.PrimaryMidHueIndex],
-                allHues[palette.PrimaryDarkHueIndex],
-                allHues);
+                allHues[palette.PrimaryDarkHueIndex]);
 
             var accentHue = palette.AccentSwatch.AccentHues.ElementAt(palette.AccentHueIndex);
             ReplaceEntry("SecondaryAccentBrush", new SolidColorBrush(accentHue.Color));
             ReplaceEntry("SecondaryAccentForegroundBrush", new SolidColorBrush(accentHue.Foreground));
+
+            PaletteChanged?.Invoke(null, new PaletteChangedEventArgs(palette));
         }
 
         /// <summary>
         /// Replaces the primary colour, selecting a balanced set of hues for the light, mid and dark hues.
         /// </summary>
         /// <param name="swatch"></param>
-        public virtual void ReplacePrimaryColor(Swatch swatch)
+        public static void ReplacePrimaryColor(Swatch swatch)
         {
             if (swatch == null) throw new ArgumentNullException(nameof(swatch));
 
@@ -75,14 +82,15 @@ namespace MaterialDesignThemes.Wpf
             var mid = list[palette.PrimaryMidHueIndex];
             var dark = list[palette.PrimaryDarkHueIndex];
 
-            ReplacePrimaryColor(swatch, light, mid, dark, list);
-        }      
+            ReplacePrimaryColor(swatch, light, mid, dark);
+            PrimarySwatchChanged?.Invoke(null, new PrimarySwatchChangedEventArgs(swatch, light, mid, dark));
+        }
 
-        public virtual void ReplacePrimaryColor(string name)
+        public static void ReplacePrimaryColor(string name)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
 
-            var swatch = new SwatchesProvider().Swatches.FirstOrDefault(
+            var swatch = _swatchesProvider.Swatches.FirstOrDefault(
                 s => string.Compare(s.Name, name, StringComparison.InvariantCultureIgnoreCase) == 0);
 
             if (swatch == null)
@@ -91,7 +99,7 @@ namespace MaterialDesignThemes.Wpf
             ReplacePrimaryColor(swatch);
         }
 
-        public virtual void ReplaceAccentColor(Swatch swatch)
+        public static void ReplaceAccentColor(Swatch swatch)
         {
             if (swatch == null) throw new ArgumentNullException(nameof(swatch));
 
@@ -109,7 +117,7 @@ namespace MaterialDesignThemes.Wpf
             ReplaceEntry("SecondaryAccentForegroundBrush", new SolidColorBrush(hue.Foreground));
         }
 
-        public virtual void ReplaceAccentColor(string name)
+        public static void ReplaceAccentColor(string name)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
 
@@ -128,16 +136,15 @@ namespace MaterialDesignThemes.Wpf
         /// <returns></returns>
         /// <exception cref="InvalidOperationException">Thrown if there is any ambiguouty regarding the palette. Provided
         /// standard guidleines have been followed for palette configureation, this should not happen.</exception>
-        public Palette QueryPalette()
+        public static Palette QueryPalette()
         {
             //it's not safe to to query for the included swatches, so we find the mid (or accent) colour, 
             //& cross match it with the entirety of all available hues to find the owning swatch.
-
-            //TODO could cache this statically
-            var swatchesProvider = new SwatchesProvider();
+            
+            var swatchesProvider = _swatchesProvider;
             var swatchByPrimaryHueIndex = swatchesProvider
                 .Swatches
-                .SelectMany(s => s.PrimaryHues.Select(h => new {s, h}))
+                .SelectMany(s => s.PrimaryHues.Select(h => new { s, h }))
                 .ToDictionary(a => a.h.Color, a => a.s);
             var swatchByAccentHueIndex = swatchesProvider
                 .Swatches
@@ -148,11 +155,9 @@ namespace MaterialDesignThemes.Wpf
             var primaryMidBrush = GetBrush("PrimaryHueMidBrush");
             var accentBrush = GetBrush("SecondaryAccentBrush");
 
-            Swatch primarySwatch;
-            if (!swatchByPrimaryHueIndex.TryGetValue(primaryMidBrush.Color, out primarySwatch))
+            if (!swatchByPrimaryHueIndex.TryGetValue(primaryMidBrush.Color, out var primarySwatch))
                 throw new InvalidOperationException("PrimaryHueMidBrush is not from standard swatches");
-            Swatch accentSwatch;
-            if (!swatchByAccentHueIndex.TryGetValue(accentBrush.Color, out accentSwatch))
+            if (!swatchByAccentHueIndex.TryGetValue(accentBrush.Color, out var accentSwatch))
                 throw new InvalidOperationException("SecondaryAccentBrush is not from standard swatches");
 
             var primaryLightBrush = GetBrush("PrimaryHueLightBrush");
@@ -166,7 +171,7 @@ namespace MaterialDesignThemes.Wpf
             return new Palette(primarySwatch, accentSwatch, primaryLightHueIndex, primaryMidHueIndex, primaryDarkHueIndex, accentHueIndex);
         }
 
-        private static void ReplacePrimaryColor(Swatch swatch, Hue light, Hue mid, Hue dark, IList<Hue> allHues)
+        private static void ReplacePrimaryColor(Swatch swatch, Hue light, Hue mid, Hue dark)
         {
             foreach (var color in swatch.PrimaryHues)
             {
@@ -180,25 +185,11 @@ namespace MaterialDesignThemes.Wpf
             ReplaceEntry("PrimaryHueMidForegroundBrush", new SolidColorBrush(mid.Foreground));
             ReplaceEntry("PrimaryHueDarkBrush", new SolidColorBrush(dark.Color));
             ReplaceEntry("PrimaryHueDarkForegroundBrush", new SolidColorBrush(dark.Foreground));
-
-            //mahapps brushes            
-            ReplaceEntry("HighlightBrush", new SolidColorBrush(dark.Color));
-            ReplaceEntry("AccentColorBrush", new SolidColorBrush(dark.Color));
-            ReplaceEntry("AccentColorBrush2", new SolidColorBrush(mid.Color));
-            ReplaceEntry("AccentColorBrush3", new SolidColorBrush(light.Color));
-            ReplaceEntry("AccentColorBrush4", new SolidColorBrush(light.Color) { Opacity = .82 });
-            ReplaceEntry("WindowTitleColorBrush", new SolidColorBrush(dark.Color));
-            ReplaceEntry("AccentSelectedColorBrush", new SolidColorBrush(dark.Foreground));
-            ReplaceEntry("ProgressBrush", new LinearGradientBrush(dark.Color, mid.Color, 90.0));
-            ReplaceEntry("CheckmarkFill", new SolidColorBrush(dark.Color));
-            ReplaceEntry("RightArrowFill", new SolidColorBrush(dark.Color));
-            ReplaceEntry("IdealForegroundColorBrush", new SolidColorBrush(dark.Foreground));
-            ReplaceEntry("IdealForegroundDisabledBrush", new SolidColorBrush(dark.Color) { Opacity = .4 });
-        }        
+        }
 
         private static int GetHueIndex(Swatch swatch, Color color, bool isAccent)
         {
-            var x = (isAccent ? swatch.AccentHues : swatch.PrimaryHues).Select((h, i) => new {h, i})
+            var x = (isAccent ? swatch.AccentHues : swatch.PrimaryHues).Select((h, i) => new { h, i })
                 .FirstOrDefault(a => a.h.Color == color);
             if (x == null)
                 throw new InvalidOperationException($"Color {color} not found in swatch {swatch.Name}.");
@@ -212,15 +203,15 @@ namespace MaterialDesignThemes.Wpf
                 .Where(a => a.e.Value is SolidColorBrush)
                 .GroupBy(a => (SolidColorBrush)a.e.Value)
                 .SingleOrDefault(g => g.First().e.Key.Equals(name));
+
             if (group == null)
                 throw new InvalidOperationException($"Unable to safely determine a single resource definition for {name}.");
-            var solidColorBrush = group.First().e.Value as SolidColorBrush;
-            if (solidColorBrush == null)
+            
+            if (!(group.First().e.Value is SolidColorBrush solidColorBrush))
                 throw new InvalidOperationException($"Expected {name} to be a SolidColorBrush");
 
             return solidColorBrush;
         }
-
 
         private static IEnumerable<DictionaryEntry> GetEntries(IDictionary dictionary)
         {
@@ -244,33 +235,11 @@ namespace MaterialDesignThemes.Wpf
         /// <summary>
         /// Replaces a certain entry anywhere in the parent dictionary and its merged dictionaries
         /// </summary>
-        /// <param name="entryName">The entry to replace</param>
-        /// <param name="newValue">The new entry value</param>
-        /// <param name="parentDictionary">The root dictionary to start searching at. Null means using Application.Current.Resources</param>
-        private static void ReplaceEntry(object entryName, object newValue, ResourceDictionary parentDictionary = null)
-        {            
-            if (parentDictionary == null)
-                parentDictionary = Application.Current.Resources;
-            
-            if (parentDictionary.Contains(entryName))
-            {
-                var brush = parentDictionary[entryName] as SolidColorBrush;
-                if (brush != null && !brush.IsFrozen)
-                {                 
-                    var animation = new ColorAnimation
-                    {
-                        From = ((SolidColorBrush)parentDictionary[entryName]).Color,
-                        To = ((SolidColorBrush)newValue).Color,
-                        Duration = new Duration(TimeSpan.FromMilliseconds(300))
-                    };
-                    brush.BeginAnimation(SolidColorBrush.ColorProperty, animation);
-                }
-                else
-                    parentDictionary[entryName] = newValue; //Set value normally
-            }
-
-            foreach (var dictionary in parentDictionary.MergedDictionaries)
-                ReplaceEntry(entryName, newValue, dictionary);
+        /// <param name="name">The entry to replace</param>
+        /// <param name="value">The new entry value</param>
+        private static void ReplaceEntry(object name, object value)
+        {
+            Application.Current.Resources.ReplaceEntry(name, value);
         }
-    }    
+    }
 }

--- a/MaterialDesignThemes.Wpf/PrimarySwatchChangedEventArgs.cs
+++ b/MaterialDesignThemes.Wpf/PrimarySwatchChangedEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using MaterialDesignColors;
+
+namespace MaterialDesignThemes.Wpf
+{
+    public class PrimarySwatchChangedEventArgs : EventArgs
+    {
+        public PrimarySwatchChangedEventArgs(Swatch swatch, Hue light, Hue mid, Hue dark)
+        {
+            Swatch = swatch;
+            Light = light;
+            Mid = mid;
+            Dark = dark;
+        }
+
+        public Swatch Swatch { get; }
+        public Hue Light { get; }
+        public Hue Mid { get; }
+        public Hue Dark { get; }
+    }
+}

--- a/MaterialDesignThemes.Wpf/ThemeAssist.cs
+++ b/MaterialDesignThemes.Wpf/ThemeAssist.cs
@@ -1,0 +1,70 @@
+﻿using System.Windows;
+
+namespace MaterialDesignThemes.Wpf
+{
+    public static class ThemeAssist
+    {
+        public static readonly DependencyProperty ThemeProperty = DependencyProperty.RegisterAttached(
+            "Theme", typeof(BaseTheme), typeof(ThemeAssist), new PropertyMetadata(default(BaseTheme), OnThemeChanged));
+
+        private static void OnThemeChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        {
+            if (dependencyObject is FrameworkElement element)
+            {
+                element.Resources.WithTheme((BaseTheme)e.NewValue);
+            }
+        }
+
+        public static void SetTheme(DependencyObject element, BaseTheme value)
+        {
+            element.SetValue(ThemeProperty, value);
+        }
+
+        public static BaseTheme GetTheme(DependencyObject element)
+        {
+            return (BaseTheme)element.GetValue(ThemeProperty);
+        }
+
+        public static readonly DependencyProperty PrimaryColorProperty = DependencyProperty.RegisterAttached(
+            "PrimaryColor", typeof(PrimaryColor), typeof(ThemeAssist), new PropertyMetadata(default(PrimaryColor), OnPrimaryColorChanged));
+
+        private static void OnPrimaryColorChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        {
+            if (dependencyObject is FrameworkElement element)
+            {
+                element.Resources.WithPrimaryColor((PrimaryColor)e.NewValue);
+            }
+        }
+
+        public static void SetPrimaryColor(DependencyObject element, PrimaryColor value)
+        {
+            element.SetValue(PrimaryColorProperty, value);
+        }
+
+        public static PrimaryColor GetPrimaryColor(DependencyObject element)
+        {
+            return (PrimaryColor)element.GetValue(PrimaryColorProperty);
+        }
+
+        public static readonly DependencyProperty AccentColorProperty = DependencyProperty.RegisterAttached(
+            "AccentColor", typeof(AccentColor), typeof(ThemeAssist), new PropertyMetadata(default(AccentColor), OnAccentColorChanged));
+
+        private static void OnAccentColorChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        {
+            if (dependencyObject is FrameworkElement element)
+            {
+                element.Resources.WithAccentColor((AccentColor)e.NewValue);
+            }
+        }
+
+        public static void SetAccentColor(DependencyObject element, AccentColor value)
+        {
+            element.SetValue(AccentColorProperty, value);
+        }
+
+        public static AccentColor GetAccentColor(DependencyObject element)
+        {
+            return (AccentColor)element.GetValue(AccentColorProperty);
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/ThemeSetEventArgs.cs
+++ b/MaterialDesignThemes.Wpf/ThemeSetEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace MaterialDesignThemes.Wpf
+{
+    public class ThemeSetEventArgs : EventArgs
+    {
+        public ThemeSetEventArgs(BaseTheme theme)
+        {
+            Theme = theme;
+        }
+
+        public BaseTheme Theme { get; }
+    }
+}


### PR DESCRIPTION
@ButchersBoy @punker76 This is a work in progress, but I wanted to get feedback before I put in more work to make sure it is something that is viable. I would like to credit @mycroes with #903 for giving me the idea.

## Objectives

- Make the colors/themes more extensible. This would be helpful for integrations with MahApps/Dragablz. It would also allow for others to release NuGets that provide integrations with other libraries. 
- Make it easier for people to get started without needing to look up examples of which resource dictionaries need to get merged in. Even I cannot quite remember, and end up always going back to another app to copy them in.
- Easier swapping of theme/color resources within the app.

## Points of interest
- (Option 1) App.xaml in the demo app. Rather than needing to include the MDIX dictionaries simply using a new derived resource dictionary class, it adds in all of the dictionaries for you. I defaulted the values to the same as the demo app. My thought is that it is better for it to default to the wrong colors, and have the programmer figure out how to change them, rather than not loading the colors and everything look horrible (or like it is not working). This dictionary is just a simple XAML way to access the extension method below. It exposes some enums as references to the various recommended color themes.
- (Option 2) App.xaml.cs in the demo app. There is an extension method on `Application` called `WithMaterialDesign` (MaterialDesignAssist.cs). This does all of the same stuff as the previous option, but it allows for a fluent syntax that can also be used to extend MDIX. If you look at the App.xaml.cs in the MahApps demo application, you will see that there is another extension method (MaterialDesignThemes.MahApps.MaterialDesignAssist.cs) that adds in all of the stuff for MahApps (this is just feature parity with the old stuff, nothing for MahApps 1.6).
- MaterialDesignColors.Wpf.RecommendedThemeProvider.cs previously it has always felt a little clunky trying to get access to complete "themes" (like the dictionaries you would previously have to set in App.xaml) rather than just swatches. This class exposes those in a similar manner making it a bit easier to work with. 
- PaletteHelper.cs. This class has had all references to MahApps stripped out of it in favor of the fluent syntax for extensibility. I have added events that would allow for other libraries/apps to hook into changes and respond appropriately. 
- ThemeAssist.cs. This class adds attached properties that allow changing the theme/color at a lower level in the tree. Currently the enums don't have a default or "none" options and perhaps they should to allow for these properties to remove a previously added dictionary.

## Known Issues/TODOs
- There are breaking API changes in PaletteHelper. Specifically I changed the class from an instance to a static. I am happy to go back and add additional overloads and whatnot to make this a non-breaking change if that is desired.
- All of the MahApps references have been moved from the main MDIX project into the MaterialDesignThemes.MahApps (arguably where they should be). This is a breaking change.
- PaletteHelper would get another event for Accent swatch changed.
- R# is not happy about the fact that it cannot find resources. This is because they are injected at run-time. Not sure I am completely happy with this. It really only matters for the control styles since the colors/brushes are typically used with `DynamicResource`.
- There are a lot of places where the MDIX brush keys are just hard coded in the code. I would like to at least move these to constants in the colors library.
- There are enums for the various color themes. These need to be moved to the colors library.
- I unloaded the MaterialDesignThemes.Wpf.Tests project rather than deal with the errors there.

Related Issues/PRs: #901 #898 #864 #853 #903