### PR TITLE
Call dialog callbacks after canceling

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
+++ b/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
@@ -37,6 +37,7 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -583,12 +583,16 @@ namespace MaterialDesignThemes.Wpf
             DialogClosingCallback?.Invoke(this, dialogClosingEventArgs);
             _asyncShowClosingEventHandler?.Invoke(this, dialogClosingEventArgs);
 
-            _dialogTaskCompletionSource?.TrySetResult(parameter);
-
+            
             if (!dialogClosingEventArgs.IsCancelled)
+            {
+                _dialogTaskCompletionSource?.TrySetResult(parameter);
                 SetCurrentValue(IsOpenProperty, false);
+            }
             else
+            {
                 CurrentSession.IsEnded = false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1212. 
After canceling a dialog, it should still invoke the event delegates.