### PR TITLE
Added ValueChanged event for RatingBar - Fixes #1027

### DIFF
--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -572,7 +572,7 @@
         <TextBlock Margin="0 32 0 0" Grid.Row="9" Style="{StaticResource MaterialDesignHeadlineTextBlock}">Rating bar</TextBlock>
         <StackPanel Grid.Row="10" Margin="0 16 0 0" Orientation="Horizontal">
             <smtx:XamlDisplay Key="buttons_58" VerticalContentAlignment="Top" Margin="5 0 0 5">
-                <materialDesign:RatingBar Value="3" x:Name="BasicRatingBar" />
+                <materialDesign:RatingBar Value="3" x:Name="BasicRatingBar"  ValueChanged="BasicRatingBar_ValueChanged"/>
             </smtx:XamlDisplay>
             <TextBlock Text="{Binding ElementName=BasicRatingBar, Path=Value, StringFormat=Rating: {0}}" VerticalAlignment="Top" Margin="10,2,0,0" />
             <smtx:XamlDisplay Key="buttons_59" Margin="24 0 0 5">

--- a/MainDemo.Wpf/Buttons.xaml.cs
+++ b/MainDemo.Wpf/Buttons.xaml.cs
@@ -1,17 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System;
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using MaterialDesignColors.WpfExample.Domain;
 
 namespace MaterialDesignColors.WpfExample
@@ -24,7 +15,6 @@ namespace MaterialDesignColors.WpfExample
         public Buttons()
         {
             InitializeComponent();
-
             FloatingActionDemoCommand = new AnotherCommandImplementation(Execute);
         }
 
@@ -36,9 +26,9 @@ namespace MaterialDesignColors.WpfExample
         }
 
         private void ButtonBase_OnClick(object sender, RoutedEventArgs e)
-	    {
+	{
             Console.WriteLine("Just checking we haven't suppressed the button.");
-		}
+	}
 
         private void PopupBox_OnOpened(object sender, RoutedEventArgs e)
         {
@@ -58,7 +48,11 @@ namespace MaterialDesignColors.WpfExample
             var next = int.Parse(CountingBadge.Badge.ToString()) + 1;
             
             CountingBadge.Badge = next < 21 ? (object)next : null;
-
+        }
+        
+        private void BasicRatingBar_ValueChanged(object sender, RoutedPropertyChangedEventArgs<int> e)
+        {
+            Debug.WriteLine($"BasicRatingBar value changed from {e.OldValue} to {e.NewValue}.");
         }
     }
 }

--- a/MaterialDesignThemes.Wpf/RatingBar.cs
+++ b/MaterialDesignThemes.Wpf/RatingBar.cs
@@ -64,14 +64,40 @@ namespace MaterialDesignThemes.Wpf
 
         private static void ValuePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
-            foreach (var button in ((RatingBar) dependencyObject).RatingButtons)
+            var ratingBar = (RatingBar)dependencyObject;
+            foreach (var button in ratingBar.RatingButtons)
                 button.IsWithinSelectedValue = button.Value <= (int)dependencyPropertyChangedEventArgs.NewValue;
+            OnValueChanged(ratingBar, dependencyPropertyChangedEventArgs);
         }
 
         public int Value
         {
             get { return (int) GetValue(ValueProperty); }
             set { SetValue(ValueProperty, value); }
+        }
+
+        public static readonly RoutedEvent ValueChangedEvent =
+            EventManager.RegisterRoutedEvent(
+                nameof(Value),
+                RoutingStrategy.Bubble,
+                typeof(RoutedPropertyChangedEventHandler<int>),
+                typeof(RatingBar));
+
+        public event RoutedPropertyChangedEventHandler<int> ValueChanged
+        {
+            add => AddHandler(ValueChangedEvent, value);
+            remove => RemoveHandler(ValueChangedEvent, value);
+        }
+
+        private static void OnValueChanged(
+            DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var instance = (RatingBar)d;
+            var args = new RoutedPropertyChangedEventArgs<int>(
+                    (int)e.OldValue,
+                    (int)e.NewValue) 
+                { RoutedEvent = ValueChangedEvent };
+            instance.RaiseEvent(args);
         }
 
         public ReadOnlyObservableCollection<RatingBarButton> RatingButtons => _ratingButtons;

--- a/MaterialDesignThemes.Wpf/RatingBar.cs
+++ b/MaterialDesignThemes.Wpf/RatingBar.cs
@@ -1,14 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
 using System.Windows.Input;
 
 namespace MaterialDesignThemes.Wpf

--- a/MaterialDesignThemes.Wpf/Ripple.cs
+++ b/MaterialDesignThemes.Wpf/Ripple.cs
@@ -26,9 +26,9 @@ namespace MaterialDesignThemes.Wpf
             DefaultStyleKeyProperty.OverrideMetadata(typeof(Ripple), new FrameworkPropertyMetadata(typeof(Ripple)));
 
             EventManager.RegisterClassHandler(typeof(ContentControl), Mouse.PreviewMouseUpEvent, new MouseButtonEventHandler(MouseButtonEventHandler), true);
-            EventManager.RegisterClassHandler(typeof(ContentControl), Mouse.MouseMoveEvent, new MouseEventHandler(MouseMouveEventHandler), true);
+            EventManager.RegisterClassHandler(typeof(ContentControl), Mouse.MouseMoveEvent, new MouseEventHandler(MouseMoveEventHandler), true);
             EventManager.RegisterClassHandler(typeof(Popup), Mouse.PreviewMouseUpEvent, new MouseButtonEventHandler(MouseButtonEventHandler), true);
-            EventManager.RegisterClassHandler(typeof(Popup), Mouse.MouseMoveEvent, new MouseEventHandler(MouseMouveEventHandler), true);
+            EventManager.RegisterClassHandler(typeof(Popup), Mouse.MouseMoveEvent, new MouseEventHandler(MouseMoveEventHandler), true);
         }
 
         public Ripple()
@@ -64,7 +64,7 @@ namespace MaterialDesignThemes.Wpf
             PressedInstances.Clear();
         }
 
-        private static void MouseMouveEventHandler(object sender, MouseEventArgs e)
+        private static void MouseMoveEventHandler(object sender, MouseEventArgs e)
         {
             foreach (var ripple in PressedInstances.ToList())
             {


### PR DESCRIPTION
Added ValueChanged event for RatingBar
Fixes #1027 

- [x] Add is ValueChangedEvent to [RatingBar](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/master/MaterialDesignThemes.Wpf/RatingBar.cs#L62-L93) control
- [x] Add an event handler to the RatingBar (`BasicRatingBar`) in [the demo app](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/master/MainDemo.Wpf/Buttons.xaml#L575). The event handler should just display using `Debug.WriteLine`

Removed some un-used using statements along with this commit. 