### PR TITLE
Fixes 1159

### DIFF
--- a/MaterialDesignThemes.Wpf/Transitions/TransitioningContentBase.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/TransitioningContentBase.cs
@@ -131,7 +131,7 @@ namespace MaterialDesignThemes.Wpf.Transitions
         {
             //https://github.com/ButchersBoy/MaterialDesignInXamlToolkit/issues/950
             //Only set the NameScope if the child does not already have a TemplateNameScope set
-            if (GetVisualChild(0) is FrameworkElement fe && NameScope.GetNameScope(fe) != null)
+            if (VisualChildrenCount > 0 && GetVisualChild(0) is FrameworkElement fe && NameScope.GetNameScope(fe) != null)
             {
                 return fe;
             }


### PR DESCRIPTION
Fixing exception that can occur if there are no visual children when trying to find the appropriate name scope.

Fixes #1159