### PR TITLE
fixed links to Demo View and Demo View Model for the Color Tool demo page of the WPF demo app

### DIFF
--- a/MainDemo.Wpf/Domain/MainWindowViewModel.cs
+++ b/MainDemo.Wpf/Domain/MainWindowViewModel.cs
@@ -39,8 +39,8 @@ namespace MaterialDesignColors.WpfExample.Domain
                         DocumentationLink.WikiLink("Brush-Names", "Brushes"),
                         DocumentationLink.WikiLink("Custom-Palette-Hues", "Custom Palettes"),
                         DocumentationLink.WikiLink("Swatches-and-Recommended-Colors", "Swatches"),
-                        DocumentationLink.DemoPageLink<PaletteSelector>("Demo View"),
-                        DocumentationLink.DemoPageLink<PaletteSelectorViewModel>("Demo View Model"),
+                        DocumentationLink.DemoPageLink<ColorTool>("Demo View"),
+                        DocumentationLink.DemoPageLink<ColorToolViewModel>("Demo View Model"),
                         DocumentationLink.ApiLink<PaletteHelper>()
                     }),
                 new DemoItem("Buttons", new Buttons { DataContext = new ButtonsViewModel() } ,


### PR DESCRIPTION
The links "Demo View" and "Demo View Model" of the Color Tool page in the WPF demo app were pointing to the view and view model of the Pallete Selector.
This changes it to point to the right files on github.