### PR TITLE
Expose Popup HorizontalOffset and VerticalOffset properties

### DIFF
--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -316,6 +316,36 @@ namespace MaterialDesignThemes.Wpf
         }
 
         /// <summary>
+        /// Get or sets the popup horizontal offset in relation to the button.
+        /// </summary>
+        public static readonly DependencyProperty PopupHorizontalOffsetProperty = DependencyProperty.Register(
+            nameof(PopupHorizontalOffset), typeof(double), typeof(PopupBox), new PropertyMetadata(default(double)));
+
+        /// <summary>
+        /// Get or sets the popup horizontal offset in relation to the button.
+        /// </summary>
+        public double PopupHorizontalOffset
+        {
+            get { return (double)GetValue(PopupHorizontalOffsetProperty); }
+            set { SetValue(PopupHorizontalOffsetProperty, value); }
+        }
+
+        /// <summary>
+        /// Get or sets the popup vertical offset in relation to the button.
+        /// </summary>
+        public static readonly DependencyProperty PopupVerticalOffsetProperty = DependencyProperty.Register(
+            nameof(PopupVerticalOffset), typeof(double), typeof(PopupBox), new PropertyMetadata(default(double)));
+
+        /// <summary>
+        /// Get or sets the popup vertical offset in relation to the button.
+        /// </summary>
+        public double PopupVerticalOffset
+        {
+            get { return (double)GetValue(PopupVerticalOffsetProperty); }
+            set { SetValue(PopupVerticalOffsetProperty, value); }
+        }
+
+        /// <summary>
         /// Framework use. Provides the method used to position the popup.
         /// </summary>
         public CustomPopupPlacementCallback PopupPlacementMethod => GetPopupPlacement;

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -70,6 +70,8 @@
         <Setter Property="ToggleContent" Value="{StaticResource MaterialDesignPopupBoxToggleContent}" />
         <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesignFlatButtonRipple}" />
         <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="PopupHorizontalOffset" Value="5"/>
+        <Setter Property="PopupVerticalOffset" Value="5"/>
         <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth3" />
         <Setter Property="TextElement.FontWeight" Value="Normal" />
         <Setter Property="Padding" Value="0 8 0 8" />
@@ -103,8 +105,8 @@
                         <controlzEx:PopupEx x:Name="PART_Popup" 
                                             IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPopupOpen, Mode=TwoWay}"
                                             CustomPopupPlacementCallback="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PopupPlacementMethod}"
-                                            HorizontalOffset="5"
-                                            VerticalOffset="5"
+                                            HorizontalOffset="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PopupHorizontalOffset}"
+                                            VerticalOffset="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PopupVerticalOffset}"
                                             PlacementTarget="{Binding ElementName=PART_Toggle}"
                                             Placement="Custom"
                                             PopupAnimation="Fade"


### PR DESCRIPTION
Closes #1387.

The bindings to the properties work as intended. However, some offset combinations seem to not work perfectly (for example, in my tests with all the bottom placement styles, I could not get the popup to open on the right of the button). This seems to be an issue with either the PopupEx itself or my tests in the demo, as can be tested by plugging in numbers directly in HorizontalOffset and VerticalOffset. Since the problem doesn't seem related to this code of binding the properties, I am leaving it as it is. Perhaps a new issue should be created regarding the offset problem (if it is a problem).