### PR TITLE
Added some tolerance to InlineActionButtonMaxHeight

### DIFF
--- a/MaterialDesignThemes.Wpf/SnackbarMessage.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessage.cs
@@ -120,14 +120,21 @@ namespace MaterialDesignThemes.Wpf
             OnActionClick();
         }
 
+        /// <summary>
+        /// Maximum total height of snackbar for the action button to be inlined.
+        /// <para>
+        /// Default value (<c>55</c>) is between single line message (<c>48</c>) and two lined snackbar-message (<c>66</c>)
+        /// because tolerance is required (see <a href="https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/1812">issue</a>)
+        /// </para>
+        /// </summary>
         public static readonly DependencyProperty InlineActionButtonMaxHeightProperty = DependencyProperty.RegisterAttached(
-            "InlineActionButtonMaxHeight", typeof(double), typeof(SnackbarMessage), new PropertyMetadata(default(double)));
+            "InlineActionButtonMaxHeight", typeof(double), typeof(SnackbarMessage), new PropertyMetadata(55d));
 
         public static void SetInlineActionButtonMaxHeight(DependencyObject element, double value) => element.SetValue(InlineActionButtonMaxHeightProperty, value);
         public static double GetInlineActionButtonMaxHeight(DependencyObject element) => (double) element.GetValue(InlineActionButtonMaxHeightProperty);
 
         public static readonly DependencyProperty ContentMaxHeightProperty = DependencyProperty.RegisterAttached(
-            "ContentMaxHeight", typeof(double), typeof(SnackbarMessage), new PropertyMetadata(default(double)));
+            "ContentMaxHeight", typeof(double), typeof(SnackbarMessage), new PropertyMetadata(36d));
 
         public static void SetContentMaxHeight(DependencyObject element, double value) => element.SetValue(ContentMaxHeightProperty, value);
         public static double GetContentMaxHeight(DependencyObject element) => (double) element.GetValue(ContentMaxHeightProperty);

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Snackbar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Snackbar.xaml
@@ -132,8 +132,6 @@
         <Setter Property="MinWidth" Value="288" />
         <Setter Property="MaxWidth" Value="568" />
         <Setter Property="ClipToBounds" Value="True" />
-        <Setter Property="wpf:SnackbarMessage.InlineActionButtonMaxHeight" Value="55" />
-        <Setter Property="wpf:SnackbarMessage.ContentMaxHeight" Value="36" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="wpf:Snackbar">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Snackbar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Snackbar.xaml
@@ -132,7 +132,7 @@
         <Setter Property="MinWidth" Value="288" />
         <Setter Property="MaxWidth" Value="568" />
         <Setter Property="ClipToBounds" Value="True" />
-        <Setter Property="wpf:SnackbarMessage.InlineActionButtonMaxHeight" Value="49" />
+        <Setter Property="wpf:SnackbarMessage.InlineActionButtonMaxHeight" Value="55" />
         <Setter Property="wpf:SnackbarMessage.ContentMaxHeight" Value="36" />
         <Setter Property="Template">
             <Setter.Value>


### PR DESCRIPTION
Fixes #1812 

Increased `InlineActionButtonMaxHeight` to `55`

Updated usages of `InlineActionButtonMaxHeight` and `ContentMaxHeight` to be the default values. Removed duplicate definition.