### PR TITLE
Better Popup-Placement for DataGrid-ComboBox

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
@@ -201,14 +201,16 @@
             </Popup>
             <ToggleButton
                 x:Name="toggleButton"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}"
                 Background="{TemplateBinding Background}"
-                Grid.ColumnSpan="2"
                 IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                 Style="{StaticResource MaterialDesignDataGridComboBoxToggleButton}" />
             <wpf:SmartHint
                 x:Name="Hint"
+                Grid.Column="0"
                 Margin="{TemplateBinding Padding}"
                 HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                 FontSize="{TemplateBinding FontSize}"
@@ -219,6 +221,7 @@
                 Hint="{TemplateBinding wpf:HintAssist.Hint}" />
             <ContentPresenter
                 x:Name="contentPresenter"
+                Grid.Column="0"
                 ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
                 ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                 Content="{TemplateBinding SelectionBoxItem}"
@@ -325,15 +328,17 @@
                 </Grid>
             </Popup>
             <ToggleButton 
-                x:Name="toggleButton" 
+                x:Name="toggleButton"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}" 
                 Background="{TemplateBinding Background}" 
-                Grid.ColumnSpan="2"
                 IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" 
                 Style="{StaticResource MaterialDesignDataGridComboBoxToggleButton}"/>
             <Border
                 x:Name="border"
+                Grid.Column="0"
                 Background="Transparent"
                 Margin="{TemplateBinding BorderThickness}">
                 <Grid>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
@@ -109,7 +109,7 @@
                                         SnapsToDevicePixels="true">
                         <Border x:Name="splitBorder" BorderBrush="Transparent" BorderThickness="0" HorizontalAlignment="Right" Margin="0" VerticalAlignment="Center"  SnapsToDevicePixels="true">
                             <Viewbox Width="8" Height="8" VerticalAlignment="Center" Margin="2 2 0 0">
-                                <Path x:Name="arrow" Data="M0,0L5,5L10,0H7Z" Fill="{TemplateBinding BorderBrush}" HorizontalAlignment="Right" Margin="0" VerticalAlignment="Center" Canvas.Left="7" SnapsToDevicePixels="True"/>                                
+                                <Path x:Name="arrow" Data="M0,0L5,5L10,0H7Z" Fill="{TemplateBinding BorderBrush}" HorizontalAlignment="Right" Margin="0" VerticalAlignment="Center" SnapsToDevicePixels="True"/>                                
                             </Viewbox>
                         </Border>
                     </Border>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
@@ -27,8 +27,17 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ComboBoxItem}">
-                    <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
-                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    <Border
+                        x:Name="Bd"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Background="{TemplateBinding Background}"
+                        Padding="{TemplateBinding Padding}"
+                        SnapsToDevicePixels="true">
+                        <ContentPresenter
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="False">
@@ -151,8 +160,19 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition MinWidth="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}" Width="0"/>
             </Grid.ColumnDefinitions>
-            <Popup x:Name="PART_Popup" AllowsTransparency="true" Grid.ColumnSpan="2" IsOpen="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="1" PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}" Placement="Bottom">
-                <Grid MaxHeight="{TemplateBinding MaxDropDownHeight}" MinWidth="{Binding ActualWidth, ElementName=templateRoot}" UseLayoutRounding="True">
+            <Popup 
+                x:Name="PART_Popup" 
+                AllowsTransparency="true" 
+                Grid.ColumnSpan="2" 
+                IsOpen="{Binding IsDropDownOpen, 
+                Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" 
+                Margin="1" 
+                PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}" 
+                Placement="Bottom">
+                <Grid
+                    MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                    MinWidth="{Binding ActualWidth, ElementName=templateRoot}"
+                    UseLayoutRounding="True">
                     <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
                         <Border x:Name="shadow" Background="{DynamicResource MaterialDesignPaper}" CornerRadius="2" BorderThickness="1"
                                 Effect="{DynamicResource MaterialDesignShadowDepth2}">
@@ -163,27 +183,51 @@
                         <ScrollViewer x:Name="DropDownScrollViewer">
                             <Grid x:Name="grid" RenderOptions.ClearTypeHint="Enabled">
                                 <Canvas x:Name="canvas" HorizontalAlignment="Left" Height="0" VerticalAlignment="Top" Width="0">
-                                    <Rectangle x:Name="opaqueRect" Fill="{Binding Background, ElementName=dropDownBorder}" Height="{Binding ActualHeight, ElementName=dropDownBorder}" Width="{Binding ActualWidth, ElementName=dropDownBorder}"/>
+                                    <Rectangle
+                                        x:Name="opaqueRect" 
+                                        Fill="{Binding Background, ElementName=dropDownBorder}" 
+                                        Height="{Binding ActualHeight, ElementName=dropDownBorder}" 
+                                        Width="{Binding ActualWidth, ElementName=dropDownBorder}"/>
                                 </Canvas>
-                                <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained" UseLayoutRounding="False" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                <ItemsPresenter 
+                                    x:Name="ItemsPresenter"
+                                    KeyboardNavigation.DirectionalNavigation="Contained" 
+                                    UseLayoutRounding="False" 
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </Grid>
                         </ScrollViewer>
                     </Border>
                 </Grid>
             </Popup>
-            <ToggleButton x:Name="toggleButton" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Grid.ColumnSpan="2" IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource MaterialDesignDataGridComboBoxToggleButton}"
-                                  />
-
-            <wpf:SmartHint x:Name="Hint"
-                           Margin="{TemplateBinding Padding}"
-                                   HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
-                                   FontSize="{TemplateBinding FontSize}"
-                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                   UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
-                                   UseFloating="{Binding Path=(wpf:HintAssist.IsFloating), RelativeSource={RelativeSource TemplatedParent}}"
-                                   HintOpacity="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"
-                                   Hint="{TemplateBinding wpf:HintAssist.Hint}" />
-            <ContentPresenter x:Name="contentPresenter" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" Content="{TemplateBinding SelectionBoxItem}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" IsHitTestVisible="false" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>            
+            <ToggleButton
+                x:Name="toggleButton"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                Background="{TemplateBinding Background}"
+                Grid.ColumnSpan="2"
+                IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                Style="{StaticResource MaterialDesignDataGridComboBoxToggleButton}" />
+            <wpf:SmartHint
+                x:Name="Hint"
+                Margin="{TemplateBinding Padding}"
+                HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
+                FontSize="{TemplateBinding FontSize}"
+                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
+                UseFloating="{Binding Path=(wpf:HintAssist.IsFloating), RelativeSource={RelativeSource TemplatedParent}}"
+                HintOpacity="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"
+                Hint="{TemplateBinding wpf:HintAssist.Hint}" />
+            <ContentPresenter
+                x:Name="contentPresenter"
+                ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                Content="{TemplateBinding SelectionBoxItem}"
+                ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
+                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                IsHitTestVisible="false"
+                Margin="{TemplateBinding Padding}"
+                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />            
         </Grid>
         <ControlTemplate.Triggers>
             <Trigger Property="HasDropShadow" SourceName="PART_Popup" Value="true">
@@ -219,8 +263,11 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TextBox}">
                     <Grid>
-                        <ScrollViewer x:Name="PART_ContentHost" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden"
-											  />
+                        <ScrollViewer
+                            x:Name="PART_ContentHost"
+                            Focusable="false"
+                            HorizontalScrollBarVisibility="Hidden"
+                            VerticalScrollBarVisibility="Hidden" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
@@ -233,39 +280,80 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition MinWidth="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}" Width="0"/>
             </Grid.ColumnDefinitions>
-            <Popup x:Name="PART_Popup" AllowsTransparency="true" Grid.ColumnSpan="2" IsOpen="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}}" PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}" Placement="Bottom">
-                <Grid MaxHeight="{TemplateBinding MaxDropDownHeight}" MinWidth="{Binding ActualWidth, ElementName=templateRoot}" UseLayoutRounding="True">
+            <Popup
+                x:Name="PART_Popup"
+                AllowsTransparency="true"
+                Grid.ColumnSpan="2"
+                IsOpen="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}"
+                Placement="Bottom">
+                <Grid
+                    MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                    MinWidth="{Binding ActualWidth, ElementName=templateRoot}"
+                    UseLayoutRounding="True">
                     <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
-                        <Border x:Name="shadow" Background="{DynamicResource MaterialDesignPaper}" CornerRadius="2" BorderThickness="1"
-                                                Effect="{DynamicResource MaterialDesignShadowDepth2}">
-                        </Border>
+                        <Border
+                            x:Name="shadow"
+                            Background="{DynamicResource MaterialDesignPaper}"
+                            CornerRadius="2"
+                            BorderThickness="1"
+                            Effect="{DynamicResource MaterialDesignShadowDepth2}" />
                     </AdornerDecorator>
-                    <Border x:Name="dropDownBorder" Margin="{Binding ElementName=shadow, Path=Margin, Mode=OneWay}" Background="Transparent"
-                            CornerRadius="2" BorderThickness="1" BorderBrush="{DynamicResource MaterialDesignDivider}">
+                    <Border x:Name="dropDownBorder"
+                            Margin="{Binding ElementName=shadow, Path=Margin, Mode=OneWay}"
+                            Background="Transparent"
+                            CornerRadius="2"
+                            BorderThickness="1"
+                            BorderBrush="{DynamicResource MaterialDesignDivider}">
                         <ScrollViewer x:Name="DropDownScrollViewer">
                             <Grid x:Name="grid" RenderOptions.ClearTypeHint="Enabled">
                                 <Canvas x:Name="canvas" HorizontalAlignment="Left" Height="0" VerticalAlignment="Top" Width="0">
-                                    <Rectangle x:Name="opaqueRect" Fill="{Binding Background, ElementName=dropDownBorder}" Height="{Binding ActualHeight, ElementName=dropDownBorder}" Width="{Binding ActualWidth, ElementName=dropDownBorder}"/>
+                                    <Rectangle
+                                        x:Name="opaqueRect"
+                                        Fill="{Binding Background, ElementName=dropDownBorder}"
+                                        Height="{Binding ActualHeight, ElementName=dropDownBorder}"
+                                        Width="{Binding ActualWidth, ElementName=dropDownBorder}" />
                                 </Canvas>
-                                <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained" UseLayoutRounding="False" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                <ItemsPresenter
+                                    x:Name="ItemsPresenter"
+                                    KeyboardNavigation.DirectionalNavigation="Contained"
+                                    UseLayoutRounding="False"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </Grid>
                         </ScrollViewer>
                     </Border>
                 </Grid>
             </Popup>
-            <ToggleButton x:Name="toggleButton" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Grid.ColumnSpan="2" IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Style="{StaticResource MaterialDesignDataGridComboBoxToggleButton}"/>
-            <Border x:Name="border" Background="Transparent" Margin="{TemplateBinding BorderThickness}">
+            <ToggleButton 
+                x:Name="toggleButton" 
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}" 
+                Background="{TemplateBinding Background}" 
+                Grid.ColumnSpan="2"
+                IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" 
+                Style="{StaticResource MaterialDesignDataGridComboBoxToggleButton}"/>
+            <Border
+                x:Name="border"
+                Background="Transparent"
+                Margin="{TemplateBinding BorderThickness}">
                 <Grid>
-                    <wpf:SmartHint x:Name="Hint"
-                                   Margin="{TemplateBinding Padding}"
-                                   HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
-                                   FontSize="{TemplateBinding FontSize}"
-                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                   UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
-                                   UseFloating="{Binding Path=(wpf:HintAssist.IsFloating), RelativeSource={RelativeSource TemplatedParent}}"
-                                   HintOpacity="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"
-                                   Hint="{TemplateBinding wpf:HintAssist.Hint}" />
-                    <TextBox x:Name="PART_EditableTextBox" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" IsReadOnly="{Binding IsReadOnly, RelativeSource={RelativeSource TemplatedParent}}" Margin="{TemplateBinding Padding}" Style="{StaticResource MaterialDesignDataGridComboBoxEditableTextBox}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    <wpf:SmartHint
+                        x:Name="Hint"
+                        Margin="{TemplateBinding Padding}"
+                        HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
+                        FontSize="{TemplateBinding FontSize}"
+                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                        UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
+                        UseFloating="{Binding Path=(wpf:HintAssist.IsFloating), RelativeSource={RelativeSource TemplatedParent}}"
+                        HintOpacity="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"
+                        Hint="{TemplateBinding wpf:HintAssist.Hint}" />
+                    <TextBox
+                        x:Name="PART_EditableTextBox"
+                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        IsReadOnly="{Binding IsReadOnly, RelativeSource={RelativeSource TemplatedParent}}"
+                        Margin="{TemplateBinding Padding}"
+                        Style="{StaticResource MaterialDesignDataGridComboBoxEditableTextBox}"
+                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
                 </Grid>
             </Border>
         </Grid>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
@@ -167,6 +167,7 @@
                 IsOpen="{TemplateBinding IsDropDownOpen}"
                 Margin="1"
                 PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}"
+                PlacementTarget="{Binding RelativeSource={RelativeSource AncestorType=DataGridCell}}"
                 Placement="Bottom">
                 <Grid
                     MaxHeight="{TemplateBinding MaxDropDownHeight}"
@@ -239,6 +240,8 @@
         <ControlTemplate.Triggers>
             <Trigger Property="HasDropShadow" SourceName="PART_Popup" Value="true">
                 <Setter Property="Margin" TargetName="shadow" Value="5,5,5,5"/>
+                <Setter TargetName="PART_Popup" Property="HorizontalOffset" Value="-5" />
+                <Setter TargetName="PART_Popup" Property="VerticalOffset" Value="-5" />
             </Trigger>
             <Trigger Property="HasItems" Value="false">
                 <Setter Property="Height" TargetName="dropDownBorder" Value="95"/>
@@ -293,6 +296,7 @@
                 Grid.ColumnSpan="2"
                 IsOpen="{TemplateBinding IsDropDownOpen}"
                 PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}"
+                PlacementTarget="{Binding RelativeSource={RelativeSource AncestorType=DataGridCell}}"
                 Placement="Bottom">
                 <Grid
                     MaxHeight="{TemplateBinding MaxDropDownHeight}"
@@ -369,6 +373,8 @@
         <ControlTemplate.Triggers>
             <Trigger Property="HasDropShadow" SourceName="PART_Popup" Value="true">
                 <Setter Property="Margin" TargetName="shadow" Value="5,5,5,5"/>
+                <Setter TargetName="PART_Popup" Property="HorizontalOffset" Value="-5" />
+                <Setter TargetName="PART_Popup" Property="VerticalOffset" Value="-5" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Opacity" TargetName="border" Value="0.56"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
@@ -160,14 +160,13 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition MinWidth="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}" Width="0"/>
             </Grid.ColumnDefinitions>
-            <Popup 
-                x:Name="PART_Popup" 
-                AllowsTransparency="true" 
-                Grid.ColumnSpan="2" 
-                IsOpen="{Binding IsDropDownOpen, 
-                Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" 
-                Margin="1" 
-                PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}" 
+            <Popup
+                x:Name="PART_Popup"
+                AllowsTransparency="true"
+                Grid.ColumnSpan="2"
+                IsOpen="{TemplateBinding IsDropDownOpen}"
+                Margin="1"
+                PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}"
                 Placement="Bottom">
                 <Grid
                     MaxHeight="{TemplateBinding MaxDropDownHeight}"
@@ -292,7 +291,7 @@
                 x:Name="PART_Popup"
                 AllowsTransparency="true"
                 Grid.ColumnSpan="2"
-                IsOpen="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                IsOpen="{TemplateBinding IsDropDownOpen}"
                 PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}"
                 Placement="Bottom">
                 <Grid

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"                    
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
@@ -171,15 +171,20 @@
                 Placement="Bottom">
                 <Grid
                     MaxHeight="{TemplateBinding MaxDropDownHeight}"
-                    MinWidth="{Binding ActualWidth, ElementName=templateRoot}"
                     UseLayoutRounding="True">
                     <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
                         <Border x:Name="shadow" Background="{DynamicResource MaterialDesignPaper}" CornerRadius="2" BorderThickness="1"
                                 Effect="{DynamicResource MaterialDesignShadowDepth2}">
                         </Border>
                     </AdornerDecorator>
-                    <Border x:Name="dropDownBorder" Margin="{Binding ElementName=shadow, Path=Margin, Mode=OneWay}" Background="Transparent"
-                            CornerRadius="2" BorderThickness="1" BorderBrush="{DynamicResource MaterialDesignDivider}">
+                    <Border
+                        x:Name="dropDownBorder"
+                        Margin="{Binding ElementName=shadow, Path=Margin, Mode=OneWay}"
+                        MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=DataGridCell}}"
+                        Background="Transparent"
+                        CornerRadius="2"
+                        BorderThickness="1"
+                        BorderBrush="{DynamicResource MaterialDesignDivider}">
                         <ScrollViewer x:Name="DropDownScrollViewer">
                             <Grid x:Name="grid" RenderOptions.ClearTypeHint="Enabled">
                                 <Canvas x:Name="canvas" HorizontalAlignment="Left" Height="0" VerticalAlignment="Top" Width="0">
@@ -292,7 +297,6 @@
                 Placement="Bottom">
                 <Grid
                     MaxHeight="{TemplateBinding MaxDropDownHeight}"
-                    MinWidth="{Binding ActualWidth, ElementName=templateRoot}"
                     UseLayoutRounding="True">
                     <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
                         <Border
@@ -304,6 +308,7 @@
                     </AdornerDecorator>
                     <Border x:Name="dropDownBorder"
                             Margin="{Binding ElementName=shadow, Path=Margin, Mode=OneWay}"
+                            MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=DataGridCell}}"
                             Background="Transparent"
                             CornerRadius="2"
                             BorderThickness="1"


### PR DESCRIPTION
Fixes #1799 

* Width is fixed by moving the property to the inner border with 618015e
* Set `PlacementTarget` for popup to `DataGridCell` with 503fa41
* Consider DropShadow-Margin for Popup alignment with 503fa41
* (Other commits improves readability and fixes minor rider warnings)

This is the result:
![image](https://user-images.githubusercontent.com/16866222/81422041-b9df8200-9152-11ea-887a-99c03631b1e1.png)
