### PR TITLE
Change MaxHeigt & Wrap Snackbar Content Control

### DIFF
--- a/MainDemo.Wpf/Snackbars.xaml
+++ b/MainDemo.Wpf/Snackbars.xaml
@@ -55,8 +55,8 @@
 
                     <smtx:XamlDisplay Key="snackbar_2">
                         <!-- long hand form for setting the message -->
-                        <materialDesign:Snackbar IsActive="False" x:Name="SnackbarTwo" >
-                            <materialDesign:SnackbarMessage Content="Hello 2" ActionContent="UNDO" />
+                        <materialDesign:Snackbar IsActive="False" x:Name="SnackbarTwo">
+                            <materialDesign:SnackbarMessage Content="This is a snahckbar using more than 1 lines of text. Max. number of lines is 4, if more will be wrapped. Like this..." ActionContent="UNDO" />
                         </materialDesign:Snackbar>
                     </smtx:XamlDisplay>
                 </Grid>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Snackbar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Snackbar.xaml
@@ -78,7 +78,7 @@
                                           ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"                                      
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           DockPanel.Dock="Left"
-                                          MaxHeight="36">
+                                          MaxHeight="72">
                             <ContentPresenter.Resources>
                                 <DataTemplate DataType="{x:Type system:String}">
                                     <TextBlock Text="{Binding}">
@@ -86,7 +86,7 @@
                                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource MaterialDesignBody1TextBlock}">
                                                 <Setter Property="FontSize" Value="14" />
                                                 <Setter Property="TextWrapping" Value="WrapWithOverflow" />
-                                                <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+                                                <Setter Property="TextTrimming" Value="WordEllipsis" />
                                             </Style>
                                         </TextBlock.Style>
                                     </TextBlock>


### PR DESCRIPTION
Fix #1422
 
* Changed maxHeigt of Snackbar's Content control to be able to display up to 4 lines of text
* Update samples to show feature (Snackbar example 2)
* Change wrap mode to `WordEllipsis` to not cut words by wrapping