### PR TITLE
Custom DialogHost background

### DIFF
--- a/MainDemo.Wpf/Dialogs.xaml
+++ b/MainDemo.Wpf/Dialogs.xaml
@@ -147,12 +147,13 @@
                 <!--#region SAMPLE 4-->
                 <TextBlock TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Top"
                            Grid.Column="3" Grid.Row="0" Margin="8 0 8 0"
-                           >SAMPLE 4: Dialog managed from view model using IsOpen and custom commands (ignoring the provided routed commands).</TextBlock>
+                           >SAMPLE 4: Dialog managed from view model using IsOpen and custom commands (ignoring the provided routed commands). This also uses a custom brush to dim the background.</TextBlock>
                 <smtx:XamlDisplay Key="dialogs_sample4"  Grid.Column="3" Grid.Row="1" >
                     <materialDesign:DialogHost HorizontalAlignment="Center" VerticalAlignment="Center"
                                            IsOpen="{Binding IsSample4DialogOpen}"
                                            DialogContent="{Binding Sample4Content}"
-                                           CloseOnClickAway="True">
+                                           CloseOnClickAway="True"
+                                           OverlayBackground="{DynamicResource PrimaryHueDarkBrush}">
                         <Border BorderThickness="1" BorderBrush="{DynamicResource PrimaryHueMidBrush}"
                             MinWidth="256" MinHeight="256" ClipToBounds="True">
                             <Button HorizontalAlignment="Center" VerticalAlignment="Center"

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -437,6 +437,18 @@ namespace MaterialDesignThemes.Wpf
             set { SetValue(PopupStyleProperty, value); }
         }
 
+        public static readonly DependencyProperty OverlayBackgroundProperty = DependencyProperty.Register(
+            nameof(OverlayBackground), typeof(Brush), typeof(DialogHost), new PropertyMetadata(Brushes.Black));
+
+        /// <summary>
+        /// Represents the overlay brush that is used to dim the background behind the dialog
+        /// </summary>
+        public Brush OverlayBackground
+        {
+            get { return (Brush)GetValue(OverlayBackgroundProperty); }
+            set { SetValue(OverlayBackgroundProperty, value); }
+        }
+
         public override void OnApplyTemplate()
         {
             if (_contentCoverGrid != null)
@@ -453,19 +465,6 @@ namespace MaterialDesignThemes.Wpf
 
             base.OnApplyTemplate();
         }
-
-
-        /// <summary>
-        /// Represents the overlay brush that is used to dim the background behind the dialog
-        /// </summary>
-        public Brush OverlayBackground
-        {
-            get { return (Brush)GetValue(OverlayBackgroundProperty); }
-            set { SetValue(OverlayBackgroundProperty, value); }
-        }
-
-        public static readonly DependencyProperty OverlayBackgroundProperty =
-            DependencyProperty.Register(nameof(OverlayBackground), typeof(Brush), typeof(DialogHost), new PropertyMetadata(Brushes.Black));
 
         #region open dialog events/callbacks
 

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -7,6 +7,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Windows.Threading;
 using MaterialDesignThemes.Wpf.Transitions;
 
@@ -452,6 +453,19 @@ namespace MaterialDesignThemes.Wpf
 
             base.OnApplyTemplate();
         }
+
+
+        /// <summary>
+        /// Represents the overlay brush that is used to dim the background behind the dialog
+        /// </summary>
+        public Brush OverlayBackground
+        {
+            get { return (Brush)GetValue(OverlayBackgroundProperty); }
+            set { SetValue(OverlayBackgroundProperty, value); }
+        }
+
+        public static readonly DependencyProperty OverlayBackgroundProperty =
+            DependencyProperty.Register(nameof(OverlayBackground), typeof(Brush), typeof(DialogHost), new PropertyMetadata(Brushes.Black));
 
         #region open dialog events/callbacks
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -13,8 +13,6 @@
         <Setter Property="Placement" Value="Center" />
     </Style>
 
-    <SolidColorBrush x:Key="BlackBackground" Color="Black" />
-
     <Style TargetType="{x:Type wpf:DialogHost}">
         <Setter Property="DialogMargin" Value="35" />
         <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth5" />
@@ -32,10 +30,6 @@
                                             <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup" Storyboard.TargetProperty="IsOpen">
                                                 <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
                                             </BooleanAnimationUsingKeyFrames>
-                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_ContentCoverGrid" 
-                                                                           Storyboard.TargetProperty="Background">
-                                                <DiscreteObjectKeyFrame Value="{StaticResource BlackBackground}" KeyTime="0" />
-                                            </ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_ContentCoverGrid" Storyboard.TargetProperty="Opacity">
                                                 <EasingDoubleKeyFrame Value="0" KeyTime="0" />
                                                 <EasingDoubleKeyFrame Value="0.56" KeyTime="0:0:0.3">
@@ -123,10 +117,6 @@
                                                                         Duration="0">
                                             <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
                                         </BooleanAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_ContentCoverGrid" 
-                                                                       Storyboard.TargetProperty="Background" Duration="0">
-                                            <DiscreteObjectKeyFrame Value="{StaticResource BlackBackground}" />
-                                        </ObjectAnimationUsingKeyFrames>
                                         <DoubleAnimation Storyboard.TargetName="PART_ContentCoverGrid" Storyboard.TargetProperty="Opacity"
                                                          Duration="0"
                                                          To=".56" />
@@ -198,6 +188,7 @@
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsOpen" Value="True">
                             <Setter TargetName="ContentPresenter" Property="IsEnabled" Value="False" />
+                            <Setter TargetName="PART_ContentCoverGrid" Property="Background" Value="{Binding OverlayBackground, RelativeSource={RelativeSource TemplatedParent}}" />
                             <Setter TargetName="PART_ContentCoverGrid" Property="IsHitTestVisible" Value="True" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -222,10 +213,6 @@
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup" Storyboard.TargetProperty="Visibility">
                                                 <DiscreteObjectKeyFrame Value="{x:Static Visibility.Visible}" KeyTime="0" />
-                                            </ObjectAnimationUsingKeyFrames>
-                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_ContentCoverGrid" 
-                                                                           Storyboard.TargetProperty="Background">
-                                                <DiscreteObjectKeyFrame Value="{StaticResource BlackBackground}" KeyTime="0" />
                                             </ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_ContentCoverGrid" Storyboard.TargetProperty="Opacity">
                                                 <EasingDoubleKeyFrame Value="0" KeyTime="0" />
@@ -314,11 +301,6 @@
                                                                        Duration="0">
                                             <DiscreteObjectKeyFrame Value="{x:Static Visibility.Visible}" KeyTime="0" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_ContentCoverGrid" 
-                                                                       Storyboard.TargetProperty="Background"
-                                                                       Duration="0">
-                                            <DiscreteObjectKeyFrame Value="{StaticResource BlackBackground}" KeyTime="0" />
-                                        </ObjectAnimationUsingKeyFrames>
                                         <DoubleAnimation Storyboard.TargetName="PART_ContentCoverGrid" Storyboard.TargetProperty="Opacity"
                                                          Duration="0"
                                                          To=".56" />
@@ -393,7 +375,7 @@
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsOpen" Value="True">
                             <Setter TargetName="ContentPresenter" Property="IsEnabled" Value="False" />
-                            <Setter TargetName="PART_ContentCoverGrid" Property="Background" Value="Black" />
+                            <Setter TargetName="PART_ContentCoverGrid" Property="Background" Value="{Binding OverlayBackground, RelativeSource={RelativeSource TemplatedParent}}" />
                             <Setter TargetName="PART_ContentCoverGrid" Property="IsHitTestVisible" Value="True" />
                         </Trigger>
                     </ControlTemplate.Triggers>


### PR DESCRIPTION
This adds  a dependency property to the DialogHost called "OverlayBackground" which allows to set a custom brush for the background behind the dialog (as described by @Keebo in #1344).
I had to remove setting the background in the VisualStateGroup and move it to the normal Triggers, because Binding is not possible inside VisualState Storyboards for Colors ([like explained here](https://social.msdn.microsoft.com/Forums/vstudio/en-US/027c364f-5d75-424f-aafd-7fb76b10b676/templatebinding-on-storyboard?forum=wpf)).
This should not have any visual changes because the duration of the animation was set to 0.

I don't now if this counts as fix for #1193 or #1344 because it is not clear for me if this OverlayBackground is what is asked for in there or if they mean the background of the dialog itself.

![grafik](https://user-images.githubusercontent.com/33566379/62826849-5aecdc80-bbc3-11e9-8bbe-e661f6eb74d4.png)

------

> 
> [Keebo on #1344] What I think needs to be done for this:
> 
> - [x] Create a dependency property on the DialogHost control of type Brush with name OverlayBackground. This property should have a default value of Black.
> - [x] Remove the BlackBackground resource from MaterialDesignTheme.DialogHost.xaml and replace its usage with bindings to the new property on the DialogHost.