### PR TITLE
Add PopupPlacement to ValidationAssist to set the popup placement property

### DIFF
--- a/MainDemo.Wpf/Domain/TextFieldsViewModel.cs
+++ b/MainDemo.Wpf/Domain/TextFieldsViewModel.cs
@@ -8,6 +8,7 @@ namespace MaterialDesignColors.WpfExample.Domain
     public class TextFieldsViewModel : INotifyPropertyChanged
     {
         private string _name;
+        private string _name2;
         private int? _selectedValueOne;
         private string _selectedTextTwo;
 
@@ -25,6 +26,15 @@ namespace MaterialDesignColors.WpfExample.Domain
             set
             {
                 this.MutateVerbose(ref _name, value, RaisePropertyChanged());
+            }
+        }
+
+        public string Name2
+        {
+            get { return _name2; }
+            set
+            {
+                this.MutateVerbose(ref _name2, value, RaisePropertyChanged());
             }
         }
 

--- a/MainDemo.Wpf/TextFields.xaml
+++ b/MainDemo.Wpf/TextFields.xaml
@@ -307,20 +307,37 @@
         </smtx:XamlDisplay>
         <TextBlock Grid.Row="7" Grid.Column="4" Style="{StaticResource MaterialDesignSubheadingTextBlock}"
                    Margin="0 48 0 0">Tight Space Validation</TextBlock>
-        <smtx:XamlDisplay Key="fields_22" Grid.Row="8" Grid.Column="4" HorizontalAlignment="Left">
-            <TextBox Width="20"
+        <StackPanel Orientation="Horizontal" Grid.Row="8" Grid.Column="4">
+            <smtx:XamlDisplay Key="fields_22" HorizontalAlignment="Left">
+                <TextBox Width="20"
                      materialDesign:ValidationAssist.UsePopup="True"
                      HorizontalAlignment="Left"
                      ToolTip="Use a popup which can escape the bounds of the control where space is limited">
-                <TextBox.Text>
-                    <Binding Path="Name" UpdateSourceTrigger="PropertyChanged">
-                        <Binding.ValidationRules>
-                            <domain1:NotEmptyValidationRule ValidatesOnTargetUpdated="True" />
-                        </Binding.ValidationRules>
-                    </Binding>
-                </TextBox.Text>
-            </TextBox>
-        </smtx:XamlDisplay>
+                    <TextBox.Text>
+                        <Binding Path="Name" UpdateSourceTrigger="PropertyChanged">
+                            <Binding.ValidationRules>
+                                <domain1:NotEmptyValidationRule ValidatesOnTargetUpdated="True" />
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </TextBox.Text>
+                </TextBox>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay Key="fields_30" Grid.Row="8" Grid.Column="5" HorizontalAlignment="Left">
+                <TextBox Width="20"
+                     materialDesign:ValidationAssist.UsePopup="True"
+                     materialDesign:ValidationAssist.PopupPlacement="Left"
+                     HorizontalAlignment="Left"
+                     ToolTip="Use a popup which can escape the bounds of the control where space is limited it can be placed in alternative positions">
+                    <TextBox.Text>
+                        <Binding Path="Name2" UpdateSourceTrigger="PropertyChanged">
+                            <Binding.ValidationRules>
+                                <domain1:NotEmptyValidationRule ValidatesOnTargetUpdated="True" />
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </TextBox.Text>
+                </TextBox>
+            </smtx:XamlDisplay>
+        </StackPanel>
         <smtx:XamlDisplay Key="fields_23" Grid.Row="9" Grid.Column="4" Grid.RowSpan="2" HorizontalAlignment="Left">
             <StackPanel>
                 <CheckBox x:Name="DisplaySelectedItemCheckBox"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
@@ -33,7 +33,7 @@
             </Border>
             <controlzEx:PopupEx x:Name="ValidationPopup"
                                 IsOpen="False"
-                                Placement="Bottom"
+                                Placement="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.PopupPlacement)}"
                                 PlacementTarget="{Binding ElementName=Placeholder, Mode=OneWay}"
                                 AllowsTransparency="True">
                 <Border x:Name="PopupBorder" Background="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.Background)}">

--- a/MaterialDesignThemes.Wpf/ValidationAssist.cs
+++ b/MaterialDesignThemes.Wpf/ValidationAssist.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 
 namespace MaterialDesignThemes.Wpf
@@ -50,6 +51,25 @@ namespace MaterialDesignThemes.Wpf
         }
 
         #endregion
+
+        /// <summary>
+        /// The hint property
+        /// </summary>
+        public static readonly DependencyProperty PopupPlacementProperty = DependencyProperty.RegisterAttached(
+            "PopupPlacement",
+            typeof(PlacementMode),
+            typeof(ValidationAssist),
+            new FrameworkPropertyMetadata(PlacementMode.Bottom, FrameworkPropertyMetadataOptions.Inherits));
+
+        public static PlacementMode GetPopupPlacement(DependencyObject element)
+        {
+            return (PlacementMode)element.GetValue(UsePopupProperty);
+        }
+
+        public static void SetPopupPlacement(DependencyObject element, PlacementMode value)
+        {
+            element.SetValue(UsePopupProperty, value);
+        }
 
         /// <summary>
         /// Framework use only.


### PR DESCRIPTION
Useful in certain circumstances. e.g. a list of tight validation fields and you want the validation to appear to the right of each row