### PR TITLE
Style name and open dialogs

### DIFF
--- a/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Defaults.xaml
+++ b/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Defaults.xaml
@@ -11,4 +11,6 @@
     </ResourceDictionary.MergedDictionaries>
     
     <Style TargetType="{x:Type controls:RangeSlider}" BasedOn="{StaticResource MaterialDesignRangeSlider}" />
+    <Style TargetType="{x:Type controls:NumericUpDown}" BasedOn="{StaticResource MaterialDesignNumericUpDown}" />
+    <Style TargetType="{x:Type controls:Flyout}" BasedOn="{StaticResource MaterialDesignFlyout}" />
 </ResourceDictionary>

--- a/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Flyout.xaml
+++ b/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Flyout.xaml
@@ -234,7 +234,7 @@
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
-    <Style TargetType="{x:Type mah:Flyout}">
+    <Style TargetType="{x:Type mah:Flyout}" x:Key="MaterialDesignFlyout">
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
         <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />

--- a/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.NumericUpDown.xaml
+++ b/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.NumericUpDown.xaml
@@ -5,7 +5,7 @@
 
     <mahShared:ThicknessBindingConverter x:Key="ThicknessBindingConverter" />
 
-    <Style TargetType="{x:Type mah:NumericUpDown}">
+    <Style x:Key="MaterialDesignNumericUpDown" TargetType="{x:Type mah:NumericUpDown}">
         <Setter Property="BorderThickness" Value="0,0,0,2" />
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource TextBoxFocusBorderBrush}" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource TextBoxMouseOverBorderBrush}" />

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -170,8 +170,6 @@ namespace MaterialDesignThemes.Wpf
         /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
         public static async Task<object> Show(object content, object dialogIdentifier, DialogOpenedEventHandler openedEventHandler, DialogClosingEventHandler closingEventHandler)
         {
-            if (content == null) throw new ArgumentNullException(nameof(content));
-
             if (LoadedInstances.Count == 0)
                 throw new InvalidOperationException("No loaded DialogHost instances.");
             LoadedInstances.First().Dispatcher.VerifyAccess();
@@ -191,7 +189,8 @@ namespace MaterialDesignThemes.Wpf
                 throw new InvalidOperationException("DialogHost is already open.");
 
             AssertTargetableContent();
-            DialogContent = content;
+            if (content != null)
+                DialogContent = content;
             _asyncShowOpenedEventHandler = openedEventHandler;
             _asyncShowClosingEventHandler = closingEventHandler;
             SetCurrentValue(IsOpenProperty, true);

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -112,7 +112,7 @@
                                         Height="17"
                                         Template="{StaticResource DropDownButtonTemplate}" />
                                 <Popup x:Name="PART_Popup" AllowsTransparency="True" 
-                                       Placement="Custom"
+                                       Placement="Custom" FlowDirection="LeftToRight"
                                        CustomPopupPlacementCallback="{x:Static wpf:CustomPopupPlacementCallbackHelper.LargePopupCallback}"
                                        PlacementTarget="{Binding ElementName=PART_TextBox}" StaysOpen="False"
                                        PopupAnimation="Fade"/>


### PR DESCRIPTION
Hi

I use this toolkit in my project and it is grate. when I was using this themes I feel that it would need some changes to be a better library. so I started to change something witch I thought they were good. this is the reasons that I changed them:
1- I wanted to create a style base on MaterialDesignTheme.MahApps.NumericUpDown but I couldn't use it so I felt if it had a key, It would be better.
2- I wanted to show a dialog host which has Identifier and DialogContext with DialogHost.Show function however there was not any way to use this function without content value. So I thought if we use  DialogHost.Show function with content value null, it should show the last DataContext.