### PR TITLE
TimePicker formatting and parsing

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
+++ b/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="PaletteHelperFixture.cs" />
     <Compile Include="PopupBoxTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TimePickerUnitTests.cs" />
     <Compile Include="VisualTreeHelper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/MaterialDesignThemes.Wpf.Tests/TimePickerUnitTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/TimePickerUnitTests.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Markup;
+using Xunit;
+
+namespace MaterialDesignThemes.Wpf.Tests
+{
+    public class TimePickerUnitTests
+    {
+        private readonly TimePicker _timePicker;
+
+        public TimePickerUnitTests()
+        {
+            _timePicker = new TimePicker();
+            _timePicker.ApplyDefaultStyle();
+        }
+
+        [StaTheory]
+        [MemberData(nameof(GetDisplaysExpectedTextData))]
+        public void DisplaysExpectedText(CultureInfo culture, DatePickerFormat format, bool is24Hour, bool withSeconds,
+            DateTime? selectedTime, string expectedText)
+        {
+            _timePicker.Language = XmlLanguage.GetLanguage(culture.IetfLanguageTag);
+            _timePicker.SelectedTimeFormat = format;
+            _timePicker.Is24Hours = is24Hour;
+            _timePicker.WithSeconds = withSeconds;
+            _timePicker.SelectedTime = selectedTime;
+
+
+            string currentTestString = $"{culture.ThreeLetterISOLanguageName} {(is24Hour ? "24 Hour" : "12 Hour")} {format} format {(withSeconds ? "with seconds" : "")}";
+            Assert.True(expectedText == _timePicker.Text, $"Expected '{expectedText}' but was '{_timePicker.Text}' - {currentTestString}");
+        }
+
+        [StaTheory]
+        [MemberData(nameof(GetParseLocalizedTimeStringData))]
+        public void CanParseLocalizedTimeString(CultureInfo culture, DatePickerFormat format, bool is24Hour, bool withSeconds,
+            string timeString, DateTime? expectedTime)
+        {
+            _timePicker.Language = XmlLanguage.GetLanguage(culture.IetfLanguageTag);
+            _timePicker.SelectedTimeFormat = format;
+            _timePicker.Is24Hours = is24Hour;
+            _timePicker.WithSeconds = withSeconds;
+
+            var textBox = _timePicker.FindVisualChild<TextBox>(TimePicker.TextBoxPartName);
+            textBox.Text = timeString;
+            textBox.RaiseEvent(new RoutedEventArgs(UIElement.LostFocusEvent));
+
+            string currentTestString = $"{culture.ThreeLetterISOLanguageName} {(is24Hour ? "24 Hour" : "12 Hour")} {format} format {(withSeconds ? "with seconds" : "")}";
+            Assert.True(expectedTime == _timePicker.SelectedTime, $"Expected '{expectedTime}' but was '{_timePicker.SelectedTime}' - {currentTestString}");
+        }
+
+        public static IEnumerable<object[]> GetParseLocalizedTimeStringData()
+        {
+            //for now just using the same set of data to make sure we can go both directions.
+            foreach (object[] data in GetDisplaysExpectedTextData())
+            {
+                var culture = (CultureInfo) data[0];
+                bool is24Hour = (bool) data[2];
+                var withSeconds = (bool) data[3];
+                var date = (DateTime) data[4];
+                var timeString = (string) data[5];
+
+                //Convert the date to Today
+                date = DateTime.Today.AddHours(date.Hour).AddMinutes(date.Minute).AddSeconds(withSeconds ? date.Second : 0);
+
+                if (!is24Hour && date.Hour > 12 &&
+                    (string.IsNullOrEmpty(culture.DateTimeFormat.AMDesignator) ||
+                    string.IsNullOrEmpty(culture.DateTimeFormat.PMDesignator)))
+                {
+                    //Because there is no AM/PM designator, 12 hour times will be treated as AM
+                    date = date.AddHours(-12);
+                }
+
+                //Invert the order of the parameters.
+                data[5] = date;
+                data[4] = timeString;
+
+
+                yield return data;
+            }
+        }
+
+        public static IEnumerable<object[]> GetDisplaysExpectedTextData()
+        {
+            //AM intentionally picks values with only a single digit to verify the DatePickerFormat is applied
+            var am = new DateTime(2000, 1, 1, 3, 5, 9);
+            //PM intentionally picks two digit values greater than 12 to ensure the 24 hour format is applied
+            var pm = new DateTime(2000, 1, 1, 16, 30, 25);
+
+            //Invariant culture
+            foreach (var data in GetDisplaysExpectedTextDataForCulture(CultureInfo.InvariantCulture, am,
+                "3:05 AM", "3:05:09 AM", //12 hour short
+                "03:05 AM", "03:05:09 AM", //12 hour long
+                "3:05", "3:05:09", //24 hour short
+                "03:05", "03:05:09")) //24 hour long
+            {
+                yield return data;
+            }
+            foreach (var data in GetDisplaysExpectedTextDataForCulture(CultureInfo.InvariantCulture, pm,
+                "4:30 PM", "4:30:25 PM", //12 hour short
+                "04:30 PM", "04:30:25 PM", //12 hour long
+                "16:30", "16:30:25", //24 hour short
+                "16:30", "16:30:25")) //24 hour long
+            {
+                yield return data;
+            }
+
+            //US English
+            var usEnglish = CultureInfo.GetCultureInfo("en-US");
+            foreach (var data in GetDisplaysExpectedTextDataForCulture(usEnglish, am,
+                "3:05 AM", "3:05:09 AM", //12 hour short
+                "03:05 AM", "03:05:09 AM", //12 hour long
+                "3:05", "3:05:09", //24 hour short
+                "03:05", "03:05:09")) //24 hour long
+            {
+                yield return data;
+            }
+            foreach (var data in GetDisplaysExpectedTextDataForCulture(usEnglish, pm,
+                "4:30 PM", "4:30:25 PM", //12 hour short
+                "04:30 PM", "04:30:25 PM", //12 hour long
+                "16:30", "16:30:25", //24 hour short
+                "16:30", "16:30:25")) //24 hour long
+            {
+                yield return data;
+            }
+
+            //Spain Spanish
+            var spainSpanish = CultureInfo.GetCultureInfo("es-ES");
+            foreach (var data in GetDisplaysExpectedTextDataForCulture(spainSpanish, am,
+                "3:05", "3:05:09", //12 hour short
+                "03:05", "03:05:09", //12 hour long
+                "3:05", "3:05:09", //24 hour short
+                "03:05", "03:05:09")) //24 hour long
+            {
+                yield return data;
+            }
+            foreach (var data in GetDisplaysExpectedTextDataForCulture(spainSpanish, pm,
+                "4:30", "4:30:25", //12 hour short
+                "04:30", "04:30:25", //12 hour long
+                "16:30", "16:30:25", //24 hour short
+                "16:30", "16:30:25")) //24 hour long
+            {
+                yield return data;
+            }
+
+            //Iran Farsi fa-IR
+            var iranFarsi = CultureInfo.GetCultureInfo("fa-IR");
+            foreach (var data in GetDisplaysExpectedTextDataForCulture(iranFarsi, am,
+                "3:05 ق.ظ", "3:05:09 ق.ظ", //12 hour short
+                "03:05 ق.ظ", "03:05:09 ق.ظ", //12 hour long
+                "3:05", "3:05:09", //24 hour short
+                "03:05", "03:05:09")) //24 hour long
+            {
+                yield return data;
+            }
+            foreach (var data in GetDisplaysExpectedTextDataForCulture(iranFarsi, pm,
+                "4:30 ب.ظ", "4:30:25 ب.ظ", //12 hour short
+                "04:30 ب.ظ", "04:30:25 ب.ظ", //12 hour long
+                "16:30", "16:30:25", //24 hour short
+                "16:30", "16:30:25")) //24 hour long
+            {
+                yield return data;
+            }
+        }
+
+        private static IEnumerable<object[]> GetDisplaysExpectedTextDataForCulture(CultureInfo culture,
+            DateTime dateTime,
+            string short12Hour, string short12HourWithSeconds,
+            string long12Hour, string long12HourWithSeconds,
+            string short24Hour, string short24HourWithSeconds,
+            string long24Hour, string long24HourWithSeconds)
+        {
+            yield return new object[]
+            {
+                culture,
+                DatePickerFormat.Short,
+                false,
+                false,
+                dateTime,
+                short12Hour
+            };
+            yield return new object[]
+            {
+                culture,
+                DatePickerFormat.Short,
+                false,
+                true,
+                dateTime,
+                short12HourWithSeconds
+            };
+            yield return new object[]
+            {
+                culture,
+                DatePickerFormat.Long,
+                false,
+                false,
+                dateTime,
+                long12Hour
+            };
+            yield return new object[]
+            {
+                culture,
+                DatePickerFormat.Long,
+                false,
+                true,
+                dateTime,
+                long12HourWithSeconds
+            };
+            yield return new object[]
+            {
+                culture,
+                DatePickerFormat.Short,
+                true,
+                false,
+                dateTime,
+                short24Hour
+            };
+            yield return new object[]
+            {
+                culture,
+                DatePickerFormat.Short,
+                true,
+                true,
+                dateTime,
+                short24HourWithSeconds
+            };
+            yield return new object[]
+            {
+                culture,
+                DatePickerFormat.Long,
+                true,
+                false,
+                dateTime,
+                long24Hour
+            };
+            yield return new object[]
+            {
+                culture,
+                DatePickerFormat.Long,
+                true,
+                true,
+                dateTime,
+                long24HourWithSeconds
+            };
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf.Tests/VisualTreeHelper.cs
+++ b/MaterialDesignThemes.Wpf.Tests/VisualTreeHelper.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Windows;
 
 using WPFVisualTreeHelper= System.Windows.Media.VisualTreeHelper;

--- a/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -10,14 +11,14 @@ using MaterialDesignThemes.Wpf.Converters;
 
 namespace MaterialDesignThemes.Wpf
 {
-    [TemplatePart(Name = ElementButton, Type = typeof(Button))]
-    [TemplatePart(Name = ElementPopup, Type = typeof(Popup))]
-    [TemplatePart(Name = ElementTextBox, Type = typeof(DatePickerTextBox))]
+    [TemplatePart(Name = ButtonPartName, Type = typeof(Button))]
+    [TemplatePart(Name = PopupPartName, Type = typeof(Popup))]
+    [TemplatePart(Name = TextBoxPartName, Type = typeof(TextBox))]
     public class TimePicker : Control
     {
-        private const string ElementButton = "PART_Button";
-        private const string ElementPopup = "PART_Popup";
-        private const string ElementTextBox = "PART_TextBox";
+        public const string ButtonPartName = "PART_Button";
+        public const string PopupPartName = "PART_Popup";
+        public const string TextBoxPartName = "PART_TextBox";
 
         private readonly ContentControl _clockHostContentControl;
         private readonly Clock _clock;
@@ -35,41 +36,39 @@ namespace MaterialDesignThemes.Wpf
 
         public TimePicker()
         {
-            _clock = new Clock
-            {
+            _clock = new Clock {
                 DisplayAutomation = ClockDisplayAutomation.ToMinutesOnly
             };
-            _clockHostContentControl = new ContentControl
-            {
+            _clockHostContentControl = new ContentControl {
                 Content = _clock
             };
             InitializeClock();
         }
 
         public static readonly DependencyProperty TextProperty = DependencyProperty.Register(
-            nameof(Text), typeof (string), typeof (TimePicker), new FrameworkPropertyMetadata(default(string), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, TextPropertyChangedCallback));
+            nameof(Text), typeof(string), typeof(TimePicker), new FrameworkPropertyMetadata(default(string), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, TextPropertyChangedCallback));
 
         private static void TextPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
-            var timePicker = (TimePicker) dependencyObject;
+            var timePicker = (TimePicker)dependencyObject;
             if (!timePicker._isManuallyMutatingText)
                 timePicker.SetSelectedTime();
             if (timePicker._textBox != null)
-                timePicker._textBox.Text = dependencyPropertyChangedEventArgs.NewValue as string;
+                timePicker._textBox.Text = dependencyPropertyChangedEventArgs.NewValue as string ?? "";
         }
 
         public string Text
         {
-            get { return (string) GetValue(TextProperty); }
-            set { SetValue(TextProperty, value); }
+            get => (string)GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
         }
 
         public static readonly DependencyProperty SelectedTimeProperty = DependencyProperty.Register(
-            nameof(SelectedTime), typeof (DateTime?), typeof (TimePicker), new FrameworkPropertyMetadata(default(DateTime?), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, SelectedTimePropertyChangedCallback));
+            nameof(SelectedTime), typeof(DateTime?), typeof(TimePicker), new FrameworkPropertyMetadata(default(DateTime?), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, SelectedTimePropertyChangedCallback));
 
         private static void SelectedTimePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
-            var timePicker = (TimePicker) dependencyObject;
+            var timePicker = (TimePicker)dependencyObject;
             timePicker._isManuallyMutatingText = true;
             timePicker.SetCurrentValue(TextProperty, timePicker.DateTimeToString(timePicker.SelectedTime));
             timePicker._isManuallyMutatingText = false;
@@ -79,9 +78,9 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public DateTime? SelectedTime
-		{
-			get { return (DateTime?) GetValue(SelectedTimeProperty); }
-			set { SetValue(SelectedTimeProperty, value); }
+        {
+            get => (DateTime?)GetValue(SelectedTimeProperty);
+            set => SetValue(SelectedTimeProperty, value);
         }
 
         public static readonly RoutedEvent SelectedTimeChangedEvent =
@@ -108,26 +107,26 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty SelectedTimeFormatProperty = DependencyProperty.Register(
-            nameof(SelectedTimeFormat), typeof (DatePickerFormat), typeof (TimePicker), new PropertyMetadata(DatePickerFormat.Short));
+            nameof(SelectedTimeFormat), typeof(DatePickerFormat), typeof(TimePicker), new PropertyMetadata(DatePickerFormat.Short));
 
         public DatePickerFormat SelectedTimeFormat
         {
-            get { return (DatePickerFormat) GetValue(SelectedTimeFormatProperty); }
-            set { SetValue(SelectedTimeFormatProperty, value); }
+            get => (DatePickerFormat)GetValue(SelectedTimeFormatProperty);
+            set => SetValue(SelectedTimeFormatProperty, value);
         }
 
         public static readonly DependencyProperty IsDropDownOpenProperty = DependencyProperty.Register(
-            nameof(IsDropDownOpen), typeof (bool), typeof (TimePicker),
+            nameof(IsDropDownOpen), typeof(bool), typeof(TimePicker),
             new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnIsDropDownOpenChanged, OnCoerceIsDropDownOpen));
 
         public bool IsDropDownOpen
         {
-            get { return (bool) GetValue(IsDropDownOpenProperty); }
-            set { SetValue(IsDropDownOpenProperty, value); }
+            get => (bool)GetValue(IsDropDownOpenProperty);
+            set => SetValue(IsDropDownOpenProperty, value);
         }
 
         public static readonly DependencyProperty Is24HoursProperty = DependencyProperty.Register(
-            nameof(Is24Hours), typeof (bool), typeof (TimePicker), new PropertyMetadata(default(bool), Is24HoursChanged));
+            nameof(Is24Hours), typeof(bool), typeof(TimePicker), new PropertyMetadata(default(bool), Is24HoursChanged));
 
         private static void Is24HoursChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
@@ -139,14 +138,14 @@ namespace MaterialDesignThemes.Wpf
 
         public bool Is24Hours
         {
-            get { return (bool) GetValue(Is24HoursProperty); }
-            set { SetValue(Is24HoursProperty, value); }
+            get => (bool)GetValue(Is24HoursProperty);
+            set => SetValue(Is24HoursProperty, value);
         }
 
         private static object OnCoerceIsDropDownOpen(DependencyObject d, object baseValue)
         {
             var timePicker = (TimePicker)d;
-        
+
             if (!timePicker.IsEnabled)
             {
                 return false;
@@ -164,7 +163,7 @@ namespace MaterialDesignThemes.Wpf
         {
             var timePicker = (TimePicker)d;
 
-            var newValue = (bool) e.NewValue;
+            var newValue = (bool)e.NewValue;
             if (timePicker._popup == null || timePicker._popup.IsOpen == newValue) return;
 
             timePicker._popup.IsOpen = newValue;
@@ -173,33 +172,33 @@ namespace MaterialDesignThemes.Wpf
                 //TODO set time
                 //dp._originalSelectedDate = dp.SelectedDate;
 
-                timePicker.Dispatcher.BeginInvoke(DispatcherPriority.Input, (Action) delegate()
+                timePicker.Dispatcher.BeginInvoke(DispatcherPriority.Input, new Action(() =>
                 {
                     timePicker._clock.Focus();
-                });
+                }));
             }
         }
 
         public static readonly DependencyProperty ClockStyleProperty = DependencyProperty.Register(
-            nameof(ClockStyle), typeof (Style), typeof (TimePicker), new PropertyMetadata(default(Style)));
+            nameof(ClockStyle), typeof(Style), typeof(TimePicker), new PropertyMetadata(default(Style)));
 
         public Style ClockStyle
         {
-            get { return (Style) GetValue(ClockStyleProperty); }
-            set { SetValue(ClockStyleProperty, value); }
+            get => (Style)GetValue(ClockStyleProperty);
+            set => SetValue(ClockStyleProperty, value);
         }
 
         public static readonly DependencyProperty ClockHostContentControlStyleProperty = DependencyProperty.Register(
-            nameof(ClockHostContentControlStyle), typeof (Style), typeof (TimePicker), new PropertyMetadata(default(Style)));
+            nameof(ClockHostContentControlStyle), typeof(Style), typeof(TimePicker), new PropertyMetadata(default(Style)));
 
         public Style ClockHostContentControlStyle
         {
-            get { return (Style) GetValue(ClockHostContentControlStyleProperty); }
-            set { SetValue(ClockHostContentControlStyleProperty, value); }
+            get => (Style)GetValue(ClockHostContentControlStyleProperty);
+            set => SetValue(ClockHostContentControlStyleProperty, value);
         }
 
         public static readonly DependencyProperty IsInvalidTextAllowedProperty = DependencyProperty.Register(
-            "IsInvalidTextAllowed", typeof (bool), typeof (TimePicker), new PropertyMetadata(default(bool)));
+            "IsInvalidTextAllowed", typeof(bool), typeof(TimePicker), new PropertyMetadata(default(bool)));
 
         /// <summary>
         /// Set to true to stop invalid text reverting back to previous valid value. Useful in cases where you
@@ -207,12 +206,12 @@ namespace MaterialDesignThemes.Wpf
         /// </summary>
         public bool IsInvalidTextAllowed
         {
-            get { return (bool) GetValue(IsInvalidTextAllowedProperty); }
-            set { SetValue(IsInvalidTextAllowedProperty, value); }
+            get => (bool)GetValue(IsInvalidTextAllowedProperty);
+            set => SetValue(IsInvalidTextAllowedProperty, value);
         }
 
         public static readonly DependencyProperty WithSecondsProperty = DependencyProperty.Register(
-            nameof(WithSeconds), typeof (bool), typeof (TimePicker),
+            nameof(WithSeconds), typeof(bool), typeof(TimePicker),
             new PropertyMetadata(default(bool), WithSecondsPropertyChanged));
 
         /// <summary>
@@ -220,8 +219,8 @@ namespace MaterialDesignThemes.Wpf
         /// </summary>
         public bool WithSeconds
         {
-            get { return (bool) GetValue(WithSecondsProperty); }
-            set { SetValue(WithSecondsProperty, value); }
+            get => (bool)GetValue(WithSecondsProperty);
+            set => SetValue(WithSecondsProperty, value);
         }
 
         private static void WithSecondsPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
@@ -253,7 +252,7 @@ namespace MaterialDesignThemes.Wpf
                 _textBox.AddHandler(LostFocusEvent, new RoutedEventHandler(TextBoxOnLostFocus));
             }
 
-            _textBox = GetTemplateChild(ElementTextBox) as TextBox;
+            _textBox = GetTemplateChild(TextBoxPartName) as TextBox;
             if (_textBox != null)
             {
                 _textBox.AddHandler(KeyDownEvent, new KeyEventHandler(TextBoxOnKeyDown));
@@ -262,20 +261,20 @@ namespace MaterialDesignThemes.Wpf
                 _textBox.Text = Text;
             }
 
-            _popup = GetTemplateChild(ElementPopup) as Popup;
+            _popup = GetTemplateChild(PopupPartName) as Popup;
             if (_popup != null)
             {
                 _popup.AddHandler(PreviewMouseLeftButtonDownEvent, new MouseButtonEventHandler(PopupOnPreviewMouseLeftButtonDown));
                 _popup.Opened += PopupOnOpened;
                 _popup.Closed += PopupOnClosed;
-                _popup.Child = _clockHostContentControl; 
+                _popup.Child = _clockHostContentControl;
                 if (IsDropDownOpen)
                 {
                     _popup.IsOpen = true;
                 }
             }
 
-            _dropDownButton = GetTemplateChild(ElementButton) as Button;
+            _dropDownButton = GetTemplateChild(ButtonPartName) as Button;
             if (_dropDownButton != null)
             {
                 _dropDownButton.Click += DropDownButtonOnClick;
@@ -381,16 +380,18 @@ namespace MaterialDesignThemes.Wpf
             }
         }
 
-        private static void ParseTime(string s, Action<DateTime> successContinuation)
+        private void ParseTime(string s, Action<DateTime> successContinuation)
         {
             if (IsTimeValid(s, out DateTime time))
                 successContinuation(time);
         }
 
-        private static bool IsTimeValid(string s, out DateTime time)
+        private bool IsTimeValid(string s, out DateTime time)
         {
+            CultureInfo culture = Language.GetSpecificCulture();
+
             return DateTime.TryParse(s,
-                                     CultureInfo.CurrentCulture,
+                                     culture,
                                      DateTimeStyles.AssumeLocal | DateTimeStyles.AllowWhiteSpaces,
                                      out time);
         }
@@ -407,44 +408,32 @@ namespace MaterialDesignThemes.Wpf
 
         private string DateTimeToString(DateTime datetime, DatePickerFormat format)
         {
-            string res = null;
+            CultureInfo culture = Language.GetSpecificCulture();
+            DateTimeFormatInfo dtfi = culture.GetDateFormat();
 
-            var dtfi = GetCultureInfo().GetDateFormat();
+            string hourFormatChar = Is24Hours ? "H" : "h";
 
-            switch (format)
+            var sb = new StringBuilder();
+            sb.Append(hourFormatChar);
+            if (format == DatePickerFormat.Long)
             {
-                case DatePickerFormat.Short:
-                    if (WithSeconds)
-                        if (Is24Hours)
-                            res = datetime.ToString("H:mm:ss");
-                        else
-                            res = datetime.ToString("h:mm:ss tt");
-                    else if (Is24Hours)
-                        res = datetime.ToString("H:mm");
-                    else
-                        res = string.Format(CultureInfo.CurrentCulture, datetime.ToString(dtfi.ShortTimePattern, dtfi));
-                    break;
-                case DatePickerFormat.Long:
-                    if (Is24Hours)
-                        if (WithSeconds)
-                            res = datetime.ToString("HH:mm:ss");
-                        else
-                            res = datetime.ToString("HH:mm");
-                    else
-                        res = string.Format(CultureInfo.CurrentCulture, datetime.ToString(dtfi.LongTimePattern, dtfi));
-                    break;
+                sb.Append(hourFormatChar);
             }
 
-            return res;
-        }
+            sb.Append(dtfi.TimeSeparator);
+            sb.Append("mm");
+            if (WithSeconds)
+            {
+                sb.Append(dtfi.TimeSeparator);
+                sb.Append("ss");
+            }
 
-        private CultureInfo GetCultureInfo()
-        {
-            CultureInfo ci;
-            ci = Language.GetSpecificCulture();
-            if (ci != null)
-                return ci;
-            return Language.GetEquivalentCulture();
+            if (!Is24Hours && (!string.IsNullOrEmpty(dtfi.AMDesignator) || !string.IsNullOrEmpty(dtfi.PMDesignator)))
+            {
+                sb.Append(" tt");
+            }
+
+            return datetime.ToString(sb.ToString(), culture);
         }
 
         private void PopupOnPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs mouseButtonEventArgs)
@@ -507,7 +496,7 @@ namespace MaterialDesignThemes.Wpf
         private void ClockChoiceMadeHandler(object sender, ClockChoiceMadeEventArgs clockChoiceMadeEventArgs)
         {
             if (
-                ( WithSeconds && (clockChoiceMadeEventArgs.Mode == ClockDisplayMode.Seconds)) ||
+                (WithSeconds && (clockChoiceMadeEventArgs.Mode == ClockDisplayMode.Seconds)) ||
                 (!WithSeconds && (clockChoiceMadeEventArgs.Mode == ClockDisplayMode.Minutes))
             )
             {
@@ -542,8 +531,7 @@ namespace MaterialDesignThemes.Wpf
 
         private BindingBase GetBinding(DependencyProperty property, IValueConverter converter = null)
         {
-            var binding = new Binding(property.Name)
-            {
+            var binding = new Binding(property.Name) {
                 Source = this,
                 Converter = converter
             };

--- a/MaterialDesignToolkit.Wpf.sln.DotSettings
+++ b/MaterialDesignToolkit.Wpf.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Controlz/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Templated/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Templated/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Transitioner/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -9,7 +9,7 @@ nuget RhinoMocks 3.6.1
 nuget Shouldly ~> 2.8
 nuget xunit ~> 2.2
 nuget xunit.runner.visualstudio ~> 2.4
-nuget Xunit.StaFact ~> 0.3.13
+nuget Xunit.StaFact ~> 0.3.18
 nuget ShowMeTheXAML ~> 1.0.12
 nuget ShowMeTheXAML.AvalonEdit ~> 1.0.12
 nuget ShowMeTheXAML.MSBuild ~> 1.0.12

--- a/paket.lock
+++ b/paket.lock
@@ -47,7 +47,7 @@ NUGET
       NETStandard.Library (>= 1.6.1) - restriction: == net45
       xunit.extensibility.core (2.4)
     xunit.runner.visualstudio (2.4)
-    Xunit.StaFact (0.3.13)
+    Xunit.StaFact (0.3.18)
       xunit.extensibility.execution (>= 2.1) - restriction: == net45
       xunit.extensibility.execution (>= 2.4) - restriction: || (&& (== net45) (>= net452)) (== net452)
 GITHUB


### PR DESCRIPTION
Superceeds #1060
Cleaned up the way the time picker displays and parses time strings.
The behavior can be customized by changing the Language (to set culture information), Is24Hour, and WithSeconds properties.