### PR TITLE
Setting min height of popup

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -524,6 +524,7 @@
                                    ClassicContentTemplate="{StaticResource PopupContentClassicTemplate}">
                     <ContentControl>
                         <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                                      MinHeight="1"
                                       Background="{Binding Background, ElementName=PART_Popup}">
                             <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained" />
                         </ScrollViewer>


### PR DESCRIPTION
This fixes the issue where an empty combobox does not show on the first click.

Fixes #1261