### PR TITLE
Fixed message discard prevents showing message at all

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/SnackbarMessageQueueItemTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/SnackbarMessageQueueItemTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Xunit;
+
+namespace MaterialDesignThemes.Wpf.Tests
+{
+    public class SnackbarMessageQueueItemTests
+    {
+        [Fact]
+        public void IsDuplicate_ThrowsOnNullArgument()
+        {
+            SnackbarMessageQueueItem item = CreateItem();
+            Assert.Throws<ArgumentNullException>(() => item.IsDuplicate(null));
+        }
+
+        [Fact]
+        public void IsDuplicate_WithDuplicateItems_ItReturnsTrue()
+        {
+            SnackbarMessageQueueItem item = CreateItem();
+            SnackbarMessageQueueItem other = CreateItem();
+
+            Assert.True(item.IsDuplicate(other));
+        }
+
+        [Fact]
+        public void IsDuplicate_IgnoreDuplicatesIsTrue_ItReturnsFalse()
+        {
+            SnackbarMessageQueueItem item = CreateItem(ignoreDuplicate:true);
+            SnackbarMessageQueueItem other = CreateItem();
+
+            Assert.False(item.IsDuplicate(other));
+        }
+
+        [Fact]
+        public void IsDuplicate_WithDifferentContent_ItReturnsFalse()
+        {
+            SnackbarMessageQueueItem item = CreateItem();
+            SnackbarMessageQueueItem other = CreateItem(content:Guid.NewGuid().ToString());
+
+            Assert.False(item.IsDuplicate(other));
+        }
+
+        [Fact]
+        public void IsDuplicate_WithDifferentActionContent_ItReturnsFalse()
+        {
+            SnackbarMessageQueueItem item = CreateItem();
+            SnackbarMessageQueueItem other = CreateItem(actionContent:Guid.NewGuid().ToString());
+
+            Assert.False(item.IsDuplicate(other));
+        }
+
+
+        private static SnackbarMessageQueueItem CreateItem(
+            string content = "Content",
+            string actionContent = null,
+            bool ignoreDuplicate = false)
+        {
+            return new SnackbarMessageQueueItem(content, TimeSpan.Zero, actionContent:actionContent, ignoreDuplicate: ignoreDuplicate);
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
@@ -156,7 +156,7 @@ namespace MaterialDesignThemes.Wpf
         public SnackbarMessageQueue(TimeSpan messageDuration)
         {
             _messageDuration = messageDuration;
-            Task.Factory.StartNew(PumpAsync);
+            Task.Factory.StartNew(PumpAsync, TaskCreationOptions.LongRunning);
         }
 
         //oh if only I had Disposable.Create in this lib :)  tempted to copy it in like dragabalz, 

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueueItem.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueueItem.cs
@@ -50,5 +50,17 @@ namespace MaterialDesignThemes.Wpf
         /// Still display this message even if it is a duplicate.
         /// </summary>
         public bool IgnoreDuplicate { get; }
+
+        /// <summary>
+        /// Checks if given item is a duplicate to this
+        /// </summary>
+        /// <param name="item">Item to check for duplicate</param>
+        /// <returns><c>true</c> if given item is a duplicate to this, <c>false</c> otherwise</returns>
+        public bool IsDuplicate(SnackbarMessageQueueItem item)
+        {
+            return !IgnoreDuplicate
+                   && Equals(item.Content, Content)
+                   && Equals(item.ActionContent, ActionContent);
+        }
     }
 }

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueueItem.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueueItem.cs
@@ -58,6 +58,11 @@ namespace MaterialDesignThemes.Wpf
         /// <returns><c>true</c> if given item is a duplicate to this, <c>false</c> otherwise</returns>
         public bool IsDuplicate(SnackbarMessageQueueItem item)
         {
+            if (item is null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
             return !IgnoreDuplicate
                    && Equals(item.Content, Content)
                    && Equals(item.ActionContent, ActionContent);


### PR DESCRIPTION
When SnackbarQueue discards duplicates it does this also after the message is already done:

![show-message-on-click-bad](https://user-images.githubusercontent.com/16866222/81312175-9fd86d80-9086-11ea-90d6-afc0b4ab6cf6.gif)

So I fixed that, to get immediate feedback:

![show-message-on-click-ok](https://user-images.githubusercontent.com/16866222/81312236-b383d400-9086-11ea-83b8-d7ecd0c8751e.gif)

I also reworked the duplicate-check to be applied before insert into queue. That way it checks not immediate following duplicates.