### PR TITLE
Fix ListBoxAssist.IsToggle toggling disabled items

### DIFF
--- a/MaterialDesignThemes.Wpf/ListBoxAssist.cs
+++ b/MaterialDesignThemes.Wpf/ListBoxAssist.cs
@@ -34,7 +34,7 @@ namespace MaterialDesignThemes.Wpf
                     ripple = dependencyObject as Ripple;
             }
 
-            if (listBoxItem == null) return;
+            if (listBoxItem == null || !listBoxItem.IsEnabled) return;
 
             listBoxItem.SetCurrentValue(ListBoxItem.IsSelectedProperty, !listBoxItem.IsSelected);
             mouseButtonEventArgs.Handled = true;


### PR DESCRIPTION
ListBoxAssist.IsToggle is used to emulate toggle buttons from list box items, and buttons should not respond to mouse clicks if disabled.

Used in MaterialDesignToolToggleListBox style.

This bug is also referenced in issue #1262.