### PR TITLE
[BottomDashedLineAdorner] Refactoring

### DIFF
--- a/MaterialDesignThemes.Wpf/BottomDashedLineAdorner.cs
+++ b/MaterialDesignThemes.Wpf/BottomDashedLineAdorner.cs
@@ -1,70 +1,90 @@
 using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Media;
+using System.Windows.Shapes;
 
 namespace MaterialDesignThemes.Wpf
 {
     public class BottomDashedLineAdorner : Adorner
     {
+        private static readonly Thickness DefaultThickness = new Thickness(1);
         private const double DefaultThicknessScale = 1.33;
         private const double DefaultOpacity = 0.56;
 
-        public BottomDashedLineAdorner(UIElement adornedElement) : base(adornedElement) { }
+        #region AttachedProperty : IsAttachedProperty
+        public static readonly DependencyProperty IsAttachedProperty
+            = DependencyProperty.RegisterAttached("IsAttached", typeof(bool), typeof(BottomDashedLineAdorner), new PropertyMetadata(default(bool), OnIsAttachedChanged));
+
+        public static bool GetIsAttached(DependencyObject element) { return (bool)element.GetValue(IsAttachedProperty); }
+        public static void SetIsAttached(DependencyObject element, bool value) { element.SetValue(IsAttachedProperty, value); }
+        #endregion
+
+        #region AttachedProperty : BrushProperty
+        public static readonly DependencyProperty BrushProperty
+            = DependencyProperty.RegisterAttached("Brush", typeof(Brush), typeof(BottomDashedLineAdorner), new PropertyMetadata(default(Brush)));
+
+        public static Brush GetBrush(DependencyObject element) { return (Brush)element.GetValue(BrushProperty); }
+        public static void SetBrush(DependencyObject element, Brush value) { element.SetValue(BrushProperty, value); }
+        #endregion
+
+        #region AttachedProperty : ThicknessProperty
+        public static readonly DependencyProperty ThicknessProperty
+            = DependencyProperty.RegisterAttached("Thickness", typeof(Thickness), typeof(BottomDashedLineAdorner), new PropertyMetadata(DefaultThickness));
+
+        public static Thickness GetThickness(DependencyObject element) { return (Thickness)element.GetValue(ThicknessProperty); }
+        public static void SetThickness(DependencyObject element, Thickness value) { element.SetValue(ThicknessProperty, value); }
+        #endregion
+
+        #region AttachedProperty : ThicknessScaleProperty
+        public static readonly DependencyProperty ThicknessScaleProperty
+            = DependencyProperty.RegisterAttached("ThicknessScale", typeof(double), typeof(BottomDashedLineAdorner), new PropertyMetadata(DefaultThicknessScale));
+
+        public static double GetThicknessScale(DependencyObject element) { return (double)element.GetValue(ThicknessScaleProperty); }
+        public static void SetThicknessScale(DependencyObject element, double value) { element.SetValue(ThicknessScaleProperty, value); }
+        #endregion
+
+        #region AttachedProperty : BrushOpacityProperty
+        public static readonly DependencyProperty BrushOpacityProperty
+            = DependencyProperty.RegisterAttached("BrushOpacity", typeof(double), typeof(BottomDashedLineAdorner), new PropertyMetadata(DefaultOpacity));
+
+        public static double GetBrushOpacity(DependencyObject element) { return (double)element.GetValue(BrushOpacityProperty); }
+        public static void SetBrushOpacity(DependencyObject element, double value) { element.SetValue(BrushOpacityProperty, value); }
+        #endregion
+
+        public BottomDashedLineAdorner(UIElement adornedElement) : base(adornedElement)
+        {
+        }
 
         protected override void OnRender(DrawingContext drawingContext)
         {
-            var element = AdornedElement;
-            var rect = new Rect(element.RenderSize);
+            var targetElementBox = new Rect(AdornedElement.RenderSize);
+            var lineThickness = GetThickness(AdornedElement).Bottom * GetThicknessScale(AdornedElement);
+            var lineOpacity = GetBrushOpacity(AdornedElement);
 
-            var pen = new Pen(GetBrush(element), GetThickness(element).Bottom * GetThicknessScale(element))
+            var pen = new Pen(GetBrush(AdornedElement), lineThickness)
             {
                 DashStyle = DashStyles.Dash,
                 DashCap = PenLineCap.Round
             };
 
-            drawingContext.PushOpacity(GetBrushOpacity(element));
-            drawingContext.DrawLine(pen, rect.BottomLeft, rect.BottomRight);
+            drawingContext.PushOpacity(lineOpacity);
+            drawingContext.DrawLine(pen, targetElementBox.BottomLeft, targetElementBox.BottomRight);
             drawingContext.Pop();
         }
 
-        public static readonly DependencyProperty IsAttachedProperty = DependencyProperty.RegisterAttached(
-            "IsAttached", typeof(bool), typeof(BottomDashedLineAdorner), new PropertyMetadata(default(bool), OnIsAttachedChanged));
-
-        public static void SetIsAttached(DependencyObject element, bool value) => element.SetValue(IsAttachedProperty, value);
-        public static bool GetIsAttached(DependencyObject element) => (bool) element.GetValue(IsAttachedProperty);
-
-        private static void OnIsAttachedChanged(DependencyObject @object, DependencyPropertyChangedEventArgs args)
+        private static void OnIsAttachedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            var element = (UIElement) @object;
-            if (args.OldValue is bool oldValue && oldValue)
-                element.RemoveAdorners<BottomDashedLineAdorner>();
+            var element = (UIElement)d;
+            var adornerIsAttached = (bool)e.NewValue;
 
-            if (args.NewValue is bool newValue && newValue)
+            if (adornerIsAttached)
+            {
                 element.AddAdorner(new BottomDashedLineAdorner(element));
-        }
-
-        public static readonly DependencyProperty BrushProperty = DependencyProperty.RegisterAttached(
-            "Brush", typeof(Brush), typeof(BottomDashedLineAdorner), new PropertyMetadata(default(Brush)));
-
-        public static void SetBrush(DependencyObject element, Brush value) => element.SetValue(BrushProperty, value);
-        public static Brush GetBrush(DependencyObject element) => (Brush) element.GetValue(BrushProperty);
-
-        public static readonly DependencyProperty ThicknessProperty = DependencyProperty.RegisterAttached(
-            "Thickness", typeof(Thickness), typeof(BottomDashedLineAdorner), new PropertyMetadata(new Thickness(1)));
-
-        public static void SetThickness(DependencyObject element, Thickness value) => element.SetValue(ThicknessProperty, value);
-        public static Thickness GetThickness(DependencyObject element) => (Thickness) element.GetValue(ThicknessProperty);
-
-        public static readonly DependencyProperty ThicknessScaleProperty = DependencyProperty.RegisterAttached(
-            "ThicknessScale", typeof(double), typeof(BottomDashedLineAdorner), new PropertyMetadata(DefaultThicknessScale));
-
-        public static void SetThicknessScale(DependencyObject element, double value) => element.SetValue(ThicknessScaleProperty, value);
-        public static double GetThicknessScale(DependencyObject element) => (double) element.GetValue(ThicknessScaleProperty);
-
-        public static readonly DependencyProperty BrushOpacityProperty = DependencyProperty.RegisterAttached(
-            "BrushOpacity", typeof(double), typeof(BottomDashedLineAdorner), new PropertyMetadata(DefaultOpacity));
-
-        public static void SetBrushOpacity(DependencyObject element, double value) => element.SetValue(BrushOpacityProperty, value);
-        public static double GetBrushOpacity(DependencyObject element) => (double) element.GetValue(BrushOpacityProperty);
+            }
+            else
+            {
+                element.RemoveAdorners<BottomDashedLineAdorner>();
+            }
+        }  
     }
 }

--- a/MaterialDesignThemes.Wpf/BottomDashedLineAdorner.cs
+++ b/MaterialDesignThemes.Wpf/BottomDashedLineAdorner.cs
@@ -1,7 +1,6 @@
 using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Media;
-using System.Windows.Shapes;
 
 namespace MaterialDesignThemes.Wpf
 {
@@ -60,8 +59,9 @@ namespace MaterialDesignThemes.Wpf
             var targetElementBox = new Rect(AdornedElement.RenderSize);
             var lineThickness = GetThickness(AdornedElement).Bottom * GetThicknessScale(AdornedElement);
             var lineOpacity = GetBrushOpacity(AdornedElement);
+            var lineBrush = GetBrush(AdornedElement);
 
-            var pen = new Pen(GetBrush(AdornedElement), lineThickness)
+            var pen = new Pen(lineBrush, lineThickness)
             {
                 DashStyle = DashStyles.Dash,
                 DashCap = PenLineCap.Round


### PR DESCRIPTION
Note: The previous behaviour in OnIsAttachedChanged seemed off to me as the value can only be a bool. I think this version makes the distinction between the two possible actions clearer.

- Streamlined AttachedProperties
- Streamlined parameter names for callbacks
- Added more speaking variables in OnRender
- Simplified OnIsAttachedChanged