### PR TITLE
No longer setting IsOpen to false on unloaded

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
@@ -198,6 +198,16 @@ namespace MaterialDesignThemes.Wpf.Tests
             Assert.Equal(1, closingCount);
         }
 
+        [StaFact]
+        [Description("Issue 1618")]
+        public void WhenDialogHostIsUnloadedIsOpenRemainsTrue()
+        {
+            _dialogHost.IsOpen = true;
+            _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
+
+            Assert.True(_dialogHost.IsOpen);
+        }
+
         private class TestDialog : Control
         {
             public void CloseDialog() => DialogHost.CloseDialogCommand.Execute(null, this);

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -705,7 +705,6 @@ namespace MaterialDesignThemes.Wpf
         private void OnUnloaded(object sender, RoutedEventArgs routedEventArgs)
         {
             LoadedInstances.Remove(this);
-            SetCurrentValue(IsOpenProperty, false);
         }
 
         private void OnLoaded(object sender, RoutedEventArgs routedEventArgs)


### PR DESCRIPTION
It does not appear to be needed as the popup will close itself when it is unloaded.

Fixes #1618