### PR TITLE
Fix snackbar not being found

### DIFF
--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
@@ -328,7 +328,7 @@ namespace MaterialDesignThemes.Wpf
                 {
                     if (!sb.IsLoaded || sb.Visibility != Visibility.Visible) return false;
                     var window = Window.GetWindow(sb);
-                    return window != null && window.WindowState != WindowState.Minimized;
+                    return window?.WindowState != WindowState.Minimized;
                 });
             });
         }


### PR DESCRIPTION
When parent window cannot be found the paired snackbar is still available. This can occur if the Snackbar is hosted outside of a WPF Window such as in a WinForms application.

Fixes #946