### PR TITLE
Update MaterialDesignTheme.MahApps for MahApps v1.6.5

### DIFF
--- a/MahMaterialDragablzMashUp/Mah.xaml
+++ b/MahMaterialDragablzMashUp/Mah.xaml
@@ -18,5 +18,7 @@
                 Style="{DynamicResource AccentedSquareButtonStyle}" />
         <controls:RangeSlider Margin="0 16 0 0" LowerValue="25" UpperValue="75" />
         <controls:RangeSlider Margin="0 16 0 0" LowerValue="25" UpperValue="75" Orientation="Vertical" Height="200"  />
+        <controls:NumericUpDown Margin="5"/>
+        <controls:NumericUpDown Culture="ar-EG" FlowDirection="RightToLeft" Margin="5"/>
     </StackPanel>
 </UserControl>

--- a/MahMaterialDragablzMashUp/MahAppsDragablzDemo.csproj
+++ b/MahMaterialDragablzMashUp/MahAppsDragablzDemo.csproj
@@ -170,6 +170,22 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2')">
       <ItemGroup>
+        <Reference Include="ControlzEx">
+          <HintPath>..\packages\ControlzEx\lib\net45\ControlzEx.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Windows.Interactivity">
+          <HintPath>..\packages\ControlzEx\lib\net45\System.Windows.Interactivity.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
         <Reference Include="Dragablz">
           <HintPath>..\packages\Dragablz\lib\net45\Dragablz.dll</HintPath>
           <Private>True</Private>
@@ -183,11 +199,6 @@
       <ItemGroup>
         <Reference Include="MahApps.Metro">
           <HintPath>..\packages\MahApps.Metro\lib\net45\MahApps.Metro.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="System.Windows.Interactivity">
-          <HintPath>..\packages\MahApps.Metro\lib\net45\System.Windows.Interactivity.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/MainDemo.Wpf/App.xaml
+++ b/MainDemo.Wpf/App.xaml
@@ -11,7 +11,6 @@
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />

--- a/MaterialDesignColors.Wpf.Tests/MaterialDesignColors.Wpf.Tests.csproj
+++ b/MaterialDesignColors.Wpf.Tests/MaterialDesignColors.Wpf.Tests.csproj
@@ -84,7 +84,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2')">
       <ItemGroup>
         <Reference Include="System.Runtime.InteropServices.RuntimeInformation">
           <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
@@ -110,9 +110,6 @@
     <Analyzer Include="..\packages\xunit.analyzers\analyzers\dotnet\cs\xunit.analyzers.dll">
       <Paket>True</Paket>
     </Analyzer>
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2')">

--- a/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.csproj
+++ b/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.csproj
@@ -101,6 +101,10 @@
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
     <AppDesigner Include="Properties\" />
+    <Page Include="Themes\MaterialDesignTheme.MahApps.NumericUpDown.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MaterialDesignThemes.Wpf\MaterialDesignThemes.Wpf.csproj">

--- a/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.csproj
+++ b/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.csproj
@@ -120,13 +120,24 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2')">
       <ItemGroup>
-        <Reference Include="MahApps.Metro">
-          <HintPath>..\packages\MahApps.Metro\lib\net45\MahApps.Metro.dll</HintPath>
+        <Reference Include="ControlzEx">
+          <HintPath>..\packages\ControlzEx\lib\net45\ControlzEx.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
         <Reference Include="System.Windows.Interactivity">
-          <HintPath>..\packages\MahApps.Metro\lib\net45\System.Windows.Interactivity.dll</HintPath>
+          <HintPath>..\packages\ControlzEx\lib\net45\System.Windows.Interactivity.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
+        <Reference Include="MahApps.Metro">
+          <HintPath>..\packages\MahApps.Metro\lib\net45\MahApps.Metro.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Defaults.xaml
+++ b/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Defaults.xaml
@@ -5,6 +5,7 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Fonts.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Flyout.xaml"/>
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.NumericUpDown.xaml"/>
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.RangeSlider.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.WindowCommands.xaml" />
     </ResourceDictionary.MergedDictionaries>

--- a/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Defaults.xaml
+++ b/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Defaults.xaml
@@ -4,7 +4,7 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Fonts.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Flyout.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Flyout.xaml"/>
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.RangeSlider.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.WindowCommands.xaml" />
     </ResourceDictionary.MergedDictionaries>

--- a/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Flyout.xaml
+++ b/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Flyout.xaml
@@ -1,46 +1,53 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Controls="http://metro.mahapps.com/winfx/xaml/controls"
+                    xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                    xmlns:mahShared="http://metro.mahapps.com/winfx/xaml/shared"
                     xmlns:mahApps="clr-namespace:MaterialDesignThemes.MahApps"
-                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf;assembly=MaterialDesignThemes.Wpf">
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf;assembly=MaterialDesignThemes.Wpf"
+                    xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity">
 
     <DataTemplate x:Key="HeaderTemplate" x:Shared="False">
         <wpf:ColorZone x:Name="PART_ColorZone"
                        wpf:ShadowAssist.ShadowDepth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mahApps:FlyoutAssist.HeaderShadowDepth)}"
                        Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mahApps:FlyoutAssist.HeaderColorMode)}">
             <DockPanel x:Name="dpHeader"
-                       Margin="{Binding Path=(Controls:ControlsHelper.HeaderMargin), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:Flyout}}, Mode=OneWay}"
+                       Margin="{Binding Path=(mah:ControlsHelper.HeaderMargin), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type mah:Flyout}}, Mode=OneWay}"
                        VerticalAlignment="Center"
                        LastChildFill="True">
                 <Button x:Name="PART_BackButton"
-                        Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}, Path=InternalCloseCommand, Mode=OneWay}"
-                        CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}, Path=CloseCommandParameter, Mode=OneWay}"
                         Width="34"
                         Height="34"
                         Margin="2 4 2 2"
                         VerticalAlignment="Bottom"
-                        Style="{DynamicResource MaterialDesignToolButton}"
-                        Foreground="{Binding RelativeSource={RelativeSource AncestorType={x:Type wpf:ColorZone}}, Path=Foreground}"
-                        FontSize="16"
                         DockPanel.Dock="Left"
-                        IsCancel="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:Flyout}}, Path=CloseButtonIsCancel}"
-                        Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:Flyout}}, Path=CloseButtonVisibility}">
+                        Foreground="{Binding RelativeSource={RelativeSource AncestorType={x:Type mah:Flyout}}, Path=Foreground}"
+                        IsCancel="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type mah:Flyout}}, Path=CloseButtonIsCancel}"
+                        Style="{DynamicResource MaterialDesignToolButton}"
+                        Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type mah:Flyout}}, Path=CloseButtonVisibility}">
+                    <i:Interaction.Triggers>
+                        <i:EventTrigger EventName="Click">
+                            <mahShared:CloseFlyoutAction Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type mah:Flyout}}, Path=CloseCommand, Mode=OneWay}" CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type mah:Flyout}}, Path=CloseCommandParameter, Mode=OneWay}" />
+                        </i:EventTrigger>
+                    </i:Interaction.Triggers>
                     <ContentControl Style="{DynamicResource PathIconContentControlStyle}"
                                     Content="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+                                    FlowDirection="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type mah:Flyout}}, Path=FlowDirection}"
                                     Width="16"
                                     Height="16" />
                 </Button>
-                <TextBlock x:Name="PART_BackHeaderText"
-                           Margin="15 0 0 0"
-                           VerticalAlignment="Center"
-                           Text="{Binding}"
-                           Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:Flyout}}, Path=TitleVisibility}" />
+                <ContentControl x:Name="PART_BackHeaderText"
+                                Margin="15 0 0 0"
+                                VerticalAlignment="Center"
+                                Content="{Binding}"
+                                Focusable="False"
+                                IsTabStop="False"
+                                Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type mah:Flyout}}, Path=TitleVisibility}" />
             </DockPanel>
         </wpf:ColorZone>
         <DataTemplate.Triggers>
-            <DataTrigger Binding="{Binding Position, RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}}" Value="Left">
+            <DataTrigger Binding="{Binding Position, RelativeSource={RelativeSource AncestorType={x:Type mah:Flyout}}}" Value="Left">
                 <Setter TargetName="PART_BackHeaderText" Property="Margin" Value="0 0 15 0" />
-                <Setter TargetName="PART_BackHeaderText" Property="TextAlignment" Value="Right" />
+                <Setter TargetName="PART_BackHeaderText" Property="HorizontalAlignment" Value="Right" />
                 <Setter TargetName="PART_BackButton" Property="DockPanel.Dock" Value="Right" />
                 <Setter TargetName="PART_BackButton" Property="LayoutTransform">
                     <Setter.Value>
@@ -48,7 +55,7 @@
                     </Setter.Value>
                 </Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding Position, RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}}" Value="Top">
+            <DataTrigger Binding="{Binding Position, RelativeSource={RelativeSource AncestorType={x:Type mah:Flyout}}}" Value="Top">
                 <Setter TargetName="PART_ColorZone" Property="VerticalAlignment" Value="Stretch" />
                 <Setter TargetName="PART_BackButton" Property="LayoutTransform">
                     <Setter.Value>
@@ -56,7 +63,7 @@
                     </Setter.Value>
                 </Setter>
             </DataTrigger>
-            <DataTrigger Binding="{Binding Position, RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}}" Value="Bottom">
+            <DataTrigger Binding="{Binding Position, RelativeSource={RelativeSource AncestorType={x:Type mah:Flyout}}}" Value="Bottom">
                 <Setter TargetName="PART_ColorZone" Property="VerticalAlignment" Value="Stretch" />
                 <Setter TargetName="PART_BackButton" Property="LayoutTransform">
                     <Setter.Value>
@@ -67,7 +74,7 @@
         </DataTemplate.Triggers>
     </DataTemplate>
 
-    <ControlTemplate x:Key="FlyoutTemplate" TargetType="{x:Type Controls:Flyout}">
+    <ControlTemplate x:Key="FlyoutTemplate" TargetType="{x:Type mah:Flyout}">
         <Grid x:Name="PART_Root"
               Background="{TemplateBinding Background}">
             <Grid.RenderTransform>
@@ -78,17 +85,21 @@
             </AdornerDecorator>
             <AdornerDecorator>
                 <DockPanel FocusVisualStyle="{x:Null}" Focusable="False">
-                    <Controls:MetroThumbContentControl x:Name="PART_Header"
-                                                       DockPanel.Dock="Top"
-                                                       FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
-                                                       FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
-                                                       FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
-                                                       Content="{TemplateBinding Header}"
-                                                       ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                                       ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
-                                                       RecognizesAccessKey="True"
-                                                       SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                    <ContentPresenter x:Name="PART_Content" DockPanel.Dock="Bottom" />
+                    <mah:MetroThumbContentControl x:Name="PART_Header"
+                                                  Content="{TemplateBinding Header}"
+                                                  ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                  ContentStringFormat="{TemplateBinding HeaderStringFormat}"
+                                                  ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                                  ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                                  DockPanel.Dock="Top"
+                                                  FontSize="{TemplateBinding mah:ControlsHelper.HeaderFontSize}"
+                                                  FontStretch="{TemplateBinding mah:ControlsHelper.HeaderFontStretch}"
+                                                  FontWeight="{TemplateBinding mah:ControlsHelper.HeaderFontWeight}"
+                                                  RecognizesAccessKey="True"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                    <ContentPresenter x:Name="PART_Content"
+                                      ContentSource="Content"
+                                      DockPanel.Dock="Bottom" />
                 </DockPanel>
             </AdornerDecorator>
             <VisualStateManager.VisualStateGroups>
@@ -223,12 +234,12 @@
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
-    <Style TargetType="{x:Type Controls:Flyout}">
+    <Style TargetType="{x:Type mah:Flyout}">
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
         <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource FlyoutHeaderFontSize}" />
-        <Setter Property="Controls:ControlsHelper.HeaderMargin" Value="10" />
+        <Setter Property="mah:ControlsHelper.HeaderFontSize" Value="{DynamicResource FlyoutHeaderFontSize}" />
+        <Setter Property="mah:ControlsHelper.HeaderMargin" Value="10" />
         <Setter Property="HeaderTemplate" Value="{StaticResource HeaderTemplate}" />
         <Setter Property="KeyboardNavigation.ControlTabNavigation" Value="Cycle" />
         <Setter Property="KeyboardNavigation.DirectionalNavigation" Value="Cycle" />
@@ -241,10 +252,10 @@
         <Setter Property="mahApps:FlyoutAssist.HeaderShadowDepth" Value="Depth2" />
         <Style.Triggers>
             <Trigger Property="Position" Value="Right">
-                <Setter Property="Controls:ControlsHelper.HeaderMargin" Value="10 25 10 10" />
+                <Setter Property="mah:ControlsHelper.HeaderMargin" Value="10 25 10 10" />
             </Trigger>
             <Trigger Property="Position" Value="Left">
-                <Setter Property="Controls:ControlsHelper.HeaderMargin" Value="10 25 10 10" />
+                <Setter Property="mah:ControlsHelper.HeaderMargin" Value="10 25 10 10" />
             </Trigger>
             <Trigger Property="TitleVisibility" Value="Collapsed">
                 <Setter Property="mahApps:FlyoutAssist.HeaderColorMode" Value="Standard" />
@@ -257,6 +268,3 @@
         </Style.Triggers>
     </Style>
 </ResourceDictionary>
-
-
-

--- a/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.NumericUpDown.xaml
+++ b/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.NumericUpDown.xaml
@@ -1,0 +1,190 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                    xmlns:mahShared="http://metro.mahapps.com/winfx/xaml/shared"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <mahShared:ThicknessBindingConverter x:Key="ThicknessBindingConverter" />
+
+    <Style TargetType="{x:Type mah:NumericUpDown}">
+        <Setter Property="BorderThickness" Value="0,0,0,2" />
+        <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource TextBoxFocusBorderBrush}" />
+        <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource TextBoxMouseOverBorderBrush}" />
+        <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource ClearTextButtonFontSize}" />
+        <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />
+        <Setter Property="mah:TextBoxHelper.IsMonitoring" Value="True" />
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FontFamily" Value="{DynamicResource ContentFontFamily}" />
+        <Setter Property="FontSize" Value="{DynamicResource ContentFontSize}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="MinHeight" Value="26" />
+        <Setter Property="MinWidth" Value="62" />
+        <Setter Property="Padding" Value="1" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="SnapsToDevicePixels" Value="true" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type mah:NumericUpDown}">
+                    <Grid SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Border x:Name="Base"
+                    Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="0,0,0,1"
+                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        <Grid Margin="{TemplateBinding Padding}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition x:Name="PART_TextBoxColumn" Width="*" />
+                                <ColumnDefinition x:Name="PART_ButtonsColumn" Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBox x:Name="PART_TextBox"
+                       Grid.Column="0"
+                       MinWidth="20"
+                       MinHeight="0"
+                       Margin="2"
+                       Padding="0"
+                       HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                       VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                       mah:ControlsHelper.DisabledVisualElementVisibility="Collapsed"
+                       mah:TextBoxHelper.ButtonContent="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
+                       mah:TextBoxHelper.ButtonContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
+                       mah:TextBoxHelper.ButtonFontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
+                       mah:TextBoxHelper.ButtonFontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
+                       mah:TextBoxHelper.ButtonWidth="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
+                       mah:TextBoxHelper.ButtonsAlignment="{TemplateBinding ButtonsAlignment}"
+                       mah:TextBoxHelper.ClearTextButton="{TemplateBinding mah:TextBoxHelper.ClearTextButton}"
+                       mah:TextBoxHelper.HasText="{TemplateBinding mah:TextBoxHelper.HasText}"
+                       mah:TextBoxHelper.SelectAllOnFocus="{TemplateBinding mah:TextBoxHelper.SelectAllOnFocus}"
+                       mah:TextBoxHelper.UseFloatingWatermark="{TemplateBinding mah:TextBoxHelper.UseFloatingWatermark}"
+                       mah:TextBoxHelper.Watermark="{TemplateBinding mah:TextBoxHelper.Watermark}"
+                       mah:TextBoxHelper.WatermarkAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
+                       mah:TextBoxHelper.WatermarkTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}"
+                       Background="{x:Null}"
+                       BorderThickness="0"
+                       FocusVisualStyle="{x:Null}"
+                       Focusable="{TemplateBinding Focusable}"
+                       FontFamily="{TemplateBinding FontFamily}"
+                       FontSize="{TemplateBinding FontSize}"
+                       Foreground="{TemplateBinding Foreground}"
+                       HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                       IsReadOnly="{TemplateBinding IsReadOnly}"
+                       IsTabStop="{TemplateBinding IsTabStop}"
+                       SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                       TabIndex="{TemplateBinding TabIndex}"
+                       VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
+                            <StackPanel x:Name="PART_Buttons"
+                          Grid.Column="1"
+                          Margin="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static mahShared:ThicknessSideType.Left}}"
+                          Orientation="Horizontal">
+                                <RepeatButton x:Name="PART_NumericUp"
+                              Width="{TemplateBinding UpDownButtonsWidth}"
+                              Delay="{TemplateBinding Delay}"
+                              Foreground="{TemplateBinding Foreground}"
+                              IsTabStop="False"
+                              Style="{DynamicResource ChromelessButtonStyle}">
+                                    <Path x:Name="PolygonUp"
+                        Width="14"
+                        Height="14"
+                        Data="F1 M 35,19L 41,19L 41,35L 57,35L 57,41L 41,41L 41,57L 35,57L 35,41L 19,41L 19,35L 35,35L 35,19 Z "
+                        Fill="{DynamicResource GrayBrush1}"
+                        Stretch="Fill" />
+                                </RepeatButton>
+                                <RepeatButton x:Name="PART_NumericDown"
+                              Width="{TemplateBinding UpDownButtonsWidth}"
+                              VerticalContentAlignment="Center"
+                              Delay="{TemplateBinding Delay}"
+                              Foreground="{TemplateBinding Foreground}"
+                              IsTabStop="False"
+                              Style="{DynamicResource ChromelessButtonStyle}">
+                                    <Path x:Name="PolygonDown"
+                        Width="14"
+                        Height="3"
+                        Data="F1 M 19,38L 57,38L 57,44L 19,44L 19,38 Z "
+                        Fill="{DynamicResource GrayBrush1}"
+                        Stretch="Fill" />
+                                </RepeatButton>
+                            </StackPanel>
+                        </Grid>
+                        <Border x:Name="DisabledVisualElement"
+                    Background="{DynamicResource ControlsDisabledBrush}"
+                    BorderBrush="{DynamicResource ControlsDisabledBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                    IsHitTestVisible="False"
+                    Opacity="0"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="ButtonsAlignment" Value="Left">
+                            <Setter TargetName="PART_Buttons" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="PART_Buttons" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static mahShared:ThicknessSideType.Right}}" />
+                            <Setter TargetName="PART_ButtonsColumn" Property="Width" Value="*" />
+                            <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
+                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
+                            <Setter TargetName="PART_TextBoxColumn" Property="Width" Value="Auto" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.6" />
+                        </Trigger>
+                        <Trigger Property="IsReadOnly" Value="True">
+                            <Setter Property="InterceptArrowKeys" Value="False" />
+                            <Setter Property="InterceptManualEnter" Value="False" />
+                            <Setter Property="InterceptMouseWheel" Value="False" />
+                            <Setter TargetName="PART_NumericDown" Property="IsEnabled" Value="False" />
+                            <Setter TargetName="PART_NumericUp" Property="IsEnabled" Value="False" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsReadOnly" Value="False" />
+                                <Condition Property="InterceptManualEnter" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_TextBox" Property="IsReadOnly" Value="True" />
+                        </MultiTrigger>
+                        <Trigger SourceName="PART_NumericUp" Property="IsMouseOver" Value="True">
+                            <Setter TargetName="PART_NumericUp" Property="Background" Value="{DynamicResource GrayBrush8}" />
+                            <Setter TargetName="PolygonUp" Property="Fill" Value="{DynamicResource AccentColorBrush}" />
+                        </Trigger>
+                        <Trigger SourceName="PART_NumericUp" Property="IsPressed" Value="True">
+                            <Setter TargetName="PART_NumericUp" Property="Background" Value="{DynamicResource BlackBrush}" />
+                            <Setter TargetName="PolygonUp" Property="Fill" Value="{DynamicResource WhiteBrush}" />
+                        </Trigger>
+                        <Trigger SourceName="PART_NumericDown" Property="IsMouseOver" Value="True">
+                            <Setter TargetName="PART_NumericDown" Property="Background" Value="{DynamicResource GrayBrush8}" />
+                            <Setter TargetName="PolygonDown" Property="Fill" Value="{DynamicResource AccentColorBrush}" />
+                        </Trigger>
+                        <Trigger SourceName="PART_NumericDown" Property="IsPressed" Value="True">
+                            <Setter TargetName="PART_NumericDown" Property="Background" Value="{DynamicResource BlackBrush}" />
+                            <Setter TargetName="PolygonDown" Property="Fill" Value="{DynamicResource WhiteBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter TargetName="Base" Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+                            <Setter TargetName="Base" Property="BorderThickness" Value="0,0,0,2" />
+                        </Trigger>
+                        <Trigger SourceName="PART_TextBox" Property="IsFocused" Value="true">
+                            <Setter TargetName="Base" Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+                            <Setter TargetName="Base" Property="BorderThickness" Value="0,0,0,2" />
+                            <Setter TargetName="PART_TextBox" Property="BorderThickness" Value="0" />
+                        </Trigger>
+                        <Trigger SourceName="PART_TextBox" Property="IsKeyboardFocused" Value="true">
+                            <Setter TargetName="PART_TextBox" Property="BorderThickness" Value="0" />
+                        </Trigger>
+                        <Trigger Property="FlowDirection" Value="RightToLeft">
+                            <Setter TargetName="PART_TextBox" Property="FontFamily" Value="Segoe UI" />
+                        </Trigger>
+                        <Trigger Property="HideUpDownButtons" Value="True">
+                            <Setter TargetName="PART_Buttons" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="UpDownButtonsWidth" Value="22" />
+        <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
+    </Style>
+</ResourceDictionary>

--- a/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
+++ b/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
@@ -130,10 +130,41 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
+        <Reference Include="System.ComponentModel.Composition">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2')">
       <ItemGroup>
         <Reference Include="System.Runtime.InteropServices.RuntimeInformation">
           <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
+        <Reference Include="System.Threading.Tasks.Extensions">
+          <HintPath>..\packages\System.Threading.Tasks.Extensions\lib\netstandard1.0\System.Threading.Tasks.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
+        <Reference Include="System.ValueTuple">
+          <HintPath>..\packages\System.ValueTuple\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
@@ -156,9 +187,6 @@
     <Analyzer Include="..\packages\xunit.analyzers\analyzers\dotnet\cs\xunit.analyzers.dll">
       <Paket>True</Paket>
     </Analyzer>
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.2')">

--- a/MaterialDesignThemes.nuspec
+++ b/MaterialDesignThemes.nuspec
@@ -1,27 +1,26 @@
 <?xml version="1.0"?>
 <package>
   <metadata>
-    <id>MaterialDesignThemes</id>
+    <id>MaterialDesignThemes.MahApps</id>
     <version>0.1.0-beta</version>
-    <title>Material Design Themes XAML Resources</title>
+    <title>Material Design Themes XAML Resources For MahApps Controls</title>
     <authors>James Willock</authors>
     <owners>James Willock</owners>
-    <licenseUrl>https://github.com/ButchersBoy/MaterialDesignInXamlToolkit/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
     <projectUrl>https://github.com/ButchersBoy/MaterialDesignInXamlToolkit</projectUrl>    
     <iconUrl>http://materialdesigninxaml.net/images/MD4XAML32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>ResourceDictionary instances containing Material Design templates and styles for WPF controls.</description>
+    <description>ResourceDictionary instances containing Material Design templates and styles for WPF controls in the MahApps library.</description>
     <releaseNotes>https://github.com/ButchersBoy/MaterialDesignInXamlToolkit/releases</releaseNotes>
     <copyright>Copyright 2015 James Willock/Mulholland Software Ltd</copyright>
     <tags>WPF XAML WinRT Material Design Theme Colour Color UI UX</tags>
     <dependencies>
-      <dependency id="MaterialDesignColors" version="1.1.2" />    
+      <dependency id="MaterialDesignColors" version="1.1.3" />    
+      <dependency id="MaterialDesignThemes" version="2.4.1" />    
+      <dependency id="MahApps.Metro" version="1.6.5" />    
     </dependencies>
   </metadata>
-  <files>
-    <file src="MaterialDesignThemes.Wpf\bin\AppVeyor\MaterialDesignThemes.Wpf.dll" target="lib\net45" />
-    <file src="MaterialDesignThemes.Wpf\bin\AppVeyor\MaterialDesignThemes.Wpf.pdb" target="lib\net45" />
-    <file src="MaterialDesignThemes.Wpf\bin\AppVeyor\MaterialDesignThemes.Wpf.xml" target="lib\net45" />
-    <file src="MaterialDesignThemes.Wpf\**\*.cs" target="src\net45" />
+  <files>    
+    <file src="MaterialDesignThemes.MahApps\bin\Release\MaterialDesignThemes.MahApps.dll" target="lib\net45" />
   </files>    
 </package>

--- a/paket.lock
+++ b/paket.lock
@@ -4,10 +4,12 @@ NUGET
     AvalonEdit (5.0.4)
     Castle.Core (4.2.1)
     Dragablz (0.0.3.197)
-    MahApps.Metro (1.5)
+    MahApps.Metro (1.6.5)
     Microsoft.NETCore.Platforms (2.0.1) - restriction: == net45
-    Moq (4.7.145)
+    Moq (4.8.1)
       Castle.Core (>= 4.2.1)
+      System.Threading.Tasks.Extensions (>= 4.3)
+      System.ValueTuple (>= 4.3)
     NETStandard.Library (2.0.1) - restriction: == net45
       Microsoft.NETCore.Platforms (>= 1.1)
       System.Runtime.InteropServices.RuntimeInformation (>= 4.3)
@@ -21,6 +23,16 @@ NUGET
     ShowMeTheXAML.MSBuild (1.0.10)
       ShowMeTheXAML (>= 1.0.10 < 1.1)
     System.Runtime.InteropServices.RuntimeInformation (4.3) - restriction: == net45
+	System.Collections (4.3)
+    System.Runtime (4.3)
+    System.Runtime.InteropServices.RuntimeInformation (4.3)
+    System.Threading.Tasks (4.3)
+    System.Threading.Tasks.Extensions (4.4)
+      System.Collections (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+    System.ValueTuple (4.4)
+      NETStandard.Library (>= 1.6.1)
     xunit (2.3.1)
       xunit.analyzers (>= 0.7)
       xunit.assert (2.3.1)
@@ -28,15 +40,15 @@ NUGET
     xunit.abstractions (2.0.1)
     xunit.analyzers (0.8)
     xunit.assert (2.3.1)
-      NETStandard.Library (>= 1.6.1) - restriction: == net45
+      NETStandard.Library (>= 1.6.1)
     xunit.core (2.3.1)
       xunit.extensibility.core (2.3.1)
       xunit.extensibility.execution (2.3.1)
     xunit.extensibility.core (2.3.1)
-      NETStandard.Library (>= 1.6.1) - restriction: == net45
+      NETStandard.Library (>= 1.6.1)
       xunit.abstractions (>= 2.0.1)
     xunit.extensibility.execution (2.3.1)
-      NETStandard.Library (>= 1.6.1) - restriction: == net45
+      NETStandard.Library (>= 1.6.1)
       xunit.extensibility.core (2.3.1)
 GITHUB
   remote: ControlzEx/ControlzEx


### PR DESCRIPTION
i used @punker76 work on https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/pull/898 then updated MahApps to the latest version (1.6.5)

Updated NumericUpDown controller to be more like MaterialDesign and fixed stretch issue with MaterialDesignInXamlToolkit Version 2.4.1 casing the textbox inside the controller to shrink to the point that user can't click on it to start typing no matter how wide it is also half of it was disappearing behind the + button

Fixed an issue with NumericUpDown controller that caused the Arabic Decimal Point with Roboto font to appear as a white square https://imgur.com/Av7x7Z6 when used with RightToLeft FlowDirection and Arabic cultures by using Segoe UI font by default if the FlowDirection was set to RightToLeft 

https://imgur.com/a/uDWLw4z

https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/wiki/MahApps.Metro-integration

there is no need to add 

`<!-- Material Design: MahApps Compatibility -->
                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Fonts.xaml" />
                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Flyout.xaml" />`

etc in App.xaml for integration just 

` <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Defaults.xaml"/>  `