### PR TITLE
Fix MaterialDesignCircularProgressBar to show full circle at 100 %

### DIFF
--- a/MainDemo.Wpf/Progress.xaml
+++ b/MainDemo.Wpf/Progress.xaml
@@ -193,7 +193,7 @@
             <EventTrigger.Actions>
                 <BeginStoryboard>
                     <Storyboard TargetName="DeterminateCircularProgress" TargetProperty="Value" RepeatBehavior="Forever" Duration="0:0:3">
-                        <DoubleAnimation From="0" To="100" Duration="0:0:2.5" FillBehavior="Stop">
+                        <DoubleAnimation From="0" To="100" Duration="0:0:2.5" FillBehavior="HoldEnd">
                             <DoubleAnimation.EasingFunction>
                                 <CircleEase EasingMode="EaseOut" />
                             </DoubleAnimation.EasingFunction>

--- a/MaterialDesignThemes.Wpf/Converters/CircularProgressBar/ArcEndPointConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/CircularProgressBar/ArcEndPointConverter.cs
@@ -7,6 +7,14 @@ namespace MaterialDesignThemes.Wpf.Converters.CircularProgressBar
 {
     public class ArcEndPointConverter : IMultiValueConverter
     {
+        /// <summary>
+        /// CircularProgressBar draws two arcs to support a full circle at 100 %.
+        /// With one arc at 100 % the start point is identical the end point, so nothing is drawn.
+        /// Midpoint at half of current percentage is the endpoint of the first arc
+        /// and the start point of the second arc.
+        /// </summary>
+        public const string ParameterMidPoint = "MidPoint";
+        
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
             var actualWidth = values[0].ExtractDouble();
@@ -27,6 +35,9 @@ namespace MaterialDesignThemes.Wpf.Converters.CircularProgressBar
             }
 
             var percent = maximum <= minimum ? 1.0 : (value - minimum) / (maximum - minimum);
+            if (Equals(parameter, ParameterMidPoint))
+                percent /= 2;
+                
             var degrees = 360 * percent;
             var radians = degrees * (Math.PI / 180);
 

--- a/MaterialDesignThemes.Wpf/Converters/CircularProgressBar/LargeArcConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/CircularProgressBar/LargeArcConverter.cs
@@ -4,6 +4,7 @@ using System.Windows.Data;
 
 namespace MaterialDesignThemes.Wpf.Converters.CircularProgressBar
 {
+    [Obsolete("usage removed with #1854")]
     public class LargeArcConverter : IMultiValueConverter
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
@@ -118,7 +118,6 @@
     <circularProgressBar:StartPointConverter x:Key="StartPointConverter" />
     <circularProgressBar:ArcSizeConverter x:Key="ArcSizeConverter" />
     <circularProgressBar:ArcEndPointConverter x:Key="ArcEndPointConverter" />
-    <circularProgressBar:LargeArcConverter x:Key="LargeArcConverter" />
     <circularProgressBar:RotateTransformCentreConverter x:Key="RotateTransformCentreConverter" />
     <converters:NotZeroConverter x:Key="NotZeroConverter" />
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
@@ -165,14 +165,20 @@
                                         <PathFigure StartPoint="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource StartPointConverter}, Mode=OneWay}">
                                             <ArcSegment Size="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource ArcSizeConverter}, Mode=OneWay}"
                                                         SweepDirection="Clockwise">
-                                                <ArcSegment.IsLargeArc>
-                                                    <MultiBinding Converter="{StaticResource LargeArcConverter}">
+                                                <ArcSegment.Point>
+                                                    <MultiBinding 
+                                                        Converter="{StaticResource ArcEndPointConverter}" 
+                                                        ConverterParameter="{x:Static circularProgressBar:ArcEndPointConverter.ParameterMidPoint}">
+                                                        <Binding ElementName="PathGrid" Path="ActualWidth" />
                                                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Value" />
                                                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Minimum" />
                                                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Maximum" />
                                                         <Binding ElementName="FullyIndeterminateGridScaleTransform" Path="ScaleX" />
                                                     </MultiBinding>
-                                                </ArcSegment.IsLargeArc>
+                                                </ArcSegment.Point>
+                                            </ArcSegment>
+                                            <ArcSegment Size="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource ArcSizeConverter}, Mode=OneWay}"
+                                                        SweepDirection="Clockwise">
                                                 <ArcSegment.Point>
                                                     <MultiBinding Converter="{StaticResource ArcEndPointConverter}">
                                                         <Binding ElementName="PathGrid" Path="ActualWidth" />


### PR DESCRIPTION
Attempt to fix #1854

Currently MaterialDesignCircularProgressBar draws one arc (considering `IsLargeArc`) to present the progression. But at 100 % this shows nothing because the start point is identical to the end point.

So I changed that to always draw two arcs. so at 100 % the first arc is from `0°` to `180°` and the second from `180°` to `360°`. that way the arcs can build a full circle.

It would also be possible to draw a single circle, but I was not able to draw that exactly over the arc making the transition flawless.