### PR TITLE
Snackbar message duration override

### DIFF
--- a/MainDemo.Wpf/Snackbars.xaml
+++ b/MainDemo.Wpf/Snackbars.xaml
@@ -188,6 +188,34 @@
                     </smtx:XamlDisplay>
                 </StackPanel>
             </Border>
+
+            <!-- example 7 -->
+            <!-- message duration override -->
+            <Border Background="{DynamicResource MaterialDesignPaper}" 
+                    Padding="8 0 8 0" Grid.Column="3" Grid.Row="1">
+                <Grid>
+                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <TextBlock TextWrapping="WrapWithOverflow" Style="{DynamicResource MaterialDesignSubheadingTextBlock}">Example 7.</TextBlock>
+                        <TextBlock TextWrapping="WrapWithOverflow">The message show duration is controlled by the message queue. But this can be overridden for a specific message.</TextBlock>
+                        <Grid Margin="0 16 0 0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Slider x:Name="MessageDurationOverrideSlider" Minimum="1" Maximum="10" Value="5"
+                                    IsSnapToTickEnabled="True" TickFrequency="0.1" VerticalAlignment="Center" />
+                            <TextBlock Text="{Binding ElementName=MessageDurationOverrideSlider, Path=Value, StringFormat={}{0:F1}}"
+                                       Margin="10,0" Grid.Column="1" VerticalAlignment="Center" />
+                            <Button Click="SnackBar7_OnClick" HorizontalAlignment="Center" Grid.Column="2">Send</Button>
+                        </Grid>
+                    </StackPanel>
+                    <smtx:XamlDisplay Key="snackbar_10">
+                        <materialDesign:Snackbar MessageQueue="{materialDesign:MessageQueue}"
+                                                 x:Name="SnackbarSeven" />
+                    </smtx:XamlDisplay>
+                </Grid>
+            </Border>
         </Grid>
     </ScrollViewer>
 </UserControl>

--- a/MainDemo.Wpf/Snackbars.xaml.cs
+++ b/MainDemo.Wpf/Snackbars.xaml.cs
@@ -39,5 +39,18 @@ namespace MaterialDesignDemo
                 s);
             }
         }
+
+        private void SnackBar7_OnClick(object sender, RoutedEventArgs e)
+        {
+            var duration = MessageDurationOverrideSlider.Value;
+            SnackbarSeven.MessageQueue.Enqueue(
+                $"Hello world! Showing message for {duration:F1} seconds.",
+                null,
+                null,
+                null,
+                false,
+                true,
+                TimeSpan.FromSeconds(duration));
+        }
     }
 }

--- a/MaterialDesignThemes.Wpf/ISnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/ISnackbarMessageQueue.cs
@@ -5,13 +5,13 @@ namespace MaterialDesignThemes.Wpf
     public interface ISnackbarMessageQueue
     {
         /// <summary>
-        /// Queues a notificaton message for display in a snackbar.
+        /// Queues a notification message for display in a snackbar.
         /// </summary>
         /// <param name="content">Message.</param>
         void Enqueue(object content);
 
         /// <summary>
-        /// Queues a notificaton message for display in a snackbar.
+        /// Queues a notification message for display in a snackbar.
         /// </summary>
         /// <param name="content">Message.</param>
         /// <param name="actionContent">Content for the action button.</param>
@@ -19,7 +19,7 @@ namespace MaterialDesignThemes.Wpf
         void Enqueue(object content, object actionContent, Action actionHandler);
 
         /// <summary>
-        /// Queues a notificaton message for display in a snackbar.
+        /// Queues a notification message for display in a snackbar.
         /// </summary>
         /// <param name="content">Message.</param>
         /// <param name="actionContent">Content for the action button.</param>
@@ -28,7 +28,7 @@ namespace MaterialDesignThemes.Wpf
         void Enqueue<TArgument>(object content, object actionContent, Action<TArgument> actionHandler, TArgument actionArgument);
 
         /// <summary>
-        /// Queues a notificaton message for display in a snackbar.
+        /// Queues a notification message for display in a snackbar.
         /// </summary>
         /// <param name="content">Message.</param>
         /// <param name="neverConsiderToBeDuplicate">Subsequent, duplicate messages queued within a short time span will 
@@ -36,7 +36,7 @@ namespace MaterialDesignThemes.Wpf
         void Enqueue(object content, bool neverConsiderToBeDuplicate);
 
         /// <summary>
-        /// Queues a notificaton message for display in a snackbar.
+        /// Queues a notification message for display in a snackbar.
         /// </summary>
         /// <param name="content">Message.</param>
         /// <param name="actionContent">Content for the action button.</param>
@@ -45,7 +45,7 @@ namespace MaterialDesignThemes.Wpf
         void Enqueue(object content, object actionContent, Action actionHandler, bool promote);
 
         /// <summary>
-        /// Queues a notificaton message for display in a snackbar.
+        /// Queues a notification message for display in a snackbar.
         /// </summary>
         /// <param name="content">Message.</param>
         /// <param name="actionContent">Content for the action button.</param>
@@ -55,7 +55,7 @@ namespace MaterialDesignThemes.Wpf
         void Enqueue<TArgument>(object content, object actionContent, Action<TArgument> actionHandler, TArgument actionArgument, bool promote);
 
         /// <summary>
-        /// Queues a notificaton message for display in a snackbar.
+        /// Queues a notification message for display in a snackbar.
         /// </summary>
         /// <param name="content">Message.</param>
         /// <param name="actionContent">Content for the action button.</param>
@@ -63,11 +63,12 @@ namespace MaterialDesignThemes.Wpf
         /// <param name="actionArgument">Argument to pass to <paramref name="actionHandler"/>.</param>
         /// <param name="promote">The message will be promoted to the front of the queue.</param>
         /// <param name="neverConsiderToBeDuplicate">The message will never be considered a duplicate.</param>
+        /// <param name="durationOverride">Message show duration override.</param>
         void Enqueue<TArgument>(object content, object actionContent, Action<TArgument> actionHandler,
-            TArgument actionArgument, bool promote, bool neverConsiderToBeDuplicate);
+            TArgument actionArgument, bool promote, bool neverConsiderToBeDuplicate, TimeSpan? durationOverride);
 
         /// <summary>
-        /// Queues a notificaton message for display in a snackbar.
+        /// Queues a notification message for display in a snackbar.
         /// </summary>
         /// <param name="content">Message.</param>
         /// <param name="actionContent">Content for the action button.</param>
@@ -75,7 +76,8 @@ namespace MaterialDesignThemes.Wpf
         /// <param name="actionArgument">Argument to pass to <paramref name="actionHandler"/>.</param>
         /// <param name="promote">The message will promoted to the front of the queue.</param>
         /// <param name="neverConsiderToBeDuplicate">The message will never be considered a duplicate.</param>
+        /// <param name="durationOverride">Message show duration override.</param>
         void Enqueue(object content, object actionContent, Action<object> actionHandler, object actionArgument,
-            bool promote, bool neverConsiderToBeDuplicate);
+            bool promote, bool neverConsiderToBeDuplicate, TimeSpan? durationOverride);
     }
 }

--- a/MaterialDesignThemes.Wpf/ISnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/ISnackbarMessageQueue.cs
@@ -65,7 +65,7 @@ namespace MaterialDesignThemes.Wpf
         /// <param name="neverConsiderToBeDuplicate">The message will never be considered a duplicate.</param>
         /// <param name="durationOverride">Message show duration override.</param>
         void Enqueue<TArgument>(object content, object actionContent, Action<TArgument> actionHandler,
-            TArgument actionArgument, bool promote, bool neverConsiderToBeDuplicate, TimeSpan? durationOverride);
+            TArgument actionArgument, bool promote, bool neverConsiderToBeDuplicate, TimeSpan? durationOverride = null);
 
         /// <summary>
         /// Queues a notification message for display in a snackbar.
@@ -78,6 +78,6 @@ namespace MaterialDesignThemes.Wpf
         /// <param name="neverConsiderToBeDuplicate">The message will never be considered a duplicate.</param>
         /// <param name="durationOverride">Message show duration override.</param>
         void Enqueue(object content, object actionContent, Action<object> actionHandler, object actionArgument,
-            bool promote, bool neverConsiderToBeDuplicate, TimeSpan? durationOverride);
+            bool promote, bool neverConsiderToBeDuplicate, TimeSpan? durationOverride = null);
     }
 }

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueueItem.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueueItem.cs
@@ -24,7 +24,7 @@ namespace MaterialDesignThemes.Wpf
         /// <summary>
         /// Message show duration.
         /// </summary>
-        public TimeSpan Duration { get; set; }
+        public TimeSpan Duration { get; }
 
         /// <summary>
         /// The content for the action button on the snackbar

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueueItem.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueueItem.cs
@@ -4,10 +4,11 @@ namespace MaterialDesignThemes.Wpf
 {
     internal class SnackbarMessageQueueItem
     {
-        public SnackbarMessageQueueItem(object content, object actionContent = null, Action<object> actionHandler = null, object actionArgument = null, 
+        public SnackbarMessageQueueItem(object content, TimeSpan duration, object actionContent = null, Action<object> actionHandler = null, object actionArgument = null, 
             bool isPromoted = false, bool ignoreDuplicate = false)
         {
             Content = content;
+            Duration = duration;
             ActionContent = actionContent;
             ActionHandler = actionHandler;
             ActionArgument = actionArgument;
@@ -19,6 +20,11 @@ namespace MaterialDesignThemes.Wpf
         /// The content to be displayed
         /// </summary>
         public object Content { get; }
+
+        /// <summary>
+        /// Message show duration.
+        /// </summary>
+        public TimeSpan Duration { get; set; }
 
         /// <summary>
         /// The content for the action button on the snackbar


### PR DESCRIPTION
This PR adds the option to override a snackbar queue's message duration on a per message basis.

Possible use cases for this feature:
- You want a longer duration to increase the chance of the user reading the message
- You want a longer duration because the message is a little long, and the user needs more time to read
- You want a shorter duration because you only need some short immediate feedback