### PR TITLE
TextFieldAssist.DecorationVisibility for FilledTextField

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -376,8 +376,13 @@
     <Style x:Key="MaterialDesignFilledTextFieldTextBox" TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}">
         <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
         <Setter Property="wpf:TextFieldAssist.RippleOnFocusEnabled" Value="True" />
-        <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />
+        <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />
         <Setter Property="wpf:TextFieldAssist.UnderlineCornerRadius" Value="0" />
+        <Style.Triggers>
+            <Trigger Property="wpf:TextFieldAssist.DecorationVisibility" Value="Visible">
+                <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4 4 0 0" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style x:Key="MaterialDesignOutlinedTextFieldTextBox" TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -157,6 +157,7 @@
                                         Background="{TemplateBinding BorderBrush}"
                                         Height="0"
                                         CornerRadius="{Binding Path=(wpf:TextFieldAssist.UnderlineCornerRadius), RelativeSource={RelativeSource TemplatedParent}}"
+                                        Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}"
                                         HorizontalAlignment="Stretch"
                                         VerticalAlignment="Bottom"
                                         SnapsToDevicePixels="True" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -376,13 +376,8 @@
     <Style x:Key="MaterialDesignFilledTextFieldTextBox" TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}">
         <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
         <Setter Property="wpf:TextFieldAssist.RippleOnFocusEnabled" Value="True" />
-        <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />
+        <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />
         <Setter Property="wpf:TextFieldAssist.UnderlineCornerRadius" Value="0" />
-        <Style.Triggers>
-            <Trigger Property="wpf:TextFieldAssist.DecorationVisibility" Value="Visible">
-                <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4 4 0 0" />
-            </Trigger>
-        </Style.Triggers>
     </Style>
 
     <Style x:Key="MaterialDesignOutlinedTextFieldTextBox" TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}">


### PR DESCRIPTION
fixes #1609

I also rounded the bottom corners, if the bottom line is gone. Think that looks better:

![image](https://user-images.githubusercontent.com/16866222/80870243-7e9e0880-8ca5-11ea-8880-847a5c1c4cb5.png)
