### PR TITLE
Custom Thumb Control and ControlTemplate to fix issue #1531

### DIFF
--- a/MaterialDesignThemes.Wpf/GridViewColumnThumb.cs
+++ b/MaterialDesignThemes.Wpf/GridViewColumnThumb.cs
@@ -1,0 +1,22 @@
+﻿using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+
+namespace MaterialDesignThemes.Wpf
+{
+    public class GridViewColumnThumb : Thumb
+    {
+        public GridViewColumnThumb() : base() { }
+
+        protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+        {
+            Mouse.OverrideCursor = Cursors.SizeWE;
+            base.OnMouseLeftButtonDown(e);
+        }
+
+        protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)
+        {
+            base.OnMouseLeftButtonUp(e);
+            Mouse.OverrideCursor = null;
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/GridViewColumnThumb.cs
+++ b/MaterialDesignThemes.Wpf/GridViewColumnThumb.cs
@@ -3,7 +3,7 @@ using System.Windows.Input;
 
 namespace MaterialDesignThemes.Wpf
 {
-    public class GridViewColumnThumb : Thumb
+    internal class GridViewColumnThumb : Thumb
     {
         public GridViewColumnThumb() : base() { }
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml
@@ -89,9 +89,9 @@
                 <ControlTemplate TargetType="GridViewColumnHeader">
                     <DockPanel>
                         <wpf:GridViewColumnThumb x:Name="PART_HeaderGripper"
-                               DockPanel.Dock="Right"
-                               Margin="0,0,-8,0"
-                               Style="{StaticResource MaterialDesignGridColumnHeaderGripper}" />
+                                                 DockPanel.Dock="Right"
+                                                 Margin="0,0,-8,0"
+                                                 Style="{StaticResource MaterialDesignGridViewColumnHeaderGripper}" />
                         <Border x:Name="HeaderBorder"
                                 Padding="{TemplateBinding Padding}"
                                 BorderThickness="{TemplateBinding BorderThickness}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml
@@ -88,7 +88,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="GridViewColumnHeader">
                     <DockPanel>
-                        <Thumb x:Name="PART_HeaderGripper"
+                        <wpf:GridViewColumnThumb x:Name="PART_HeaderGripper"
                                DockPanel.Dock="Right"
                                Margin="0,0,-8,0"
                                Style="{StaticResource MaterialDesignGridColumnHeaderGripper}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Thumb.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Thumb.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="clr-namespace:MaterialDesignTheme">
+                    xmlns:local="clr-namespace:MaterialDesignThemes.Wpf">
 
     <Style x:Key="MaterialDesignThumb" TargetType="{x:Type Thumb}">
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -27,6 +27,10 @@
     <Style x:Key="MaterialDesignGridColumnHeaderGripper" TargetType="{x:Type Thumb}" BasedOn="{StaticResource MaterialDesignThumb}">
         <Setter Property="Width" Value="8"/>
         <Setter Property="Cursor" Value="SizeWE"/>
+    </Style>
+
+    <Style x:Key="MaterialDesignGridViewColumnHeaderGripper" TargetType="{x:Type Thumb}" BasedOn="{StaticResource MaterialDesignThumb}">
+        <Setter Property="Width" Value="8"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Thumb}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Thumb.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Thumb.xaml
@@ -27,6 +27,17 @@
     <Style x:Key="MaterialDesignGridColumnHeaderGripper" TargetType="{x:Type Thumb}" BasedOn="{StaticResource MaterialDesignThumb}">
         <Setter Property="Width" Value="8"/>
         <Setter Property="Cursor" Value="SizeWE"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Thumb}">
+                    <Border x:Name="PART_Border"
+                            Cursor="SizeWE"
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
Hi,
I created a ControlTemplate (in ```MaterialDesignGridColumnHeaderGripper```) that sets the cursor to SizeWE. This is necessary because the Cursor needs to be explicitly set in ControlTemplate or else the cursor is set to "None" or in some cases disappears in the GridViewColumnHeader.
I also created a Thumb Control to override the cursor when dragging. This is necessary because when dragging, the cursor will revert to "None".

With these changes, a GridView be consistent with the DataGrid control.