### PR TITLE
Fixing ElementName bindings in TransitioningContent

### DIFF
--- a/MainDemo.Wpf/TransitionsDemo/TransitionsDemoHome.xaml
+++ b/MainDemo.Wpf/TransitionsDemo/TransitionsDemoHome.xaml
@@ -26,6 +26,10 @@
         <smtx:XamlDisplay Key="transitions" Grid.Row="1">
             <!-- the transitioner will manage your transitions. notice how SelectedIndex is set to zero: the first slide (instead of the default of -1) -->
             <materialDesign:Transitioner SelectedIndex="0" AutoApplyTransitionOrigins="True">
+                <materialDesign:Transitioner.InputBindings>
+                    <KeyBinding Key="Left" Command="{x:Static materialDesign:Transitioner.MovePreviousCommand}" />
+                    <KeyBinding Key="Right" Command="{x:Static materialDesign:Transitioner.MoveNextCommand}" />
+                </materialDesign:Transitioner.InputBindings>
 
                 <!-- you can use a slide for each page, let's add a touch of fade for our first page  -->
                 <materialDesign:TransitionerSlide OpeningEffect="{materialDesign:TransitionEffect FadeIn}">

--- a/MaterialDesignThemes.Wpf/Transitions/IZIndexController.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/IZIndexController.cs
@@ -2,6 +2,6 @@ namespace MaterialDesignThemes.Wpf.Transitions
 {
     public interface IZIndexController
     {
-        void Stack(params TransitionerSlide[] highestToLowest);        
+        void Stack(params TransitionerSlide[] highestToLowest);
     }
 }

--- a/MaterialDesignThemes.Wpf/Transitions/TransitionEffectTypeConverter.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/TransitionEffectTypeConverter.cs
@@ -14,20 +14,20 @@ namespace MaterialDesignThemes.Wpf.Transitions
 
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            TransitionEffectBase transitionEffect = null;
+            TransitionEffectBase transitionEffect;
 
-            var stringValue = value as string;
-            if (stringValue != null)
+            if (value is string stringValue && 
+                Enum.TryParse(stringValue, out TransitionEffectKind effectKind))
             {
-                TransitionEffectKind effectKind;
-                if (Enum.TryParse(stringValue, out effectKind))
-                    transitionEffect = new TransitionEffect(effectKind);
+                transitionEffect = new TransitionEffect(effectKind);
             }
             else
+            {
                 transitionEffect = value as TransitionEffectBase;
+            }
 
             if (transitionEffect == null)
-                throw new XamlParseException($"Could not parse to type {typeof (TransitionEffectKind).FullName} or {typeof (TransitionEffectBase).FullName}.");
+                throw new XamlParseException($"Could not parse to type {typeof(TransitionEffectKind).FullName} or {typeof(TransitionEffectBase).FullName}.");
 
             return transitionEffect;
         }

--- a/MaterialDesignThemes.Wpf/Transitions/Transitioner.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/Transitioner.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -21,12 +20,12 @@ namespace MaterialDesignThemes.Wpf.Transitions
         }
 
         /// <summary>
-        /// Causes the the next slide to be displayed (affectively increments <see cref="SelectedIndex"/>).
+        /// Causes the the next slide to be displayed (affectively increments <see cref="Selector.SelectedIndex"/>).
         /// </summary>
         public static RoutedCommand MoveNextCommand = new RoutedCommand();
 
         /// <summary>
-        /// Causes the the previous slide to be displayed (affectively decrements <see cref="SelectedIndex"/>).
+        /// Causes the the previous slide to be displayed (affectively decrements <see cref="Selector.SelectedIndex"/>).
         /// </summary>
         public static RoutedCommand MovePreviousCommand = new RoutedCommand();
 
@@ -41,15 +40,15 @@ namespace MaterialDesignThemes.Wpf.Transitions
         public static RoutedCommand MoveLastCommand = new RoutedCommand();
 
         public static readonly DependencyProperty AutoApplyTransitionOriginsProperty = DependencyProperty.Register(
-            "AutoApplyTransitionOrigins", typeof (bool), typeof (Transitioner), new PropertyMetadata(default(bool)));
-        
+            "AutoApplyTransitionOrigins", typeof(bool), typeof(Transitioner), new PropertyMetadata(default(bool)));
+
         /// <summary>
         /// If enabled, transition origins will be applied to wipes, according to where a transition was triggered from.  For example, the mouse point where a user clicks a button.
         /// </summary>
         public bool AutoApplyTransitionOrigins
         {
-            get { return (bool) GetValue(AutoApplyTransitionOriginsProperty); }
-            set { SetValue(AutoApplyTransitionOriginsProperty, value); }
+            get => (bool)GetValue(AutoApplyTransitionOriginsProperty);
+            set => SetValue(AutoApplyTransitionOriginsProperty, value);
         }
 
         public static readonly DependencyProperty DefaultTransitionOriginProperty = DependencyProperty.Register(
@@ -57,8 +56,8 @@ namespace MaterialDesignThemes.Wpf.Transitions
 
         public Point DefaultTransitionOrigin
         {
-            get { return (Point)GetValue(DefaultTransitionOriginProperty); }
-            set { SetValue(DefaultTransitionOriginProperty, value); }
+            get => (Point)GetValue(DefaultTransitionOriginProperty);
+            set => SetValue(DefaultTransitionOriginProperty, value);
         }
 
         public Transitioner()
@@ -78,11 +77,11 @@ namespace MaterialDesignThemes.Wpf.Transitions
         protected override bool IsItemItsOwnContainerOverride(object item)
         {
             return item is TransitionerSlide;
-        }        
+        }
 
         protected override DependencyObject GetContainerForItemOverride()
         {
-            return new TransitionerSlide();            
+            return new TransitionerSlide();
         }
 
         protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
@@ -190,17 +189,17 @@ namespace MaterialDesignThemes.Wpf.Transitions
                     slide.SetCurrentValue(TransitionerSlide.StateProperty, TransitionerSlideState.Previous);
                 }
                 else
-                {                    
+                {
                     slide.SetCurrentValue(TransitionerSlide.StateProperty, TransitionerSlideState.None);
                 }
-                Panel.SetZIndex(slide, 0);                
+                Panel.SetZIndex(slide, 0);
             }
 
             if (newSlide != null)
             {
                 newSlide.Opacity = 1;
             }
-                          
+
             if (oldSlide != null && newSlide != null)
             {
                 var wipe = selectedIndex > unselectedIndex ? oldSlide.ForwardWipe : oldSlide.BackwardWipe;
@@ -220,23 +219,23 @@ namespace MaterialDesignThemes.Wpf.Transitions
                 DoStack(oldSlide ?? newSlide);
                 if (oldSlide != null)
                 {
-                    oldSlide.Opacity = 0;                    
+                    oldSlide.Opacity = 0;
                 }
-            }            
+            }
 
             _nextTransitionOrigin = null;
         }
 
         private Point GetTransitionOrigin(TransitionerSlide slide)
         {
-            if(_nextTransitionOrigin != null)
+            if (_nextTransitionOrigin != null)
             {
                 return _nextTransitionOrigin.Value;
             }
 
-            if(slide.ReadLocalValue(TransitionerSlide.TransitionOriginProperty) != DependencyProperty.UnsetValue)
+            if (slide.ReadLocalValue(TransitionerSlide.TransitionOriginProperty) != DependencyProperty.UnsetValue)
             {
-                return slide.TransitionOrigin;             
+                return slide.TransitionOrigin;
             }
 
             return DefaultTransitionOrigin;

--- a/MaterialDesignThemes.Wpf/Transitions/TransitionerSlide.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/TransitionerSlide.cs
@@ -19,59 +19,59 @@ namespace MaterialDesignThemes.Wpf.Transitions
         }
 
         public static readonly DependencyProperty TransitionOriginProperty = DependencyProperty.Register(
-            "TransitionOrigin", typeof(Point), typeof(Transitioner), new PropertyMetadata(new Point(0.5,0.5)));
+            "TransitionOrigin", typeof(Point), typeof(Transitioner), new PropertyMetadata(new Point(0.5, 0.5)));
 
         public Point TransitionOrigin
         {
-            get { return (Point)GetValue(TransitionOriginProperty); }
-            set { SetValue(TransitionOriginProperty, value); }
+            get => (Point)GetValue(TransitionOriginProperty);
+            set => SetValue(TransitionOriginProperty, value);
         }
 
         public static RoutedEvent InTransitionFinished =
-            EventManager.RegisterRoutedEvent("InTransitionFinished", RoutingStrategy.Bubble, typeof (RoutedEventHandler),
-                typeof (TransitionerSlide));
+            EventManager.RegisterRoutedEvent("InTransitionFinished", RoutingStrategy.Bubble, typeof(RoutedEventHandler),
+                typeof(TransitionerSlide));
 
         protected void OnInTransitionFinished(RoutedEventArgs e)
         {
             RaiseEvent(e);
         }
 
-        public static readonly DependencyProperty StateProperty = DependencyProperty.Register("State", typeof (TransitionerSlideState), typeof (TransitionerSlide), new PropertyMetadata(default(TransitionerSlideState), new PropertyChangedCallback(StatePropertyChangedCallback)));
+        public static readonly DependencyProperty StateProperty = DependencyProperty.Register("State", typeof(TransitionerSlideState), typeof(TransitionerSlide), new PropertyMetadata(default(TransitionerSlideState), new PropertyChangedCallback(StatePropertyChangedCallback)));
 
         private static void StatePropertyChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            ((TransitionerSlide) d).AnimateToState();
+            ((TransitionerSlide)d).AnimateToState();
         }
 
         public TransitionerSlideState State
         {
-            get { return (TransitionerSlideState) GetValue(StateProperty); }
-            set { SetValue(StateProperty, value); }
+            get => (TransitionerSlideState)GetValue(StateProperty);
+            set => SetValue(StateProperty, value);
         }
 
         public static readonly DependencyProperty ForwardWipeProperty = DependencyProperty.Register(
-            "ForwardWipe", typeof (ITransitionWipe), typeof (TransitionerSlide), new PropertyMetadata(new CircleWipe()));
+            "ForwardWipe", typeof(ITransitionWipe), typeof(TransitionerSlide), new PropertyMetadata(new CircleWipe()));
 
         public ITransitionWipe ForwardWipe
         {
-            get { return (ITransitionWipe) GetValue(ForwardWipeProperty); }
-            set { SetValue(ForwardWipeProperty, value); }
+            get => (ITransitionWipe)GetValue(ForwardWipeProperty);
+            set => SetValue(ForwardWipeProperty, value);
         }
 
         public static readonly DependencyProperty BackwardWipeProperty = DependencyProperty.Register(
-            "BackwardWipe", typeof (ITransitionWipe), typeof (TransitionerSlide), new PropertyMetadata(new SlideOutWipe()));
+            "BackwardWipe", typeof(ITransitionWipe), typeof(TransitionerSlide), new PropertyMetadata(new SlideOutWipe()));
 
         public ITransitionWipe BackwardWipe
         {
-            get { return (ITransitionWipe) GetValue(BackwardWipeProperty); }
-            set { SetValue(BackwardWipeProperty, value); }
+            get => (ITransitionWipe)GetValue(BackwardWipeProperty);
+            set => SetValue(BackwardWipeProperty, value);
         }
 
         private void AnimateToState()
         {
-            if (State != TransitionerSlideState.Current) return;                                              
+            if (State != TransitionerSlideState.Current) return;
 
             RunOpeningEffects();
-        }        
+        }
     }
 }

--- a/MaterialDesignThemes.Wpf/Transitions/TransitioningContent.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/TransitioningContent.cs
@@ -30,12 +30,12 @@ namespace MaterialDesignThemes.Wpf.Transitions
         }
 
         public static readonly DependencyProperty RunHintProperty = DependencyProperty.Register(
-            "RunHint", typeof(TransitioningContentRunHint), typeof(TransitioningContent), new PropertyMetadata(TransitioningContentRunHint.All));
+            nameof(RunHint), typeof(TransitioningContentRunHint), typeof(TransitioningContent), new PropertyMetadata(TransitioningContentRunHint.All));
 
         public TransitioningContentRunHint RunHint
         {
-            get { return (TransitioningContentRunHint)GetValue(RunHintProperty); }
-            set { SetValue(RunHintProperty, value); }
+            get => (TransitioningContentRunHint)GetValue(RunHintProperty);
+            set => SetValue(RunHintProperty, value);
         }
 
         private void Run(TransitioningContentRunHint requiredHint)

--- a/MaterialDesignThemes.Wpf/Transitions/TransitioningContentBase.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/TransitioningContentBase.cs
@@ -23,52 +23,49 @@ namespace MaterialDesignThemes.Wpf.Transitions
         private SkewTransform _skewTransform;
         private TranslateTransform _translateTransform;
 
-        private bool _isOpeningEffectPending = false;
+        private bool _isOpeningEffectPending;
 
         static TransitioningContentBase()
         {
-            DefaultStyleKeyProperty.OverrideMetadata(typeof (TransitioningContentBase), new FrameworkPropertyMetadata(typeof (TransitioningContentBase)));
-        }
-
-        public TransitioningContentBase()
-        {
-            NameScope.SetNameScope(this, new NameScope());
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(TransitioningContentBase), new FrameworkPropertyMetadata(typeof(TransitioningContentBase)));
         }
 
         public override void OnApplyTemplate()
         {
+            FrameworkElement nameScopeRoot = GetNameScopeRoot();
+
             _matrixTransform = GetTemplateChild(MatrixTransformPartName) as MatrixTransform;
             _rotateTransform = GetTemplateChild(RotateTransformPartName) as RotateTransform;
             _scaleTransform = GetTemplateChild(ScaleTransformPartName) as ScaleTransform;
             _skewTransform = GetTemplateChild(SkewTransformPartName) as SkewTransform;
             _translateTransform = GetTemplateChild(TranslateTransformPartName) as TranslateTransform;
-            
+
             UnregisterNames(MatrixTransformPartName, RotateTransformPartName, ScaleTransformPartName, SkewTransformPartName, TranslateTransformPartName);
             if (_matrixTransform != null)
-                RegisterName(MatrixTransformPartName, _matrixTransform);
+                nameScopeRoot.RegisterName(MatrixTransformPartName, _matrixTransform);
             if (_rotateTransform != null)
-                RegisterName(RotateTransformPartName, _rotateTransform);
+                nameScopeRoot.RegisterName(RotateTransformPartName, _rotateTransform);
             if (_scaleTransform != null)
-                RegisterName(ScaleTransformPartName, _scaleTransform);
+                nameScopeRoot.RegisterName(ScaleTransformPartName, _scaleTransform);
             if (_skewTransform != null)
-                RegisterName(SkewTransformPartName, _skewTransform);
+                nameScopeRoot.RegisterName(SkewTransformPartName, _skewTransform);
             if (_translateTransform != null)
-                RegisterName(TranslateTransformPartName, _translateTransform);            
+                nameScopeRoot.RegisterName(TranslateTransformPartName, _translateTransform);
 
             base.OnApplyTemplate();
 
             RunOpeningEffects();
-        }
 
-        private void UnregisterNames(params string[] names)
-        {
-            foreach (var name in names.Where(n => FindName(n) != null))
+            void UnregisterNames(params string[] names)
             {
-                UnregisterName(name);
-            }            
+                foreach (var name in names.Where(n => FindName(n) != null))
+                {
+                    UnregisterName(name);
+                }
+            }
         }
 
-        public static readonly DependencyProperty OpeningEffectProperty = DependencyProperty.Register("OpeningEffect", typeof (TransitionEffectBase), typeof (TransitioningContentBase), new PropertyMetadata(default(TransitionEffectBase)));
+        public static readonly DependencyProperty OpeningEffectProperty = DependencyProperty.Register("OpeningEffect", typeof(TransitionEffectBase), typeof(TransitioningContentBase), new PropertyMetadata(default(TransitionEffectBase)));
 
         /// <summary>
         /// Gets or sets the transition to run when the content is loaded and made visible.
@@ -76,20 +73,20 @@ namespace MaterialDesignThemes.Wpf.Transitions
         [TypeConverter(typeof(TransitionEffectTypeConverter))]
         public TransitionEffectBase OpeningEffect
         {
-            get { return (TransitionEffectBase) GetValue(OpeningEffectProperty); }
-            set { SetValue(OpeningEffectProperty, value); }
+            get => (TransitionEffectBase)GetValue(OpeningEffectProperty);
+            set => SetValue(OpeningEffectProperty, value);
         }
 
         public static readonly DependencyProperty OpeningEffectsOffsetProperty = DependencyProperty.Register(
-            "OpeningEffectsOffset", typeof (TimeSpan), typeof (TransitioningContentBase), new PropertyMetadata(default(TimeSpan)));
+            "OpeningEffectsOffset", typeof(TimeSpan), typeof(TransitioningContentBase), new PropertyMetadata(default(TimeSpan)));
 
         /// <summary>
         /// Delay offset to be applied to all opening effect transitions.
         /// </summary>
         public TimeSpan OpeningEffectsOffset
         {
-            get { return (TimeSpan) GetValue(OpeningEffectsOffsetProperty); }
-            set { SetValue(OpeningEffectsOffsetProperty, value); }
+            get => (TimeSpan)GetValue(OpeningEffectsOffsetProperty);
+            set => SetValue(OpeningEffectsOffsetProperty, value);
         }
 
         /// <summary>
@@ -99,7 +96,7 @@ namespace MaterialDesignThemes.Wpf.Transitions
 
         string ITransitionEffectSubject.MatrixTransformName => MatrixTransformPartName;
 
-        string ITransitionEffectSubject.RotateTransformName  => RotateTransformPartName;
+        string ITransitionEffectSubject.RotateTransformName => RotateTransformPartName;
 
         string ITransitionEffectSubject.ScaleTransformName => ScaleTransformPartName;
 
@@ -127,7 +124,24 @@ namespace MaterialDesignThemes.Wpf.Transitions
                 storyboard.Children.Add(effect);
             }
 
-            storyboard.Begin(this);
+            storyboard.Begin(GetNameScopeRoot());
+        }
+
+        private FrameworkElement GetNameScopeRoot()
+        {
+            //https://github.com/ButchersBoy/MaterialDesignInXamlToolkit/issues/950
+            //Only set the NameScope if the child does not already have a TemplateNameScope set
+            if (GetVisualChild(0) is FrameworkElement fe && NameScope.GetNameScope(fe) != null)
+            {
+                return fe;
+            }
+
+            if (NameScope.GetNameScope(this) == null)
+            {
+                NameScope.SetNameScope(this, new NameScope());
+            }
+
+            return this;
         }
     }
 }


### PR DESCRIPTION
Fixing name scope issue that would cause ElementName bindings to fail when used inside of a TransitioningContentBase.

Fixes #950