### PR TITLE
ButtonProgressAssist support in MaterialDesignTabRadioButton

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
@@ -246,18 +246,6 @@
                             <RowDefinition Height="*" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
-                        <Border Background="{TemplateBinding Background}">
-                            <wpf:Ripple Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Focusable="False"
-                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                        Padding="{TemplateBinding Padding}"
-                                        x:Name="contentPresenter"
-                                        Opacity=".82"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </Border>
-                        <Border x:Name="SelectionHighlightBorder" Background="{TemplateBinding BorderBrush}" Height="2"
-                                Grid.Row="1"
-                                Visibility="Hidden" />
                         <ProgressBar x:Name="ProgressBar"
                                        Style="{DynamicResource MaterialDesignLinearProgressBar}"
                                        Minimum="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Minimum)}"
@@ -275,6 +263,18 @@
                                        BorderThickness="0"
                                        Grid.Row="0"
                                        Grid.RowSpan="2" />
+                        <Border Background="{TemplateBinding Background}" Grid.Row="0">
+                            <wpf:Ripple Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Focusable="False"
+                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                        Padding="{TemplateBinding Padding}"
+                                        x:Name="contentPresenter"
+                                        Opacity=".82"
+                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Border>
+                        <Border x:Name="SelectionHighlightBorder" Background="{TemplateBinding BorderBrush}" Height="2"
+                                Grid.Row="1"
+                                Visibility="Hidden" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="True">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
@@ -233,7 +233,11 @@
         <Setter Property="TextBlock.FontWeight" Value="Medium"/>
         <Setter Property="TextBlock.FontSize" Value="14"/>
         <Setter Property="HorizontalContentAlignment" Value="Center"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>      
+        <Setter Property="wpf:ButtonProgressAssist.IndicatorForeground" Value="{DynamicResource MaterialDesignDivider}" />
+        <Setter Property="wpf:ButtonProgressAssist.IndicatorBackground" Value="Transparent" />
+        <Setter Property="wpf:ButtonProgressAssist.IsIndicatorVisible" Value="False" />
+        <Setter Property="wpf:ButtonProgressAssist.Opacity" Value=".4" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RadioButton}">
@@ -253,7 +257,24 @@
                         </Border>
                         <Border x:Name="SelectionHighlightBorder" Background="{TemplateBinding BorderBrush}" Height="2"
                                 Grid.Row="1"
-                                Visibility="Hidden"/>
+                                Visibility="Hidden" />
+                        <ProgressBar x:Name="ProgressBar"
+                                       Style="{DynamicResource MaterialDesignLinearProgressBar}"
+                                       Minimum="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Minimum)}"
+                                       Maximum="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Maximum)}"
+                                       Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IndicatorForeground)}"
+                                       Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IndicatorBackground)}"
+                                       Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Value)}"
+                                       IsIndeterminate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IsIndeterminate)}"
+                                       Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IsIndicatorVisible), Converter={StaticResource BooleanToVisibilityConverter}}"
+                                       Height="{TemplateBinding Height}"
+                                       Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ButtonBase}}, Path=ActualWidth}"
+                                       Opacity="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Opacity)}"
+                                       HorizontalAlignment="Left"
+                                       VerticalAlignment="Center"
+                                       BorderThickness="0"
+                                       Grid.Row="0"
+                                       Grid.RowSpan="2" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="True">


### PR DESCRIPTION
Support ButtonProgressAssist in MaterialDesignTabRadioButton. Related to #1885 
![image](https://user-images.githubusercontent.com/39737429/83714943-8813eb00-a62c-11ea-81e9-76ee0940eb72.png)
