### PR TITLE
Fixes #1105

### DIFF
--- a/MaterialDesignThemes.nuspec
+++ b/MaterialDesignThemes.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright 2015 James Willock/Mulholland Software Ltd</copyright>
     <tags>WPF XAML WinRT Material Design Theme Colour Color UI UX</tags>
     <dependencies>
-      <dependency id="MaterialDesignColors" version="1.1.*" />
+      <dependency id="MaterialDesignColors" version="1.1.2" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Address a regression in the nuspec file that could allow transient nuget environment (such as the new PackageReference) to attempt to load 1.1.0 of the MaterialDesignColors lib which is incompatible.

Fixes #1105 