### PR TITLE
Fix for MaterialDesignCardGroupBox ColorZone bindings.

### DIFF
--- a/MainDemo.Wpf/GroupBoxes.xaml
+++ b/MainDemo.Wpf/GroupBoxes.xaml
@@ -25,6 +25,7 @@
         <Grid.RowDefinitions>
             <RowDefinition/>
             <RowDefinition/>
+            <RowDefinition/>
         </Grid.RowDefinitions>
 
         <smtx:XamlDisplay Key="groupbox_1" Grid.Column="0" Grid.Row="0">
@@ -53,7 +54,15 @@
             </GroupBox>
         </smtx:XamlDisplay>
 
+
         <smtx:XamlDisplay Key="groupbox_5" Grid.Column="1" Grid.Row="1">
+        <GroupBox Header="Custom Header" Style="{DynamicResource MaterialDesignGroupBox}" Margin="16" 
+                  materialDesign:ColorZoneAssist.Mode="Custom" materialDesign:ColorZoneAssist.Background="Black" materialDesign:ColorZoneAssist.Foreground="White">
+                <TextBlock>My Content</TextBlock>
+            </GroupBox>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay Key="groupbox_6" Grid.Column="0" Grid.Row="2">
             <GroupBox  Header="Card Group Box" Style="{DynamicResource MaterialDesignCardGroupBox}" Margin="16">
                 <GroupBox.HeaderTemplate>
                     <DataTemplate>
@@ -67,11 +76,36 @@
             </GroupBox>
         </smtx:XamlDisplay>
 
-            <smtx:XamlDisplay Key="groupbox_6" Grid.Column="2" Grid.Row="1">
-            <GroupBox Header="Custom Header" Style="{DynamicResource MaterialDesignGroupBox}" Margin="16" materialDesign:ColorZoneAssist.Mode="Custom" materialDesign:ColorZoneAssist.Background="Black" materialDesign:ColorZoneAssist.Foreground="White">
-                    <TextBlock>My Content</TextBlock>
-                </GroupBox>
-            </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay Key="groupbox_7" Grid.Column="1" Grid.Row="2">
+            <GroupBox  Header="Card Group Box Accent" Style="{DynamicResource MaterialDesignCardGroupBox}" Margin="16" 
+                materialDesign:ColorZoneAssist.Mode="Accent">
+                <GroupBox.HeaderTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal">
+                            <materialDesign:PackIcon Kind="ImageArea" Height="32" Width="32" VerticalAlignment="Center" />
+                            <TextBlock Margin="8,0,0,0" VerticalAlignment="Center" Style="{StaticResource MaterialDesignSubtitle1TextBlock}" Text="{Binding}"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </GroupBox.HeaderTemplate>
+                <Image Source="Resources/Contact.png" VerticalAlignment="Center" HorizontalAlignment="Center" />
+            </GroupBox>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay Key="groupbox_8" Grid.Column="2" Grid.Row="2">
+            <GroupBox  Header="Card Group Box Custom" Style="{DynamicResource MaterialDesignCardGroupBox}" Margin="16" 
+                materialDesign:ColorZoneAssist.Mode="Custom" materialDesign:ColorZoneAssist.Background="Black" materialDesign:ColorZoneAssist.Foreground="White">
+                <GroupBox.HeaderTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal">
+                            <materialDesign:PackIcon Kind="ImageArea" Height="32" Width="32" VerticalAlignment="Center" />
+                            <TextBlock Margin="8,0,0,0" VerticalAlignment="Center" Style="{StaticResource MaterialDesignSubtitle1TextBlock}" Text="{Binding}"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </GroupBox.HeaderTemplate>
+                <Image Source="Resources/Contact.png" VerticalAlignment="Center" HorizontalAlignment="Center" />
+            </GroupBox>
+        </smtx:XamlDisplay>
     </Grid>
 </UserControl>
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.GroupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.GroupBox.xaml
@@ -70,7 +70,11 @@
                 <ControlTemplate TargetType="{x:Type GroupBox}">
                     <wpf:Card VerticalAlignment="Stretch">
                         <DockPanel Background="{TemplateBinding Background}">
-                            <wpf:ColorZone x:Name="PART_ColorZone" DockPanel.Dock="Top" Padding="{TemplateBinding Padding}" Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}" Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}">
+                            <wpf:ColorZone x:Name="PART_ColorZone" DockPanel.Dock="Top" Padding="{TemplateBinding Padding}" 
+                                           Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}" 
+                                           Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}"                                           
+                                           wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
+                                           wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}">
                                 <ContentPresenter ContentSource="Header" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                   ContentStringFormat="{TemplateBinding HeaderStringFormat}"
                                                   ContentTemplate="{TemplateBinding HeaderTemplate}"


### PR DESCRIPTION
- Fixed the binding of the ColorZone to be able to change the header similar to the MaterialDesignGroupBox style.
- Added examples to the Demo for accent and custom Card GroupBox