### PR TITLE
Adding new overload to theme assist

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
+++ b/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
@@ -8,9 +8,6 @@
     <Product>MaterialDesignThemes.Wpf.Tests</Product>
     <Copyright>Copyright ©  2015</Copyright>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />


### PR DESCRIPTION
This lets you easily apply a light/dark theme to a resource dictionary.

Fixes #1087