### PR TITLE
Changing TimePicker text box to a derived class

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -9,12 +9,12 @@
     <converters:MathConverter Operation="Divide" x:Key="DivisionMathConverter" />
 
     <Style x:Key="MaterialDesignTimePicker" TargetType="{x:Type wpf:TimePicker}">
-		<Setter Property="VerticalAlignment" Value="Center"/>
-		<Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
-		<Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextBoxBorder}" />
-		<Setter Property="Background" Value="Transparent"/>
-		<Setter Property="BorderThickness" Value="0 0 0 1"/>
-		<Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextBoxBorder}" />
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0 0 0 1"/>
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         <Setter Property="IsTabStop" Value="False"/>
         <Setter Property="wpf:HintAssist.Hint" Value="Select time" />
         <Setter Property="ClockStyle" Value="{DynamicResource MaterialDesignClock}" />
@@ -100,7 +100,7 @@
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
-                                <TextBox BorderThickness="0" x:Name="PART_TextBox"
+                                <wpf:TimePickerTextBox BorderThickness="0" x:Name="PART_TextBox"
                                          wpf:TextFieldAssist.TextBoxViewMargin=".5 0 0 0"
                                          Margin="0"
                                          Template="{StaticResource TextBoxTemplate}"

--- a/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -13,7 +13,7 @@ namespace MaterialDesignThemes.Wpf
 {
     [TemplatePart(Name = ButtonPartName, Type = typeof(Button))]
     [TemplatePart(Name = PopupPartName, Type = typeof(Popup))]
-    [TemplatePart(Name = TextBoxPartName, Type = typeof(TextBox))]
+    [TemplatePart(Name = TextBoxPartName, Type = typeof(TimePickerTextBox))]
     public class TimePicker : Control
     {
         public const string ButtonPartName = "PART_Button";
@@ -36,10 +36,12 @@ namespace MaterialDesignThemes.Wpf
 
         public TimePicker()
         {
-            _clock = new Clock {
+            _clock = new Clock 
+            {
                 DisplayAutomation = ClockDisplayAutomation.ToMinutesOnly
             };
-            _clockHostContentControl = new ContentControl {
+            _clockHostContentControl = new ContentControl 
+            {
                 Content = _clock
             };
             InitializeClock();
@@ -172,7 +174,7 @@ namespace MaterialDesignThemes.Wpf
                 //TODO set time
                 //dp._originalSelectedDate = dp.SelectedDate;
 
-                timePicker.Dispatcher.BeginInvoke(DispatcherPriority.Input, new Action(() =>
+                timePicker.Dispatcher?.BeginInvoke(DispatcherPriority.Input, new Action(() =>
                 {
                     timePicker._clock.Focus();
                 }));
@@ -438,14 +440,13 @@ namespace MaterialDesignThemes.Wpf
 
         private void PopupOnPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
-            var popup = sender as Popup;
-            if (popup == null || popup.StaysOpen) return;
+            if (!(sender is Popup popup) || popup.StaysOpen) return;
 
             if (_dropDownButton?.InputHitTest(mouseButtonEventArgs.GetPosition(_dropDownButton)) != null)
             {
                 // This popup is being closed by a mouse press on the drop down button 
                 // The following mouse release will cause the closed popup to immediately reopen. 
-                // Raise a flag to block reopeneing the popup
+                // Raise a flag to block re-opening the popup
                 _disablePopupReopen = true;
             }
         }
@@ -495,10 +496,8 @@ namespace MaterialDesignThemes.Wpf
 
         private void ClockChoiceMadeHandler(object sender, ClockChoiceMadeEventArgs clockChoiceMadeEventArgs)
         {
-            if (
-                (WithSeconds && (clockChoiceMadeEventArgs.Mode == ClockDisplayMode.Seconds)) ||
-                (!WithSeconds && (clockChoiceMadeEventArgs.Mode == ClockDisplayMode.Minutes))
-            )
+            if (WithSeconds && clockChoiceMadeEventArgs.Mode == ClockDisplayMode.Seconds ||
+                !WithSeconds && clockChoiceMadeEventArgs.Mode == ClockDisplayMode.Minutes)
             {
                 TogglePopup();
                 if (SelectedTime == null)

--- a/MaterialDesignThemes.Wpf/TimePickerTextBox.cs
+++ b/MaterialDesignThemes.Wpf/TimePickerTextBox.cs
@@ -1,0 +1,13 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace MaterialDesignThemes.Wpf
+{
+    public class TimePickerTextBox : TextBox
+    {
+        static TimePickerTextBox()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(TimePickerTextBox), new FrameworkPropertyMetadata(typeof(TimePickerTextBox)));
+        }
+    }
+}


### PR DESCRIPTION
This matches how the DatePicker works and prevents implicit styles on TextBox from accidentally affecting it.

Fixes #1554