### PR TITLE
Fixed System.ArgumentNullException when double click the grayed grid to dismiss the dialog.

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using Xunit;
 
 namespace MaterialDesignThemes.Wpf.Tests
@@ -14,6 +15,7 @@ namespace MaterialDesignThemes.Wpf.Tests
         public DialogHostTests()
         {
             _dialogHost = new DialogHost();
+            _dialogHost.ApplyDefaultStyle();
             _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
         }
 
@@ -169,6 +171,31 @@ namespace MaterialDesignThemes.Wpf.Tests
 
             Assert.Equal("SecondResult", result);
             Assert.Equal(2, closeInvokeCount);
+        }
+
+        [StaFact]
+        [Description("Issue 1328")]
+        public async Task WhenDoubleClickAwayDialogCloses()
+        {
+            _dialogHost.CloseOnClickAway = true;
+            Grid contentCover = _dialogHost.FindVisualChild<Grid>(DialogHost.ContentCoverGridName);
+
+            int closingCount = 0;
+            Task shownDialog = _dialogHost.ShowDialog("Content", new DialogClosingEventHandler((sender, args) =>
+            {
+                closingCount++;
+            }));
+
+            contentCover.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 1, MouseButton.Left) {
+                RoutedEvent = UIElement.MouseLeftButtonUpEvent
+            });
+            contentCover.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 1, MouseButton.Left) {
+                RoutedEvent = UIElement.MouseLeftButtonUpEvent
+            });
+
+            await shownDialog;
+
+            Assert.Equal(1, closingCount);
         }
 
         private class TestDialog : Control

--- a/MaterialDesignThemes.Wpf/DialogClosingEventArgs.cs
+++ b/MaterialDesignThemes.Wpf/DialogClosingEventArgs.cs
@@ -7,26 +7,23 @@ namespace MaterialDesignThemes.Wpf
     {
         public DialogClosingEventArgs(DialogSession session, object parameter)
         {
-            if (session == null) throw new ArgumentNullException(nameof(session));
-            Session = session;
+            Session = session ?? throw new ArgumentNullException(nameof(session));
 
-            Parameter = parameter;         
+            Parameter = parameter;
         }
 
         public DialogClosingEventArgs(DialogSession session, object parameter, RoutedEvent routedEvent) : base(routedEvent)
         {
-            if (session == null) throw new ArgumentNullException(nameof(session));
-            Session = session;
+            Session = session ?? throw new ArgumentNullException(nameof(session));
 
-            Parameter = parameter;            
+            Parameter = parameter;
         }
 
         public DialogClosingEventArgs(DialogSession session, object parameter, RoutedEvent routedEvent, object source) : base(routedEvent, source)
         {
-            if (session == null) throw new ArgumentNullException(nameof(session));
-            Session = session;
+            Session = session ?? throw new ArgumentNullException(nameof(session));
 
-            Parameter = parameter;            
+            Parameter = parameter;
         }
 
         /// <summary>
@@ -43,12 +40,12 @@ namespace MaterialDesignThemes.Wpf
         public bool IsCancelled { get; private set; }
 
         /// <summary>
-        /// Gets the paramter originally provided to <see cref="DialogHost.CloseDialogCommand"/>/
+        /// Gets the parameter originally provided to <see cref="DialogHost.CloseDialogCommand"/>/
         /// </summary>
         public object Parameter { get; }
 
         /// <summary>
-        /// Allows interation with the current dialog session.
+        /// Allows interaction with the current dialog session.
         /// </summary>
         public DialogSession Session { get; }
 

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -638,7 +638,7 @@ namespace MaterialDesignThemes.Wpf
 
         private void ContentCoverGridOnMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
-            if (CloseOnClickAway)
+            if (CloseOnClickAway && CurrentSession != null)
                 Close(CloseOnClickAwayParameter);
         }
 

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -646,8 +646,7 @@ namespace MaterialDesignThemes.Wpf
         {
             if (executedRoutedEventArgs.Handled) return;
 
-            var dependencyObject = executedRoutedEventArgs.OriginalSource as DependencyObject;
-            if (dependencyObject != null)
+            if (executedRoutedEventArgs.OriginalSource is DependencyObject dependencyObject)
             {
                 _attachedDialogOpenedEventHandler = GetDialogOpenedAttached(dependencyObject);
                 _attachedDialogClosingEventHandler = GetDialogClosingAttached(dependencyObject);


### PR DESCRIPTION
On the Close Dialog Command, a CanExecute method was on place to check if the `CurrentSession` isn't changed in the meantime, but on the  PreviewMouseUpwasn't checked this state.

Because of this, if the user double-clicked the grayed grid and the CurrentSession was assigned to null before the second click was intercepted by PreviewMouseUp, an ArgumentNullException occurs on the constructor of the DialogClosingEventArgs.