### PR TITLE
DialogContent doesn't inheritingTexElement Property

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -147,8 +147,6 @@
                                         wpf:ShadowAssist.ShadowDepth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth)}"
                                         UniformCornerRadius="4"
                                         TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-                                        TextElement.FontWeight="Regular"
-                                        TextElement.FontSize="13"
                                         TextOptions.TextFormattingMode="Ideal"
                                         TextOptions.TextRenderingMode="Auto" 
                                         FocusManager.IsFocusScope="False"


### PR DESCRIPTION
In DialogHost control template, inheritable property TextElement was overridden for DialogContent. This causes we have to specify TextElement property once again in DialogContent UIElement same as specified in mainwindow.

Where:
In DialogHost control template, under "PART_PopupContentElement.

Proposed action:
Please remove following lines in favor inheriting parent property,
TextElement.FontWeight="Regular"
TextElement.FontSize="13"