### PR TITLE
Fixed DataGrid sorting arrow reversed issue

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -292,7 +292,7 @@
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="Direction">
                                 <VisualStateGroup.Transitions>
-                                    <VisualTransition From="None" GeneratedDuration="0" To="Ascending">
+                                    <VisualTransition From="None" GeneratedDuration="0" To="Descending">
                                         <VisualTransition.GeneratedEasingFunction>
                                             <CubicEase EasingMode="EaseOut"/>
                                         </VisualTransition.GeneratedEasingFunction>
@@ -301,7 +301,7 @@
                                             <DoubleAnimation Duration="0:0:0.2" To="90" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[2].(RotateTransform.Angle)" Storyboard.TargetName="path" BeginTime="0:0:0.2"/>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="None" GeneratedDuration="0" To="Descending">
+                                    <VisualTransition From="None" GeneratedDuration="0" To="Ascending">
                                         <VisualTransition.GeneratedEasingFunction>
                                             <CubicEase EasingMode="EaseOut"/>
                                         </VisualTransition.GeneratedEasingFunction>
@@ -314,7 +314,7 @@
                                             </DoubleAnimation>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="Ascending" GeneratedDuration="0" To="Descending">
+                                    <VisualTransition From="Descending" GeneratedDuration="0" To="Ascending">
                                         <VisualTransition.GeneratedEasingFunction>
                                             <CubicEase EasingMode="EaseOut"/>
                                         </VisualTransition.GeneratedEasingFunction>
@@ -327,7 +327,7 @@
                                             <DoubleAnimation Duration="0:0:0.2" To="-90" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[2].(RotateTransform.Angle)" Storyboard.TargetName="path" From="90"/>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="Ascending" GeneratedDuration="0" To="None">
+                                    <VisualTransition From="Descending" GeneratedDuration="0" To="None">
                                         <VisualTransition.GeneratedEasingFunction>
                                             <CubicEase EasingMode="EaseOut"/>
                                         </VisualTransition.GeneratedEasingFunction>
@@ -340,12 +340,12 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="Descending" GeneratedDuration="0" To="Ascending">
+                                    <VisualTransition From="Ascending" GeneratedDuration="0" To="Descending">
                                         <Storyboard>
                                             <DoubleAnimation Duration="0:0:0.2" To="90" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[2].(RotateTransform.Angle)" Storyboard.TargetName="path" From="-90"/>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="Descending" GeneratedDuration="0" To="None">
+                                    <VisualTransition From="Ascending" GeneratedDuration="0" To="None">
                                         <Storyboard>
                                             <DoubleAnimation Duration="0" To="-90" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[2].(RotateTransform.Angle)" Storyboard.TargetName="path"/>
                                             <DoubleAnimation Duration="0:0:0.2" To="0" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleY)" Storyboard.TargetName="path"/>
@@ -363,7 +363,7 @@
                                         </DoubleAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
-                                <VisualState x:Name="Ascending">
+                                <VisualState x:Name="Descending">
                                     <Storyboard>
                                         <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleY)" Storyboard.TargetName="path">
                                             <EasingDoubleKeyFrame KeyTime="0" Value="1"/>
@@ -373,7 +373,7 @@
                                         </DoubleAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
-                                <VisualState x:Name="Descending">
+                                <VisualState x:Name="Ascending">
                                     <Storyboard>
                                         <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[2].(RotateTransform.Angle)" Storyboard.TargetName="path">
                                             <EasingDoubleKeyFrame KeyTime="0" Value="-90"/>
@@ -479,7 +479,7 @@
             </Trigger>
         </Style.Triggers>
     </Style>
-    
+
     <SolidColorBrush x:Key="BlackBackground" Color="Black" />
 
     <Style TargetType="{x:Type local:DrawerHost}">


### PR DESCRIPTION
Fixes #1136

Reversed the DataGrid arrow as per the Material Design (https://material.io/design/components/data-tables.html#anatomy)