### PR TITLE
Outlined-Button: keep IsMouseOver-Background while pressed

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
@@ -246,9 +246,6 @@
                         <Trigger Property="IsMouseOver" Value="true">
                             <Setter Property="Background" TargetName="border" Value="{DynamicResource PrimaryHueMidBrush}" />
                         </Trigger>
-                        <Trigger Property="IsPressed" Value="true">
-                            <Setter Property="Background" TargetName="border" Value="Transparent" />
-                        </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
                             <Setter Property="Opacity" Value="0.23"/>
                         </Trigger>


### PR DESCRIPTION
Removed trigger to override `Background` when `IsPressed` for `MaterialDesignOutlinedButton`

from https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/pull/1873#issuecomment-638489169