### PR TITLE
 Implement ButtonAssist to support round corner button

### DIFF
--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -39,6 +39,8 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <TextBlock Style="{StaticResource MaterialDesignHeadlineTextBlock}">Buttons</TextBlock>
         <Grid Grid.Row="1" >
@@ -277,8 +279,53 @@
         <Border Margin="0 16 0 0" BorderThickness="0 1 0 0" BorderBrush="{DynamicResource MaterialDesignDivider}" Grid.Row="4" />
 
         <TextBlock Style="{StaticResource MaterialDesignHeadlineTextBlock}"
-                   Grid.Row="5" Margin="0 12 0 12">Buttons - With Progress</TextBlock>
+                   Grid.Row="5" Margin="0 12 0 12">Buttons - With Customize Round Corner</TextBlock>
         <StackPanel Grid.Row="6" Orientation="Horizontal">
+            <smtx:XamlDisplay Key="button_roundcorner_1" Margin="5 0 0 0">
+                <Grid Width="124">
+                    <Button Style="{StaticResource MaterialDesignRaisedLightButton}"
+                            Height="50"
+                            materialDesign:ButtonAssist.CornerRadius="5"
+                            ToolTip="MaterialDesignRaisedLightButton with Round Corner">
+                        <TextBlock Text="5/50 Radius" />
+                    </Button>
+                </Grid>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay Key="button_roundcorner_2" Margin="5 0 0 0">
+                <Grid Width="124">
+                    <Button Style="{StaticResource MaterialDesignRaisedButton}"
+                            Height="50"
+                            materialDesign:ButtonAssist.CornerRadius="10"
+                            ToolTip="MaterialDesignRaisedButton with Round Corner">
+                        <TextBlock Text="10/50 Radius" />
+                    </Button>
+                </Grid>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay Key="button_roundcorner_3" Margin="5 0 0 0">
+                <Grid Width="124">
+                    <Button Style="{StaticResource MaterialDesignRaisedDarkButton}"
+                            Height="50"
+                            materialDesign:ButtonAssist.CornerRadius="15"
+                            ToolTip="MaterialDesignRaisedDarkButton with Round Corner">
+                        <TextBlock Text="15/50 Radius" />
+                    </Button>
+                </Grid>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay Key="button_roundcorner_4" Margin="5 0 0 0">
+                <Grid Width="124">
+                    <Button Style="{StaticResource MaterialDesignRaisedAccentButton}"
+                            Height="50"
+                            materialDesign:ButtonAssist.CornerRadius="25"
+                            ToolTip="MaterialDesignRaisedAccentButton with Round Corner">
+                        <TextBlock Text="25/50 Radius" />
+                    </Button>
+                </Grid>
+            </smtx:XamlDisplay>
+        </StackPanel>
+        <TextBlock Style="{StaticResource MaterialDesignHeadlineTextBlock}"
+                   Grid.Row="7" Margin="0 12 0 12">Buttons - With Progress</TextBlock>
+        <StackPanel Grid.Row="8" Orientation="Horizontal">
             <smtx:XamlDisplay Key="buttons_26" Margin="5 0 0 0">
                 <Grid Width="124">
                     <!-- raised button with progress, useful to auto dismiss/accept something -->
@@ -375,8 +422,8 @@
         </StackPanel>
         <Border Margin="0 16 0 0" BorderThickness="0 1 0 0" BorderBrush="{DynamicResource MaterialDesignDivider}" Grid.Row="7" />
 
-        <TextBlock Margin="0 32 0 24" Grid.Row="7" Style="{StaticResource MaterialDesignHeadlineTextBlock}">Toggles</TextBlock>
-        <Grid Grid.Row="8">
+        <TextBlock Margin="0 32 0 24" Grid.Row="9" Style="{StaticResource MaterialDesignHeadlineTextBlock}">Toggles</TextBlock>
+        <Grid Grid.Row="10">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -602,8 +649,8 @@
         </Grid>
 
         <Border Grid.Row="9" Margin="0 16 0 0" BorderThickness="0 1 0 0" BorderBrush="{DynamicResource MaterialDesignDivider}" />
-        <TextBlock Margin="0 32 0 0" Grid.Row="9" Style="{StaticResource MaterialDesignHeadlineTextBlock}">Rating bar</TextBlock>
-        <StackPanel Grid.Row="10" Margin="0 16 0 0" Orientation="Horizontal">
+        <TextBlock Margin="0 32 0 0" Grid.Row="11" Style="{StaticResource MaterialDesignHeadlineTextBlock}">Rating bar</TextBlock>
+        <StackPanel Grid.Row="12" Margin="0 16 0 0" Orientation="Horizontal">
             <smtx:XamlDisplay Key="buttons_58" VerticalContentAlignment="Top" Margin="5 0 0 5">
                 <materialDesign:RatingBar Value="3" x:Name="BasicRatingBar"  ValueChanged="BasicRatingBar_ValueChanged"/>
             </smtx:XamlDisplay>
@@ -632,4 +679,3 @@
         </StackPanel>
     </Grid>
 </UserControl>
-

--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -286,7 +286,7 @@
                     <Button Style="{StaticResource MaterialDesignRaisedLightButton}"
                             Height="50"
                             materialDesign:ButtonAssist.CornerRadius="5"
-                            ToolTip="MaterialDesignRaisedLightButton with Round Corner">
+                            ToolTip="MaterialDesignRaisedLightButton with Round Corners">
                         <TextBlock Text="5/50 Radius" />
                     </Button>
                 </Grid>
@@ -296,7 +296,7 @@
                     <Button Style="{StaticResource MaterialDesignRaisedButton}"
                             Height="50"
                             materialDesign:ButtonAssist.CornerRadius="10"
-                            ToolTip="MaterialDesignRaisedButton with Round Corner">
+                            ToolTip="MaterialDesignRaisedButton with Round Corners">
                         <TextBlock Text="10/50 Radius" />
                     </Button>
                 </Grid>
@@ -305,9 +305,9 @@
                 <Grid Width="124">
                     <Button Style="{StaticResource MaterialDesignRaisedDarkButton}"
                             Height="50"
-                            materialDesign:ButtonAssist.CornerRadius="15"
-                            ToolTip="MaterialDesignRaisedDarkButton with Round Corner">
-                        <TextBlock Text="15/50 Radius" />
+                            materialDesign:ButtonAssist.CornerRadius="25"
+                            ToolTip="MaterialDesignRaisedDarkButton with Round Corners">
+                        <TextBlock Text="25/50 Radius" />
                     </Button>
                 </Grid>
             </smtx:XamlDisplay>
@@ -316,8 +316,8 @@
                 <Grid Width="124">
                     <Button Style="{StaticResource MaterialDesignRaisedAccentButton}"
                             Height="50"
-                            materialDesign:ButtonAssist.CornerRadius="25"
-                            ToolTip="MaterialDesignRaisedAccentButton with Round Corner">
+                            materialDesign:ButtonAssist.CornerRadius="25 25 0 0"
+                            ToolTip="MaterialDesignRaisedAccentButton with Round Top Corners">
                         <TextBlock Text="25/50 Radius" />
                     </Button>
                 </Grid>

--- a/MaterialDesignThemes.Wpf/ButtonAssist.cs
+++ b/MaterialDesignThemes.Wpf/ButtonAssist.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace MaterialDesignThemes.Wpf
+{
+    /// <summary>
+    /// Helper properties for working with for make round corner.
+    /// </summary>
+    public static class ButtonAssist
+    {
+        /// <summary>
+        /// Controls the corner radius of the surrounding box.
+        /// </summary>
+        public static readonly DependencyProperty CornerRadiusProperty = DependencyProperty.RegisterAttached(
+            "CornerRadius", typeof(CornerRadius), typeof(ButtonAssist), new PropertyMetadata(new CornerRadius(2.0)));
+
+        public static void SetCornerRadius(DependencyObject element, CornerRadius value)
+        {
+            element.SetValue(CornerRadiusProperty, value);
+        }
+
+        public static CornerRadius GetCornerRadius(DependencyObject element)
+        {
+            return (CornerRadius)element.GetValue(CornerRadiusProperty);
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
+++ b/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
@@ -334,6 +334,7 @@
     <Compile Include="PackIconExtension.cs" />
     <Compile Include="Palette.cs" />
     <Compile Include="Plane3D.cs" />
+    <Compile Include="ButtonAssist.cs" />
     <Compile Include="ScaleHost.cs" />
     <Compile Include="ScrollViewerAssist.cs" />
     <Compile Include="Screen.cs" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
@@ -53,7 +53,8 @@
                     <Grid>
                         <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
                             <Grid>
-                                <Border Background="{TemplateBinding Background}" CornerRadius="2"
+                                <Border Background="{TemplateBinding Background}" 
+                                        CornerRadius="{Binding Path=(wpf:ButtonAssist.CornerRadius), RelativeSource={RelativeSource TemplatedParent}}"
                                         BorderThickness="{TemplateBinding BorderThickness}"
                                         BorderBrush="{TemplateBinding BorderBrush}"                                    
                                         x:Name="border"


### PR DESCRIPTION
Based on https://material.io/design/material-studies/crane.html

Here is a basic implement for customize round corner for buttons.
This change will affect all "MaterialDesignRaisedButton" series style.

In style, Border's CornerRadius is binding to ButtonAssist.CornerRadius.
Default round corner radius "2" now is hard coded in "ButtonAssist" class.

TODO: WPF's CornerRadius is only support "pixel", and some developers prefer to use unit like pt, cm or in. Wish to implement a converter to handle this.