### PR TITLE
Fix the background problem on MaterialDesignToolToggleListBox

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
@@ -142,7 +142,7 @@
     </Style>
 
     <Style x:Key="MaterialDesignToolToggleListBox" TargetType="{x:Type ListBox}">
-        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Background" Value="{DynamicResource MaterialDesignToolBarBackground}"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}"/>
@@ -174,10 +174,9 @@
                     <Border x:Name="Bd" 
                             BorderBrush="{TemplateBinding BorderBrush}" 
                             BorderThickness="{TemplateBinding BorderThickness}" 
-                            Background="{TemplateBinding Background}" 
                             SnapsToDevicePixels="true"
                             Padding="{TemplateBinding Padding}">
-                        <wpf:Card wpf:ShadowAssist.ShadowDepth="{TemplateBinding wpf:ShadowAssist.ShadowDepth}" HorizontalAlignment="Left" Background="{DynamicResource MaterialDesignToolBarBackground}">
+                        <wpf:Card wpf:ShadowAssist.ShadowDepth="{TemplateBinding wpf:ShadowAssist.ShadowDepth}" HorizontalAlignment="Left" Background="{TemplateBinding Background}">
                             <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                         </wpf:Card>
                     </Border>


### PR DESCRIPTION
Hi. I make some trange on _MaterialDesignToolToggleListBox_.
Now it support using transparent as background by just setting `Background="{x:Null}"` or `Background="Transparent"`. Or change its background color by setting _Background_ to another color.
It's very useful When users using Gradient or Image as background of the window.
Forgive my bad English ;-)

For example, this is the toolbar on MaterialDesignDemo
```xml
<ToolBarTray Background="{x:Null}">
                <ToolBar Style="{DynamicResource MaterialDesignToolBar}" ClipToBounds="False" Background="{x:Null}">
                    <Button ToolTip="Follow me on Twitter" Click="TwitterButton_OnClick">
                        <materialDesign:PackIcon Kind="TwitterBox" />
                    </Button>
                    <Button ToolTip="Save">
                        <materialDesign:PackIcon Kind="ContentSave" />
                    </Button>
                    <Separator />
                    <Button Command="Cut" ToolTip="Cut" ToolBar.OverflowMode="AsNeeded">
                        <materialDesign:PackIcon Kind="ContentCut" />
                    </Button>
                    <Button Command="Copy" ToolTip="Copy that stuff" ToolBar.OverflowMode="AsNeeded">
                        <materialDesign:PackIcon Kind="ContentCopy" />
                    </Button>
                    <Separator />
                    <Button Command="Paste" ToolTip="Paste some stuff" ToolBar.OverflowMode="AsNeeded">
                        <materialDesign:PackIcon Kind="ContentPaste" />
                    </Button>
                    <!-- when badging in a toolbar, make sure the parent ToolBar.ClipToBounds="False", and 
                     manually apply the button style -->
                    <materialDesign:Badged ToolBar.OverflowMode="AsNeeded" Badge="{materialDesign:PackIcon Alert}">
                        <Button ToolTip="Badge it up!" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}">
                            <materialDesign:PackIcon Kind="AirplaneTakeoff" />
                        </Button>
                    </materialDesign:Badged>
                    <Separator/>
                    <ListBox Background="{x:Null}">
                        <ListBoxItem ToolTip="This is a lonley toggle with TextBlock instead of icon">
                            <TextBlock>W</TextBlock>
                        </ListBoxItem>
                    </ListBox>
                    <Separator/>
                    <ListBox SelectedIndex="0" Background="{x:Null}">
                        <ListBox.ToolTip>
                            <StackPanel>
                                <TextBlock Text="MaterialDesignToolToggleFlatListBox" />
                                <TextBlock Text="Exclusive selection" />
                                <TextBlock Text="ListBoxAssist.IsToggle allows more natural toggle behaviour" />
                            </StackPanel>
                        </ListBox.ToolTip>
                        <ListBoxItem >
                            <materialDesign:PackIcon Kind="FormatAlignLeft"/>
                        </ListBoxItem>
                        <ListBoxItem>
                            <materialDesign:PackIcon Kind="FormatAlignCenter"/>
                        </ListBoxItem>
                        <ListBoxItem>
                            <materialDesign:PackIcon Kind="FormatAlignRight"/>
                        </ListBoxItem>
                        <ListBoxItem>
                            <materialDesign:PackIcon Kind="FormatAlignJustify"/>
                        </ListBoxItem>
                    </ListBox>
                    <Separator/>
                    <ListBox SelectionMode="Extended" Background="Transparent">
                        <ListBox.ToolTip>
                            <StackPanel>
                                <TextBlock Text="MaterialDesignToolToggleListBox" />
                                <TextBlock Text="Multiple selection" />
                                <TextBlock Text="ListBoxAssist.IsToggle allows more natural toggle behaviour" />
                            </StackPanel>
                        </ListBox.ToolTip>
                        <ListBoxItem>
                            <materialDesign:PackIcon Kind="FormatBold"/>
                        </ListBoxItem>
                        <ListBoxItem>
                            <materialDesign:PackIcon Kind="FormatItalic"/>
                        </ListBoxItem>
                        <ListBoxItem x:Name="UnderlineCheckbox">
                            <materialDesign:PackIcon Kind="FormatUnderline"/>
                        </ListBoxItem>
                    </ListBox>
                    <Separator/>
                    <Label Content="Font size:" VerticalAlignment="Center"/>
                    <ComboBox>
                        <ComboBoxItem Content="10"/>
                        <ComboBoxItem IsSelected="True" Content="12"/>
                        <ComboBoxItem Content="14"/>
                        <ComboBoxItem Content="16"/>
                    </ComboBox>
                    <CheckBox>
                        Check
                    </CheckBox>
                    <Button ToolTip="Take a nap" ToolBar.OverflowMode="Always">
                        <materialDesign:PackIcon Kind="Hotel" />
                    </Button>
                    <RadioButton GroupName="XXX" Content="Radio" />
                    <RadioButton GroupName="XXX" Content="Ga Ga" />
                    <ToggleButton/>
                </ToolBar>
            </ToolBarTray>
```
I add a `Background="{x:Null}"` or `Background="Transparent"` Property on Listboxs.
Before:
![before](https://user-images.githubusercontent.com/29349119/44943892-863a4980-ae00-11e8-9dda-a5fdb2eb8700.png)
after:
![after](https://user-images.githubusercontent.com/29349119/44943895-89353a00-ae00-11e8-94d9-9054b3e4dd3b.png)

In normal usage, it doesn't make any difference.
Thanks.
