### PR TITLE
Prevent TimePicker to overwrite date

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/TimePickerUnitTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/TimePickerUnitTests.cs
@@ -75,7 +75,7 @@ namespace MaterialDesignThemes.Wpf.Tests
                 var timeString = (string) data[5];
 
                 //Convert the date to Today
-                date = DateTime.Today.AddHours(date.Hour).AddMinutes(date.Minute).AddSeconds(withSeconds ? date.Second : 0);
+                date = DateTime.MinValue.AddHours(date.Hour).AddMinutes(date.Minute).AddSeconds(withSeconds ? date.Second : 0);
 
                 if (!is24Hour && date.Hour > 12 &&
                     (string.IsNullOrEmpty(culture.DateTimeFormat.AMDesignator) ||

--- a/MaterialDesignThemes.Wpf.Tests/TimePickerUnitTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/TimePickerUnitTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Windows;
@@ -17,6 +17,16 @@ namespace MaterialDesignThemes.Wpf.Tests
         {
             _timePicker = new TimePicker();
             _timePicker.ApplyDefaultStyle();
+        }
+
+        [StaFact]
+        public void DontOverwriteDate()
+        {
+            var expectedDate = new DateTime(2000, 1, 1, 20, 0, 0);
+
+            _timePicker.SelectedTime = expectedDate;
+
+            Assert.True(_timePicker.SelectedTime == expectedDate, $"Expected '{expectedDate}' but was '{_timePicker.SelectedTime}'");
         }
 
         [StaTheory]

--- a/MaterialDesignThemes.Wpf.Tests/TimePickerUnitTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/TimePickerUnitTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
@@ -20,13 +21,14 @@ namespace MaterialDesignThemes.Wpf.Tests
         }
 
         [StaFact]
+        [Description("Issue 1691")]
         public void DontOverwriteDate()
         {
             var expectedDate = new DateTime(2000, 1, 1, 20, 0, 0);
 
             _timePicker.SelectedTime = expectedDate;
 
-            Assert.True(_timePicker.SelectedTime == expectedDate, $"Expected '{expectedDate}' but was '{_timePicker.SelectedTime}'");
+            Assert.Equal(_timePicker.SelectedTime, expectedDate);
         }
 
         [StaTheory]
@@ -40,9 +42,7 @@ namespace MaterialDesignThemes.Wpf.Tests
             _timePicker.WithSeconds = withSeconds;
             _timePicker.SelectedTime = selectedTime;
 
-
-            string currentTestString = $"{culture.ThreeLetterISOLanguageName} {(is24Hour ? "24 Hour" : "12 Hour")} {format} format {(withSeconds ? "with seconds" : "")}";
-            Assert.True(expectedText == _timePicker.Text, $"Expected '{expectedText}' but was '{_timePicker.Text}' - {currentTestString}");
+            Assert.Equal(expectedText, _timePicker.Text);
         }
 
         [StaTheory]
@@ -59,8 +59,7 @@ namespace MaterialDesignThemes.Wpf.Tests
             textBox.Text = timeString;
             textBox.RaiseEvent(new RoutedEventArgs(UIElement.LostFocusEvent));
 
-            string currentTestString = $"{culture.ThreeLetterISOLanguageName} {(is24Hour ? "24 Hour" : "12 Hour")} {format} format {(withSeconds ? "with seconds" : "")}";
-            Assert.True(expectedTime == _timePicker.SelectedTime, $"Expected '{expectedTime}' but was '{_timePicker.SelectedTime}' - {currentTestString}");
+            Assert.Equal(expectedTime, _timePicker.SelectedTime);
         }
 
         public static IEnumerable<object[]> GetParseLocalizedTimeStringData()

--- a/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -299,7 +299,7 @@ namespace MaterialDesignThemes.Wpf
             }
 
             if (IsTimeValid(_textBox.Text, out DateTime time))
-                SetCurrentValue(SelectedTimeProperty, time);
+                SetCurrentValue(SelectedTimeProperty, SelectedTime?.Date.Add(time.TimeOfDay) ?? time);
 
             else // Invalid time, jump back to previous good time
                 SetInvalidTime();
@@ -378,7 +378,7 @@ namespace MaterialDesignThemes.Wpf
                 ParseTime(_textBox.Text, t =>
                 {
                     if (!beCautious || DateTimeToString(t) == _textBox.Text)
-                        SetCurrentValue(SelectedTimeProperty, t);
+                        SetCurrentValue(SelectedTimeProperty, SelectedTime?.Date.Add(t.TimeOfDay) ?? t);
                 });
             }
             else
@@ -399,7 +399,7 @@ namespace MaterialDesignThemes.Wpf
 
             return DateTime.TryParse(s,
                                      culture,
-                                     DateTimeStyles.AssumeLocal | DateTimeStyles.AllowWhiteSpaces,
+                                     DateTimeStyles.AssumeLocal | DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.NoCurrentDateDefault,
                                      out time);
         }
 


### PR DESCRIPTION
In one of my app I use a DatePicker and a TimePicker binded on a same DateTime.
When loading the page, the DateTime is reset to the current date.
I found that the issue is caused by the TimePicker.
When the TimePicker init itself, it overwrite the date part which cause trouble.
So I modified the code to prevent that.