### PR TITLE
Popup box open on focus (optional by PopupMode)

### DIFF
--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -84,7 +84,12 @@ namespace MaterialDesignThemes.Wpf
         /// <summary>
         /// Open when the mouse goes over the toggle button, or the space in which the popup box would occupy should it be open.
         /// </summary>
-        MouseOverEager
+        MouseOverEager,
+        /// <summary>
+        /// Open when the toggle or its chidren have keyboard focus;
+        /// </summary>
+        FocusWithin
+
     }
 
     /// <summary>
@@ -446,6 +451,10 @@ namespace MaterialDesignThemes.Wpf
             if (IsPopupOpen && !IsKeyboardFocusWithin && !StaysOpen)
             {
                 Close();
+            }
+            else if (!IsPopupOpen && PopupMode == PopupBoxPopupMode.FocusWithin && IsKeyboardFocusWithin)
+            {
+                SetCurrentValue(IsPopupOpenProperty, true);
             }
         }
 

--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -461,8 +461,8 @@ namespace MaterialDesignThemes.Wpf
             base.OnGotKeyboardFocus(e);
             if (supressfirstElementGotFocus == false) { return; }
 
-            if (!IsPopupOpen && (PopupMode == PopupBoxPopupMode.ClickOrFocusWithin | 
-                                 PopupMode == PopupBoxPopupMode.MouseOverEagerOrFocusWithin | PopupMode == PopupBoxPopupMode.MouseOverOrFocusWithin)
+            if (!IsPopupOpen && (PopupMode == PopupBoxPopupMode.ClickOrFocusWithin || 
+                                 PopupMode == PopupBoxPopupMode.MouseOverEagerOrFocusWithin || PopupMode == PopupBoxPopupMode.MouseOverOrFocusWithin)
                              && IsKeyboardFocusWithin)
             {
                 SetCurrentValue(IsPopupOpenProperty, true);
@@ -575,10 +575,11 @@ namespace MaterialDesignThemes.Wpf
             if (_popupContentControl != null && !_popupContentControl.IsKeyboardFocusWithin)
             {
                 supressfirstElementGotFocus = true;
-
                 if (firstchildelement != null)
+                {
                     firstchildelement.GotKeyboardFocus -= InnerFirstElement_GotKeyboardFocus;
                     firstchildelement.LostKeyboardFocus -= InnerFirstElement_LostKeyboardFocus;
+                }
             }
         }
 
@@ -836,7 +837,7 @@ namespace MaterialDesignThemes.Wpf
 
         private void ToggleButtonOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
-            if ((PopupMode == PopupBoxPopupMode.Click | PopupMode == PopupBoxPopupMode.ClickOrFocusWithin) || !IsPopupOpen) return;
+            if ((PopupMode == PopupBoxPopupMode.Click || PopupMode == PopupBoxPopupMode.ClickOrFocusWithin) || !IsPopupOpen) return;
 
             if (ToggleCheckedContent != null)
             {

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -347,7 +347,7 @@
                                 <Border Background="White" Opacity="0.002" />
                                 <ContentControl Content="{TemplateBinding PopupContent}" ContentTemplate="{TemplateBinding PopupContentTemplate}"      
                                                 Visibility="{TemplateBinding IsEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                                Margin="5" Padding="8"
+                                                Margin="5" Padding="8" Focusable="False" IsTabStop="False"
                                                 Opacity="0" x:Name="PART_PopupContentControl">
                                     <ContentControl.Resources>
                                         <ResourceDictionary>


### PR DESCRIPTION
Added a behaviour to auto open de PopupBox's popup when it gets KeyboardFocus (if PopupMode is set to it).

Implemented Keyboard Tab Stop on focusable Child Itens, avoiding infinite  navigation cycling inside in Popup Visual Tree, moving back to main Visual Tree when the first Popup's item gets the second-timefocus OR when pressing Shift + Tab on it.

Changed PART_PopupContentControl.Focusable and PART_PopupContentControl.IsTabStop to False.