### PR TITLE
Support search for aliases of pack icons

### DIFF
--- a/MainDemo.Wpf/ButtonsViewModel.cs
+++ b/MainDemo.Wpf/ButtonsViewModel.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel;
 using System.Windows.Input;
 using System.Windows.Threading;
+using MaterialDesignDemo.Domain;
 
 namespace MaterialDesignColors.WpfExample
 {

--- a/MainDemo.Wpf/Converters/StringJoinConverter.cs
+++ b/MainDemo.Wpf/Converters/StringJoinConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+
+namespace MaterialDesignDemo.Converters
+{
+    public class StringJoinConverter : IValueConverter
+    {
+        public string Separator { get; set; }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            IEnumerable values = value as IEnumerable ?? Array.Empty<object>();
+            return string.Join(Separator ?? "", values.OfType<object>());
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MainDemo.Wpf/Domain/DemoItem.cs
+++ b/MainDemo.Wpf/Domain/DemoItem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
+using MaterialDesignDemo.Domain;
 
 namespace MaterialDesignColors.WpfExample.Domain
 {

--- a/MainDemo.Wpf/Domain/NotifyPropertyChangedExtension.cs
+++ b/MainDemo.Wpf/Domain/NotifyPropertyChangedExtension.cs
@@ -3,15 +3,16 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
-namespace MaterialDesignColors.WpfExample.Domain
+namespace MaterialDesignDemo.Domain
 {
     public static class NotifyPropertyChangedExtension
     {
-        public static void MutateVerbose<TField>(this INotifyPropertyChanged instance, ref TField field, TField newValue, Action<PropertyChangedEventArgs> raise, [CallerMemberName] string propertyName = null)
+        public static bool MutateVerbose<TField>(this INotifyPropertyChanged instance, ref TField field, TField newValue, Action<PropertyChangedEventArgs> raise, [CallerMemberName] string propertyName = null)
         {
-            if (EqualityComparer<TField>.Default.Equals(field, newValue)) return;
+            if (EqualityComparer<TField>.Default.Equals(field, newValue)) return false;
             field = newValue;
             raise?.Invoke(new PropertyChangedEventArgs(propertyName));
+            return true;
         }
     }
 }

--- a/MainDemo.Wpf/Domain/TextFieldsViewModel.cs
+++ b/MainDemo.Wpf/Domain/TextFieldsViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using MaterialDesignDemo.Domain;
 
 namespace MaterialDesignColors.WpfExample.Domain
 {

--- a/MainDemo.Wpf/Domain/TreesViewModel.cs
+++ b/MainDemo.Wpf/Domain/TreesViewModel.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using MaterialDesignDemo.Domain;
 
 namespace MaterialDesignColors.WpfExample.Domain
 {

--- a/MainDemo.Wpf/IconPack.xaml
+++ b/MainDemo.Wpf/IconPack.xaml
@@ -6,13 +6,20 @@
              xmlns:materialDesignDemo="clr-namespace:MaterialDesignDemo"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:virtualCollection="clr-namespace:VirtualCollection.VirtualCollection"
+             xmlns:converters="clr-namespace:MaterialDesignDemo.Converters"
+             xmlns:system="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="300" d:DataContext="{d:DesignInstance materialDesignDemo:IconPackViewModel}">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBlock.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Button.xaml" />
             </ResourceDictionary.MergedDictionaries>
+
+            <materialDesign:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
+
+            <converters:StringJoinConverter x:Key="StringJoinConverter" Separator="{x:Static system:Environment.NewLine}"/>
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
@@ -40,8 +47,8 @@
             </ListBox.ItemsPanel>
             <ListBox.ItemTemplate>
                 <DataTemplate DataType="materialDesignDemo:PackIconKindGroup">
-                    <DockPanel ToolTip="{Binding ToolTip}" Width="64" Height="64" Background="Transparent">
-                        <TextBlock Text="{Binding PrimaryName}" DockPanel.Dock="Bottom" TextTrimming="CharacterEllipsis" HorizontalAlignment="Center" />
+                    <DockPanel ToolTip="{Binding Aliases, Converter={StaticResource StringJoinConverter}}" Width="64" Height="64" Background="Transparent">
+                        <TextBlock Text="{Binding Kind}" DockPanel.Dock="Bottom" TextTrimming="CharacterEllipsis" HorizontalAlignment="Center" />
                         <materialDesign:PackIcon Kind="{Binding Kind}" VerticalAlignment="Center" HorizontalAlignment="Center" Width="32" Height="32" />
                     </DockPanel>
                 </DataTemplate>

--- a/MainDemo.Wpf/IconPack.xaml
+++ b/MainDemo.Wpf/IconPack.xaml
@@ -1,20 +1,20 @@
 ﻿<UserControl x:Class="MaterialDesignDemo.IconPack"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:materialDesignDemo="clr-namespace:MaterialDesignDemo"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:virtualCollection="clr-namespace:VirtualCollection.VirtualCollection"
-             mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300">
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="300" d:DataContext="{d:DesignInstance materialDesignDemo:IconPackViewModel}">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBlock.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
-    </UserControl.Resources>    
+    </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -28,24 +28,21 @@
                 Material Design In XAML Toolkit includes the Material Design Icons collection.
             </TextBlock>
             <TextBlock Margin="0 12 0 0">
-                For more information on Material Design Icons see the official website: 
+                For more information on Material Design Icons see the official website:
                 <Hyperlink Command="{Binding OpenDotComCommand}">materialdesignicons.com</Hyperlink>
             </TextBlock>
         </StackPanel>
-        <ListBox ItemsSource="{Binding Kinds}" Grid.Row="1" Margin="0 8 0 0"
-                 x:Name="KindsListBox">
+        <ListBox ItemsSource="{Binding Kinds}" Grid.Row="1" Margin="0 8 0 0" SelectedItem="{Binding Group}">
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
                     <virtualCollection:VirtualizingWrapPanel ItemHeight="80" ItemWidth="80" />
                 </ItemsPanelTemplate>
             </ListBox.ItemsPanel>
             <ListBox.ItemTemplate>
-                <DataTemplate DataType="materialDesign:PackIconKind">
-                    <DockPanel ToolTip="{Binding }" Width="64" Height="64" Background="Transparent">
-                        <TextBlock Text="{Binding }" DockPanel.Dock="Bottom" TextTrimming="CharacterEllipsis" HorizontalAlignment="Center" />
-                        <materialDesign:PackIcon Kind="{Binding }" VerticalAlignment="Center" HorizontalAlignment="Center"
-                                                 Width="32" Height="32"                                                 
-                                                 />
+                <DataTemplate DataType="materialDesignDemo:PackIconKindGroup">
+                    <DockPanel ToolTip="{Binding ToolTip}" Width="64" Height="64" Background="Transparent">
+                        <TextBlock Text="{Binding PrimaryName}" DockPanel.Dock="Bottom" TextTrimming="CharacterEllipsis" HorizontalAlignment="Center" />
+                        <materialDesign:PackIcon Kind="{Binding Kind}" VerticalAlignment="Center" HorizontalAlignment="Center" Width="32" Height="32" />
                     </DockPanel>
                 </DataTemplate>
             </ListBox.ItemTemplate>
@@ -58,7 +55,7 @@
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <Button Style="{DynamicResource MaterialDesignToolButton}" 
+                        <Button Style="{DynamicResource MaterialDesignToolButton}"
                                 Command="{Binding SearchCommand}" x:Name="SearchButton"
                                 CommandParameter="{Binding ElementName=SearchBox, Path=Text}"
                                 Height="24" Width="24">
@@ -78,12 +75,13 @@
                              FontFamily="Courier New"
                              FontWeight="Bold"
                              GotFocus="TextBox_OnGotFocus"
-                             Text="{Binding  ElementName=KindsListBox, Path=SelectedValue, StringFormat='&lt;materialDesign:PackIcon Kind=&quot;{0}&quot; \/>'}" />
+                             Text="{Binding Kind, StringFormat='&lt;materialDesign:PackIcon Kind=&quot;{0}&quot; \/>'}" />
                 </materialDesign:ColorZone>
-                <materialDesign:PackIcon Kind="{Binding ElementName=KindsListBox, Path=SelectedValue}" VerticalAlignment="Center" />
-                <Button Margin="8 0" Command="{Binding CopyToClipboardCommand, Mode=OneTime}" CommandParameter="{Binding ElementName=KindsListBox, Path=SelectedValue}">
+                <materialDesign:PackIcon Kind="{Binding Kind}" VerticalAlignment="Center"
+                                         Visibility="{Binding Kind, Converter={StaticResource NullableToVisibilityConverter}}" />
+                <Button Margin="8 0" Command="{Binding CopyToClipboardCommand, Mode=OneTime}" CommandParameter="{Binding Kind}">
                     <StackPanel Orientation="Horizontal">
-                        <materialDesign:PackIcon Kind="ContentCopy"/>
+                        <materialDesign:PackIcon Kind="ContentCopy" />
                         <TextBlock Text="Copy To Clipboard" Margin="8 0 0 0" />
                     </StackPanel>
                 </Button>

--- a/MainDemo.Wpf/IconPackViewModel.cs
+++ b/MainDemo.Wpf/IconPackViewModel.cs
@@ -1,20 +1,36 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Windows;
-using System.Windows.Input;
-using MaterialDesignColors.WpfExample.Domain;
+﻿using MaterialDesignColors.WpfExample.Domain;
 using MaterialDesignDemo.Domain;
 using MaterialDesignThemes.Wpf;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
 
 namespace MaterialDesignDemo
 {
+    public class PackIconKindGroup
+    {
+        public PackIconKindGroup(PackIconKind kind, string[] all)
+        {
+            Kind = kind;
+            Aliases = all;
+            PrimaryName = all[0];
+            ToolTip = string.Join(Environment.NewLine, all);
+        }
+
+        public PackIconKind Kind { get; }
+        public string[] Aliases { get; }
+        public string PrimaryName { get; }
+        public string ToolTip { get; }
+    }
+
     public class IconPackViewModel : INotifyPropertyChanged
     {
-        private readonly Lazy<IEnumerable<PackIconKind>> _packIconKinds;
+        private readonly Lazy<IEnumerable<PackIconKindGroup>> _packIconKinds;
         private readonly ISnackbarMessageQueue _snackbarMessageQueue;
 
         public IconPackViewModel(ISnackbarMessageQueue snackbarMessageQueue)
@@ -24,25 +40,50 @@ namespace MaterialDesignDemo
             OpenDotComCommand = new AnotherCommandImplementation(OpenDotCom);
             SearchCommand = new AnotherCommandImplementation(Search);
             CopyToClipboardCommand = new AnotherCommandImplementation(CopyToClipboard);
-            _packIconKinds = new Lazy<IEnumerable<PackIconKind>>(() =>
-                Enum.GetValues(typeof(PackIconKind))
-                    .OfType<PackIconKind>()
-                    .Distinct()
-                    .OrderBy(k => k.ToString(), StringComparer.InvariantCultureIgnoreCase).ToList()
-                );
+
+            _packIconKinds = new Lazy<IEnumerable<PackIconKindGroup>>(() =>
+                Enum.GetNames(typeof(PackIconKind))
+                    .GroupBy(k => (PackIconKind) Enum.Parse(typeof(PackIconKind), k))
+                    .Select(g => new PackIconKindGroup(g.Key, g.OrderBy(i => i.ToString(), StringComparer.InvariantCultureIgnoreCase).ToArray()))
+                    .OrderBy(i => i.Aliases[0], StringComparer.InvariantCultureIgnoreCase)
+                    .ToList());
         }
 
         public ICommand OpenDotComCommand { get; }
         public ICommand SearchCommand { get; }
         public ICommand CopyToClipboardCommand { get; }
 
-        private IEnumerable<PackIconKind> _kinds;
-        public IEnumerable<PackIconKind> Kinds
+        private IEnumerable<PackIconKindGroup> _kinds;
+        private PackIconKindGroup _group;
+        private PackIconKind? _kind;
+
+        public IEnumerable<PackIconKindGroup> Kinds
         {
-            get { return _kinds ?? (_kinds = _packIconKinds.Value); }
+            get => _kinds ??= _packIconKinds.Value;
             set
             {
                 _kinds = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public PackIconKindGroup Group
+        {
+            get => _group;
+            set
+            {
+                _group = value;
+                Kind = value?.Kind;
+                OnPropertyChanged();
+            }
+        }
+
+        public PackIconKind? Kind
+        {
+            get => _kind;
+            set
+            {
+                _kind = value;
                 OnPropertyChanged();
             }
         }
@@ -52,28 +93,27 @@ namespace MaterialDesignDemo
             Link.OpenInBrowser("https://materialdesignicons.com/");
         }
 
-        private void Search(object obj)
+        private async void Search(object obj)
         {
             var text = obj as string;
             if (string.IsNullOrWhiteSpace(text))
                 Kinds = _packIconKinds.Value;
             else
-                Kinds =
-                    _packIconKinds.Value.Where(
-                        x => x.ToString().IndexOf(text, StringComparison.CurrentCultureIgnoreCase) >= 0);
+                Kinds = await Task.Run(() => _packIconKinds.Value
+                    .Where(x => x.ToolTip.ToString().IndexOf(text, StringComparison.CurrentCultureIgnoreCase) >= 0)
+                    .ToList());
         }
 
         private void CopyToClipboard(object obj)
         {
-            var kind = (PackIconKind?)obj;
-            string toBeCopied = $"<materialDesign:PackIcon Kind=\"{kind}\" />";
+            var toBeCopied = $"<materialDesign:PackIcon Kind=\"{obj}\" />";
             Clipboard.SetDataObject(toBeCopied);
             _snackbarMessageQueue.Enqueue(toBeCopied + " copied to clipboard");
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }

--- a/MainDemo.Wpf/PackIconKindGroup.cs
+++ b/MainDemo.Wpf/PackIconKindGroup.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MaterialDesignDemo
+{
+    public class PackIconKindGroup
+    {
+        public PackIconKindGroup(IEnumerable<string> kinds)
+        {
+            if (kinds is null) throw new ArgumentNullException(nameof(kinds));
+            var allValues = kinds.ToList();
+            if (!allValues.Any()) throw new ArgumentException($"{nameof(kinds)} must contain at least one value");
+            Kind = allValues.First();
+            Aliases = allValues
+                .OrderBy(x => x, StringComparer.InvariantCultureIgnoreCase)
+                .ToArray();
+        }
+
+        public string Kind { get; }
+        public string[] Aliases { get; }
+    }
+}


### PR DESCRIPTION
I use the Icon Pack page in the demo app quite often. PackIconKind has lot of aliases for icons, which can only be found be "correct" one. I extended the Icon Pack page in the demo app so that search can find them by the alias names as well.