### PR TITLE
changed DialogHost to use a TaskCompletionSource

### DIFF
--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -58,7 +58,9 @@ namespace MaterialDesignThemes.Wpf
 
         private static readonly HashSet<DialogHost> LoadedInstances = new HashSet<DialogHost>();
 
-        private readonly ManualResetEvent _asyncShowWaitHandle = new ManualResetEvent(false);
+        // waiting for the Dialog to end is now handled by a TaskCompletionSource in DialogSession
+        //private readonly ManualResetEvent _asyncShowWaitHandle = new ManualResetEvent(false);
+
         private DialogOpenedEventHandler _asyncShowOpenedEventHandler;
         private DialogClosingEventHandler _asyncShowClosingEventHandler;
 
@@ -196,13 +198,13 @@ namespace MaterialDesignThemes.Wpf
             _asyncShowClosingEventHandler = closingEventHandler;
             SetCurrentValue(IsOpenProperty, true);
 
-            var task = new Task(() =>
-            {
-                _asyncShowWaitHandle.WaitOne();
-            });
-            task.Start();
-
-            await task;
+            //var task = new Task(() =>
+            //{
+            //    _asyncShowWaitHandle.WaitOne();
+            //});
+            //task.Start();
+            
+            await _session.Task;
 
             _asyncShowOpenedEventHandler = null;
             _asyncShowClosingEventHandler = null;
@@ -251,7 +253,7 @@ namespace MaterialDesignThemes.Wpf
             }
             else
             {
-                dialogHost._asyncShowWaitHandle.Set();
+                //dialogHost._asyncShowWaitHandle.Set(); 
                 dialogHost._attachedDialogClosingEventHandler = null;
                 if (dialogHost._currentSnackbarMessageQueueUnPauseAction != null)
                 {
@@ -270,7 +272,7 @@ namespace MaterialDesignThemes.Wpf
                 return;
             }
 
-            dialogHost._asyncShowWaitHandle.Reset();
+            //dialogHost._asyncShowWaitHandle.Reset();
             dialogHost._session = new DialogSession(dialogHost);
             var window = Window.GetWindow(dialogHost);
             dialogHost._restoreFocusDialogClose = window != null ? FocusManager.GetFocusedElement(window) : null;

--- a/MaterialDesignThemes.Wpf/DialogSession.cs
+++ b/MaterialDesignThemes.Wpf/DialogSession.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using System.Windows.Threading;
 
 namespace MaterialDesignThemes.Wpf
@@ -8,7 +9,9 @@ namespace MaterialDesignThemes.Wpf
     /// </summary>
     public class DialogSession
     {
-        private readonly DialogHost _owner;    
+        private readonly DialogHost _owner;
+
+        private readonly TaskCompletionSource<object> _taskCompletionSource = new TaskCompletionSource<object>();
 
         internal DialogSession(DialogHost owner)
         {
@@ -24,6 +27,11 @@ namespace MaterialDesignThemes.Wpf
         /// Client code cannot set this directly, this is internally managed.  To end the dicalog session use <see cref="Close()"/>.
         /// </remarks>
         public bool IsEnded { get; internal set; }
+
+        /// <summary>
+        /// Allows to await the sessions's end.
+        /// </summary>
+        public Task<object> Task { get { return _taskCompletionSource.Task; } }
 
         /// <summary>
         /// Gets the <see cref="DialogHost.DialogContent"/> which is currently displayed, so this could be a view model or a UI element.
@@ -53,6 +61,7 @@ namespace MaterialDesignThemes.Wpf
             if (IsEnded) throw new InvalidOperationException("Dialog session has ended.");
 
             _owner.Close(null);
+            _taskCompletionSource.TrySetResult(null);
         }
 
         /// <summary>
@@ -65,6 +74,7 @@ namespace MaterialDesignThemes.Wpf
             if (IsEnded) throw new InvalidOperationException("Dialog session has ended.");
 
             _owner.Close(parameter);
+            _taskCompletionSource.TrySetResult(parameter);
         }
     }
 }


### PR DESCRIPTION
 Changed DialogHost to use a TaskCompletionSource to await the session end instead of a ManualResetEvent.

DialogHost.ShowInternal used a ManualResetEvent to literally wait for the dialog to close. This wasted a threadpool thread which did nothing but wait blockingly for the user to close the dialog. Using a TaskCompletionSource this can easily be done without blocking any threads. 