### PR TITLE
SDK setting rollForward "latestFeature"

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "3.1",
-    "rollForward": "latestFeature"
+    "rollForward": "latestMajor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1"
+    "version": "3.1",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
The sdk in `global.json` is set to `3.1`. when I try to run this I get the error `MSB4236: The SDK 'Microsoft.NET.Sdk' specified could not be found`.

`dotnet --list-sdks` returns
```
2.2.207 [C:\Program Files\dotnet\sdk]
3.0.101 [C:\Program Files\dotnet\sdk]
3.1.100 [C:\Program Files\dotnet\sdk]
3.1.201 [C:\Program Files\dotnet\sdk]
```
So I changed the SDK locally to `3.1.201`, which is a bit risky because I could commit that any time. So I looked for a solution. But at https://dotnet.microsoft.com/download/dotnet-core/3.1 there is no exact `3.1` to download.

Then I found on https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?tabs=netcore3x#rollforward that with the property `rollForward` dotnet can find the latest installed `3.1` SDK.

This seems to be a good solution. What do you think?