### PR TITLE
Support use of ColorZoneAssist in ComboBox

### DIFF
--- a/MainDemo.Wpf/ColorZones.xaml
+++ b/MainDemo.Wpf/ColorZones.xaml
@@ -52,6 +52,15 @@
                         <StackPanel Orientation="Horizontal"
                             materialDesign:RippleAssist.IsCentered="True">
                             <ToggleButton Style="{DynamicResource MaterialDesignHamburgerToggleButton}" />
+                            <ComboBox SelectedIndex="0" Margin="8 0 0 0" BorderThickness="0" 
+                                      materialDesign:ColorZoneAssist.Mode="Standard" 
+                                      materialDesign:TextFieldAssist.UnderlineBrush="{DynamicResource MaterialDesignPaper}"
+                                      BorderBrush="{DynamicResource MaterialDesignPaper}">
+                                <ComboBoxItem>Android</ComboBoxItem>
+                                <ComboBoxItem>iOS</ComboBoxItem>
+                                <ComboBoxItem>Linux</ComboBoxItem>
+                                <ComboBoxItem>Windows</ComboBoxItem>
+                            </ComboBox>
                             <materialDesign:ColorZone Mode="Standard" Padding="8 4 8 4" CornerRadius="2" Panel.ZIndex="1"
                                    Margin="16 0 0 0"
                                    materialDesign:ShadowAssist.ShadowDepth="Depth1">
@@ -75,26 +84,6 @@
                             <Button Style="{DynamicResource MaterialDesignToolForegroundButton}" Margin="8 0 0 0" Panel.ZIndex="0">
                                 <materialDesign:PackIcon Kind="Send" />
                             </Button>
-                            <ComboBox materialDesign:HintAssist.Hint="OS" Margin="8 0 0 0" materialDesign:ColorZoneAssist.Mode="Standard">
-                                <ComboBoxItem>Android</ComboBoxItem>
-                                <ComboBoxItem>iOS</ComboBoxItem>
-                                <ComboBoxItem>Linux</ComboBoxItem>
-                                <ComboBoxItem>Windows</ComboBoxItem>
-                            </ComboBox>
-
-                            <ComboBox materialDesign:HintAssist.Hint="OS" Margin="8 0 0 0" materialDesign:ColorZoneAssist.Mode="Inverted">
-                                <ComboBoxItem>Android</ComboBoxItem>
-                                <ComboBoxItem>iOS</ComboBoxItem>
-                                <ComboBoxItem>Linux</ComboBoxItem>
-                                <ComboBoxItem>Windows</ComboBoxItem>
-                            </ComboBox>
-
-                            <ComboBox materialDesign:HintAssist.Hint="OS" Margin="8 0 0 0" materialDesign:ColorZoneAssist.Mode="Accent">
-                                <ComboBoxItem>Android</ComboBoxItem>
-                                <ComboBoxItem>iOS</ComboBoxItem>
-                                <ComboBoxItem>Linux</ComboBoxItem>
-                                <ComboBoxItem>Windows</ComboBoxItem>
-                            </ComboBox>
                         </StackPanel>
                     </DockPanel>
                 </materialDesign:ColorZone>

--- a/MainDemo.Wpf/ColorZones.xaml
+++ b/MainDemo.Wpf/ColorZones.xaml
@@ -75,6 +75,26 @@
                             <Button Style="{DynamicResource MaterialDesignToolForegroundButton}" Margin="8 0 0 0" Panel.ZIndex="0">
                                 <materialDesign:PackIcon Kind="Send" />
                             </Button>
+                            <ComboBox materialDesign:HintAssist.Hint="OS" Margin="8 0 0 0" materialDesign:ColorZoneAssist.Mode="Standard">
+                                <ComboBoxItem>Android</ComboBoxItem>
+                                <ComboBoxItem>iOS</ComboBoxItem>
+                                <ComboBoxItem>Linux</ComboBoxItem>
+                                <ComboBoxItem>Windows</ComboBoxItem>
+                            </ComboBox>
+
+                            <ComboBox materialDesign:HintAssist.Hint="OS" Margin="8 0 0 0" materialDesign:ColorZoneAssist.Mode="Inverted">
+                                <ComboBoxItem>Android</ComboBoxItem>
+                                <ComboBoxItem>iOS</ComboBoxItem>
+                                <ComboBoxItem>Linux</ComboBoxItem>
+                                <ComboBoxItem>Windows</ComboBoxItem>
+                            </ComboBox>
+
+                            <ComboBox materialDesign:HintAssist.Hint="OS" Margin="8 0 0 0" materialDesign:ColorZoneAssist.Mode="Accent">
+                                <ComboBoxItem>Android</ComboBoxItem>
+                                <ComboBoxItem>iOS</ComboBoxItem>
+                                <ComboBoxItem>Linux</ComboBoxItem>
+                                <ComboBoxItem>Windows</ComboBoxItem>
+                            </ComboBox>
                         </StackPanel>
                     </DockPanel>
                 </materialDesign:ColorZone>

--- a/MainDemo.Wpf/TextFields.xaml
+++ b/MainDemo.Wpf/TextFields.xaml
@@ -169,6 +169,8 @@
                       materialDesign:TextFieldAssist.HasClearButton="True" 
                       Style="{StaticResource MaterialDesignFloatingHintComboBox}"
                       materialDesign:TextFieldAssist.SuffixText="sw"
+                      materialDesign:ColorZoneAssist.Mode="Inverted"
+                      materialDesign:TextFieldAssist.UnderlineBrush="{DynamicResource SecondaryAccentBrush}"
                       materialDesign:HintAssist.HelperText="Select one OS">
                 <ComboBoxItem>Android</ComboBoxItem>
                 <ComboBoxItem>iOS</ComboBoxItem>
@@ -290,7 +292,7 @@
             </ComboBox>
         </smtx:XamlDisplay>
 
-        <materialDesign:PackIcon Grid.Row="6" Grid.Column="0" Kind="Key"
+        <materialDesign:PackIcon Grid.Row="7" Grid.Column="0" Kind="Key"
                                  Margin="0 12 0 0"
                                  Foreground="{Binding ElementName=FloatingPasswordBox, Path=BorderBrush}" />
         <smtx:XamlDisplay Key="fields_18" Grid.Row="6" Grid.Column="1" Margin="0 12 0 0">

--- a/MainDemo.Wpf/Toggles.xaml
+++ b/MainDemo.Wpf/Toggles.xaml
@@ -267,7 +267,7 @@
         </StackPanel>
         <Border Margin="0 24 0 0" BorderThickness="0 1 0 0" BorderBrush="{DynamicResource MaterialDesignDivider}" Grid.Row="6" Grid.ColumnSpan="2" />
         <TextBlock Grid.Row="7" Style="{StaticResource MaterialDesignHeadline5TextBlock}" Margin="0 24">Checkboxes</TextBlock>
-        <smtx:XamlDisplay Key="fields_31" Grid.Row="8" HorizontalAlignment="Left">
+        <smtx:XamlDisplay Key="fields_35" Grid.Row="8" HorizontalAlignment="Left">
             <StackPanel Margin="8 0">
                 <CheckBox IsChecked="True">Checked</CheckBox>
                 <CheckBox IsChecked="False">Unchecked</CheckBox>

--- a/MaterialDesignThemes.Wpf/ComboBoxPopup.cs
+++ b/MaterialDesignThemes.Wpf/ComboBoxPopup.cs
@@ -173,6 +173,7 @@ namespace MaterialDesignThemes.Wpf
         public ComboBoxPopup()
         {
             CustomPopupPlacementCallback = ComboBoxCustomPopupPlacementCallback;
+            
         }
 
         protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)

--- a/MaterialDesignThemes.Wpf/Converters/RemoveAlphaBrushConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/RemoveAlphaBrushConverter.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace MaterialDesignThemes.Wpf.Converters
+{
+    internal class RemoveAlphaBrushConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is SolidColorBrush brush)
+            {
+                Color background = Colors.White;
+                if (parameter is Color color)
+                {
+                    background = color;
+                }
+                return new SolidColorBrush(RgbaToRgb(brush.Color, background));
+            }
+            return Binding.DoNothing;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static Color RgbaToRgb(Color rgba, Color background)
+        {
+            double alpha = (double)rgba.A / byte.MaxValue;
+            return Color.FromRgb(
+                (byte)((1 - alpha) * background.R + alpha * rgba.R),
+                (byte)((1 - alpha) * background.G + alpha * rgba.G),
+                (byte)((1 - alpha) * background.B + alpha * rgba.B)
+            );
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -190,28 +190,6 @@ namespace MaterialDesignThemes.Wpf
         }
 
         /// <summary>
-        /// The color for highlighting effects on the border of a text box.
-        /// </summary>
-        public static readonly DependencyProperty UnderlineBrushProperty = DependencyProperty.RegisterAttached(
-            "UnderlineBrush", typeof(Brush), typeof(TextFieldAssist), new PropertyMetadata(null));
-
-        /// <summary>
-        /// Sets the color for highlighting effects on the border of a text box.
-        /// </summary>
-        public static void SetUnderlineBrush(DependencyObject element, Brush value)
-        {
-            element.SetValue(UnderlineBrushProperty, value);
-        }
-
-        /// <summary>
-        /// Gets the color for highlighting effects on the border of a text box.
-        /// </summary>
-        public static Brush GetUnderlineBrush(DependencyObject element)
-        {
-            return (Brush)element.GetValue(UnderlineBrushProperty);
-        }
-
-        /// <summary>
         /// Automatically inserts spelling suggestions into the text box context menu.
         /// </summary>
         public static readonly DependencyProperty IncludeSpellingSuggestionsProperty = DependencyProperty.RegisterAttached(

--- a/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -69,7 +69,32 @@ namespace MaterialDesignThemes.Wpf
         }
 
         /// <summary>
-        /// Controls the visibility of the filled text field.
+        /// The attached WPF property for getting or setting the <see cref="Brush"/> value for an underline decoration.
+        /// </summary>
+        public static readonly DependencyProperty UnderlineBrushProperty = DependencyProperty.RegisterAttached(
+            "UnderlineBrush", typeof(Brush), typeof(TextFieldAssist), new PropertyMetadata(Brushes.Transparent));
+
+        /// <summary>
+        /// Sets the <see cref="Brush"/> used for underline decoration.
+        /// </summary>
+        /// <param name="element"></param>
+        /// <param name="value"></param>
+        public static void SetUnderlineBrush(DependencyObject element, Brush value)
+        {
+            element.SetValue(UnderlineBrushProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Brush"/> used for underline decoration.
+        /// </summary>
+        /// <param name="element"></param>
+        public static Brush GetUnderlineBrush(DependencyObject element)
+        {
+            return (Brush)element.GetValue(UnderlineBrushProperty);
+        }
+
+        /// <summary>
+        /// Controls the visbility of the text field box.
         /// </summary>
         public static readonly DependencyProperty HasFilledTextFieldProperty = DependencyProperty.RegisterAttached(
             "HasFilledTextField", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(false));

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -191,7 +191,8 @@
     </Style>
 
     <Style TargetType="{x:Type local:Underline}">
-        <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
+        <Setter Property="local:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}"/>
+        <Setter Property="Background" Value="{Binding Path=(local:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="HorizontalAlignment" Value="Stretch"/>
         <Setter Property="VerticalAlignment" Value="Bottom"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -2,8 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:system="clr-namespace:System;assembly=mscorlib"
-                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
-                    xmlns:materialDesign="clr-namespace:MaterialDesignThemes.Wpf">
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
@@ -494,7 +493,8 @@
                       X1="0" X2="{Binding ActualWidth, ElementName=toggleButton}" Y1="0" Y2="0" 
                       Stroke="{TemplateBinding BorderBrush}" Opacity="0.56" />
                 <wpf:Underline x:Name="Underline"
-                               Grid.ColumnSpan="2" Grid.Column="0"
+                               Grid.ColumnSpan="2"
+                               wpf:TextFieldAssist.UnderlineBrush="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource TemplatedParent}}"
                                IsActive="{Binding ElementName=PART_EditableTextBox, Path=IsKeyboardFocused}"
                                Visibility="{Binding Path=(wpf:TextFieldAssist.DecorationVisibility), RelativeSource={RelativeSource TemplatedParent}}"
                                Background="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource TemplatedParent}}" />
@@ -542,7 +542,7 @@
             </Grid>
         </Grid>
         <ControlTemplate.Triggers>
-            <Trigger SourceName="PART_Popup" Property="PopupPlacement" Value="{x:Static materialDesign:ComboBoxPopupPlacement.Classic}">
+            <Trigger SourceName="PART_Popup" Property="PopupPlacement" Value="{x:Static wpf:ComboBoxPopupPlacement.Classic}">
                 <Setter Property="ItemContainerStyle" Value="{StaticResource MaterialDesignComboBoxItemStyle}" />
             </Trigger>
             <Trigger SourceName="PART_Popup" Property="IsOpen" Value="True">
@@ -629,8 +629,8 @@
                     <Condition Property="IsMouseOver" Value="true" />
                     <Condition Property="Validation.HasError" Value="false" />
                 </MultiTrigger.Conditions>
-                <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
-                <Setter TargetName="Underline" Property="Background" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource TemplatedParent}}" />
+                <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}"/>
+                <Setter TargetName="Underline" Property="Background" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}"/>
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
@@ -718,6 +718,7 @@
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="Validation.ErrorTemplate" Value="{StaticResource MaterialDesignValidationErrorTemplate}"/>
         <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="1 0 1 0" />
+        <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="wpf:ColorZoneAssist.Mode" Value="Standard" />
         <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -519,6 +519,7 @@
                                    DefaultVerticalOffset="5"
                                    DownVerticalOffset="-15.5"
                                    UpVerticalOffset="15"
+                                   wpf:ColorZoneAssist.Mode="{Binding Path=(wpf:ColorZoneAssist.Mode), RelativeSource={RelativeSource TemplatedParent}}"
                                    Tag="{DynamicResource MaterialDesignPaper}"
                                    ClassicMode="{Binding Path=(wpf:ComboBoxAssist.ClassicMode), RelativeSource={RelativeSource TemplatedParent}}"
                                    UpContentTemplate="{StaticResource PopupContentUpTemplate}"
@@ -546,7 +547,7 @@
             </Trigger>
             <Trigger SourceName="PART_Popup" Property="IsOpen" Value="True">
                 <Setter Property="Background" TargetName="templateRoot" Value="{Binding Background, ElementName=PART_Popup}" />
-            </Trigger>
+            </Trigger>  
             <Trigger Property="IsEnabled" Value="False">
                 <Setter TargetName="templateRoot" Property="Opacity" Value="0.56"/>
                 <Setter TargetName="toggleButton" Property="BorderBrush" Value="Transparent"/>
@@ -631,6 +632,70 @@
                 <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
                 <Setter TargetName="Underline" Property="Background" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource TemplatedParent}}" />
             </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
+                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Standard"/>
+                </MultiTrigger.Conditions>
+                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesignBody}" />
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
+                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Inverted"/>
+                </MultiTrigger.Conditions>
+                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource MaterialDesignBody}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesignPaper}" />
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
+                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="PrimaryLight" />
+                </MultiTrigger.Conditions>
+                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource PrimaryHueLightBrush}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource PrimaryHueLightForegroundBrush}" />
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
+                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid"/>
+                </MultiTrigger.Conditions>
+                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
+                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="PrimaryDark"/>
+                </MultiTrigger.Conditions>
+                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource PrimaryHueDarkBrush}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource PrimaryHueDarkForegroundBrush}" />
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
+                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Accent"/>
+                </MultiTrigger.Conditions>
+                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource SecondaryAccentBrush}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}" />
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
+                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Light"/>
+                </MultiTrigger.Conditions>
+                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource MaterialDesignLightBackground}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesignLightForeground}" />
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
+                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Dark"/>
+                </MultiTrigger.Conditions>
+                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource MaterialDesignDarkBackground}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesignDarkForeground}" />
+            </MultiTrigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
@@ -653,6 +718,7 @@
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="Validation.ErrorTemplate" Value="{StaticResource MaterialDesignValidationErrorTemplate}"/>
         <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="1 0 1 0" />
+        <Setter Property="wpf:ColorZoneAssist.Mode" Value="Standard" />
         <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="Template" Value="{StaticResource MaterialDesignFloatingHintComboBoxTemplate}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -17,6 +17,7 @@
     <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearTextConverter" />
     <converters:NotConverter x:Key="NotConverter" />
     <converters:FallbackBrushConverter x:Key="FallbackBrushConverter" />
+    <converters:RemoveAlphaBrushConverter x:Key="RemoveAlphaBrushConverter" />
 
     <system:Double x:Key="PopupContentPresenterExtend">4</system:Double>
     <system:Double x:Key="PopupTopBottomMargin">8</system:Double>
@@ -637,7 +638,9 @@
                     <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
                     <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Standard"/>
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
+                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesignPaper}" />
+                <Setter TargetName="PART_Popup" Property="Background" 
+                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
                 <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesignBody}" />
             </MultiTrigger>
             <MultiTrigger>
@@ -645,7 +648,9 @@
                     <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
                     <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Inverted"/>
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource MaterialDesignBody}" />
+                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesignBody}" />
+                <Setter TargetName="PART_Popup" Property="Background" 
+                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
                 <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesignPaper}" />
             </MultiTrigger>
             <MultiTrigger>
@@ -653,7 +658,9 @@
                     <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
                     <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="PrimaryLight" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource PrimaryHueLightBrush}" />
+                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource PrimaryHueLightBrush}" />
+                <Setter TargetName="PART_Popup" Property="Background" 
+                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
                 <Setter Property="TextElement.Foreground" Value="{DynamicResource PrimaryHueLightForegroundBrush}" />
             </MultiTrigger>
             <MultiTrigger>
@@ -661,7 +668,9 @@
                     <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
                     <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid"/>
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource PrimaryHueMidBrush}" />
+                <Setter TargetName="PART_Popup" Property="Background" 
+                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
                 <Setter Property="TextElement.Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
             </MultiTrigger>
             <MultiTrigger>
@@ -669,7 +678,9 @@
                     <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
                     <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="PrimaryDark"/>
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource PrimaryHueDarkBrush}" />
+                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource PrimaryHueDarkBrush}" />
+                <Setter TargetName="PART_Popup" Property="Background" 
+                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
                 <Setter Property="TextElement.Foreground" Value="{DynamicResource PrimaryHueDarkForegroundBrush}" />
             </MultiTrigger>
             <MultiTrigger>
@@ -677,7 +688,9 @@
                     <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
                     <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Accent"/>
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource SecondaryAccentBrush}" />
+                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource SecondaryAccentBrush}" />
+                <Setter TargetName="PART_Popup" Property="Background" 
+                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
                 <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}" />
             </MultiTrigger>
             <MultiTrigger>
@@ -685,7 +698,9 @@
                     <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
                     <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Light"/>
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource MaterialDesignLightBackground}" />
+                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesignLightBackground}" />
+                <Setter TargetName="PART_Popup" Property="Background" 
+                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
                 <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesignLightForeground}" />
             </MultiTrigger>
             <MultiTrigger>
@@ -693,7 +708,9 @@
                     <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
                     <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Dark"/>
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Background" Value="{DynamicResource MaterialDesignDarkBackground}" />
+                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesignDarkBackground}" />
+                <Setter TargetName="PART_Popup" Property="Background" 
+                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
                 <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesignDarkForeground}" />
             </MultiTrigger>
         </ControlTemplate.Triggers>


### PR DESCRIPTION
First part is addressing #679. Only when the ComboBox displays it's pop-over will the ColorZone take effect.
This does not change the border away from the primary mid brush.

Things to do:

- [X] Set the background and foreground when the popover is open.
- [x] Add a property for setting the border colour
- [x] ~~Copy changes over to UWP and adjust accordingly.~~

Please note that I'm still learning WPF and may not have taken the best approach for solving the issue.