### PR TITLE
Shadow forces rerender in Cards #835

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -14,15 +14,15 @@
             <converters:ShadowEdgeConverter x:Key="ShadowEdgeConverter" />
         </ControlTemplate.Resources>
         <Grid Margin="{TemplateBinding Margin}" Background="Transparent">
-            <Grid.OpacityMask>
-                <MultiBinding Converter="{StaticResource ShadowEdgeConverter}">
-                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualWidth"/>
-                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualHeight"/>
-                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:ShadowAssist.ShadowDepth)" />
-                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:ShadowAssist.ShadowEdges)" />
-                </MultiBinding>
-            </Grid.OpacityMask>
             <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
+                <AdornerDecorator.OpacityMask>
+                    <MultiBinding Converter="{StaticResource ShadowEdgeConverter}">
+                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualWidth"/>
+                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualHeight"/>
+                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:ShadowAssist.ShadowDepth)" />
+                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:ShadowAssist.ShadowEdges)" />
+                    </MultiBinding>
+                </AdornerDecorator.OpacityMask>
                 <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
                         CornerRadius="{TemplateBinding UniformCornerRadius}">
                     <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" 


### PR DESCRIPTION
The shadow forces the controls to rerender on a simple change to the controls within a card. (i.e. checking/unchecking a checkbox). To resolve problem, I simply moved the Shadow from the grid to the AdornerDecorator.

Explanation:
https://stackoverflow.com/questions/6436501/wpf-why-does-text-and-elements-blur-if-i-use-dropshadow-effect-on-a-parent-item

Issue: https://github.com/ButchersBoy/MaterialDesignInXamlToolkit/issues/835