### PR TITLE
Set MaterialDesignToolButton ripple effect IsCentered property to true

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
@@ -254,6 +254,7 @@
     <Style x:Key="MaterialDesignToolButton" TargetType="{x:Type ButtonBase}" BasedOn="{StaticResource MaterialDesignFlatButton}">
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignToolForeground}"/>
         <Setter Property="Padding" Value="4"/>
+        <Setter Property="wpf:RippleAssist.IsCentered" Value="True"/>
         <Setter Property="wpf:RippleAssist.ClipToBounds" Value="False"/>
         <Setter Property="Template">
             <Setter.Value>


### PR DESCRIPTION
Set `MaterialDesignToolButton` ripple effect `IsCentered` property to true by default.