### PR TITLE
Added Template Binding to MaterialDesignDatePicker Fixes #1552

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -375,6 +375,7 @@
                         <DatePickerTextBox x:Name="PART_TextBox"
                                            Grid.Column="0"
                                            Focusable="{TemplateBinding Focusable}"
+                                           Background="{TemplateBinding Background}"
                                            Grid.Row="0"
                                            Padding="0,0,8,0"
                                            VerticalContentAlignment="Center"


### PR DESCRIPTION
Added in a template binding to the background property in the MaterialDesignDatePicker, this now makes it so when setting Background on a datepicker it will reflect the change.
Fixes #1552 