### PR TITLE
1291/transitioner command enhancement

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
+++ b/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="PopupBoxTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TimePickerUnitTests.cs" />
+    <Compile Include="TransitionerTests.cs" />
     <Compile Include="VisualTreeHelper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
+++ b/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
@@ -55,7 +55,6 @@
     <Compile Include="PopupBoxTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TimePickerUnitTests.cs" />
-    <Compile Include="TransitionerTests.cs" />
     <Compile Include="VisualTreeHelper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/MaterialDesignThemes.Wpf.Tests/TransitionerTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/TransitionerTests.cs
@@ -1,0 +1,57 @@
+﻿using System.Windows.Controls;
+using MaterialDesignThemes.Wpf.Transitions;
+using Xunit;
+
+namespace MaterialDesignThemes.Wpf.Tests
+{
+    public class TransitionerTests
+    {
+        [StaFact]
+        public void WhenMoveNext_ItCanAdvanceMultipleSlides()
+        {
+            //Arrange
+            var child1 = new UserControl();
+            var child2 = new UserControl();
+            var child3 = new UserControl();
+
+            var transitioner = new Transitioner();
+            transitioner.Items.Add(child1);
+            transitioner.Items.Add(child2);
+            transitioner.Items.Add(child3);
+            transitioner.SelectedIndex = 0;
+
+            object parameter = 2;
+
+            //Act
+            Assert.True(Transitioner.MoveNextCommand.CanExecute(parameter, transitioner));
+            Transitioner.MoveNextCommand.Execute(parameter, transitioner);
+
+            //Assert
+            Assert.Equal(2, transitioner.SelectedIndex);
+        }
+
+        [StaFact]
+        public void WhenMovePrevious_ItCanRetreatMultipleSlides()
+        {
+            //Arrange
+            var child1 = new UserControl();
+            var child2 = new UserControl();
+            var child3 = new UserControl();
+
+            var transitioner = new Transitioner();
+            transitioner.Items.Add(child1);
+            transitioner.Items.Add(child2);
+            transitioner.Items.Add(child3);
+            transitioner.SelectedIndex = 2;
+
+            object parameter = 2;
+
+            //Act
+            Assert.True(Transitioner.MovePreviousCommand.CanExecute(parameter, transitioner));
+            Transitioner.MovePreviousCommand.Execute(parameter, transitioner);
+
+            //Assert
+            Assert.Equal(0, transitioner.SelectedIndex);
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/Transitions/Transitioner.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/Transitioner.cs
@@ -121,14 +121,20 @@ namespace MaterialDesignThemes.Wpf.Transitions
         {
             if (AutoApplyTransitionOrigins)
                 _nextTransitionOrigin = GetNavigationSourcePoint(executedRoutedEventArgs);
-            SetCurrentValue(SelectedIndexProperty, Math.Min(Items.Count - 1, SelectedIndex + 1));
+            var slides = 1;
+            if (executedRoutedEventArgs.Parameter is int && (int)executedRoutedEventArgs.Parameter > 0)
+                slides = (int)executedRoutedEventArgs.Parameter;
+            SetCurrentValue(SelectedIndexProperty, Math.Min(Items.Count - 1, SelectedIndex + slides));
         }
 
         private void MovePreviousHandler(object sender, ExecutedRoutedEventArgs executedRoutedEventArgs)
         {
             if (AutoApplyTransitionOrigins)
                 _nextTransitionOrigin = GetNavigationSourcePoint(executedRoutedEventArgs);
-            SetCurrentValue(SelectedIndexProperty, Math.Max(0, SelectedIndex - 1));
+            var slides = 1;
+            if (executedRoutedEventArgs.Parameter is int && (int)executedRoutedEventArgs.Parameter > 0)
+                slides = (int)executedRoutedEventArgs.Parameter;
+            SetCurrentValue(SelectedIndexProperty, Math.Max(0, SelectedIndex - slides));
         }
 
         private void MoveFirstHandler(object sender, ExecutedRoutedEventArgs executedRoutedEventArgs)


### PR DESCRIPTION
Fixes #1291 
 
- [x] In the `MoveNextHandler` and `MovePreviousHandler` methods you will need to handle the parameter on the `ExecutedRoutedEventArgs` if it is a **non-negative integer** then go ahead and use it in the current algorithm to set the `SelectedIndexProperty` otherwise simply use `1`
 
- [x] Add unit tests to ensure the control behaves as expected. 