### PR TITLE
Added MaterialDesignDefaultContextMenu with SelectAll

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -5,8 +5,9 @@
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml" />
+        <ResourceDictionary Source="MaterialDesignTheme.Shadows.xaml" />
+        <ResourceDictionary Source="MaterialDesignTheme.ValidationErrorTemplate.xaml" />
+        <ResourceDictionary Source="MaterialDesignTheme.Menu.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <converters:TextFieldHintVisibilityConverter x:Key="TextFieldHintVisibilityConverter" IsNotEmptyValue="Collapsed" />
@@ -200,26 +201,7 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="ContextMenu">
-            <Setter.Value>
-                <ContextMenu>
-                    <MenuItem Command="Cut">
-                        <MenuItem.Icon>
-                            <wpf:PackIcon Kind="ContentCut"/>
-                        </MenuItem.Icon>
-                    </MenuItem>
-                    <MenuItem Command="Copy">
-                        <MenuItem.Icon>
-                            <wpf:PackIcon Kind="ContentCopy" />
-                        </MenuItem.Icon>
-                    </MenuItem>
-                    <MenuItem Command="Paste">
-                        <MenuItem.Icon>
-                            <wpf:PackIcon Kind="ContentPaste"/>
-                        </MenuItem.Icon>
-                    </MenuItem>
-                </ContextMenu>
-            </Setter.Value>
+        <Setter Property="ContextMenu" Value="{StaticResource MaterialDesignDefaultContextMenu}">
         </Setter>
     </Style>
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -6,6 +6,7 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="MaterialDesignTheme.Calendar.xaml" />
         <ResourceDictionary Source="MaterialDesignTheme.ValidationErrorTemplate.xaml" />
+        <ResourceDictionary Source="MaterialDesignTheme.Menu.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <converters:TextFieldHintVisibilityConverter x:Key="TextFieldHintVisibilityConverter" />
@@ -27,28 +28,7 @@
         <Setter Property="VerticalContentAlignment" Value="Top"/>
         <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
         <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
-        <!-- cludge the default context menu -->
-        <Setter Property="ContextMenu">
-            <Setter.Value>
-                <ContextMenu>
-                    <MenuItem Command="Cut">
-                        <MenuItem.Icon>
-                            <wpf:PackIcon Kind="ContentCut"/>
-                        </MenuItem.Icon>
-                    </MenuItem>
-                    <MenuItem Command="Copy">
-                        <MenuItem.Icon>
-                            <wpf:PackIcon Kind="ContentCopy" />
-                        </MenuItem.Icon>
-                    </MenuItem>
-                    <MenuItem Command="Paste">
-                        <MenuItem.Icon>
-                            <wpf:PackIcon Kind="ContentPaste"/>
-                        </MenuItem.Icon>
-                    </MenuItem>
-                </ContextMenu>
-            </Setter.Value>
-        </Setter>
+        <Setter Property="ContextMenu" Value="{StaticResource MaterialDesignDefaultContextMenu}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePickerTextBox}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
@@ -8,6 +8,30 @@
 
     <converters:TextFieldHintVisibilityConverter x:Key="StringIsEmptyVisibilityConverter" IsEmptyValue="Collapsed" IsNotEmptyValue="Visible"/>
     <converters:BrushRoundConverter x:Key="BrushRoundConverter"/>
+    
+    <ContextMenu x:Key="MaterialDesignDefaultContextMenu">
+        <MenuItem Command="Cut">
+            <MenuItem.Icon>
+                <wpf:PackIcon Kind="ContentCut" />
+            </MenuItem.Icon>
+        </MenuItem>
+        <MenuItem Command="Copy">
+            <MenuItem.Icon>
+                <wpf:PackIcon Kind="ContentCopy" />
+            </MenuItem.Icon>
+        </MenuItem>
+        <MenuItem Command="Paste">
+            <MenuItem.Icon>
+                <wpf:PackIcon Kind="ContentPaste" />
+            </MenuItem.Icon>
+        </MenuItem>
+        <Separator />
+        <MenuItem Command="SelectAll">
+            <MenuItem.Icon>
+                <wpf:PackIcon Kind="SelectAll" />
+            </MenuItem.Icon>
+        </MenuItem>
+    </ContextMenu>
 
     <Style x:Key="MaterialDesignSeparator" TargetType="{x:Type Separator}">
         <Setter Property="Background" Value="{DynamicResource MaterialDesignSelection}"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -5,6 +5,7 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="MaterialDesignTheme.ValidationErrorTemplate.xaml" />
+        <ResourceDictionary Source="MaterialDesignTheme.Menu.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <converters:BooleanToVisibilityConverter x:Key="InverseBoolToVisConverter" TrueValue="Collapsed" FalseValue="Visible"/>
@@ -34,27 +35,7 @@
         <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="Cursor" Value="IBeam"/>
-        <Setter Property="ContextMenu">
-            <Setter.Value>
-                <ContextMenu>
-                    <MenuItem Command="Cut">
-                        <MenuItem.Icon>
-                            <wpf:PackIcon Kind="ContentCut" />
-                        </MenuItem.Icon>
-                    </MenuItem>
-                    <MenuItem Command="Copy">
-                        <MenuItem.Icon>
-                            <wpf:PackIcon Kind="ContentCopy" />
-                        </MenuItem.Icon>
-                    </MenuItem>
-                    <MenuItem Command="Paste">
-                        <MenuItem.Icon>
-                            <wpf:PackIcon Kind="ContentPaste" />
-                        </MenuItem.Icon>
-                    </MenuItem>
-                </ContextMenu>
-            </Setter.Value>
-        </Setter>
+        <Setter Property="ContextMenu" Value="{StaticResource MaterialDesignDefaultContextMenu}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type PasswordBox}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -5,6 +5,7 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="MaterialDesignTheme.ValidationErrorTemplate.xaml" />
+        <ResourceDictionary Source="MaterialDesignTheme.Menu.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <converters:TextFieldHintVisibilityConverter x:Key="TextFieldHintVisibilityConverter" />
@@ -33,28 +34,7 @@
         <Setter Property="wpf:TextFieldAssist.IncludeSpellingSuggestions" Value="{Binding RelativeSource={RelativeSource Self}, Path=(SpellCheck.IsEnabled)}" />
         <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
-        <!-- cludge the default context menu -->
-        <Setter Property="ContextMenu">
-            <Setter.Value>
-                <ContextMenu>
-                    <MenuItem Command="Cut">
-                        <MenuItem.Icon>
-                            <wpf:PackIcon Kind="ContentCut"/>
-                        </MenuItem.Icon>
-                    </MenuItem>
-                    <MenuItem Command="Copy">
-                        <MenuItem.Icon>
-                            <wpf:PackIcon Kind="ContentCopy" />
-                        </MenuItem.Icon>
-                    </MenuItem>
-                    <MenuItem Command="Paste">
-                        <MenuItem.Icon>
-                            <wpf:PackIcon Kind="ContentPaste"/>
-                        </MenuItem.Icon>
-                    </MenuItem>
-                </ContextMenu>
-            </Setter.Value>
-        </Setter>
+        <Setter Property="ContextMenu" Value="{StaticResource MaterialDesignDefaultContextMenu}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TextBoxBase}">


### PR DESCRIPTION
Fixes #1781 

Added a `MaterialDesignDefaultContextMenu` instance to `MaterialDesignTheme.Menu.xaml` to reduce redundancy.

Used in:
* `MaterialDesignTheme.ComboBox.xaml`
* `MaterialDesignTheme.DatePicker.xaml`
* `MaterialDesignTheme.PasswordBox.xaml`
* `MaterialDesignTheme.TextBox.xaml`