### PR TITLE
Tests to verify color definitions

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/ColorDefinitionsTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/ColorDefinitionsTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections;
+using System.Linq;
+using System.Windows;
+using System.Windows.Media;
+using Xunit;
+
+namespace MaterialDesignThemes.Wpf.Tests
+{
+    public class ColorDefinitionsTests
+    {
+        public ColorDefinitionsTests()
+        {
+            if (!UriParser.IsKnownScheme("pack"))
+                Assert.NotNull(new Application());
+        }
+
+        [Fact]
+        public void VerifyLightXamlColorsInTheme()
+        {
+            AssertXamlColorsInTheme("MaterialDesignTheme.Light.xaml", new MaterialDesignLightTheme());
+        }
+
+        [Fact]
+        public void VerifyDarkXamlColorsInTheme()
+        {
+            AssertXamlColorsInTheme("MaterialDesignTheme.Dark.xaml", new MaterialDesignDarkTheme());
+        }
+
+        private static void AssertXamlColorsInTheme(string xaml, IBaseTheme baseTheme)
+        {
+            var theme = new Theme();
+            theme.SetBaseTheme(baseTheme);
+
+            var uri = new Uri("pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/" + xaml);
+            var resourceDictionary = new ResourceDictionary { Source = uri };
+
+            foreach (var (key, solidColorBrush) in resourceDictionary
+                .OfType<DictionaryEntry>()
+                .Where(e => e.Value is SolidColorBrush)
+                .Select(e => ((string) e.Key, (SolidColorBrush) e.Value))
+                .OrderBy(e => e.Item1))
+            {
+                var baseThemePropertyName = key == "ValidationErrorBrush"
+                    ? "ValidationErrorColor"
+                    : key;
+                var baseThemeProperty = baseTheme.GetType().GetProperty(baseThemePropertyName);
+                Assert.False(baseThemeProperty == null, $"{baseThemePropertyName} from {xaml} not found in {baseTheme.GetType()}");
+
+                var themePropertyName = key == "ValidationErrorBrush"
+                    ? "ValidationError"
+                    : key.Replace("MaterialDesign", "");
+                var themeProperty = theme.GetType().GetProperty(themePropertyName);
+                Assert.False(themeProperty == null, $"{themePropertyName} from {xaml} not found in {theme.GetType()}");
+                Assert.NotNull(themeProperty);
+
+                Assert.Equal(solidColorBrush.Color, themeProperty.GetValue(theme));
+            }
+        }
+
+        [Fact]
+        public void VerifyLightThemeColorsInXaml()
+        {
+            AssertThemeColorsInXaml(new MaterialDesignLightTheme(), "MaterialDesignTheme.Light.xaml");
+        }
+
+        [Fact]
+        public void VerifyDarkThemeColorsInXaml()
+        {
+            AssertThemeColorsInXaml(new MaterialDesignDarkTheme(), "MaterialDesignTheme.Dark.xaml");
+        }
+
+        private static void AssertThemeColorsInXaml(IBaseTheme baseTheme, string xaml)
+        {
+            var theme = new Theme();
+            theme.SetBaseTheme(baseTheme);
+
+            var uri = new Uri("pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/" + xaml);
+            var resourceDictionary = new ResourceDictionary { Source = uri };
+
+            var updatedDictionary = new ResourceDictionary();
+            updatedDictionary.SetTheme(theme);
+
+            foreach (var property in theme.GetType().GetProperties().Where(p => p.PropertyType == typeof(Color)))
+            {
+                var propertyColor = (Color) property.GetValue(theme)!;
+                var (nameBrush, nameColor) = property.Name == "ValidationError"
+                    ? ("ValidationErrorBrush", "ValidationErrorColor")
+                    : ("MaterialDesign" + property.Name, "MaterialDesign" + property.Name + "Color");
+
+                Assert.True(resourceDictionary.Contains(nameBrush), $"{nameBrush} from {theme.GetType()} not found in {xaml}");
+
+                var xamlValue = resourceDictionary[nameBrush];
+                Assert.True(xamlValue is SolidColorBrush, $"{nameBrush} in {xaml} is no SolidColorBrush");
+                Assert.Equal(propertyColor, ((SolidColorBrush) xamlValue).Color);
+
+                Assert.True(updatedDictionary.Contains(nameColor), $"{nameColor} from {theme.GetType()} not set via ResourceDictionaryExtensions.SetTheme");
+                Assert.Equal(propertyColor, updatedDictionary[nameColor]);
+            }
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf.Tests/ColorDefinitionsTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/ColorDefinitionsTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Linq;
 using System.Windows;
@@ -9,12 +8,6 @@ namespace MaterialDesignThemes.Wpf.Tests
 {
     public class ColorDefinitionsTests
     {
-        public ColorDefinitionsTests()
-        {
-            if (!UriParser.IsKnownScheme("pack"))
-                Assert.NotNull(new Application());
-        }
-
         [Fact]
         public void VerifyLightXamlColorsInTheme()
         {
@@ -32,11 +25,10 @@ namespace MaterialDesignThemes.Wpf.Tests
             var theme = new Theme();
             theme.SetBaseTheme(baseTheme);
 
-            var uri = new Uri("pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/" + xaml);
-            var resourceDictionary = new ResourceDictionary { Source = uri };
+            var resourceDictionary = MdixHelper.GetResourceDictionary(xaml);
 
             foreach (var (key, solidColorBrush) in resourceDictionary
-                .OfType<DictionaryEntry>()
+                .Cast<DictionaryEntry>()
                 .Where(e => e.Value is SolidColorBrush)
                 .Select(e => ((string) e.Key, (SolidColorBrush) e.Value))
                 .OrderBy(e => e.Item1))
@@ -75,8 +67,7 @@ namespace MaterialDesignThemes.Wpf.Tests
             var theme = new Theme();
             theme.SetBaseTheme(baseTheme);
 
-            var uri = new Uri("pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/" + xaml);
-            var resourceDictionary = new ResourceDictionary { Source = uri };
+            var resourceDictionary = MdixHelper.GetResourceDictionary(xaml);
 
             var updatedDictionary = new ResourceDictionary();
             updatedDictionary.SetTheme(theme);

--- a/MaterialDesignThemes.Wpf.Tests/MdixHelper.cs
+++ b/MaterialDesignThemes.Wpf.Tests/MdixHelper.cs
@@ -1,8 +1,8 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
-using System.Windows.Controls;
 using Xunit;
 
 namespace MaterialDesignThemes.Wpf.Tests
@@ -14,13 +14,13 @@ namespace MaterialDesignThemes.Wpf.Tests
             var _ = Application.Current;
         }
 
-        private static ResourceDictionary DefaultResourceDictionary => GetThemeResourceDictionary("Defaults");
+        private static ResourceDictionary DefaultResourceDictionary => GetResourceDictionary("MaterialDesignTheme.Defaults.xaml");
 
-        private static ResourceDictionary GenericResourceDictionary => GetGenericResourceDictionary();
+        private static ResourceDictionary GenericResourceDictionary => GetResourceDictionary("Generic.xaml");
 
         public static void ApplyStyle<T>(this T control, object styleKey, bool applyTemplate = true) where T : FrameworkElement
         {
-            Style style = GetStyle(styleKey);
+            var style = GetStyle(styleKey);
             Assert.True(style != null, $"Could not find style with key '{styleKey}' for control type {typeof(T).FullName}");
             control.Style = style;
             if (applyTemplate)
@@ -32,53 +32,22 @@ namespace MaterialDesignThemes.Wpf.Tests
         public static void ApplyDefaultStyle<T>(this T control) where T : FrameworkElement => control.ApplyStyle(typeof(T));
 
         public static IEnumerable<object> GetStyleKeysFor<T>()
-        {
-            foreach (object key in GetKeysFromResourceDictionary(DefaultResourceDictionary))
-            {
-                yield return key;
-            }
-            ResourceDictionary controlResourceDictionary = GetThemeResourceDictionary(typeof(T).Name);
-            foreach (object key in GetKeysFromResourceDictionary(controlResourceDictionary))
-            {
-                yield return key;
-            }
+            => DefaultResourceDictionary.GetStyleKeysFor<T>()
+                .Concat(GetResourceDictionary($"MaterialDesignTheme.{typeof(T).Name}.xaml").GetStyleKeysFor<T>());
 
-            //TODO: Make static once we go to C# 8
-            IEnumerable<object> GetKeysFromResourceDictionary(ResourceDictionary resourceDictionary)
-            {
-                foreach (object key in resourceDictionary.Keys)
-                {
-                    if (resourceDictionary[key] is Style style)
-                    {
-                        if (style.TargetType == typeof(T))
-                        {
-                            yield return key;
-                        }
-                    }
-                }
-            }
-        }
+        private static IEnumerable<object> GetStyleKeysFor<T>(this IEnumerable dictionary)
+            => dictionary
+                .Cast<DictionaryEntry>()
+                .Where(e => e.Value is Style style && style.TargetType is T)
+                .Select(e => e.Key);
 
         private static Style GetStyle(object key)
-        {
-            return DefaultResourceDictionary[key] as Style ??
-                   GenericResourceDictionary[key] as Style;
-        }
+            => DefaultResourceDictionary[key] as Style
+               ?? GenericResourceDictionary[key] as Style;
 
-        private static ResourceDictionary GetThemeResourceDictionary(string name)
+        public static ResourceDictionary GetResourceDictionary(string xamlName)
         {
-            var uri = new Uri(
-                $"/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.{name}.xaml", UriKind.Relative);
-            return new ResourceDictionary
-            {
-                Source = uri
-            };
-        }
-
-        private static ResourceDictionary GetGenericResourceDictionary()
-        {
-            var uri = new Uri(
-                $"/MaterialDesignThemes.Wpf;component/Themes/Generic.xaml", UriKind.Relative);
+            var uri = new Uri($"/MaterialDesignThemes.Wpf;component/Themes/{xamlName}", UriKind.Relative);
             return new ResourceDictionary
             {
                 Source = uri

--- a/MaterialDesignThemes.Wpf/IBaseTheme.cs
+++ b/MaterialDesignThemes.Wpf/IBaseTheme.cs
@@ -17,6 +17,8 @@ namespace MaterialDesignThemes.Wpf
         Color MaterialDesignTextBoxBorder { get; }
         Color MaterialDesignDivider { get; }
         Color MaterialDesignSelection { get; }
+        Color MaterialDesignToolForeground { get; }
+        Color MaterialDesignToolBackground { get; }
         Color MaterialDesignFlatButtonClick { get; }
         Color MaterialDesignFlatButtonRipple { get; }
         Color MaterialDesignToolTipBackground { get; }

--- a/MaterialDesignThemes.Wpf/ITheme.cs
+++ b/MaterialDesignThemes.Wpf/ITheme.cs
@@ -27,6 +27,9 @@ namespace MaterialDesignThemes.Wpf
 
         Color Divider { get; set; }
         Color Selection { get; set; }
+        
+        Color ToolForeground { get; set; }
+        Color ToolBackground { get; set; }
 
         Color FlatButtonClick { get; set; }
         Color FlatButtonRipple { get; set; }

--- a/MaterialDesignThemes.Wpf/MaterialDesignDarkTheme.cs
+++ b/MaterialDesignThemes.Wpf/MaterialDesignDarkTheme.cs
@@ -17,6 +17,8 @@ namespace MaterialDesignThemes.Wpf
         public Color MaterialDesignTextBoxBorder { get; } = (Color)ColorConverter.ConvertFromString("#89FFFFFF");
         public Color MaterialDesignDivider { get; } = (Color)ColorConverter.ConvertFromString("#1FFFFFFF");
         public Color MaterialDesignSelection { get; } = (Color)ColorConverter.ConvertFromString("#757575");
+        public Color MaterialDesignToolForeground { get; } = (Color)ColorConverter.ConvertFromString("#FF616161");
+        public Color MaterialDesignToolBackground { get; } = (Color)ColorConverter.ConvertFromString("#FFe0e0e0");
         public Color MaterialDesignFlatButtonClick { get; } = (Color)ColorConverter.ConvertFromString("#19757575");
         public Color MaterialDesignFlatButtonRipple { get; } = (Color)ColorConverter.ConvertFromString("#FFB6B6B6");
         public Color MaterialDesignToolTipBackground { get; } = (Color)ColorConverter.ConvertFromString("#eeeeee");

--- a/MaterialDesignThemes.Wpf/MaterialDesignLightTheme.cs
+++ b/MaterialDesignThemes.Wpf/MaterialDesignLightTheme.cs
@@ -17,6 +17,8 @@ namespace MaterialDesignThemes.Wpf
         public Color MaterialDesignTextBoxBorder { get; } = (Color)ColorConverter.ConvertFromString("#89000000");
         public Color MaterialDesignDivider { get; } = (Color)ColorConverter.ConvertFromString("#1F000000");
         public Color MaterialDesignSelection { get; } = (Color)ColorConverter.ConvertFromString("#FFDeDeDe");
+        public Color MaterialDesignToolForeground { get; } = (Color)ColorConverter.ConvertFromString("#FF616161");
+        public Color MaterialDesignToolBackground { get; } = (Color)ColorConverter.ConvertFromString("#FFe0e0e0");
         public Color MaterialDesignFlatButtonClick { get; } = (Color)ColorConverter.ConvertFromString("#FFDeDeDe");
         public Color MaterialDesignFlatButtonRipple { get; } = (Color)ColorConverter.ConvertFromString("#FFB6B6B6");
         public Color MaterialDesignToolTipBackground { get; } = (Color)ColorConverter.ConvertFromString("#757575");

--- a/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs
+++ b/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs
@@ -50,6 +50,8 @@ namespace MaterialDesignThemes.Wpf
             SetSolidColorBrush(resourceDictionary, "MaterialDesignTextBoxBorder", theme.TextBoxBorder);
             SetSolidColorBrush(resourceDictionary, "MaterialDesignDivider", theme.Divider);
             SetSolidColorBrush(resourceDictionary, "MaterialDesignSelection", theme.Selection);
+            SetSolidColorBrush(resourceDictionary, "MaterialDesignToolForeground", theme.ToolForeground);
+            SetSolidColorBrush(resourceDictionary, "MaterialDesignToolBackground", theme.ToolBackground);
             SetSolidColorBrush(resourceDictionary, "MaterialDesignFlatButtonClick", theme.FlatButtonClick);
             SetSolidColorBrush(resourceDictionary, "MaterialDesignFlatButtonRipple", theme.FlatButtonRipple);
             SetSolidColorBrush(resourceDictionary, "MaterialDesignToolTipBackground", theme.ToolTipBackground);

--- a/MaterialDesignThemes.Wpf/Theme.cs
+++ b/MaterialDesignThemes.Wpf/Theme.cs
@@ -41,6 +41,8 @@ namespace MaterialDesignThemes.Wpf
         public Color CheckBoxDisabled { get; set; }
         public Color Divider { get; set; }
         public Color Selection { get; set; }
+        public Color ToolForeground { get; set; }
+        public Color ToolBackground { get; set; }
         public Color FlatButtonClick { get; set; }
         public Color FlatButtonRipple { get; set; }
         public Color ToolTipBackground { get; set; }

--- a/MaterialDesignThemes.Wpf/ThemeExtensions.cs
+++ b/MaterialDesignThemes.Wpf/ThemeExtensions.cs
@@ -53,6 +53,8 @@ namespace MaterialDesignThemes.Wpf
             theme.CheckBoxDisabled = baseTheme.MaterialDesignCheckBoxDisabled;
             theme.Divider = baseTheme.MaterialDesignDivider;
             theme.Selection = baseTheme.MaterialDesignSelection;
+            theme.ToolForeground = baseTheme.MaterialDesignToolForeground;
+            theme.ToolBackground = baseTheme.MaterialDesignToolBackground;
             theme.FlatButtonClick = baseTheme.MaterialDesignFlatButtonClick;
             theme.FlatButtonRipple = baseTheme.MaterialDesignFlatButtonRipple;
             theme.ToolTipBackground = baseTheme.MaterialDesignToolTipBackground;


### PR DESCRIPTION
These tests verifies, that colors are registered correctly in ...
* `MaterialDesignTheme.Light.xaml` and `MaterialDesignTheme.Dark.xaml`
* `ITheme`
* `IBaseTheme` (`MaterialDesignLightTheme` and `MaterialDesignDarkTheme`)
* `ResourceDictionaryExtensions`
* `ThemeExtensions`
* and `Color` values are identical

Theses tests showed, that `ToolForeground` and `ToolBackground` were also missing. So I added them 7372bd0