### PR TITLE
Change Outlined Text Fields Hint Style

### DIFF
--- a/MaterialDesignThemes.Wpf/Converters/FontSizeToHintOffsetConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/FontSizeToHintOffsetConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace MaterialDesignThemes.Wpf.Converters
+{
+    public class FontSizeToHintOffsetConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var fontSize = System.Convert.ToDouble(value);
+            var hintOffset = fontSize / 2 + 12;
+            return new Point(0, -hintOffset);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -11,6 +11,7 @@
     <converters:MathConverter Operation="Divide" x:Key="DivisionMathConverter" />
     <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearTextConverter" />
     <converters:NotConverter x:Key="NotConverter" />
+    <converters:FontSizeToHintOffsetConverter x:Key="FontSizeToHintOffsetConverter" />
 
     <Style x:Key="MaterialDesignPasswordBox" TargetType="{x:Type PasswordBox}">
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
@@ -115,15 +116,22 @@
                                                       />
                                         <wpf:SmartHint x:Name="Hint"
                                                        Grid.Column="0"
-                                                       Hint="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource TemplatedParent}}"
                                                        HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
+                                                       FontSize="{TemplateBinding FontSize}"
+                                                       Padding="{TemplateBinding Padding}"
                                                        HintOpacity="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"
                                                        UseFloating="{Binding Path=(wpf:HintAssist.IsFloating), RelativeSource={RelativeSource TemplatedParent}}"
                                                        FloatingScale="{Binding Path=(wpf:HintAssist.FloatingScale), RelativeSource={RelativeSource TemplatedParent}}"
-                                                       FloatingOffset="{Binding Path=(wpf:HintAssist.FloatingOffset), RelativeSource={RelativeSource TemplatedParent}}"
-                                                       FontSize="{TemplateBinding FontSize}"
-                                                       Padding="{TemplateBinding Padding}"
-                                                       />
+                                                       FloatingOffset="{Binding Path=(wpf:HintAssist.FloatingOffset), RelativeSource={RelativeSource TemplatedParent}}">
+                                            <wpf:SmartHint.Hint>
+                                                <Border x:Name="HintBackgroundBorder" Background="Transparent" CornerRadius="2">
+                                                    <TextBlock 
+                                                        x:Name="HintTextBlock" 
+                                                        Text="{Binding Path=(wpf:HintAssist.Hint),
+                                                               RelativeSource={RelativeSource TemplatedParent}}"/>
+                                                </Border>
+                                            </wpf:SmartHint.Hint>
+                                        </wpf:SmartHint>
                                 <Button x:Name="PART_ClearButton" Height="Auto" Grid.Column="1" Padding="2,0,0,0" 
                                             Style="{DynamicResource MaterialDesignToolButton}">
                                     <Button.Visibility>
@@ -170,7 +178,7 @@
                             <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
                         </MultiTrigger>
                         <Trigger Property="wpf:HintAssist.IsFloating" Value="True">
-                            <Setter TargetName="border" Property="Padding" Value="0 15.5 0 4" />
+                            <Setter TargetName="border" Property="Margin" Value="0 15.5 0 4" />
                         </Trigger>
                         <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
                             <Setter TargetName="passwordFieldBoxBorder" Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxHoverBackground}" />
@@ -197,20 +205,26 @@
                             <Setter TargetName="passwordFieldBoxBorder" Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
                             <Setter TargetName="passwordFieldBoxBorder" Property="Padding" Value="0,8,0,0" />
                             <Setter TargetName="passwordFieldBoxBorder" Property="Margin" Value="-1" />
-                            <Setter TargetName="passwordFieldGrid" Property="Margin" Value="16,0,16,0" />
+                            <Setter TargetName="passwordFieldGrid" Property="Margin" Value="12,0,12,0" />
                             <Setter TargetName="border" Property="BorderThickness" Value="0" />
                             <Setter TargetName="border" Property="Cursor" Value="IBeam" />
+                            <Setter TargetName="border" Property="Margin" Value="0 0 0 0" />
                             <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
-                            <Setter TargetName="Hint" Property="Margin" Value="0,0,0,16" />
-                            <Setter TargetName="PART_ContentHost" Property="Margin" Value="0,8,0,8" />
+                            <Setter TargetName="PART_ContentHost" Property="Margin" Value="0,0,0,8" />
+                            <Setter TargetName="Hint" Property="Margin" Value="0,0,0,0" />
+                            <Setter TargetName="Hint" Property="FloatingOffset" Value="{Binding FontSize, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FontSizeToHintOffsetConverter}}" />
+                            <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
+                            <Setter TargetName="HintTextBlock" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
+                            <Setter TargetName="HintBackgroundBorder" Property="Padding" Value="4, 0" />
+                            <Setter TargetName="HintBackgroundBorder" Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-                                <Condition Property="wpf:HintAssist.IsFloating" Value="False" />
+                                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                                <Condition Property="IsKeyboardFocused" Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_ContentHost" Property="Margin" Value="0,0,0,8" />
-                            <Setter TargetName="Hint" Property="Margin" Value="0,0,0,0" />
+                            <Setter TargetName="HintTextBlock" Property="Opacity" Value="1" />
                         </MultiTrigger>
                         <Trigger Property="IsEnabled" Value="false">
                             <Setter Property="Opacity" TargetName="border" Value="0.42"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -12,6 +12,7 @@
     <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearTextConverter" />
     <converters:NotConverter x:Key="NotConverter" />
+    <converters:FontSizeToHintOffsetConverter x:Key="FontSizeToHintOffsetConverter" />
 
     <Style x:Key="MaterialDesignTextBoxBase" TargetType="{x:Type TextBoxBase}">
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
@@ -117,15 +118,22 @@
                                                       />
                                         <wpf:SmartHint x:Name="Hint"
                                                        Grid.Column="0"
-                                                       Hint="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource TemplatedParent}}"
                                                        HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                                        FontSize="{TemplateBinding FontSize}"
                                                        Padding="{TemplateBinding Padding}"
                                                        HintOpacity="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"
                                                        UseFloating="{Binding Path=(wpf:HintAssist.IsFloating), RelativeSource={RelativeSource TemplatedParent}}"
                                                        FloatingScale="{Binding Path=(wpf:HintAssist.FloatingScale), RelativeSource={RelativeSource TemplatedParent}}"
-                                                       FloatingOffset="{Binding Path=(wpf:HintAssist.FloatingOffset), RelativeSource={RelativeSource TemplatedParent}}"
-                                                       />
+                                                       FloatingOffset="{Binding Path=(wpf:HintAssist.FloatingOffset), RelativeSource={RelativeSource TemplatedParent}}">
+                                            <wpf:SmartHint.Hint>
+                                                <Border x:Name="HintBackgroundBorder" Background="Transparent" CornerRadius="2">
+                                                    <TextBlock 
+                                                        x:Name="HintTextBlock" 
+                                                        Text="{Binding Path=(wpf:HintAssist.Hint),
+                                                               RelativeSource={RelativeSource TemplatedParent}}"/>
+                                                </Border>
+                                            </wpf:SmartHint.Hint>
+                                        </wpf:SmartHint>
                                     <StackPanel Orientation="Horizontal" Grid.Column="1"  >
                                         <TextBlock VerticalAlignment="Bottom"
                                                    FontSize="{TemplateBinding FontSize}"
@@ -220,20 +228,26 @@
                             <Setter TargetName="textFieldBoxBorder" Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
                             <Setter TargetName="textFieldBoxBorder" Property="Padding" Value="0,8,0,0" />
                             <Setter TargetName="textFieldBoxBorder" Property="Margin" Value="-1" />
-                            <Setter TargetName="textFieldGrid" Property="Margin" Value="16,0,16,0" />
+                            <Setter TargetName="textFieldGrid" Property="Margin" Value="12,0,12,0" />
                             <Setter TargetName="border" Property="BorderThickness" Value="0" />
                             <Setter TargetName="border" Property="Cursor" Value="IBeam" />
+                            <Setter TargetName="border" Property="Margin" Value="0 0 0 0" />
                             <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
-                            <Setter TargetName="Hint" Property="Margin" Value="0,0,0,16" />
-                            <Setter TargetName="PART_ContentHost" Property="Margin" Value="0,8,0,8" />
+                            <Setter TargetName="PART_ContentHost" Property="Margin" Value="0,0,0,8" />
+                            <Setter TargetName="Hint" Property="Margin" Value="0,0,0,0" />
+                            <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
+                            <Setter TargetName="Hint" Property="FloatingOffset" Value="{Binding FontSize, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FontSizeToHintOffsetConverter}}" />
+                            <Setter TargetName="HintTextBlock" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
+                            <Setter TargetName="HintBackgroundBorder" Property="Padding" Value="4, 0" />
+                            <Setter TargetName="HintBackgroundBorder" Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-                                <Condition Property="wpf:HintAssist.IsFloating" Value="False" />
+                                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                                <Condition Property="IsKeyboardFocused" Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_ContentHost" Property="Margin" Value="0,0,0,8" />
-                            <Setter TargetName="Hint" Property="Margin" Value="0,0,0,0" />
+                            <Setter TargetName="HintTextBlock" Property="Opacity" Value="1" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>


### PR DESCRIPTION
I changed the `OutlinedTextField` hint style based on material.io documentation:
![Material Text box](http://uupload.ir/files/sv3x_11111.png)

**Preview:**
**[Changes Preview](http://uupload.ir/files/jy7p_preview.gif)**