### PR TITLE
Unify converter access modifiers to public.

### DIFF
--- a/MaterialDesignThemes.Wpf/Converters/BorderClipConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/BorderClipConverter.cs
@@ -6,7 +6,7 @@ using System.Windows.Media;
 
 namespace MaterialDesignThemes.Wpf.Converters
 {
-    internal class BorderClipConverter : IMultiValueConverter
+    public class BorderClipConverter : IMultiValueConverter
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {

--- a/MaterialDesignThemes.Wpf/Converters/ClockItemIsCheckedConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/ClockItemIsCheckedConverter.cs
@@ -4,7 +4,7 @@ using System.Windows.Data;
 
 namespace MaterialDesignThemes.Wpf.Converters
 {
-    internal class ClockItemIsCheckedConverter : IValueConverter
+    public class ClockItemIsCheckedConverter : IValueConverter
     {
         private readonly Func<DateTime> _currentTimeGetter;
         private readonly ClockDisplayMode _displayMode;

--- a/MaterialDesignThemes.Wpf/Converters/ExpanderDirectionConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/ExpanderDirectionConverter.cs
@@ -6,7 +6,7 @@ using System.Windows.Data;
 
 namespace MaterialDesignThemes.Wpf.Converters
 {
-    internal class ExpanderDirectionConverter : IValueConverter
+    public class ExpanderDirectionConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {

--- a/MaterialDesignThemes.Wpf/Converters/FallbackBrushConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/FallbackBrushConverter.cs
@@ -6,7 +6,7 @@ using System.Windows.Media;
 
 namespace MaterialDesignThemes.Wpf.Converters
 {
-    internal class FallbackBrushConverter : IMultiValueConverter
+    public class FallbackBrushConverter : IMultiValueConverter
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {

--- a/MaterialDesignThemes.Wpf/Converters/FloatingHintTransformConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/FloatingHintTransformConverter.cs
@@ -6,7 +6,7 @@ using System.Windows.Media;
 
 namespace MaterialDesignThemes.Wpf.Converters
 {
-    internal class FloatingHintTransformConverter : IMultiValueConverter
+    public class FloatingHintTransformConverter : IMultiValueConverter
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {

--- a/MaterialDesignThemes.Wpf/Converters/HorizontalThicknessConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/HorizontalThicknessConverter.cs
@@ -5,7 +5,7 @@ using System.Windows.Data;
 
 namespace MaterialDesignThemes.Wpf.Converters
 {
-    internal class HorizontalThicknessConverter : IValueConverter
+    public class HorizontalThicknessConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {

--- a/MaterialDesignThemes.Wpf/Converters/IsDarkConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/IsDarkConverter.cs
@@ -6,7 +6,7 @@ using MaterialDesignColors.ColorManipulation;
 
 namespace MaterialDesignThemes.Wpf.Converters
 {
-    internal class IsDarkConverter : IValueConverter
+    public class IsDarkConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {

--- a/MaterialDesignThemes.Wpf/Converters/RemoveAlphaBrushConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/RemoveAlphaBrushConverter.cs
@@ -5,7 +5,7 @@ using System.Windows.Media;
 
 namespace MaterialDesignThemes.Wpf.Converters
 {
-    internal class RemoveAlphaBrushConverter : IValueConverter
+    public class RemoveAlphaBrushConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {


### PR DESCRIPTION
When overwriting the default style with a modification of the default style template, the converter may not be referenced.
Please change the access modifiers of some converters if possible.