### PR TITLE
Fixes HintAssist.Background for Text- and PasswordBox

### DIFF
--- a/MaterialDesignThemes.Wpf/HintAssist.cs
+++ b/MaterialDesignThemes.Wpf/HintAssist.cs
@@ -158,7 +158,7 @@ namespace MaterialDesignThemes.Wpf
         /// The color for the background of a focused control.
         /// </summary>
         public static readonly DependencyProperty BackgroundProperty = DependencyProperty.RegisterAttached(
-            "Background", typeof(Brush), typeof(HintAssist), new PropertyMetadata(null));
+            "Background", typeof(Brush), typeof(HintAssist), new PropertyMetadata(new SolidColorBrush(Colors.Transparent)));
 
         /// <summary>
         /// Gets the color for the background of a focused control.

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -109,7 +109,10 @@
                                                        FloatingScale="{Binding Path=(wpf:HintAssist.FloatingScale), RelativeSource={RelativeSource TemplatedParent}}"
                                                        FloatingOffset="{Binding Path=(wpf:HintAssist.FloatingOffset), RelativeSource={RelativeSource TemplatedParent}}">
                                             <wpf:SmartHint.Hint>
-                                                <Border x:Name="HintBackgroundBorder" Background="Transparent" CornerRadius="2">
+                                                <Border 
+                                                    x:Name="HintBackgroundBorder"
+                                                    Background="{TemplateBinding wpf:HintAssist.Background}"
+                                                    CornerRadius="2">
                                                     <ContentPresenter 
                                                         x:Name="HintWrapper" 
                                                         Content="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource TemplatedParent}}"/>
@@ -204,7 +207,7 @@
                             <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
                             <Setter TargetName="HintWrapper" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
                             <Setter TargetName="HintBackgroundBorder" Property="Padding" Value="4, 0" />
-                            <Setter TargetName="HintBackgroundBorder" Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
+                            <Setter Property="wpf:HintAssist.Background" Value="{DynamicResource MaterialDesignPaper}" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -33,7 +33,6 @@
         <Setter Property="wpf:TextFieldAssist.IncludeSpellingSuggestions" Value="{Binding RelativeSource={RelativeSource Self}, Path=(SpellCheck.IsEnabled)}" />
         <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
-        <Setter Property="wpf:HintAssist.Background" Value="Transparent" />
         <Setter Property="ContextMenu" Value="{StaticResource MaterialDesignDefaultContextMenu}"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -110,10 +109,13 @@
                                                        FloatingScale="{Binding Path=(wpf:HintAssist.FloatingScale), RelativeSource={RelativeSource TemplatedParent}}"
                                                        FloatingOffset="{Binding Path=(wpf:HintAssist.FloatingOffset), RelativeSource={RelativeSource TemplatedParent}}">
                                             <wpf:SmartHint.Hint>
-                                                <Border x:Name="HintBackgroundBorder" Background="Transparent" CornerRadius="2">
-                                                    <ContentPresenter 
-                                                        x:Name="HintWrapper" 
-                                                        Content="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource TemplatedParent}}"/>
+                                                <Border
+                                                    x:Name="HintBackgroundBorder"
+                                                    Background="{TemplateBinding wpf:HintAssist.Background}"
+                                                    CornerRadius="2">
+                                                    <ContentPresenter
+                                                        x:Name="HintWrapper"
+                                                        Content="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource TemplatedParent}}" />
                                                 </Border>
                                             </wpf:SmartHint.Hint>
                                         </wpf:SmartHint>
@@ -167,7 +169,6 @@
                         </MultiTrigger>
                         <Trigger Property="wpf:HintAssist.IsFloating" Value="True">
                             <Setter TargetName="border" Property="Margin" Value="0 18 0 0" />
-                            <Setter TargetName="HintBackgroundBorder" Property="Background" Value="{Binding Path=(wpf:HintAssist.Background), RelativeSource={RelativeSource TemplatedParent}}" />
                         </Trigger>
                         <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
                             <Setter TargetName="textFieldBoxBorder" Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxHoverBackground}"/>


### PR DESCRIPTION
make following expression work
```
<PasswordBox
   Style="{StaticResource MaterialDesignOutlinedPasswordFieldPasswordBox}"
   ...
   materialDesign:HintAssist.Background="Lime" />
```

Fixes #1860

fixed for `MaterialDesignTextBoxBase` and `MaterialDesignPasswordBox`

* Setting background of `HintBackgroundBorder` via `HintAssist.Background`
* changed default value of `HintAssist.Background` to `Transparent`
* trigger `wpf:TextFieldAssist.HasOutlinedTextField` = `True` sets background to `MaterialDesignPaper`
* removed other triggers setting background

