### PR TITLE
Filled and Outlined DatePicker styles

### DIFF
--- a/MainDemo.Wpf/Pickers.xaml
+++ b/MainDemo.Wpf/Pickers.xaml
@@ -72,6 +72,12 @@
                                         Style="{StaticResource MaterialDesignFloatingHintTimePicker}"
                                         materialDesign:HintAssist.Hint="Disabled" />
                 </smtx:XamlDisplay>
+                <smtx:XamlDisplay Key="pickers_13" HorizontalAlignment="Left" Margin="0 32 0 0">
+                    <DatePicker Width="140" materialDesign:HintAssist.Hint="Pick Date" Style="{StaticResource MaterialDesignFilledDatePicker}" />
+                </smtx:XamlDisplay>
+                <smtx:XamlDisplay Key="pickers_14" HorizontalAlignment="Left" Margin="0 16 0 0">
+                    <DatePicker Width="140" materialDesign:HintAssist.Hint="Pick Date" Style="{StaticResource MaterialDesignOutlinedDatePicker}" />
+                </smtx:XamlDisplay>
             </StackPanel>
 
             <smtx:XamlDisplay Key="pickers_7" Grid.Row="1" Grid.Column="2" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0 16 0 0">

--- a/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -48,7 +48,7 @@ namespace MaterialDesignThemes.Wpf
         /// Controls the visibility of the underline decoration.
         /// </summary>
         public static readonly DependencyProperty DecorationVisibilityProperty = DependencyProperty.RegisterAttached(
-            "DecorationVisibility", typeof(Visibility), typeof(TextFieldAssist), new FrameworkPropertyMetadata(default(Visibility), FrameworkPropertyMetadataOptions.Inherits));
+            "DecorationVisibility", typeof(Visibility), typeof(TextFieldAssist), new PropertyMetadata(default(Visibility)));
 
         /// <summary>
         /// Controls the visibility of the underline decoration.
@@ -72,7 +72,7 @@ namespace MaterialDesignThemes.Wpf
         /// Controls the visibility of the filled text field.
         /// </summary>
         public static readonly DependencyProperty HasFilledTextFieldProperty = DependencyProperty.RegisterAttached(
-            "HasFilledTextField", typeof(bool), typeof(TextFieldAssist), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits));
+            "HasFilledTextField", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(false));
 
         public static void SetHasFilledTextField(DependencyObject element, bool value)
         {
@@ -88,7 +88,7 @@ namespace MaterialDesignThemes.Wpf
         /// Controls the visibility of the text field area box.
         /// </summary>
         public static readonly DependencyProperty HasOutlinedTextFieldProperty = DependencyProperty.RegisterAttached(
-            "HasOutlinedTextField", typeof(bool), typeof(TextFieldAssist), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits));
+            "HasOutlinedTextField", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(false));
 
         public static void SetHasOutlinedTextField(DependencyObject element, bool value)
         {
@@ -104,7 +104,7 @@ namespace MaterialDesignThemes.Wpf
         /// Controls the corner radius of the surrounding box.
         /// </summary>
         public static readonly DependencyProperty TextFieldCornerRadiusProperty = DependencyProperty.RegisterAttached(
-            "TextFieldCornerRadius", typeof(CornerRadius), typeof(TextFieldAssist), new FrameworkPropertyMetadata(new CornerRadius(0.0), FrameworkPropertyMetadataOptions.Inherits));
+            "TextFieldCornerRadius", typeof(CornerRadius), typeof(TextFieldAssist), new PropertyMetadata(new CornerRadius(0.0)));
 
         public static void SetTextFieldCornerRadius(DependencyObject element, CornerRadius value)
         {
@@ -120,7 +120,7 @@ namespace MaterialDesignThemes.Wpf
         /// Controls the corner radius of the bottom line of the surrounding box.
         /// </summary>
         public static readonly DependencyProperty UnderlineCornerRadiusProperty = DependencyProperty.RegisterAttached(
-            "UnderlineCornerRadius", typeof(CornerRadius), typeof(TextFieldAssist), new FrameworkPropertyMetadata(new CornerRadius(0.0), FrameworkPropertyMetadataOptions.Inherits));
+            "UnderlineCornerRadius", typeof(CornerRadius), typeof(TextFieldAssist), new PropertyMetadata(new CornerRadius(0.0)));
 
         public static void SetUnderlineCornerRadius(DependencyObject element, CornerRadius value)
         {
@@ -136,7 +136,7 @@ namespace MaterialDesignThemes.Wpf
         /// Controls the highlighting style of a text box.
         /// </summary>
         public static readonly DependencyProperty NewSpecHighlightingEnabledProperty = DependencyProperty.RegisterAttached(
-            "NewSpecHighlightingEnabled", typeof(bool), typeof(TextFieldAssist), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits));
+            "NewSpecHighlightingEnabled", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(false));
 
         public static void SetNewSpecHighlightingEnabled(DependencyObject element, bool value)
         {
@@ -152,7 +152,7 @@ namespace MaterialDesignThemes.Wpf
         /// Enables a ripple effect on focusing the text box.
         /// </summary>
         public static readonly DependencyProperty RippleOnFocusEnabledProperty = DependencyProperty.RegisterAttached(
-            "RippleOnFocusEnabled", typeof(bool), typeof(TextFieldAssist), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits));
+            "RippleOnFocusEnabled", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(false));
 
         public static void SetRippleOnFocusEnabled(DependencyObject element, bool value)
         {
@@ -168,7 +168,7 @@ namespace MaterialDesignThemes.Wpf
         /// The color for highlighting effects on the border of a text box.
         /// </summary>
         public static readonly DependencyProperty UnderlineBrushProperty = DependencyProperty.RegisterAttached(
-            "UnderlineBrush", typeof(Brush), typeof(TextFieldAssist), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.Inherits));
+            "UnderlineBrush", typeof(Brush), typeof(TextFieldAssist), new PropertyMetadata(null));
 
         /// <summary>
         /// Sets the color for highlighting effects on the border of a text box.

--- a/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -48,7 +48,7 @@ namespace MaterialDesignThemes.Wpf
         /// Controls the visibility of the underline decoration.
         /// </summary>
         public static readonly DependencyProperty DecorationVisibilityProperty = DependencyProperty.RegisterAttached(
-            "DecorationVisibility", typeof(Visibility), typeof(TextFieldAssist), new PropertyMetadata(default(Visibility)));
+            "DecorationVisibility", typeof(Visibility), typeof(TextFieldAssist), new FrameworkPropertyMetadata(default(Visibility), FrameworkPropertyMetadataOptions.Inherits));
 
         /// <summary>
         /// Controls the visibility of the underline decoration.
@@ -72,7 +72,7 @@ namespace MaterialDesignThemes.Wpf
         /// Controls the visibility of the filled text field.
         /// </summary>
         public static readonly DependencyProperty HasFilledTextFieldProperty = DependencyProperty.RegisterAttached(
-            "HasFilledTextField", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(false));
+            "HasFilledTextField", typeof(bool), typeof(TextFieldAssist), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits));
 
         public static void SetHasFilledTextField(DependencyObject element, bool value)
         {
@@ -88,7 +88,7 @@ namespace MaterialDesignThemes.Wpf
         /// Controls the visibility of the text field area box.
         /// </summary>
         public static readonly DependencyProperty HasOutlinedTextFieldProperty = DependencyProperty.RegisterAttached(
-            "HasOutlinedTextField", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(false));
+            "HasOutlinedTextField", typeof(bool), typeof(TextFieldAssist), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits));
 
         public static void SetHasOutlinedTextField(DependencyObject element, bool value)
         {
@@ -104,7 +104,7 @@ namespace MaterialDesignThemes.Wpf
         /// Controls the corner radius of the surrounding box.
         /// </summary>
         public static readonly DependencyProperty TextFieldCornerRadiusProperty = DependencyProperty.RegisterAttached(
-            "TextFieldCornerRadius", typeof(CornerRadius), typeof(TextFieldAssist), new PropertyMetadata(new CornerRadius(0.0)));
+            "TextFieldCornerRadius", typeof(CornerRadius), typeof(TextFieldAssist), new FrameworkPropertyMetadata(new CornerRadius(0.0), FrameworkPropertyMetadataOptions.Inherits));
 
         public static void SetTextFieldCornerRadius(DependencyObject element, CornerRadius value)
         {
@@ -120,7 +120,7 @@ namespace MaterialDesignThemes.Wpf
         /// Controls the corner radius of the bottom line of the surrounding box.
         /// </summary>
         public static readonly DependencyProperty UnderlineCornerRadiusProperty = DependencyProperty.RegisterAttached(
-            "UnderlineCornerRadius", typeof(CornerRadius), typeof(TextFieldAssist), new PropertyMetadata(new CornerRadius(0.0)));
+            "UnderlineCornerRadius", typeof(CornerRadius), typeof(TextFieldAssist), new FrameworkPropertyMetadata(new CornerRadius(0.0), FrameworkPropertyMetadataOptions.Inherits));
 
         public static void SetUnderlineCornerRadius(DependencyObject element, CornerRadius value)
         {
@@ -136,7 +136,7 @@ namespace MaterialDesignThemes.Wpf
         /// Controls the highlighting style of a text box.
         /// </summary>
         public static readonly DependencyProperty NewSpecHighlightingEnabledProperty = DependencyProperty.RegisterAttached(
-            "NewSpecHighlightingEnabled", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(false));
+            "NewSpecHighlightingEnabled", typeof(bool), typeof(TextFieldAssist), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits));
 
         public static void SetNewSpecHighlightingEnabled(DependencyObject element, bool value)
         {
@@ -152,7 +152,7 @@ namespace MaterialDesignThemes.Wpf
         /// Enables a ripple effect on focusing the text box.
         /// </summary>
         public static readonly DependencyProperty RippleOnFocusEnabledProperty = DependencyProperty.RegisterAttached(
-            "RippleOnFocusEnabled", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(false));
+            "RippleOnFocusEnabled", typeof(bool), typeof(TextFieldAssist), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits));
 
         public static void SetRippleOnFocusEnabled(DependencyObject element, bool value)
         {
@@ -168,7 +168,7 @@ namespace MaterialDesignThemes.Wpf
         /// The color for highlighting effects on the border of a text box.
         /// </summary>
         public static readonly DependencyProperty UnderlineBrushProperty = DependencyProperty.RegisterAttached(
-            "UnderlineBrush", typeof(Brush), typeof(TextFieldAssist), new PropertyMetadata(null));
+            "UnderlineBrush", typeof(Brush), typeof(TextFieldAssist), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.Inherits));
 
         /// <summary>
         /// Sets the color for highlighting effects on the border of a text box.

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -9,15 +9,45 @@
     </ResourceDictionary.MergedDictionaries>
 
     <converters:TextFieldHintVisibilityConverter x:Key="TextFieldHintVisibilityConverter" />
+    <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     <converters:MathConverter Operation="Divide" x:Key="DivisionMathConverter" />
 
     <Style x:Key="MaterialDesignDatePickerTextBox" TargetType="{x:Type DatePickerTextBox}">
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
-        <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="0 0 0 0" />
-        <Setter Property="Background" Value="Transparent" />
-        <Setter Property="CaretBrush" Value="{Binding RelativeSource={RelativeSource Self}, Path=BorderBrush}" />
-        <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
-        <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+        <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="1 0 1 0" />
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="CaretBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextBoxBorder}" />
+        <Setter Property="BorderThickness" Value="0 0 0 1"/>
+        <Setter Property="KeyboardNavigation.TabNavigation" Value="Local"/>
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        <Setter Property="VerticalContentAlignment" Value="Top"/>
+        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <!-- cludge the default context menu -->
+        <Setter Property="ContextMenu">
+            <Setter.Value>
+                <ContextMenu>
+                    <MenuItem Command="Cut">
+                        <MenuItem.Icon>
+                            <wpf:PackIcon Kind="ContentCut"/>
+                        </MenuItem.Icon>
+                    </MenuItem>
+                    <MenuItem Command="Copy">
+                        <MenuItem.Icon>
+                            <wpf:PackIcon Kind="ContentCopy" />
+                        </MenuItem.Icon>
+                    </MenuItem>
+                    <MenuItem Command="Paste">
+                        <MenuItem.Icon>
+                            <wpf:PackIcon Kind="ContentPaste"/>
+                        </MenuItem.Icon>
+                    </MenuItem>
+                </ContextMenu>
+            </Setter.Value>
+        </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePickerTextBox}">
@@ -46,34 +76,243 @@
                                 </VisualState>
                             </VisualStateGroup>
                             <VisualStateGroup x:Name="FocusStates">
-                                <VisualStateGroup.Transitions>
-                                    <VisualTransition GeneratedDuration="0" />
-                                </VisualStateGroup.Transitions>
-                                <VisualState x:Name="Unfocused" />
-                                <VisualState x:Name="Focused" />
+                                <VisualState x:Name="Focused">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="ScaleTransform" From="0" To="1" Duration="0:0:0.3">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseOut" />
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="ScaleTransform" From="0" To="1" Duration="0:0:0.3">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseOut" />
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="ScaleTransform" To="0" BeginTime="0:0:0.45" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="ScaleTransform" To="0" BeginTime="0:0:0.45" Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Unfocused">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="ScaleTransform" To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="ScaleTransform" To="0" Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Grid x:Name="WatermarkContent" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                            <wpf:SmartHint x:Name="Hint"
-                                           FontSize="{TemplateBinding FontSize}"
-                                           UseFloating="{Binding Path=(wpf:HintAssist.IsFloating), RelativeSource={RelativeSource TemplatedParent}}"
-                                           FloatingScale="{Binding Path=(wpf:HintAssist.FloatingScale), RelativeSource={RelativeSource TemplatedParent}}"
-                                           FloatingOffset="{Binding Path=(wpf:HintAssist.FloatingOffset), RelativeSource={RelativeSource TemplatedParent}}"
-                                           Hint="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource TemplatedParent}}"
-                                           HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
-                                           HintOpacity="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
-                            <ContentControl x:Name="PART_Watermark" Focusable="False" IsHitTestVisible="False" Opacity="0" Visibility="Collapsed" />
-                            <ScrollViewer x:Name="PART_ContentHost" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="0" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
-                        </Grid>
+                        <Border HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                                Background="{DynamicResource MaterialDesignTextFieldBoxHoverBackground}"
+                                CornerRadius="{Binding Path=(wpf:TextFieldAssist.TextFieldCornerRadius), RelativeSource={RelativeSource TemplatedParent}}"
+                                Visibility="{Binding Path=(wpf:TextFieldAssist.RippleOnFocusEnabled), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                RenderTransformOrigin="0.5,0.5">
+                            <Border.RenderTransform>
+                                <ScaleTransform x:Name="ScaleTransform" ScaleX="0" ScaleY="0" />
+                            </Border.RenderTransform>
+                        </Border>
+                        <Border x:Name="textFieldBoxBorder" Background="{TemplateBinding Background}"
+                                CornerRadius="{Binding Path=(wpf:TextFieldAssist.TextFieldCornerRadius), RelativeSource={RelativeSource TemplatedParent}}"
+                                SnapsToDevicePixels="True">
+                            <Grid>
+                                <Border x:Name="border"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        SnapsToDevicePixels="True"
+                                        Padding="0 4 0 4">
+                                    <Grid x:Name="textFieldGrid"
+                                          Margin="{TemplateBinding Padding}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          MinWidth="1">
+                                        <ContentControl x:Name="PART_Watermark" Focusable="False" IsHitTestVisible="False" Opacity="0" Visibility="Collapsed" />
+                                        <ScrollViewer x:Name="PART_ContentHost" Focusable="false"
+                                                      HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden"
+                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                      UseLayoutRounding="{TemplateBinding UseLayoutRounding}" />
+                                        <wpf:SmartHint x:Name="Hint"
+                                                       Hint="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource TemplatedParent}}"
+                                                       HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
+                                                       FontSize="{TemplateBinding FontSize}"
+                                                       Padding="{TemplateBinding Padding}"
+                                                       HintOpacity="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"
+                                                       UseFloating="{Binding Path=(wpf:HintAssist.IsFloating), RelativeSource={RelativeSource TemplatedParent}}"
+                                                       FloatingScale="{Binding Path=(wpf:HintAssist.FloatingScale), RelativeSource={RelativeSource TemplatedParent}}"
+                                                       FloatingOffset="{Binding Path=(wpf:HintAssist.FloatingOffset), RelativeSource={RelativeSource TemplatedParent}}" />
+                                    </Grid>
+                                </Border>
+                                <Border x:Name="textFieldBoxBottomLine"
+                                        Background="{TemplateBinding BorderBrush}"
+                                        Height="0"
+                                        CornerRadius="{Binding Path=(wpf:TextFieldAssist.UnderlineCornerRadius), RelativeSource={RelativeSource TemplatedParent}}"
+                                        HorizontalAlignment="Stretch"
+                                        VerticalAlignment="Bottom"
+                                        SnapsToDevicePixels="True" />
+                                <Line x:Name="DashedLine" VerticalAlignment="Bottom" Visibility="Collapsed"
+                                      X1="0" X2="{Binding ActualWidth, ElementName=border}" Y1="0" Y2="0" 
+                                      StrokeThickness="1.25" StrokeDashArray="1,2.5" StrokeDashCap="Round"
+                                      Stroke="{TemplateBinding BorderBrush}" Opacity="0.56" />
+                                <wpf:Underline x:Name="Underline" Visibility="{Binding Path=(wpf:TextFieldAssist.DecorationVisibility), RelativeSource={RelativeSource TemplatedParent}}"
+                                               CornerRadius="{Binding Path=(wpf:TextFieldAssist.UnderlineCornerRadius), RelativeSource={RelativeSource TemplatedParent}}"
+                                               Background="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource TemplatedParent}}" />
+                                <Canvas VerticalAlignment="Bottom">
+                                    <TextBlock Canvas.Top="2" FontSize="10" MaxWidth="{Binding ActualWidth, ElementName=border}"
+                                           Opacity="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"
+                                           Text="{Binding Path=(wpf:HintAssist.HelperText), RelativeSource={RelativeSource TemplatedParent}}" />
+                                </Canvas>
+                            </Grid>
+                        </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition SourceName="Hint" Property="IsContentNullOrEmpty" Value="False" />
+                                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
                                 <Condition Property="IsKeyboardFocused" Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="Hint" Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+                            <Setter TargetName="Hint" Property="Foreground" Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
                             <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
+                        </MultiTrigger>
+                        <Trigger Property="wpf:HintAssist.IsFloating" Value="True">
+                            <Setter TargetName="border" Property="Margin" Value="0 12 0 0" />
+                        </Trigger>
+                        <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
+                            <Setter TargetName="textFieldBoxBorder" Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxHoverBackground}"/>
+                            <Setter Property="VerticalContentAlignment" Value="Top" />
+                            <Setter TargetName="textFieldBoxBorder" Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
+                            <Setter TargetName="textFieldBoxBorder" Property="Padding" Value="0,8,0,0" />
+                            <Setter TargetName="textFieldGrid" Property="Margin" Value="16,0,16,0" />
+                            <Setter TargetName="border" Property="BorderThickness" Value="0" />
+                            <Setter TargetName="border" Property="Cursor" Value="IBeam" />
+                            <Setter TargetName="Hint" Property="Margin" Value="0,0,0,16" />
+                            <Setter TargetName="PART_ContentHost" Property="Margin" Value="0,8,0,8" />
+                        </Trigger>
+                        <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
+                            <Setter Property="VerticalContentAlignment" Value="Top" />
+                            <Setter TargetName="textFieldBoxBorder" Property="BorderThickness" Value="1" />
+                            <Setter TargetName="textFieldBoxBorder" Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
+                            <Setter TargetName="textFieldBoxBorder" Property="Padding" Value="0,8,0,0" />
+                            <Setter TargetName="textFieldBoxBorder" Property="Margin" Value="-1" />
+                            <Setter TargetName="textFieldGrid" Property="Margin" Value="16,0,16,0" />
+                            <Setter TargetName="border" Property="BorderThickness" Value="0" />
+                            <Setter TargetName="border" Property="Cursor" Value="IBeam" />
+                            <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="Hint" Property="Margin" Value="0,0,0,16" />
+                            <Setter TargetName="PART_ContentHost" Property="Margin" Value="0,8,0,8" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                                <Condition Property="wpf:HintAssist.IsFloating" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_ContentHost" Property="Margin" Value="0,0,0,8" />
+                            <Setter TargetName="Hint" Property="Margin" Value="0,0,0,0" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_ContentHost" Property="Height" Value="{Binding Height, RelativeSource={RelativeSource TemplatedParent}}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="AcceptsReturn" Value="true" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter Property="VerticalContentAlignment" Value="Top" />
+                        </MultiTrigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="border" Property="Opacity" Value="0.42" />
+                            <Setter TargetName="textFieldBoxBottomLine" Property="Height" Value="0" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsEnabled" Value="false" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="textFieldBoxBorder" Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaInactiveBorder}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsEnabled" Value="false" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter Property="Opacity" TargetName="border" Value="0.42"/>
+                            <Setter TargetName="border" Property="BorderBrush" Value="Transparent" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsEnabled" Value="false" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="DashedLine" Property="Visibility" Value="Visible" />
+                        </MultiTrigger>
+                        <Trigger Property="IsKeyboardFocused" Value="true">
+                            <Setter TargetName="Underline" Property="IsActive" Value="True"/>
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsKeyboardFocused" Value="True" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="textFieldBoxBorder" Property="Margin" Value="-2" />
+                            <Setter TargetName="textFieldBoxBorder" Property="BorderThickness" Value="2" />
+                            <Setter TargetName="textFieldBoxBorder" Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource TemplatedParent}}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsKeyboardFocused" Value="True" />
+                                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="textFieldBoxBottomLine" Property="Height" Value="2" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" Value="True" />
+                                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                                <Condition Property="wpf:TextFieldAssist.NewSpecHighlightingEnabled" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" Value="True" />
+                                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                                <Condition Property="wpf:TextFieldAssist.NewSpecHighlightingEnabled" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="border" Property="BorderThickness" Value="0,0,0,2" />
+                            <Setter TargetName="border" Property="Padding" Value="0,4,0,3" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" Value="True" />
+                                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="textFieldBoxBorder" Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxHoverBackground}" />
+                            <Setter TargetName="textFieldBoxBottomLine" Property="Height" Value="1" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" Value="True" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="textFieldBoxBorder" Property="Margin" Value="-2" />
+                            <Setter TargetName="textFieldBoxBorder" Property="BorderThickness" Value="2" />
+                        </MultiTrigger>
+                        <Trigger Property="wpf:ValidationAssist.HasError" Value="True">
+                            <Setter Property="BorderBrush" Value="{DynamicResource ValidationErrorBrush}"/>
+                            <Setter TargetName="Underline" Property="Background" Value="{DynamicResource ValidationErrorBrush}"/>
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="wpf:ValidationAssist.HasError" Value="True" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="textFieldBoxBorder" Property="Margin" Value="-2" />
+                            <Setter TargetName="textFieldBoxBorder" Property="BorderThickness" Value="2" />
+                            <Setter TargetName="textFieldBoxBorder" Property="BorderBrush" Value="{DynamicResource ValidationErrorBrush}" />
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -111,108 +350,85 @@
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="Margin" Value="0 0 0 0" />
         <Setter Property="Validation.ErrorTemplate" Value="{StaticResource MaterialDesignValidationErrorTemplate}" />
+        <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePicker}">
-                    <Grid>
-                        <Border BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                Background="{TemplateBinding Background}"
-                                x:Name="border"
-                                Padding="0 4 0 4"
-                                SnapsToDevicePixels="True">
-                            <VisualStateManager.VisualStateGroups>
-                                <VisualStateGroup x:Name="CommonStates">
-                                    <VisualState x:Name="Normal" />
-                                    <VisualState x:Name="Disabled">
-                                        <Storyboard>
-                                            <DoubleAnimation Duration="0" To=".56" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="PART_Root" />
-                                        </Storyboard>
-                                    </VisualState>
-                                </VisualStateGroup>
-                            </VisualStateManager.VisualStateGroups>
-                            <Grid x:Name="PART_Root"
-                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                  Background="Transparent">
-                                <Grid.Resources>
-                                    <ControlTemplate x:Key="DropDownButtonTemplate" TargetType="{x:Type Button}">
-                                        <Grid Background="Transparent">
-                                            <VisualStateManager.VisualStateGroups>
-                                                <VisualStateGroup x:Name="CommonStates">
-                                                    <VisualStateGroup.Transitions>
-                                                        <VisualTransition GeneratedDuration="0" />
-                                                        <VisualTransition GeneratedDuration="0:0:0.1" To="MouseOver" />
-                                                        <VisualTransition GeneratedDuration="0:0:0.1" To="Pressed" />
-                                                    </VisualStateGroup.Transitions>
-                                                    <VisualState x:Name="Normal" />
-                                                    <VisualState x:Name="MouseOver" />
-                                                    <VisualState x:Name="Pressed" />
-                                                    <VisualState x:Name="Disabled" />
-                                                </VisualStateGroup>
-                                            </VisualStateManager.VisualStateGroups>
-                                            <Viewbox>
-                                                <Canvas Width="24" Height="24">
-                                                    <Path Data="M19,19H5V8H19M16,1V3H8V1H6V3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3H18V1M17,12H12V17H17V12Z" Fill="{TemplateBinding Foreground}" />
-                                                </Canvas>
-                                            </Viewbox>
-                                        </Grid>
-                                    </ControlTemplate>
-                                </Grid.Resources>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Button x:Name="PART_Button"
-                                        Grid.Column="1"
-                                        Foreground="{TemplateBinding BorderBrush}"
-                                        Focusable="False"
-                                        HorizontalAlignment="Right"
-                                        Margin="4 0 0 -3"
-                                        Template="{StaticResource DropDownButtonTemplate}" 
-                                        Padding="0"
-                                        Height="17" />
-                                <DatePickerTextBox x:Name="PART_TextBox"
-                                                   Grid.Column="0"
-                                                   Focusable="{TemplateBinding Focusable}"
-                                                   HorizontalContentAlignment="Stretch"
-                                                   Grid.Row="0"
-                                                   VerticalContentAlignment="Center"
-                                                   Style="{DynamicResource MaterialDesignDatePickerTextBox}"
-                                                   HorizontalAlignment="Stretch" 
-                                                   wpf:HintAssist.HintOpacity="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"/>
-                                <Popup x:Name="PART_Popup" AllowsTransparency="True" 
-                                       Placement="Custom"
-                                       CustomPopupPlacementCallback="{x:Static wpf:CustomPopupPlacementCallbackHelper.LargePopupCallback}"
-                                       PlacementTarget="{Binding ElementName=PART_TextBox}" StaysOpen="False"
-                                       PopupAnimation="Fade"  />
+                    <ControlTemplate.Resources>
+                        <ControlTemplate x:Key="DropDownButtonTemplate" TargetType="{x:Type Button}">
+                            <Grid Background="Transparent">
+                                <Viewbox>
+                                    <Canvas Width="24" Height="24">
+                                        <Path Data="M19,19H5V8H19M16,1V3H8V1H6V3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3H18V1M17,12H12V17H17V12Z" Fill="{TemplateBinding Foreground}" />
+                                    </Canvas>
+                                </Viewbox>
                             </Grid>
-                        </Border>
-                        <Line x:Name="DashedLine" VerticalAlignment="Bottom" Visibility="Hidden"
-                              StrokeThickness="{Binding BorderThickness.Bottom, ElementName=border, Converter={StaticResource DivisionMathConverter}, ConverterParameter=0.75}" StrokeDashArray="1,2.5" StrokeDashCap="Round"
-                              X1="0" X2="{Binding ActualWidth, ElementName=border}" Y1="0" Y2="0" 
-                              Stroke="{TemplateBinding BorderBrush}" Opacity="0.56" />
-                        <wpf:Underline x:Name="Underline" Visibility="{Binding Path=(wpf:TextFieldAssist.DecorationVisibility), RelativeSource={RelativeSource TemplatedParent}}" />
+                        </ControlTemplate>
+                    </ControlTemplate.Resources>
+                    <Grid x:Name="PART_Root">
+                        <DatePickerTextBox x:Name="PART_TextBox"
+                                           Grid.Column="0"
+                                           Focusable="{TemplateBinding Focusable}"
+                                           Grid.Row="0"
+                                           Padding="0,0,8,0"
+                                           VerticalContentAlignment="Center"
+                                           Style="{DynamicResource MaterialDesignDatePickerTextBox}"
+                                           HorizontalAlignment="Stretch" 
+                                           wpf:HintAssist.HintOpacity="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"/>
+                        <Button x:Name="PART_Button"
+                                Foreground="{TemplateBinding BorderBrush}"
+                                Focusable="False"
+                                HorizontalAlignment="Right"
+                                Margin="4 0 0 -3"
+                                Template="{StaticResource DropDownButtonTemplate}" 
+                                Padding="0"
+                                Height="17" />
+                        <Popup x:Name="PART_Popup" AllowsTransparency="True" 
+                               Placement="Custom"
+                               CustomPopupPlacementCallback="{x:Static wpf:CustomPopupPlacementCallbackHelper.LargePopupCallback}"
+                               PlacementTarget="{Binding ElementName=PART_TextBox}" StaysOpen="False"
+                               PopupAnimation="Fade"  />
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Opacity" TargetName="border" Value="0.56" />
-                            <Setter Property="Visibility" TargetName="DashedLine"  Value="Visible" />
-                            <Setter Property="BorderBrush" TargetName="border" Value="Transparent" />
+                        <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
+                            <Setter TargetName="PART_TextBox" Property="Padding" Value="0,0,22,0" />
+                            <Setter TargetName="PART_Button" Property="Margin" Value="4 0 12 -3" />
+                            <Setter TargetName="PART_Button" Property="Height" Value="20" />
                         </Trigger>
-                        <Trigger Property="IsMouseOver" Value="true">
+                        <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
+                            <Setter TargetName="PART_TextBox" Property="Padding" Value="0,0,22,0" />
+                            <Setter TargetName="PART_Button" Property="Margin" Value="4 0 12 -3" />
+                            <Setter TargetName="PART_Button" Property="Height" Value="20" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_Button" Property="Margin" Value="4 0 0 -15" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                                <Condition Property="IsMouseOver" Value="True" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsEnabled" Value="True" />
+                                <Condition SourceName="PART_Button" Property="IsMouseOver" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_Button" Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}"/>
+                        </MultiTrigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="PART_Button" Property="Opacity" Value="0.56"/>
                         </Trigger>
-                        <Trigger Property="IsKeyboardFocusWithin" Value="true">
-                            <Setter TargetName="Underline" Property="IsActive" Value="True" />
-                            <Setter Property="BorderBrush"  Value="{DynamicResource PrimaryHueMidBrush}" />
-                        </Trigger>
-                        <Trigger Property="Validation.HasError" Value="true">
-                            <Setter Property="BorderBrush" Value="{DynamicResource ValidationErrorBrush}" />
-                            <Setter TargetName="Underline" Property="Background" Value="{DynamicResource ValidationErrorBrush}" />
-                        </Trigger>
-                        <Trigger Property="wpf:HintAssist.IsFloating" Value="True">
-                            <Setter TargetName="border" Property="Margin" Value="0 12 0 0" />
+                        <Trigger Property="Validation.HasError" Value="True">
+                            <Setter TargetName="PART_TextBox" Property="wpf:ValidationAssist.HasError" Value="True" />
+                            <Setter TargetName="PART_Button" Property="Foreground" Value="{DynamicResource ValidationErrorBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -223,4 +439,16 @@
     <Style x:Key="MaterialDesignFloatingHintDatePicker" TargetType="{x:Type DatePicker}" BasedOn="{StaticResource MaterialDesignDatePicker}">
         <Setter Property="wpf:HintAssist.IsFloating" Value="True" />
     </Style>
+
+    <Style x:Key="MaterialDesignFilledDatePicker" TargetType="{x:Type DatePicker}" BasedOn="{StaticResource MaterialDesignFloatingHintDatePicker}">
+        <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
+        <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />
+        <Setter Property="wpf:TextFieldAssist.UnderlineCornerRadius" Value="0" />
+    </Style>
+
+    <Style x:Key="MaterialDesignOutlinedDatePicker" TargetType="{x:Type DatePicker}" BasedOn="{StaticResource MaterialDesignFloatingHintDatePicker}">
+        <Setter Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+        <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />
+    </Style>
+
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -350,6 +350,7 @@
         <Setter Property="Margin" Value="0 0 0 0" />
         <Setter Property="Validation.ErrorTemplate" Value="{StaticResource MaterialDesignValidationErrorTemplate}" />
         <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePicker}">
@@ -373,7 +374,25 @@
                                            VerticalContentAlignment="Center"
                                            Style="{DynamicResource MaterialDesignDatePickerTextBox}"
                                            HorizontalAlignment="Stretch" 
-                                           wpf:HintAssist.HintOpacity="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"/>
+                                           wpf:HintAssist.IsFloating="{Binding Path=(wpf:HintAssist.IsFloating), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:HintAssist.FloatingScale="{Binding Path=(wpf:HintAssist.FloatingScale), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:HintAssist.FloatingOffset="{Binding Path=(wpf:HintAssist.FloatingOffset), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:HintAssist.Hint="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:HintAssist.HintOpacity="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:HintAssist.Foreground="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:HintAssist.HelperText="{Binding Path=(wpf:HintAssist.HelperText), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:TextFieldAssist.TextBoxViewMargin="{Binding Path=(wpf:TextFieldAssist.TextBoxViewMargin), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:TextFieldAssist.DecorationVisibility="{Binding Path=(wpf:TextFieldAssist.DecorationVisibility), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:TextFieldAssist.HasFilledTextField="{Binding Path=(wpf:TextFieldAssist.HasFilledTextField), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:TextFieldAssist.HasOutlinedTextField="{Binding Path=(wpf:TextFieldAssist.HasOutlinedTextField), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:TextFieldAssist.TextFieldCornerRadius="{Binding Path=(wpf:TextFieldAssist.TextFieldCornerRadius), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:TextFieldAssist.UnderlineCornerRadius="{Binding Path=(wpf:TextFieldAssist.UnderlineCornerRadius), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:TextFieldAssist.NewSpecHighlightingEnabled="{Binding Path=(wpf:TextFieldAssist.NewSpecHighlightingEnabled), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:TextFieldAssist.RippleOnFocusEnabled="{Binding Path=(wpf:TextFieldAssist.RippleOnFocusEnabled), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:TextFieldAssist.UnderlineBrush="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:TextFieldAssist.HasClearButton="{Binding Path=(wpf:TextFieldAssist.HasClearButton), RelativeSource={RelativeSource TemplatedParent}}"
+                                           wpf:TextFieldAssist.SuffixText="{Binding Path=(wpf:TextFieldAssist.SuffixText), RelativeSource={RelativeSource TemplatedParent}}"
+                                           />
                         <Button x:Name="PART_Button"
                                 Foreground="{TemplateBinding BorderBrush}"
                                 Focusable="False"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -174,7 +174,6 @@
                             <Setter TargetName="border" Property="Margin" Value="0 12 0 0" />
                         </Trigger>
                         <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
-                            <Setter TargetName="textFieldBoxBorder" Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxHoverBackground}"/>
                             <Setter Property="VerticalContentAlignment" Value="Top" />
                             <Setter TargetName="textFieldBoxBorder" Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
                             <Setter TargetName="textFieldBoxBorder" Property="Padding" Value="0,8,0,0" />

--- a/MaterialDesignThemes.Wpf/ValidationAssist.cs
+++ b/MaterialDesignThemes.Wpf/ValidationAssist.cs
@@ -122,5 +122,21 @@ namespace MaterialDesignThemes.Wpf
         {
             return (double)element.GetValue(FontSizeProperty);
         }
+
+        public static readonly DependencyProperty HasErrorProperty = DependencyProperty.RegisterAttached(
+            "HasError",
+            typeof(bool),
+            typeof(ValidationAssist),
+            new PropertyMetadata(default(bool)));
+
+        public static void SetHasError(DependencyObject element, bool value)
+        {
+            element.SetValue(HasErrorProperty, value);
+        }
+
+        public static bool GetHasError(DependencyObject element)
+        {
+            return (bool)element.GetValue(HasErrorProperty);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1478

![FilledAndOutlinedDatePickerStyles](https://user-images.githubusercontent.com/1404846/68230283-05c13b00-fff9-11e9-913c-206b864e54ad.png)

The new `DatePickerTextBox` style is a modified version of `MaterialDesignTextBoxBase`. The spacing in the styles are perhaps not exactly like the spec, but it's identical to the new Filled and Outlined TextBox styles in this library. I felt it was better to be consistent with those.

This PR replaces the template in `MaterialDesignDatePicker`, but I've attempted to make certain that the default style is not changed.