### PR TITLE
Fix for Selected-Background on DataGridCell

### DIFF
--- a/MainDemo.Wpf/DataGrids.xaml
+++ b/MainDemo.Wpf/DataGrids.xaml
@@ -104,7 +104,11 @@
             </smtx:XamlDisplay>
             <TextBlock Style="{StaticResource MaterialDesignHeadline5TextBlock}" Text="Auto Generated Columns" Margin="0 24 0 0"/>
             <smtx:XamlDisplay Key="grids_2">
-                <DataGrid ItemsSource="{Binding Items2}" CanUserSortColumns="True" CanUserAddRows="False" />
+                <DataGrid ItemsSource="{Binding Items2}"
+                          CanUserSortColumns="True"
+                          CanUserAddRows="False"
+                          SelectionUnit="Cell"
+                          SelectionMode="Extended" />
             </smtx:XamlDisplay>
             <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Custom Padding" Margin="0 24 0 0"/>
             <smtx:XamlDisplay Key="grids_3">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
@@ -212,9 +212,12 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGridCell}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
+                            SnapsToDevicePixels="True">
                         <ContentPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                          Margin="{TemplateBinding Padding}"/>
+                                          Margin="{TemplateBinding Padding}" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
@@ -223,13 +226,23 @@
             <Trigger Property="IsKeyboardFocusWithin" Value="True">
                 <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextBoxBorder}"/>
             </Trigger>
-            <MultiTrigger>
-                <MultiTrigger.Conditions>
-                    <Condition Property="IsSelected" Value="True"/>
-                    <Condition Property="Selector.IsSelectionActive" Value="True"/>
-                </MultiTrigger.Conditions>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True"/>
+                    <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=DataGridRow}}" Value="False" />
+                    <Condition Binding="{Binding (Selector.IsSelectionActive), RelativeSource={RelativeSource Self}}" Value="False"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Background" Value="{DynamicResource MaterialDesignSelection}"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True"/>
+                    <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=DataGridRow}}" Value="False" />
+                    <Condition Binding="{Binding (Selector.IsSelectionActive), RelativeSource={RelativeSource Self}}" Value="True"/>
+                </MultiDataTrigger.Conditions>
                 <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}"/>
-            </MultiTrigger>
+                <Setter Property="Background" Value="{DynamicResource MaterialDesignSelection}" />
+            </MultiDataTrigger>
             <Trigger Property="IsEnabled" Value="False">
                 <Setter Property="Opacity" Value=".56"/>
             </Trigger>


### PR DESCRIPTION
Fixes #1720 

Restored the DataGridCell-Triggers for Background. Added condition to only set backgrounds when when `IsMouseOver` is `False` on corresponding `DataGridRow`

Updated second DataGrid in Demo-App with SelectionUnit=Cell and SelectionMode=Extended to showcase https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/1720#issuecomment-625479586

![select-cell-background](https://user-images.githubusercontent.com/16866222/81408567-bee60680-913d-11ea-9ab4-196ba9a18b16.gif)
