### PR TITLE
Added SnackbarMessageQueue.IgnoreDuplicate

### DIFF
--- a/MainDemo.Wpf/Snackbars.xaml
+++ b/MainDemo.Wpf/Snackbars.xaml
@@ -110,6 +110,7 @@
                     <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                         <TextBlock TextWrapping="WrapWithOverflow" Style="{DynamicResource MaterialDesignSubheadingTextBlock}">Example 4.</TextBlock>
                         <TextBlock TextWrapping="WrapWithOverflow">Illustrates queueing (including discarding of duplicates), and handling of commands. Action a notification to see a System.Trace response..</TextBlock>
+                        <CheckBox Name="DiscardDuplicateCheckBox" IsChecked="True">Discard duplicates</CheckBox>
                         <Grid Margin="0 16 0 0">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />

--- a/MainDemo.Wpf/Snackbars.xaml.cs
+++ b/MainDemo.Wpf/Snackbars.xaml.cs
@@ -28,6 +28,8 @@ namespace MaterialDesignDemo
 
         private void SnackBar4_OnClick(object sender, RoutedEventArgs e)
         {
+            SnackbarFour.MessageQueue.IgnoreDuplicate = !(DiscardDuplicateCheckBox.IsChecked ?? false);
+
             foreach (var s in ExampleFourTextBox.Text.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries))
             {
                 SnackbarFour.MessageQueue.Enqueue(
@@ -35,6 +37,7 @@ namespace MaterialDesignDemo
                 "TRACE",
                 param => Trace.WriteLine("Actioned: " + param),
                 s);
+
             }
         }
     }

--- a/MainDemo.Wpf/Snackbars.xaml.cs
+++ b/MainDemo.Wpf/Snackbars.xaml.cs
@@ -37,7 +37,6 @@ namespace MaterialDesignDemo
                 "TRACE",
                 param => Trace.WriteLine("Actioned: " + param),
                 s);
-
             }
         }
     }

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
@@ -185,6 +185,12 @@ namespace MaterialDesignThemes.Wpf
             };
         }
 
+        /// <summary>
+        /// Gets or sets a value that indicates whether this message queue displays messages without discarding duplicates. 
+        /// True to show every message even if there are duplicates.
+        /// </summary>
+        public bool IgnoreDuplicate { get; set; }
+
         public void Enqueue(object content)
         {
             Enqueue(content, false);
@@ -298,6 +304,7 @@ namespace MaterialDesignThemes.Wpf
                     var message = _snackbarMessages.First.Value;
                     _snackbarMessages.RemoveFirst();
                     if (_latestShownItem == null
+                        || IgnoreDuplicate
                         || message.IgnoreDuplicate
                         || !Equals(_latestShownItem.Item1.Content, message.Content)
                         || !Equals(_latestShownItem.Item1.ActionContent, message.ActionContent)


### PR DESCRIPTION
This adds an easier way to enable/disable duplicate messages in a SnackbarMessageQueue, resolving #1140 

I also changed the snackbar demo to show this feature.