### PR TITLE
Fix #1709

### DIFF
--- a/MainDemo.Wpf/Grids.xaml
+++ b/MainDemo.Wpf/Grids.xaml
@@ -19,7 +19,7 @@
             <TextBlock>Custom Columns</TextBlock>
             <smtx:XamlDisplay Key="grids_1">
                 <DataGrid Margin="0 8 0 0" ItemsSource="{Binding Items3}" CanUserSortColumns="True" CanUserAddRows="False" AutoGenerateColumns="False"
-                          materialDesign:DataGridAssist.CellPadding="13 8 8 8" materialDesign:DataGridAssist.ColumnHeaderPadding="8">
+                          materialDesign:DataGridAssist.CellPadding="13 8 8 8" materialDesign:DataGridAssist.ColumnHeaderPadding="8" HeadersVisibility="All">
                     <DataGrid.Columns>
                         <DataGridCheckBoxColumn Binding="{Binding IsSelected}" 
                                                 ElementStyle="{StaticResource MaterialDesignDataGridCheckBoxColumnStyle}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
@@ -128,8 +128,8 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
                     <Grid>
-                        <Rectangle x:Name="Border" Fill="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" SnapsToDevicePixels="True"/>
-                        <Polygon x:Name="Arrow" Fill="Black" HorizontalAlignment="Right" Margin="8,8,3,3" Opacity="0.15" Points="0,10 10,10 10,0" Stretch="Uniform" VerticalAlignment="Bottom"/>
+                        <Rectangle x:Name="Border" Fill="Transparent" SnapsToDevicePixels="True"/>
+                        <Polygon x:Name="Arrow" Fill="{DynamicResource MaterialDesignBody}" HorizontalAlignment="Right" Margin="8,8,3,3" Opacity="0.5" Points="0,10 10,10 10,0" Stretch="Uniform" VerticalAlignment="Bottom"/>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">


### PR DESCRIPTION
The select all button had a non dynamic background, which made theming difficult. With this change, the button behaves more in line with other elements.

![Dark_WithoutFocus](https://user-images.githubusercontent.com/61351036/77587741-d0a28000-6ee8-11ea-97b9-6597ffde42d5.PNG)
![Dark_WithFocus](https://user-images.githubusercontent.com/61351036/77587744-d13b1680-6ee8-11ea-8982-2a93cd53e1b7.PNG)
![Light_WithoutFocus](https://user-images.githubusercontent.com/61351036/77587746-d13b1680-6ee8-11ea-8c70-522c297f44be.PNG)
![Light_WithFocus](https://user-images.githubusercontent.com/61351036/77587747-d1d3ad00-6ee8-11ea-9c49-b980321d2c6f.PNG)
