### PR TITLE
Fixes #945

### DIFF
--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -386,8 +386,6 @@ namespace MaterialDesignThemes.Wpf
 
         public override void OnApplyTemplate()
         {
-            if (_popup != null)
-                _popup.Loaded -= PopupOnLoaded;
             if (_toggleButton != null)
                 _toggleButton.PreviewMouseLeftButtonUp -= ToggleButtonOnPreviewMouseLeftButtonUp;
 
@@ -396,9 +394,7 @@ namespace MaterialDesignThemes.Wpf
             _popup = GetTemplateChild(PopupPartName) as PopupEx;
             _popupContentControl = GetTemplateChild(PopupContentControlPartName) as ContentControl;
             _toggleButton = GetTemplateChild(TogglePartName) as ToggleButton;
-
-            if (_popup != null)
-                _popup.Loaded += PopupOnLoaded;
+            
             if (_toggleButton != null)
                 _toggleButton.PreviewMouseLeftButtonUp += ToggleButtonOnPreviewMouseLeftButtonUp;
 
@@ -725,12 +721,6 @@ namespace MaterialDesignThemes.Wpf
         }
 
         #endregion
-
-        private void PopupOnLoaded(object sender, RoutedEventArgs routedEventArgs)
-        {
-            if (PopupMode == PopupBoxPopupMode.MouseOverEager)
-                _popup.IsOpen = true;
-        }
 
         private void ToggleButtonOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -101,8 +101,9 @@
                                       Cursor="Hand"
                                       VerticalAlignment="Center"
                                       />
-                        <controlzEx:PopupEx x:Name="PART_Popup" IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPopupOpen, Mode=TwoWay}"
-                                            CustomPopupPlacementCallback="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PopupPlacementMethod}"                                            
+                        <controlzEx:PopupEx x:Name="PART_Popup" 
+                                            IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPopupOpen, Mode=TwoWay}"
+                                            CustomPopupPlacementCallback="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PopupPlacementMethod}"
                                             HorizontalOffset="5"
                                             VerticalOffset="5"
                                             PlacementTarget="{Binding ElementName=PART_Toggle}"
@@ -114,7 +115,7 @@
                                       FontSize="15"
                                       FontWeight="Regular"
                                       Padding="{TemplateBinding Padding}"
-                                      RenderOptions.ClearTypeHint="Enabled"                                      
+                                      RenderOptions.ClearTypeHint="Enabled"
                                       Margin="5">
                                 <wpf:Card.Resources>
                                     <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignPopupBoxButton}" />
@@ -305,13 +306,14 @@
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid>
-                        <ToggleButton x:Name="PART_Toggle" Style="{StaticResource ToggleButtonStyle}" IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPopupOpen, Mode=TwoWay}"                                      
+                        <ToggleButton x:Name="PART_Toggle" Style="{StaticResource ToggleButtonStyle}" 
+                                      IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPopupOpen, Mode=TwoWay}"                                      
                                       Cursor="Hand"
                                       Background="{TemplateBinding Background}"
                                       BorderBrush="{TemplateBinding BorderBrush}"
                                       Foreground="{TemplateBinding Foreground}"
                                       VerticalAlignment="Stretch"
-                                      HorizontalAlignment="Stretch"                                      
+                                      HorizontalAlignment="Stretch"
                                       ToolTip="{TemplateBinding ToolTip}"
                                       ToolTipService.Placement="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:PopupBox}, Path=(ToolTipService.Placement)}">
                             <Grid>
@@ -332,14 +334,14 @@
                         </ToggleButton>
                         <controlzEx:PopupEx x:Name="PART_Popup" 
                                           IsOpen="False"
-                                          CustomPopupPlacementCallback="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PopupPlacementMethod}"                                                                                    
+                                          CustomPopupPlacementCallback="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PopupPlacementMethod}"
                                           PlacementTarget="{Binding ElementName=PART_Toggle}"
                                           Placement="Custom"
-                                          PopupAnimation="None"                                          
+                                          PopupAnimation="None"
                                           AllowsTransparency="True">
                             <Grid>
                                 <!-- with PopupBox.PopupMode == MouseOverEager the popup is always open, with 
-                                     content hidden. but Transparent doesnt seem to register hit test in the popup.
+                                     content hidden. but Transparent doesn't seem to register hit test in the popup.
                                      this opacity is the lowest I could get to register hit test. might try and speak
                                      to MS about this one, I *think* it is a bug -->
                                 <Border Background="White" Opacity="0.002" />
@@ -377,9 +379,13 @@
                                 <BeginStoryboard Storyboard="{StaticResource Close}" />
                             </Trigger.ExitActions>
                         </Trigger>
-                        <Trigger Property="PopupMode" Value="MouseOverEager">
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="PopupMode" Value="MouseOverEager" />
+                                <Condition Property="IsVisible" Value="True" />
+                            </MultiTrigger.Conditions>
                             <Setter TargetName="PART_Popup" Property="IsOpen" Value="True" />
-                        </Trigger>
+                        </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
The issue is the PopupOnLoaded method that was setting the IsOpen property directly on the Popup. This would lock the popup in an opened state when it was hidden by the tab control. When coming back to the popup box the popup would not properly trigger the IpOpen change from the trigger preventing it from showing up again, effectively killing all of the contents in the popup.

Fixes #945 