### PR TITLE
ComboBox style fix stretching of selected content

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -425,7 +425,7 @@
                           <ColumnDefinition Width="Auto"/>
                       </Grid.ColumnDefinitions>
                       <Grid x:Name="InputRoot"
-                            HorizontalAlignment="Left">
+                            HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                           <ContentPresenter x:Name="contentPresenter"
                                             Content="{TemplateBinding SelectionBoxItem}"
                                             ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
@@ -434,7 +434,7 @@
                                             IsHitTestVisible="False"/>
                           <TextBox x:Name="PART_EditableTextBox"
                                    IsReadOnly="{Binding IsReadOnly, RelativeSource={RelativeSource TemplatedParent}}"
-                                   HorizontalAlignment="Left"
+                                   HorizontalAlignment="Stretch"
                                    HorizontalContentAlignment="Stretch"
                                    Style="{StaticResource MaterialDesignComboBoxEditableTextBox}"
                                    CaretBrush="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderBrush}"


### PR DESCRIPTION
Currently the contents of the selected ComboBox item is left alligned. For this fix the grid container is now set to stretch.