### PR TITLE
Fix lost mouse clicks on inactive window (#1021)

### DIFF
--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -632,7 +632,10 @@ namespace MaterialDesignThemes.Wpf
         {
             var window = Window.GetWindow(this);
             if (window != null && !window.IsActive)
+            {
                 window.Activate();
+                window.Focus();
+            }
             base.OnPreviewMouseDown(e);
         }
 

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -628,17 +628,6 @@ namespace MaterialDesignThemes.Wpf
             return child;
         }
 
-        protected override void OnPreviewMouseDown(MouseButtonEventArgs e)
-        {
-            var window = Window.GetWindow(this);
-            if (window != null && !window.IsActive)
-            {
-                window.Activate();
-                window.Focus();
-            }
-            base.OnPreviewMouseDown(e);
-        }
-
         private void ContentCoverGridOnMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
             if (CloseOnClickAway && CurrentSession != null)


### PR DESCRIPTION
The click on the dialog is lost when `window.Activate()` is called. The clicks works normal when the call is removed or the window gets the focus with `window.Focus()`