### PR TITLE
Adding support for customization of visualtransition duration of combobox item to normal state

### DIFF
--- a/MaterialDesignThemes.Wpf/BindingProxy .cs
+++ b/MaterialDesignThemes.Wpf/BindingProxy .cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace MaterialDesignThemes.Wpf
+{
+    /// <summary>
+    /// The proxy class is used to hand the DataContext of an upper
+    /// element down to the elements in or outside of the visual tree.
+    /// Please refer to the url for more info: https://stackoverflow.com/questions/42487517/bind-to-controls-property-inside-visualstatemanager
+    /// </summary>
+    public class BindingProxy : Freezable
+    {
+        #region Overrides of Freezable
+
+        protected override Freezable CreateInstanceCore()
+        {
+            return new BindingProxy();
+        }
+
+        #endregion
+
+        public object Data
+        {
+            get { return (object)GetValue(DataProperty); }
+            set { SetValue(DataProperty, value); }
+        }
+
+        public static readonly DependencyProperty DataProperty =
+            DependencyProperty.Register("Data", typeof(object),
+                                         typeof(BindingProxy));
+    }
+}

--- a/MaterialDesignThemes.Wpf/ComboBoxAssist.cs
+++ b/MaterialDesignThemes.Wpf/ComboBoxAssist.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 
 namespace MaterialDesignThemes.Wpf
 {
@@ -44,6 +45,42 @@ namespace MaterialDesignThemes.Wpf
         public static void SetShowSelectedItem(DependencyObject element, object value)
         {
             element.SetValue(ShowSelectedItemProperty, value);
+        }
+
+        /// <summary>
+        /// The transition duration of a ComboBoxItem from the selected/mouse over state to the normal state
+        /// </summary>
+        public static readonly DependencyProperty ComboBoxItemToNormalVisualStateTransitionDurationProperty = DependencyProperty.RegisterAttached(
+            "ComboBoxItemToNormalVisualStateTransitionDuration",
+            typeof(Duration),
+            typeof(ComboBoxAssist),
+            new FrameworkPropertyMetadata(new Duration(TimeSpan.FromMilliseconds(0)),
+                FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits, VisualTransitionDurationChanged));
+
+        public static Duration GetComboBoxItemToNormalVisualStateTransitionDuration(DependencyObject element)
+        {
+            return (Duration)element.GetValue(ComboBoxItemToNormalVisualStateTransitionDurationProperty);
+        }
+
+        public static void SetComboBoxItemToNormalVisualStateTransitionDuration(DependencyObject element, object value)
+        {
+            // Set the value of the GeneratedDuration property if a target element is VisualTransition
+            VisualTransition visualTransition = element as VisualTransition;
+            if (visualTransition != null)
+            {
+                visualTransition.GeneratedDuration = (Duration)value;
+            }
+
+            element.SetValue(ComboBoxItemToNormalVisualStateTransitionDurationProperty, value);
+        }
+
+        private static void VisualTransitionDurationChanged(DependencyObject element, DependencyPropertyChangedEventArgs e)
+        {
+            // Update the value of the GeneratedDuration property with new value if a target element is VisualTransition
+            if (element is VisualTransition)
+            {
+                (element as VisualTransition).GeneratedDuration = (Duration)e.NewValue;
+            }
         }
     }
 }

--- a/MaterialDesignThemes.Wpf/ComboBoxAssist.cs
+++ b/MaterialDesignThemes.Wpf/ComboBoxAssist.cs
@@ -77,7 +77,8 @@ namespace MaterialDesignThemes.Wpf
         private static void VisualTransitionDurationChanged(DependencyObject element, DependencyPropertyChangedEventArgs e)
         {
             // Update the value of the GeneratedDuration property with new value if a target element is VisualTransition
-            if (element is VisualTransition)
+            VisualTransition visualTransition = element as VisualTransition;
+            if (visualTransition != null)
             {
                 (element as VisualTransition).GeneratedDuration = (Duration)e.NewValue;
             }

--- a/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
+++ b/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
@@ -272,6 +272,7 @@
   <ItemGroup>
     <Compile Include="Badged.cs" />
     <Compile Include="BaseTheme.cs" />
+    <Compile Include="BindingProxy .cs" />
     <Compile Include="ButtonAssist.cs" />
     <Compile Include="ButtonProgressAssist.cs" />
     <Compile Include="Card.cs" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -596,6 +596,7 @@
         <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="1 0 1 0" />
         <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <Setter Property="wpf:ComboBoxAssist.ComboBoxItemToNormalVisualStateTransitionDuration" Value="0:0:0.3" />
         <Setter Property="Template" Value="{StaticResource MaterialDesignFloatingHintComboBoxTemplate}" />
         <Style.Triggers>
             <Trigger Property="IsKeyboardFocused" Value="true">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -211,6 +211,9 @@
 
     <ControlTemplate x:Key="MaterialDesignComboBoxItemTemplate" TargetType="{x:Type ComboBoxItem}">
         <Grid x:Name="GridWrapper">
+            <Grid.Resources>
+                <materialdesign:BindingProxy x:Key="CustomControlPropertyProxy" Data="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(wpf:ComboBoxAssist.ComboBoxItemToNormalVisualStateTransitionDuration)}" />
+            </Grid.Resources>
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup Name="CommonStates">
                     <VisualStateGroup.Transitions>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -217,7 +217,7 @@
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup Name="CommonStates">
                     <VisualStateGroup.Transitions>
-                        <VisualTransition GeneratedDuration="0:0:0.3" To="Normal">
+                        <VisualTransition wpf:ComboBoxAssist.ComboBoxItemToNormalVisualStateTransitionDuration="{Binding Source={StaticResource CustomControlPropertyProxy}, Path=Data}" To="Normal">
                             <VisualTransition.GeneratedEasingFunction>
                                 <CircleEase EasingMode="EaseOut" />
                             </VisualTransition.GeneratedEasingFunction>
@@ -249,7 +249,7 @@
                 </VisualStateGroup>
                 <VisualStateGroup Name="FocusStates">
                     <VisualStateGroup.Transitions>
-                        <VisualTransition GeneratedDuration="0:0:0.3" To="Unfocused" />
+                        <VisualTransition wpf:ComboBoxAssist.ComboBoxItemToNormalVisualStateTransitionDuration="{Binding Source={StaticResource CustomControlPropertyProxy}, Path=Data}" To="Unfocused" />
                     </VisualStateGroup.Transitions>
                     <VisualState Name="Focused">
                         <Storyboard>


### PR DESCRIPTION
Hi!!!
I thought that it'd be a good to be able to specify the duration of VisualStateTransition of ComboBoxItem to Normal State (from Focused and MouseHover states), because sometimes (e.g. in my case) you may want to instant transition to normal state without any expanded visual effects involved in that transition. Currently the value of transition is hardcoded being set to 0:0:0.3.
The idea is that you will be able to set transition duration in a combobox, then that value will go down to the individual ComboBoxItems' of this combobox and set their transition duration to that value. Below is what i have done to implement that feature:
1) I created the new dependency property ComboBoxItemToNormalVisualStateTransitionDuration of type Duration in ComboBoxAssist, which will be used for setting the specific value for duration. The reason why i needed to created this property is because GeneratedDuration property of VisualStateTransition is the regular property not the dependency one, thereby it can not be used in bindings through which i want to transit duration value from ComboBox to the ComboBoxItem. Also i registered the PropertyChanged event handler to set the duration property to the value this dependency property is being set to (hope you got what i meant since i am not native english speaker so my English is not quite well).

2) Since VisualState is not part of the visual tree it can't be directly bound to the ComboBox properties, so i created the BindingProxy, which is used to mediate in the binding process between ComboBox and its items (More on this:  https://stackoverflow.com/questions/42487517/bind-to-controls-property-inside-visualstatemanager)
3) I definded the ComboBoxItemToNormalVisualStateTransitionDuration dependency property for the ComboBox and defaulted it to the value of 0:0:0.3 (as it was previousy in the VisualStateTransition duration).
4) I defined  the ProxyBinding resource of the Grid in the template for the ComboBoxItem and binded it to the dependency property of ComboBox specified in the previous step.
5) I deleted the assignment of GeneratedDuration property of VisualTransition to the value of 0:0:0.3, and instead defined the ComboBoxItemToNormalVisualStateTransitionDuration dependency property and binded it to the ProxyBinding resource object.

Now the GeneratedDuration property can be set to the specific value by setting the ComboBoxItemToNormalVisualStateTransitionDuration property of the ComboBox, and the default value is still 0:0:0.3 if nothing is specified. 
If you have some questions or suggestions, leave the comment. And i hope this PR to be useful and eventually approved. Thank you!!!