### PR TITLE
Fixed .NET Core version for UseDotNet step in Azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ variables:
   solution: 'MaterialDesignToolkit.Wpf.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'AppVeyor'
-  dotNetCoreVersion: '3.0.*'
+  dotNetCoreVersion: '3.0.x'
 
 steps:
 - task: UseDotNet@2


### PR DESCRIPTION
The [Azure pipeline builds](https://dev.azure.com/MaterialDesignInXAML/MaterialDesignInXaml/_build?definitionId=2) are currently failing [because](https://dev.azure.com/MaterialDesignInXAML/MaterialDesignInXaml/_build/results?buildId=745)
> ##[error]Version 3.0.* is not allowed. Allowed version types are: majorVersion.x, majorVersion.minorVersion.x, majorVersion.minorVersion.patchVersion. More details: The version number: 3.0.* doesn't have the correct format. Versions can be given in the following formats: 2.x   => Install latest in major version. 2.2.x => Install latest in major and minor version. 2.2.104 => Install exact version. Find the value of `version` for installing SDK/Runtime, from the releases.json. The link to releases.json of that major.minor version can be found in [**releases-index file.**](https://github.com/dotnet/core/blob/master/release-notes/releases-index.json). Like link to releases.json for 2.2 version is https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.2/releases.json

This PR just changes `3.0.*` to the expected format of `3.0.x`.

My project at work is also using version 2 of the [UseDotNet](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops) task.  I tested using `3.0.x` there, and it works with the relevant section of the logs being
> Tool to install: .NET Core sdk version 3.0.x.
> Found version 3.0.100 in channel 3.0 for user specified version spec: 3.0.x
