### PR TITLE
Fix #826 timepicker 24 hour bug

### DIFF
--- a/MaterialDesignThemes.Wpf/Clock.cs
+++ b/MaterialDesignThemes.Wpf/Clock.cs
@@ -114,11 +114,11 @@ namespace MaterialDesignThemes.Wpf
 		private static void IsPostMeridiemPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
 		{
 			var clock = (Clock)dependencyObject;
-			if (clock.IsPostMeridiem && clock.Time.Hour < 12)
-				clock.Time = new DateTime(clock.Time.Year, clock.Time.Month, clock.Time.Day, clock.Time.Hour + 12, clock.Time.Minute, clock.Time.Second);
-			else if (!clock.IsPostMeridiem && clock.Time.Hour >= 12)
-				clock.Time = new DateTime(clock.Time.Year, clock.Time.Month, clock.Time.Day, clock.Time.Hour - 12, clock.Time.Minute, clock.Time.Second);
-		}
+		    if (!clock.Is24Hours && clock.IsPostMeridiem && clock.Time.Hour < 12)
+		        clock.Time = new DateTime(clock.Time.Year, clock.Time.Month, clock.Time.Day, clock.Time.Hour + 12, clock.Time.Minute, clock.Time.Second);
+		    else if (!clock.Is24Hours && !clock.IsPostMeridiem && clock.Time.Hour >= 12)
+		        clock.Time = new DateTime(clock.Time.Year, clock.Time.Month, clock.Time.Day, clock.Time.Hour - 12, clock.Time.Minute, clock.Time.Second);
+        }
 
 		public bool IsPostMeridiem
 		{
@@ -391,7 +391,7 @@ namespace MaterialDesignThemes.Wpf
             clock.IsMiddayHour = clock.Time.Hour == 12;
         }
 
-        private BindingBase GetBinding(string propertyName, object owner = null, IValueConverter converter = null, object converterParameter = null)
+	    private BindingBase GetBinding(string propertyName, object owner = null, IValueConverter converter = null, object converterParameter = null)
 		{
 			var result = new Binding(propertyName) {Source = owner ?? this, Converter = converter, ConverterParameter = converterParameter};
 			return result;

--- a/MaterialDesignThemes.Wpf/Converters/NullableDateTimeToCurrentDateConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/NullableDateTimeToCurrentDateConverter.cs
@@ -14,7 +14,7 @@ namespace MaterialDesignThemes.Wpf.Converters
         {
             if (value is DateTime)
                 return value;
-            return DateTime.Now.Date;
+            return DateTime.Now;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
@@ -358,10 +358,10 @@
                             </Canvas>
                             <RadioButton Content="AM" GroupName="Meridien" HorizontalAlignment="Left" Height="47.333" Margin="31.666,0,0,37.667" Grid.Row="1" VerticalAlignment="Bottom" Width="47.333" Style="{StaticResource MaterialDesignCalendarMeridiemRadioButton}"
                                          x:Name="AMRadioButton"
-                                         IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                                         IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}}" />
                             <RadioButton Content="PM" GroupName="Meridien" HorizontalAlignment="Right" Height="47.333" Margin="0,0,31.667,37.667" Grid.Row="1" VerticalAlignment="Bottom" Width="47.333" Style="{StaticResource MaterialDesignCalendarMeridiemRadioButton}"
                                          x:Name="PMRadioButton"
-                                         IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                                         IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem}" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
@@ -358,10 +358,10 @@
                             </Canvas>
                             <RadioButton Content="AM" GroupName="Meridien" HorizontalAlignment="Left" Height="47.333" Margin="31.666,0,0,37.667" Grid.Row="1" VerticalAlignment="Bottom" Width="47.333" Style="{StaticResource MaterialDesignCalendarMeridiemRadioButton}"
                                          x:Name="AMRadioButton"
-                                         IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}}" />
+                                         IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
                             <RadioButton Content="PM" GroupName="Meridien" HorizontalAlignment="Right" Height="47.333" Margin="0,0,31.667,37.667" Grid.Row="1" VerticalAlignment="Bottom" Width="47.333" Style="{StaticResource MaterialDesignCalendarMeridiemRadioButton}"
                                          x:Name="PMRadioButton"
-                                         IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem}" />
+                                         IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>

--- a/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -413,8 +413,8 @@ namespace MaterialDesignThemes.Wpf
 			_clock.AddHandler(Clock.ClockChoiceMadeEvent, new ClockChoiceMadeEventHandler(ClockChoiceMadeHandler));
             _clock.SetBinding(ForegroundProperty, GetBinding(ForegroundProperty));
 			_clock.SetBinding(StyleProperty, GetBinding(ClockStyleProperty));
-			_clock.SetBinding(Clock.TimeProperty, GetBinding(SelectedTimeProperty, new NullableDateTimeToCurrentDateConverter()));
-		    _clock.SetBinding(Clock.Is24HoursProperty, GetBinding(Is24HoursProperty));
+		    _clock.SetBinding(Clock.TimeProperty, GetBinding(SelectedTimeProperty, new NullableDateTimeToCurrentDateConverter()));
+            _clock.SetBinding(Clock.Is24HoursProperty, GetBinding(Is24HoursProperty));
 			_clockHostContentControl.SetBinding(StyleProperty, GetBinding(ClockHostContentControlStyleProperty));
 		}
 


### PR DESCRIPTION
 Not sure why this converter only returns Date property but it seems to resolve, or at least provide a workaround to, issue #826 

I had a look at [this binding](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/2740f14a814896d42032ae0013b765a8a0ec04c3/MaterialDesignThemes.Wpf/TimePicker.cs#L416) and [this line](https://github.com/ButchersBoy/MaterialDesignInXamlToolkit/blob/2740f14a814896d42032ae0013b765a8a0ec04c3/MaterialDesignThemes.Wpf/Clock.cs#L120) which gets hit.  The issue is it gets hit resulting in a change from PM -> AM time when removing the value in any unrelated Timepicker in the control which I couldn't figure out.  .  