### PR TITLE
Added MaterialDesignOutlinedButton Style

### DIFF
--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -199,7 +199,7 @@
                     <Button Style="{StaticResource MaterialDesignOutlinedButton}" ToolTip="MaterialDesignOutlinedButton">LEARN MORE</Button>
                 </smtx:XamlDisplay>
                 <smtx:XamlDisplay Key="buttons_outlined_2" >
-                    <Button Style="{StaticResource MaterialDesignOutlinedButton}" IsEnabled="False" >LEAR LESS</Button>
+                    <Button Style="{StaticResource MaterialDesignOutlinedButton}" IsEnabled="False" >LEARN LESS</Button>
                 </smtx:XamlDisplay>
             </StackPanel>
         </StackPanel>

--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -195,6 +195,12 @@
                 <smtx:XamlDisplay Key="buttons_25_4" Margin="8 0">
                     <Button Style="{StaticResource MaterialDesignFlatAccentBgButton}" ToolTip="MaterialDesignFlatAccentBackgroundButton">Okay</Button>
                 </smtx:XamlDisplay>
+                <smtx:XamlDisplay Key="buttons_outlined_1" Margin="20 0 0 0">
+                    <Button Style="{StaticResource MaterialDesignOutlinedButton}" ToolTip="MaterialDesignOutlinedButton">LEARN MORE</Button>
+                </smtx:XamlDisplay>
+                <smtx:XamlDisplay Key="buttons_outlined_2" >
+                    <Button Style="{StaticResource MaterialDesignOutlinedButton}" IsEnabled="False" >LEAR LESS</Button>
+                </smtx:XamlDisplay>
             </StackPanel>
         </StackPanel>
         <Border Margin="0 24 0 0" BorderThickness="0 1 0 0" BorderBrush="{DynamicResource MaterialDesignDivider}" Grid.Row="2" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
@@ -184,6 +184,39 @@
         <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth0" />
     </Style>
 
+    <Style x:Key="MaterialDesignOutlinedButton" TargetType="{x:Type ButtonBase}" BasedOn="{StaticResource MaterialDesignFlatButton}">
+        <Setter Property="BorderBrush" Value="{StaticResource MaterialDesignDivider}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ButtonBase}">
+                    <Grid>
+                        <Border Background="{TemplateBinding Background}" x:Name="border" CornerRadius="2"
+                                BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+                            <wpf:Ripple Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Focusable="False"    
+                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                        Padding="{TemplateBinding Padding}" 
+                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter Property="Background" TargetName="border" Value="{DynamicResource MaterialDesignFlatButtonClick}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="true">
+                            <Setter Property="Background" TargetName="border" Value="Transparent" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Opacity" Value="0.23"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="MaterialDesignToolButton" TargetType="{x:Type ButtonBase}" BasedOn="{StaticResource MaterialDesignFlatButton}">
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignToolForeground}"/>
         <Setter Property="Padding" Value="4"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
@@ -188,13 +188,19 @@
         <Setter Property="BorderBrush" Value="{StaticResource MaterialDesignDivider}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <Setter Property="wpf:ButtonAssist.CornerRadius" Value="2" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ButtonBase}">
                     <Grid>
-                        <Border Background="{TemplateBinding Background}" x:Name="border" CornerRadius="2"
-                                BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
-                            <wpf:Ripple Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Focusable="False"    
+                        <Border Background="{TemplateBinding Background}"
+                                x:Name="border" 
+                                CornerRadius="{Binding Path=(wpf:ButtonAssist.CornerRadius), RelativeSource={RelativeSource TemplatedParent}}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}">
+                            <wpf:Ripple Content="{TemplateBinding Content}" 
+                                        ContentTemplate="{TemplateBinding ContentTemplate}" 
+                                        Focusable="False"
                                         HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" 
                                         VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                         Padding="{TemplateBinding Padding}" 


### PR DESCRIPTION
Basically get the Flat Design and added a `BorderThickness` = 1, and changed the `RippleEffect` color. Also changed the background when it is pressed to not see the gray color, as in
[MaterialDesign Outlined Button](https://material.io/design/components/buttons.html#outlined-button)

Also added two buttons in the Demo Enabled and disabled, next to the flat ones. 

![MaterialDesignOutlinedButton](https://user-images.githubusercontent.com/38870744/57404696-e3cb3500-71dc-11e9-93a0-d4f9893ac265.gif)

Issue: [#1075](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/1075)