### PR TITLE
Adding ShowMeTheXaml to MahAppsDragablzDemo

### DIFF
--- a/MahMaterialDragablzMashUp/App.xaml
+++ b/MahMaterialDragablzMashUp/App.xaml
@@ -3,6 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:dragablz="clr-namespace:Dragablz;assembly=Dragablz"
+             xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
+             xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
+             xmlns:smtxAe="clr-namespace:ShowMeTheXAML.AvalonEdit;assembly=ShowMeTheXAML.AvalonEdit"           
+             xmlns:system="clr-namespace:System;assembly=mscorlib"
+             xmlns:mahDemo="clr-namespace:MahAppsDragablzDemo"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>
@@ -21,6 +26,9 @@
 
                 <!-- Dragablz Material Design -->
                 <ResourceDictionary Source="pack://application:,,,/Dragablz;component/Themes/materialdesign.xaml"/>
+
+                <!-- ShowMeTheXaml -->
+                <ResourceDictionary Source="pack://application:,,,/ShowMeTheXAML.AvalonEdit;component/Themes/xamldisplayer.xaml" />
 
             </ResourceDictionary.MergedDictionaries>
             <!-- MahApps Brushes -->
@@ -42,6 +50,95 @@
 
             <!-- Dragablz Material Design -->
             <Style TargetType="{x:Type dragablz:TabablzControl}" BasedOn="{StaticResource MaterialDesignTabablzControlStyle}" />
+
+            <Style TargetType="smtx:XamlDisplay" BasedOn="{StaticResource {x:Type smtx:XamlDisplay}}">
+                <Style.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.MergedDictionaries>
+                            <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Button.xaml" />
+                            <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ToggleButton.xaml" />
+                        </ResourceDictionary.MergedDictionaries>
+
+                        <smtxAe:TextDocumentValueConverter x:Key="TextDocumentValueConverter"/>
+                    </ResourceDictionary>
+                </Style.Resources>
+                <Setter Property="VerticalContentAlignment" Value="Bottom" />
+                <Setter Property="HorizontalContentAlignment" Value="Right" />
+                <Setter Property="mahDemo:XamlDisplayEx.ButtonDock" Value="Right" />
+                <Setter Property="Formatter">
+                    <Setter.Value>
+                        <smtx:XamlFormatter NewLineOnAttributes="True" Indent="  ">
+                            <smtx:XamlFormatter.NamespacesToRemove>
+                                <system:String>http://materialdesigninxaml.net/winfx/xaml/themes</system:String>
+                            </smtx:XamlFormatter.NamespacesToRemove>
+                        </smtx:XamlFormatter>
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="smtx:XamlDisplay">
+                            <DockPanel>
+                                <materialDesign:PopupBox DockPanel.Dock="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mahDemo:XamlDisplayEx.ButtonDock)}"
+                                                         Padding="10" StaysOpen="True" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                         VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
+                                                         x:Name="PopupBox">
+                                    <materialDesign:PopupBox.ToggleContent>
+                                        <materialDesign:PackIcon Kind="Xaml" Cursor="Hand" ToolTip="View XAML" 
+                                                                 Foreground="{DynamicResource PrimaryHueDarkBrush}" 
+                                                                 Background="Transparent" 
+                                                                 Margin="3">
+                                            <materialDesign:PackIcon.Style>
+                                                <Style TargetType="materialDesign:PackIcon" BasedOn="{StaticResource {x:Type materialDesign:PackIcon}}">
+                                                    <Setter Property="Opacity" Value="0.2" />
+                                                    <Style.Triggers>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter Property="Opacity" Value="1" />
+                                                        </Trigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </materialDesign:PackIcon.Style>
+                                        </materialDesign:PackIcon>
+                                    </materialDesign:PopupBox.ToggleContent>
+                                    <Border MaxHeight="600" MaxWidth="800">
+                                        <DockPanel>
+                                            <Button
+                                                Margin="0 10 0 0"
+                                                Tag="{Binding Xaml, RelativeSource={RelativeSource TemplatedParent}}"
+                                                HorizontalAlignment="Right"
+                                                Command="Copy"
+                                                CommandParameter="{Binding Xaml, RelativeSource={RelativeSource TemplatedParent}}"
+                                                Content="_COPY"
+                                                DockPanel.Dock="Bottom"
+                                                Style="{StaticResource MaterialDesignRaisedButton}">
+                                            </Button>
+                                            <avalonEdit:TextEditor Document="{Binding Xaml, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TextDocumentValueConverter}}" 
+                                                                   Style="{StaticResource AvalonTextEditorXamlDisplay}" />
+                                        </DockPanel>
+                                    </Border>
+
+                                </materialDesign:PopupBox>
+                                <Grid>
+                                    <AdornerDecorator>
+                                        <Border BorderBrush="{DynamicResource SecondaryAccentBrush}" Opacity=".4" Margin="-5">
+                                            <Border.Style>
+                                                <Style TargetType="Border">
+                                                    <Setter Property="BorderThickness" Value="0" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding ElementName=PopupBox, Path=IsPopupOpen}" Value="True">
+                                                            <Setter Property="BorderThickness" Value="5" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Border.Style>
+                                        </Border>
+                                    </AdornerDecorator>
+                                    <ContentPresenter />
+                                </Grid>
+                            </DockPanel>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/MahMaterialDragablzMashUp/App.xaml.cs
+++ b/MahMaterialDragablzMashUp/App.xaml.cs
@@ -3,6 +3,7 @@ using MaterialDesignThemes.MahApps;
 using MaterialDesignThemes.Wpf;
 using System.Windows;
 using MaterialDesignColors;
+using ShowMeTheXAML;
 
 namespace MahMaterialDragablzMashUp
 {
@@ -13,6 +14,7 @@ namespace MahMaterialDragablzMashUp
     {
         protected override void OnStartup(StartupEventArgs e)
         {
+            XamlDisplay.Init();
             base.OnStartup(e);
         }
     }

--- a/MahMaterialDragablzMashUp/Mah.xaml
+++ b/MahMaterialDragablzMashUp/Mah.xaml
@@ -7,71 +7,90 @@
              xmlns:local="clr-namespace:MahAppsDragablzDemo"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
              xmlns:mdix="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <UserControl.DataContext>
         <local:MahViewModel/>
     </UserControl.DataContext>
+    <UserControl.Resources>
+        <ObjectDataProvider x:Key="EnumValues"
+                                            MethodName="GetValues" ObjectType="{x:Type system:Enum}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="local:EnumValues"/>
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
+    </UserControl.Resources>
     <StackPanel>
         <TextBlock TextWrapping="Wrap">All controls using MahApps themes, will use Material Design pallete.</TextBlock>
 
         <controls:MetroAnimatedSingleRowTabControl TabStripPlacement="Left" Background="Transparent">
             <TabItem Header="ListBox">
-                <ListBox Margin="0 8 0 0">
-                    <ListBoxItem IsSelected="True">MahApps</ListBoxItem>
-                    <ListBoxItem>Dragablz</ListBoxItem>
-                    <ListBoxItem>Material</ListBoxItem>
-                </ListBox>
+                <smtx:XamlDisplay Key="ListBox_1">
+                    <ListBox Margin="0 8 0 0">
+                        <ListBoxItem IsSelected="True">MahApps</ListBoxItem>
+                        <ListBoxItem>Dragablz</ListBoxItem>
+                        <ListBoxItem>Material</ListBoxItem>
+                    </ListBox>
+                </smtx:XamlDisplay>
             </TabItem>
             <TabItem Header="Button/Switch">
                 <StackPanel>
-                    <controls:ToggleSwitch IsChecked="True" HorizontalAlignment="Left" />
-                    <Button Width="100" Margin="0 8 0 0" Content="Nice" HorizontalAlignment="Left"
+                    <smtx:XamlDisplay Key="ToggleSwitch_1" HorizontalAlignment="Left">
+                        <controls:ToggleSwitch IsChecked="True" HorizontalAlignment="Left" />
+                    </smtx:XamlDisplay>
+                    <smtx:XamlDisplay Key="AccentSquareButton_1" HorizontalAlignment="Left">
+                        <Button Width="100" Margin="0 8 0 0" Content="Nice" HorizontalAlignment="Left"
                             Style="{StaticResource MahApps.Styles.Button.AccentedSquare}" />
+                    </smtx:XamlDisplay>
                 </StackPanel>
             </TabItem>
             <TabItem Header="Sliders">
                 <StackPanel>
-                    <Slider Margin="6 16 6 0" TickPlacement="BottomRight" TickFrequency="10" />
-                    <controls:RangeSlider Margin="6 16 6 0" LowerValue="25" UpperValue="75" TickPlacement="BottomRight" TickFrequency="10" />
-                    <controls:RangeSlider Margin="0 16 0 0" LowerValue="25" UpperValue="75" Orientation="Vertical" Height="200"  />
+                    <smtx:XamlDisplay Key="Slider_1">
+                        <Slider Margin="6 16 6 0" TickPlacement="BottomRight" TickFrequency="10" />
+                    </smtx:XamlDisplay>
+                    <smtx:XamlDisplay Key="Slider_2">
+                        <controls:RangeSlider Margin="6 16 6 0" LowerValue="25" UpperValue="75" TickPlacement="BottomRight" TickFrequency="10" />
+                    </smtx:XamlDisplay>
+                    <smtx:XamlDisplay Key="Slider_3">
+                        <controls:RangeSlider Margin="0 16 0 0" LowerValue="25" UpperValue="75" Orientation="Vertical" Height="200"  />
+                    </smtx:XamlDisplay>
                 </StackPanel>
             </TabItem>
             <TabItem Header="NumericUpDown">
                 <StackPanel>
-                    <controls:NumericUpDown Margin="5" Value="{Binding UpDownValue, ValidatesOnExceptions=True}"/>
-                    <controls:NumericUpDown Culture="ar-EG" FlowDirection="RightToLeft" Margin="5" controls:TextBoxHelper.SelectAllOnFocus="True"/>
+                    <smtx:XamlDisplay Key="NumericUpDown_1">
+                        <controls:NumericUpDown Margin="5" Value="{Binding UpDownValue, ValidatesOnExceptions=True}"/>
+                    </smtx:XamlDisplay>
+                    <smtx:XamlDisplay Key="NumericUpDown_2">
+                        <controls:NumericUpDown Culture="ar-EG" FlowDirection="RightToLeft" Margin="5" controls:TextBoxHelper.SelectAllOnFocus="True"/>
+                    </smtx:XamlDisplay>
                 </StackPanel>
             </TabItem>
             <TabItem Header="DataGrid">
-                <DataGrid ItemsSource="{Binding GridData}" AutoGenerateColumns="False">
-                    <DataGrid.Resources>
-                        <ObjectDataProvider x:Key="EnumValues"
-                                            MethodName="GetValues" ObjectType="{x:Type system:Enum}">
-                            <ObjectDataProvider.MethodParameters>
-                                <x:Type TypeName="local:EnumValues"/>
-                            </ObjectDataProvider.MethodParameters>
-                        </ObjectDataProvider>
-                    </DataGrid.Resources>
-                    <DataGrid.Columns>
-                        <DataGridCheckBoxColumn Binding="{Binding IsChecked}"
+                <smtx:XamlDisplay Key="DataGrid_1">
+                    <DataGrid ItemsSource="{Binding GridData}" AutoGenerateColumns="False">
+                        <DataGrid.Columns>
+                            <DataGridCheckBoxColumn Binding="{Binding IsChecked}"
                                                 ElementStyle="{StaticResource MaterialDesignDataGridCheckBoxColumnStyle}"
                                                 EditingElementStyle="{StaticResource MaterialDesignDataGridCheckBoxColumnEditingStyle}">
-                            <DataGridCheckBoxColumn.Header>
-                                <CheckBox IsChecked="False" IsEnabled="False"/>
-                            </DataGridCheckBoxColumn.Header>
-                        </DataGridCheckBoxColumn>
-                        <mdix:DataGridTextColumn Header="Text" Binding="{Binding Text}" 
+                                <DataGridCheckBoxColumn.Header>
+                                    <CheckBox IsChecked="False" IsEnabled="False"/>
+                                </DataGridCheckBoxColumn.Header>
+                            </DataGridCheckBoxColumn>
+                            <mdix:DataGridTextColumn Header="Text" Binding="{Binding Text}" 
                                                  EditingElementStyle="{StaticResource MaterialDesignDataGridTextColumnPopupEditingStyle}"/>
-                        <mdix:DataGridComboBoxColumn Header="Combo" SelectedItemBinding="{Binding EnumValue}" ItemsSource="{Binding Source={StaticResource EnumValues}}"/>
-                        <controls:DataGridNumericUpDownColumn Binding="{Binding IntValue}"
+                            <mdix:DataGridComboBoxColumn Header="Combo" SelectedItemBinding="{Binding EnumValue}" ItemsSource="{Binding Source={StaticResource EnumValues}}"/>
+                            <controls:DataGridNumericUpDownColumn Binding="{Binding IntValue}"
                                                               Header="Numeric"
                                                               Width="300"
                                                               TextAlignment="Center"
                                                               Minimum="0"
                                                               StringFormat="{}{0} km" />
-                    </DataGrid.Columns>
-                </DataGrid>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </smtx:XamlDisplay>
             </TabItem>
         </controls:MetroAnimatedSingleRowTabControl>
 

--- a/MahMaterialDragablzMashUp/MainWindow.xaml
+++ b/MahMaterialDragablzMashUp/MainWindow.xaml
@@ -12,6 +12,9 @@
                       GlowBrush="{DynamicResource MahApps.Brushes.Accent}"
                       FontFamily="{StaticResource MahApps.Fonts.Default}"
                       Title="Material-MahApps-Dragablz Mash Up" Height="640" Width="800">
+    <Window.CommandBindings>
+        <CommandBinding Command="Copy" Executed="OnCopy" />
+    </Window.CommandBindings>
     <controls:MetroWindow.Flyouts>
         <controls:FlyoutsControl>
             <controls:Flyout x:Name="LeftFlyout" Position="Left" Header="Settings" wpf:FlyoutAssist.HeaderColorMode="Accent">

--- a/MahMaterialDragablzMashUp/MainWindow.xaml.cs
+++ b/MahMaterialDragablzMashUp/MainWindow.xaml.cs
@@ -1,4 +1,9 @@
-﻿namespace MahMaterialDragablzMashUp
+﻿using System;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Input;
+
+namespace MahMaterialDragablzMashUp
 {
     /// <summary>
     /// Interaction logic for MainWindow.xaml
@@ -8,6 +13,21 @@
         public MainWindow()
         {
             InitializeComponent();
+        }
+
+        private void OnCopy(object sender, ExecutedRoutedEventArgs e)
+        {
+            if (e.Parameter is string stringValue)
+            {
+                try
+                {
+                    Clipboard.SetDataObject(stringValue);
+                }
+                catch (Exception ex)
+                {
+                    Trace.WriteLine(ex.ToString());
+                }
+            }
         }
     }
 }

--- a/MahMaterialDragablzMashUp/XamlDisplayEx.cs
+++ b/MahMaterialDragablzMashUp/XamlDisplayEx.cs
@@ -1,0 +1,21 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+
+namespace MahAppsDragablzDemo
+{
+    public static class XamlDisplayEx
+    {
+        public static readonly DependencyProperty ButtonDockProperty = DependencyProperty.RegisterAttached(
+            "ButtonDock", typeof(Dock), typeof(XamlDisplayEx), new PropertyMetadata(default(Dock)));
+
+        public static void SetButtonDock(DependencyObject element, Dock value)
+        {
+            element.SetValue(ButtonDockProperty, value);
+        }
+
+        public static Dock GetButtonDock(DependencyObject element)
+        {
+            return (Dock) element.GetValue(ButtonDockProperty);
+        }
+    }
+}

--- a/MahMaterialDragablzMashUp/paket.references
+++ b/MahMaterialDragablzMashUp/paket.references
@@ -1,4 +1,7 @@
 MahApps.Metro
 Dragablz
 Microsoft.CSharp
+ShowMeTheXAML
+ShowMeTheXAML.AvalonEdit
+ShowMeTheXAML.MSBuild
 System.Data.DataSetExtensions

--- a/MainDemo.Wpf/MainWindow.xaml
+++ b/MainDemo.Wpf/MainWindow.xaml
@@ -16,7 +16,7 @@
         FontFamily="{materialDesign:MaterialDesignFont}" 
         Icon="favicon.ico">
     <Window.CommandBindings>
-        <CommandBinding Command="Copy" Executed="OnCopy"></CommandBinding>
+        <CommandBinding Command="Copy" Executed="OnCopy" />
     </Window.CommandBindings>
     <Window.Resources>
         <ResourceDictionary>

--- a/MainDemo.Wpf/MainWindow.xaml.cs
+++ b/MainDemo.Wpf/MainWindow.xaml.cs
@@ -14,7 +14,8 @@ namespace MaterialDesignColors.WpfExample
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
-    public partial class MainWindow : Window {
+    public partial class MainWindow : Window
+    {
         public static Snackbar Snackbar;
         public MainWindow()
         {
@@ -33,7 +34,7 @@ namespace MaterialDesignColors.WpfExample
             DataContext = new MainWindowViewModel(MainSnackbar.MessageQueue);
 
             Snackbar = this.MainSnackbar;
-        }        
+        }
 
         private void UIElement_OnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
@@ -50,12 +51,11 @@ namespace MaterialDesignColors.WpfExample
 
         private async void MenuPopupButton_OnClick(object sender, RoutedEventArgs e)
         {
-            var sampleMessageDialog = new SampleMessageDialog
-            {
-                Message = {Text = ((ButtonBase) sender).Content.ToString()}
+            var sampleMessageDialog = new SampleMessageDialog {
+                Message = { Text = ((ButtonBase)sender).Content.ToString() }
             };
 
-            await DialogHost.Show(sampleMessageDialog, "RootDialog");            
+            await DialogHost.Show(sampleMessageDialog, "RootDialog");
         }
 
         private void OnCopy(object sender, ExecutedRoutedEventArgs e)
@@ -72,5 +72,5 @@ namespace MaterialDesignColors.WpfExample
                 }
             }
         }
-    } 
+    }
 }

--- a/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Flyout.xaml
+++ b/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Flyout.xaml
@@ -11,7 +11,7 @@
                        wpf:ShadowAssist.ShadowDepth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mahApps:FlyoutAssist.HeaderShadowDepth)}"
                        Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mahApps:FlyoutAssist.HeaderColorMode)}">
             <DockPanel x:Name="dpHeader"
-                       Margin="{Binding Path=(mah:ControlsHelper.HeaderMargin), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type mah:Flyout}}, Mode=OneWay}"
+                       Margin="{Binding Path=(mah:HeaderedControlHelper.HeaderMargin), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type mah:Flyout}}, Mode=OneWay}"
                        VerticalAlignment="Center"
                        LastChildFill="True">
                 <Button x:Name="PART_BackButton"


### PR DESCRIPTION
This adds the ShowMeTheXaml dislplaying like in the normal demo app to the MahAppDragablzDemo.
It is right now only used int the Mah tabs, since in the dialog tab there is nothing special (only three default buttons) and the pallete selector is the same as in the other demo app.
This sadly adds more design time errors to the Mah.xaml file.
And I don't know why the copy button is not working here.