### PR TITLE
Added SelectedTimeChanged event for TimePicker control

### DIFF
--- a/MainDemo.Wpf/Pickers.xaml
+++ b/MainDemo.Wpf/Pickers.xaml
@@ -63,7 +63,7 @@
                                            materialDesign:HintAssist.Hint="Custom hint" />
             </smtx:XamlDisplay>
             <smtx:XamlDisplay Key="pickers_7" Grid.Row="1" Grid.Column="2" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0 16 0 0">
-                <materialDesign:TimePicker Is24Hours="True" x:Name="PresetTimePicker" Width="100" />
+                <materialDesign:TimePicker Is24Hours="True" x:Name="PresetTimePicker" Width="100" SelectedTimeChanged="PresetTimePicker_SelectedTimeChanged"/>
             </smtx:XamlDisplay>
             <smtx:XamlDisplay Key="pickers_8" Grid.Row="1" Grid.Column="3" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0 16 0 0">
                 <materialDesign:TimePicker 

--- a/MainDemo.Wpf/Pickers.xaml.cs
+++ b/MainDemo.Wpf/Pickers.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using MaterialDesignThemes.Wpf;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Windows.Controls;
@@ -73,6 +74,14 @@ namespace MaterialDesignColors.WpfExample
         {
             if (Equals(eventArgs.Parameter, "1"))
                 ((PickersViewModel)DataContext).Time = Clock.Time;
+        }
+
+        private void PresetTimePicker_SelectedTimeChanged(object sender, System.Windows.RoutedPropertyChangedEventArgs<System.DateTime?> e)
+        {
+            var oldValue = e.OldValue.HasValue ? e.OldValue.Value.ToLongTimeString() : "NULL";
+            var newValue = e.NewValue.HasValue ? e.NewValue.Value.ToLongTimeString() : "NULL";
+
+            Debug.WriteLine($"PresentTimePicker's SelectedTime changed from {oldValue} to {newValue}");
         }
     }
 }

--- a/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -74,15 +74,40 @@ namespace MaterialDesignThemes.Wpf
 			timePicker.SetCurrentValue(TextProperty, timePicker.DateTimeToString(timePicker.SelectedTime));
             timePicker._isManuallyMutatingText = false;
             timePicker._lastValidTime = timePicker.SelectedTime;
+
+            OnSelectedTimeChanged(timePicker, dependencyPropertyChangedEventArgs);
         }
 
         public DateTime? SelectedTime
 		{
 			get { return (DateTime?) GetValue(SelectedTimeProperty); }
 			set { SetValue(SelectedTimeProperty, value); }
-		}
+        }
 
-		public static readonly DependencyProperty SelectedTimeFormatProperty = DependencyProperty.Register(
+        public static readonly RoutedEvent SelectedTimeChangedEvent =
+            EventManager.RegisterRoutedEvent(
+                nameof(SelectedTime),
+                RoutingStrategy.Bubble,
+                typeof(RoutedPropertyChangedEventHandler<DateTime?>),
+                typeof(TimePicker));
+
+        public event RoutedPropertyChangedEventHandler<DateTime?> SelectedTimeChanged
+        {
+            add => AddHandler(SelectedTimeChangedEvent, value);
+            remove => RemoveHandler(SelectedTimeChangedEvent, value);
+        }
+
+        private static void OnSelectedTimeChanged(
+            DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var instance = (TimePicker)d;
+            var args = new RoutedPropertyChangedEventArgs<DateTime?>(
+                    (DateTime?)e.OldValue,
+                    (DateTime?)e.NewValue) { RoutedEvent = SelectedTimeChangedEvent };
+            instance.RaiseEvent(args);
+        }
+
+        public static readonly DependencyProperty SelectedTimeFormatProperty = DependencyProperty.Register(
             nameof(SelectedTimeFormat), typeof (DatePickerFormat), typeof (TimePicker), new PropertyMetadata(DatePickerFormat.Short));
 
 		public DatePickerFormat SelectedTimeFormat


### PR DESCRIPTION
Fixes #1033 

- [x] Add `SelectedTimeChanged` routed event to the `TimePicker` control
- [x] Register for the event on one of the `TimePicker` control in the [demo app](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/master/MainDemo.Wpf/Pickers.xaml#L66). The event handler should just display using `Debug.WriteLine`