### PR TITLE
Collapse ListSortDirectionIndicator if sorting is disabled

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
@@ -290,7 +290,8 @@
                                     Width="0"
                                     Height="12"
                                     Margin="-16 0 0 0"
-                                    Opacity="0.45" />
+                                    Opacity="0.45"
+                                    Visibility="{Binding CanUserSortColumns, RelativeSource={RelativeSource AncestorType=DataGrid}, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                 <ContentPresenter
                                     RecognizesAccessKey="True"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"


### PR DESCRIPTION
Collapse `ListSortDirectionIndicator` on `CanUserSortColumns` is false 

fixes #1828