### PR TITLE
Added attachable property Background to HintAssist. 

### DIFF
--- a/MaterialDesignThemes.Wpf/HintAssist.cs
+++ b/MaterialDesignThemes.Wpf/HintAssist.cs
@@ -154,6 +154,28 @@ namespace MaterialDesignThemes.Wpf
             element.SetValue(ForegroundProperty, value);
         }
 
+        /// <summary>
+        /// The color for the background of a focused control.
+        /// </summary>
+        public static readonly DependencyProperty BackgroundProperty = DependencyProperty.RegisterAttached(
+            "Background", typeof(Brush), typeof(HintAssist), new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets the color for the background of a focused control.
+        /// </summary>
+        public static Brush GetBackground(DependencyObject element)
+        {
+            return (Brush)element.GetValue(BackgroundProperty);
+        }
+
+        /// <summary>
+        /// Sets the color for the background of a focused control.
+        /// </summary>
+        public static void SetBackground(DependencyObject element, Brush value)
+        {
+            element.SetValue(BackgroundProperty, value);
+        }
+
         #endregion
 
         #region HelperText

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -34,6 +34,7 @@
         <Setter Property="wpf:TextFieldAssist.IncludeSpellingSuggestions" Value="{Binding RelativeSource={RelativeSource Self}, Path=(SpellCheck.IsEnabled)}" />
         <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <Setter Property="wpf:HintAssist.Background" Value="Transparent" />
         <Setter Property="ContextMenu" Value="{StaticResource MaterialDesignDefaultContextMenu}"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -165,6 +166,7 @@
                         </MultiTrigger>
                         <Trigger Property="wpf:HintAssist.IsFloating" Value="True">
                             <Setter TargetName="border" Property="Margin" Value="0 18 0 0" />
+                            <Setter TargetName="HintBackgroundBorder" Property="Background" Value="{Binding Path=(wpf:HintAssist.Background), RelativeSource={RelativeSource TemplatedParent}}" />
                         </Trigger>
                         <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
                             <Setter TargetName="textFieldBoxBorder" Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxHoverBackground}"/>
@@ -210,7 +212,6 @@
                             <Setter TargetName="Hint" Property="FloatingOffset" Value="{Binding FontSize, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FontSizeToHintOffsetConverter}}" />
                             <Setter TargetName="HintWrapper" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
                             <Setter TargetName="HintBackgroundBorder" Property="Padding" Value="4, 0" />
-                            <Setter TargetName="HintBackgroundBorder" Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -353,6 +354,7 @@
     <Style x:Key="MaterialDesignOutlinedTextFieldTextBox" TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}">
         <Setter Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
         <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />
+        <Setter Property="wpf:HintAssist.Background" Value="{DynamicResource MaterialDesignPaper}" />
     </Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
As per my suggestion in  #1804 

Set default value as Transparent for TextBoxBase
Set default for as MaterialDesignPaper for MaterialDesignOutlinedTextFieldTextBox


____


Tested by checking a bunch of different TextBox combinations to see consistent behavior:

```xaml
<StackPanel Margin="24">
        <TextBox Style="{StaticResource MaterialDesignFloatingHintTextBox}" wpf:HintAssist.Hint="Hint 1" wpf:HintAssist.Background="Red" FontSize="18" MinWidth="120" />
        <TextBox Style="{StaticResource MaterialDesignFloatingHintTextBox}" wpf:HintAssist.Hint="Hint 1" FontSize="18" MinWidth="120" />
        <TextBox Background="Aqua" Style="{StaticResource MaterialDesignFloatingHintTextBox}" wpf:HintAssist.Hint="Hint 1" FontSize="18" MinWidth="120" />
        <TextBox Background="Aqua" Style="{StaticResource MaterialDesignFloatingHintTextBox}" wpf:HintAssist.Background="Red" wpf:HintAssist.Hint="Hint 1" FontSize="18" MinWidth="120" />
        <TextBox Style="{StaticResource MaterialDesignOutlinedTextFieldTextBox}" wpf:HintAssist.Hint="Hint 1" wpf:HintAssist.Background="Red" FontSize="18" MinWidth="120" />
        <TextBox Style="{StaticResource MaterialDesignOutlinedTextFieldTextBox}" wpf:HintAssist.Hint="Hint 1" FontSize="18" MinWidth="120" />
        <TextBox Background="Aqua" Style="{StaticResource MaterialDesignOutlinedTextFieldTextBox}" wpf:HintAssist.Hint="Hint 1" FontSize="18" MinWidth="120" />
        <TextBox Background="Aqua" Style="{StaticResource MaterialDesignOutlinedTextFieldTextBox}" wpf:HintAssist.Background="Red" wpf:HintAssist.Hint="Hint 1" FontSize="18" MinWidth="120" />
        <TextBox Style="{StaticResource MaterialDesignFilledTextFieldTextBox}" wpf:HintAssist.Hint="Hint 1" wpf:HintAssist.Background="Red" FontSize="18" MinWidth="120" />
    </StackPanel>
```