### PR TITLE
Disabled strong name for demo apps

### DIFF
--- a/MahMaterialDragablzMashUp/MahAppsDragablzDemo.csproj
+++ b/MahMaterialDragablzMashUp/MahAppsDragablzDemo.csproj
@@ -10,6 +10,7 @@
     <Product>MahMaterialDragablzMashUp</Product>
     <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
     <Prefer32Bit>true</Prefer32Bit>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
     <None Include="paket.references" />

--- a/MainDemo.Wpf/MaterialDesignDemo.csproj
+++ b/MainDemo.Wpf/MaterialDesignDemo.csproj
@@ -11,6 +11,7 @@
     <Prefer32Bit>true</Prefer32Bit>
     <ApplicationIcon>favicon.ico</ApplicationIcon>
     <UseWPF>true</UseWPF>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <Import Project="..\packages\ShowMeTheXAML.MSBuild\build\ShowMeTheXAML.MSBuild.targets" Label="Paket" />
   <Target Name="ShowMeTheXAML_EnsureXamlCreated" AfterTargets="BeforeCompile">


### PR DESCRIPTION
Since strong name was enabled at #1890, demo apps cannot run on .NET Framework anymore.
Demo apps uses ShowMeTheXAML and Dragablz, but they have not been signed.