### PR TITLE
Add RoutedCommand to PopupBox - Issue:#1191

### DIFF
--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -155,8 +155,8 @@
                                 </ComboBox>
 
                                 <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right">
-                                    <Button Content="_Save" />
-                                    <Button Content="_Cancel">
+                                    <Button Content="_Save" Command="{x:Static materialDesign:PopupBox.ClosePopupCommand}" />
+                                    <Button Content="_Cancel" Command="{x:Static materialDesign:PopupBox.ClosePopupCommand}">
                                         <Button.Style>
                                             <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignPopupBoxButton}">
                                                 <Setter Property="Foreground" Value="Red" />

--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -105,7 +105,7 @@ namespace MaterialDesignThemes.Wpf
         public const string PopupIsClosedStateName = "IsClosed";
 
         /// <summary>
-        /// Routed command to be used inside dialog content to close a dialog. Use a <see cref="Button.CommandParameter"/> to indicate the result of the parameter.
+        /// Routed command to be used inside of a popup content to close it.
         /// </summary>
         public static RoutedCommand ClosePopupCommand = new RoutedCommand();
 
@@ -401,7 +401,7 @@ namespace MaterialDesignThemes.Wpf
             _popupContentControl = GetTemplateChild(PopupContentControlPartName) as ContentControl;
             _toggleButton = GetTemplateChild(TogglePartName) as ToggleButton;
 
-            _popup.CommandBindings.Add(new CommandBinding(ClosePopupCommand, ClosePopupHandler));
+            _popup?.CommandBindings.Add(new CommandBinding(ClosePopupCommand, ClosePopupHandler));
 
             if (_toggleButton != null)
                 _toggleButton.PreviewMouseLeftButtonUp += ToggleButtonOnPreviewMouseLeftButtonUp;

--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -103,6 +103,12 @@ namespace MaterialDesignThemes.Wpf
         public const string PopupContentControlPartName = "PART_PopupContentControl";
         public const string PopupIsOpenStateName = "IsOpen";
         public const string PopupIsClosedStateName = "IsClosed";
+
+        /// <summary>
+        /// Routed command to be used inside dialog content to close a dialog. Use a <see cref="Button.CommandParameter"/> to indicate the result of the parameter.
+        /// </summary>
+        public static RoutedCommand ClosePopupCommand = new RoutedCommand();
+
         private PopupEx _popup;
         private ContentControl _popupContentControl;
         private ToggleButton _toggleButton;
@@ -394,7 +400,9 @@ namespace MaterialDesignThemes.Wpf
             _popup = GetTemplateChild(PopupPartName) as PopupEx;
             _popupContentControl = GetTemplateChild(PopupContentControlPartName) as ContentControl;
             _toggleButton = GetTemplateChild(TogglePartName) as ToggleButton;
-            
+
+            CommandBindings.Add(new CommandBinding(ClosePopupCommand, ClosePopupHandler));
+
             if (_toggleButton != null)
                 _toggleButton.PreviewMouseLeftButtonUp += ToggleButtonOnPreviewMouseLeftButtonUp;
 
@@ -438,6 +446,11 @@ namespace MaterialDesignThemes.Wpf
                 SetCurrentValue(IsPopupOpenProperty, true);
             }
             base.OnMouseEnter(e);
+        }
+
+        private void ClosePopupHandler(object sender, ExecutedRoutedEventArgs executedRoutedEventArgs)
+        {
+            IsPopupOpen = false;
         }
 
         private void OnLayoutUpdated(object sender, EventArgs eventArgs)

--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -401,7 +401,7 @@ namespace MaterialDesignThemes.Wpf
             _popupContentControl = GetTemplateChild(PopupContentControlPartName) as ContentControl;
             _toggleButton = GetTemplateChild(TogglePartName) as ToggleButton;
 
-            CommandBindings.Add(new CommandBinding(ClosePopupCommand, ClosePopupHandler));
+            _popup.CommandBindings.Add(new CommandBinding(ClosePopupCommand, ClosePopupHandler));
 
             if (_toggleButton != null)
                 _toggleButton.PreviewMouseLeftButtonUp += ToggleButtonOnPreviewMouseLeftButtonUp;


### PR DESCRIPTION
I think I have followed the requests, but I am happy to learn from my mistakes. I am not sure about point 2, as in the Dialog it does add to the CommandBindings directly and here it says to add it to the member _popup. 

1.  Create a new routed command on PopupBox named `ClosePopupCommand`. 
2.  In `PopupBox.OnApplyTemplate()` add a CommandBinding to `_popup` to handle the routed command.
3. When the command is executing simply set `IsPopupOpen` to be `false`
4. Add the new command to the existing ["Save" and "Cancel" buttons on the demo app]