### PR TITLE
Changed visuals for checkboxes based on material design guideline (#1123)

### DIFF
--- a/MainDemo.Wpf/TextFields.xaml
+++ b/MainDemo.Wpf/TextFields.xaml
@@ -70,6 +70,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Style="{StaticResource MaterialDesignHeadlineTextBlock}">Common Fields</TextBlock>
         <materialDesign:PackIcon Grid.Row="1" Grid.Column="0" Kind="Account" Foreground="{Binding ElementName=NameTextBox, Path=BorderBrush}" />
@@ -411,6 +412,19 @@
                              VerticalAlignment="Top"
                              IsEnabled="{Binding Path=IsChecked, ElementName=MaterialDesignOutlinedPasswordFieldPasswordBoxEnabledComboBox}"
                              materialDesign:HintAssist.Hint="Password" />
+            </StackPanel>
+        </smtx:XamlDisplay>
+
+        <TextBlock Grid.Row="18" Grid.Column="1" Grid.ColumnSpan="3" Style="{StaticResource MaterialDesignHeadlineTextBlock}" Margin="32,32,0,16">Checkboxes</TextBlock>
+        <smtx:XamlDisplay Key="fields_31" Grid.Row="19" Grid.Column="1" Grid.ColumnSpan="3" Margin="32,0,0,0">
+            <StackPanel>
+                <CheckBox IsChecked="True">Checked</CheckBox>
+                <CheckBox IsChecked="False">Unchecked</CheckBox>
+                <CheckBox IsChecked="{x:Null}">Indeterminate</CheckBox>
+
+                <CheckBox IsChecked="True" IsEnabled="False">Disabled Checked</CheckBox>
+                <CheckBox IsChecked="False" IsEnabled="False">Disabled Unchecked</CheckBox>
+                <CheckBox IsChecked="{x:Null}" IsEnabled="False">Disabled Indeterminate</CheckBox>
             </StackPanel>
         </smtx:XamlDisplay>
     </Grid>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
@@ -114,18 +114,18 @@
                             <Setter Property="FocusVisualStyle" Value="{StaticResource OptionMarkFocusVisual}"/>
                             <Setter Property="Padding" Value="4,2,0,0"/>
                         </Trigger>
-                        <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Fill" TargetName="Graphic" Value="{DynamicResource MaterialDesignCheckBoxDisabled}" />
-                            <Setter Property="Opacity" Value="0.26"/>
-                        </Trigger>
                         <Trigger Property="IsPressed" Value="true"/>
                         <Trigger Property="IsChecked" Value="true">
                             <Setter Property="Data" TargetName="Graphic" Value="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3Z" />
                             <Setter Property="Fill" TargetName="Graphic" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Background}" />
                         </Trigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Fill" TargetName="Graphic" Value="{DynamicResource MaterialDesignCheckBoxDisabled}" />
+                            <Setter Property="Opacity" Value="0.56"/>
+                        </Trigger>
                         <Trigger Property="IsChecked" Value="{x:Null}">
-                            <Setter Property="Data" TargetName="Graphic" Value="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3Z" />
-                            <Setter Property="Opacity" TargetName="Graphic" Value="0.56"/>
+                            <Setter Property="Data" TargetName="Graphic" Value="M6,13L6,11L18,11L18,13M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3Z" />
+                            <Setter Property="Fill" TargetName="Graphic" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Background}" />
                         </Trigger>
                         <Trigger Property="Validation.HasError" Value="true">
                             <Setter Property="Fill" TargetName="Graphic" Value="{DynamicResource ValidationErrorBrush}" />


### PR DESCRIPTION
See https://material.io/design/components/selection-controls.html#checkboxes for details

In detail, the following changes have been applied:
* IsEnabled trigger has been moved after IsChecked trigger to make sure the correct MaterialDesignCheckBoxDisabled (gray) background is aplied to disabled checkboxes
* The SVG for the indeterminate checkbox has been changed to the correct display
* The background color for the indeterminate checkbox has been set to the checkboxes base color
* Opacity of disabled elements is now less opaq