### PR TITLE
Set Dialog-Task-Result after IsOpen to prevent "DialogHost is already open."

### DIFF
--- a/MaterialDesignThemes.Wpf/DialogClosingEventArgs.cs
+++ b/MaterialDesignThemes.Wpf/DialogClosingEventArgs.cs
@@ -5,11 +5,14 @@ namespace MaterialDesignThemes.Wpf
 {
     public class DialogClosingEventArgs : RoutedEventArgs
     {
-        public DialogClosingEventArgs(DialogSession session, object parameter, RoutedEvent routedEvent) : base(routedEvent)
+        [Obsolete("Use DialogClosingEventArgs(DialogSession, RoutedEvent), the parameter should be set on the DialogSession.CloseParameter")]
+        public DialogClosingEventArgs(DialogSession session, object parameter, RoutedEvent routedEvent) 
+            : this(session, routedEvent)
+        { }
+
+        public DialogClosingEventArgs(DialogSession session, RoutedEvent routedEvent) : base(routedEvent)
         {
             Session = session ?? throw new ArgumentNullException(nameof(session));
-
-            Parameter = parameter;
         }
 
         /// <summary>
@@ -28,7 +31,7 @@ namespace MaterialDesignThemes.Wpf
         /// <summary>
         /// Gets the parameter originally provided to <see cref="DialogHost.CloseDialogCommand"/>/
         /// </summary>
-        public object Parameter { get; }
+        public object Parameter => Session.CloseParameter;
 
         /// <summary>
         /// Allows interaction with the current dialog session.

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -75,7 +75,7 @@ namespace MaterialDesignThemes.Wpf
             DefaultStyleKeyProperty.OverrideMetadata(typeof(DialogHost), new FrameworkPropertyMetadata(typeof(DialogHost)));
         }
 
-        #region .Show overloads
+        #region Show overloads
 
         /// <summary>
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
@@ -578,7 +578,7 @@ namespace MaterialDesignThemes.Wpf
 
         internal void Close(object parameter)
         {
-            var dialogClosingEventArgs = new DialogClosingEventArgs(CurrentSession, parameter, DialogClosingEvent);
+            var dialogClosingEventArgs = new DialogClosingEventArgs(CurrentSession, DialogClosingEvent);
 
             CurrentSession.CloseParameter = parameter;
             CurrentSession.IsEnded = true;

--- a/MaterialDesignThemes.Wpf/DialogSession.cs
+++ b/MaterialDesignThemes.Wpf/DialogSession.cs
@@ -22,6 +22,11 @@ namespace MaterialDesignThemes.Wpf
         /// Client code cannot set this directly, this is internally managed.  To end the dialog session use <see cref="Close()"/>.
         /// </remarks>
         public bool IsEnded { get; internal set; }
+        
+        /// <summary>
+        /// The parameter passed to the <see cref="DialogHost.CloseDialogCommand" /> and return by <see cref="DialogHost.Show(object)"/>
+        /// </summary>
+        internal object CloseParameter { get; set; }
 
         /// <summary>
         /// Gets the <see cref="DialogHost.DialogContent"/> which is currently displayed, so this could be a view model or a UI element.


### PR DESCRIPTION
We experienced a threading problem on slow devices when we chained dialogs:

Imagine the following flow:

```
var result1 = await DialogHost.Show(new Button
{
	Content = "Close it",
	Command = DialogHost.CloseDialogCommand,
	CommandParameter = "result1"
}, "RootDialog");

await DialogHost.Show(new Button
{
	Content = $"previous result: {result1}",
	Command = DialogHost.CloseDialogCommand,
}, "RootDialog");
```

When the first dialog is closed then (sometimes) an `InvalidOperationException` with `DialogHost is already open.` is thrown.

The reason for that lies in the order of the two instructions DialogHost#598

```
_dialogTaskCompletionSource?.TrySetResult(parameter);
SetCurrentValue(IsOpenProperty, false);
```

The task gets the result before IsOpen is set to false. And depending on the threads if the await continues before IsOpen updated the show()-call for the second dialog fails with the exception above.

I did not experienced this race condition on my PC and to be honest I do not really understand this, But on other slower devices this exception is easy to reproduce. We did some workarounds using dispatcher, but they were never a good solution.

So my proposal here is to set the result for the `_dialogTaskCompletionSource` after IsOpen is set to false. To pass the parameter I use an internal property in `DialogSession`