### PR TITLE
Close ComboBox-DropDown on edit end

### DIFF
--- a/MaterialDesignThemes.Wpf/DataGridComboBoxColumn.cs
+++ b/MaterialDesignThemes.Wpf/DataGridComboBoxColumn.cs
@@ -88,6 +88,20 @@ namespace MaterialDesignThemes.Wpf
             return style;
         }
 
+        protected override void CancelCellEdit(FrameworkElement editingElement, object uneditedValue)
+        {
+            if (editingElement is ComboBox comboBox)
+                comboBox.SetCurrentValue(ComboBox.IsDropDownOpenProperty, false);
+            base.CancelCellEdit(editingElement, uneditedValue);
+        }
+
+        protected override bool CommitCellEdit(FrameworkElement editingElement)
+        {
+            if (editingElement is ComboBox comboBox)
+                comboBox.SetCurrentValue(ComboBox.IsDropDownOpenProperty, false);
+            return base.CommitCellEdit(editingElement);
+        }
+
         /*
         /// <summary>
         ///     Assigns the Binding to the desired property on the target object.


### PR DESCRIPTION
Fixes #1817 (at least for me the dropdown did not stay open)

When ComboBox edit ended (trough cancel or commit) the dropdown is closed.

