### PR TITLE
Allow for setting Inherit for the base theme

### DIFF
--- a/MahMaterialDragablzMashUp/App.xaml
+++ b/MahMaterialDragablzMashUp/App.xaml
@@ -5,14 +5,14 @@
              xmlns:dragablz="clr-namespace:Dragablz;assembly=Dragablz"
              xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
              xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
-             xmlns:smtxAe="clr-namespace:ShowMeTheXAML.AvalonEdit;assembly=ShowMeTheXAML.AvalonEdit"           
+             xmlns:smtxAe="clr-namespace:ShowMeTheXAML.AvalonEdit;assembly=ShowMeTheXAML.AvalonEdit"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
              xmlns:mahDemo="clr-namespace:MahAppsDragablzDemo"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <materialDesign:MahAppsBundledTheme BaseTheme="Light" PrimaryColor="DeepPurple" SecondaryColor="Purple"/>
+                <materialDesign:MahAppsBundledTheme BaseTheme="Inherit" PrimaryColor="DeepPurple" SecondaryColor="Purple"/>
 
                 <!-- MahApps -->
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />

--- a/MainDemo.Wpf/App.xaml
+++ b/MainDemo.Wpf/App.xaml
@@ -12,15 +12,16 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <!-- This is the current way to setup your app's initial theme -->
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
-
-                <!-- However, however you can make it simpler by just using one of the built-in themes. This is functionally identical to what is above.-->
-                <!--<materialDesign:BundledTheme BaseTheme="Light" PrimaryColor="DeepPurple" SecondaryColor="Lime" />-->
+                <materialDesign:BundledTheme BaseTheme="Inherit" PrimaryColor="DeepPurple" SecondaryColor="Lime" />
 
                 <!-- If you would prefer to use your own colors there is an option for that as well -->
                 <!--<materialDesign:CustomColorTheme BaseTheme="Light" PrimaryColor="Aqua" SecondaryColor="DarkGreen" />-->
+
+                <!-- You can also use the built in theme dictionaries as well
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
+                -->
 
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
 

--- a/MaterialDesignThemes.MahApps/BaseThemeExtensions.cs
+++ b/MaterialDesignThemes.MahApps/BaseThemeExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using ControlzEx.Theming;
 using MaterialDesignThemes.Wpf;
+using Theme = MaterialDesignThemes.Wpf.Theme;
 
 namespace MaterialDesignThemes.MahApps
 {
@@ -12,6 +13,11 @@ namespace MaterialDesignThemes.MahApps
             {
                 BaseTheme.Light => ThemeManager.BaseColorLightConst,
                 BaseTheme.Dark => ThemeManager.BaseColorDarkConst,
+                BaseTheme.Inherit => Theme.GetSystemTheme() switch
+                    {
+                        BaseTheme.Dark => ThemeManager.BaseColorDarkConst,
+                        _ => ThemeManager.BaseColorLightConst
+                    },
                 _ => throw new InvalidOperationException()
             };
         }

--- a/MaterialDesignThemes.Wpf/Theme.cs
+++ b/MaterialDesignThemes.Wpf/Theme.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows.Media;
 using MaterialDesignColors;
+using Microsoft.Win32;
 
 namespace MaterialDesignThemes.Wpf
 {
@@ -8,6 +9,31 @@ namespace MaterialDesignThemes.Wpf
     {
         public static IBaseTheme Light { get; } = new MaterialDesignLightTheme();
         public static IBaseTheme Dark { get; } = new MaterialDesignDarkTheme();
+
+        /// <summary>
+        /// Get the current Windows theme.
+        /// Based on ControlzEx
+        /// https://github.com/ControlzEx/ControlzEx/blob/48230bb023c588e1b7eb86ea83f7ddf7d25be735/src/ControlzEx/Theming/WindowsThemeHelper.cs#L19
+        /// </summary>
+        /// <returns></returns>
+        public static BaseTheme? GetSystemTheme()
+        {
+            try
+            {
+                var registryValue = Registry.GetValue(@"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize", "AppsUseLightTheme", null);
+
+                if (registryValue is null)
+                {
+                    return null;
+                }
+
+                return Convert.ToBoolean(registryValue) ? BaseTheme.Light : BaseTheme.Dark;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
 
         public static Theme Create(IBaseTheme baseTheme, Color primary, Color accent)
         {

--- a/MaterialDesignThemes.Wpf/ThemeExtensions.cs
+++ b/MaterialDesignThemes.Wpf/ThemeExtensions.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Windows.Media;
 using MaterialDesignColors;
 using MaterialDesignColors.ColorManipulation;
+using Microsoft.Win32;
 
 namespace MaterialDesignThemes.Wpf
 {
@@ -33,6 +35,11 @@ namespace MaterialDesignThemes.Wpf
             {
                 case BaseTheme.Dark: return Theme.Dark;
                 case BaseTheme.Light: return Theme.Light;
+                case BaseTheme.Inherit: return Theme.GetSystemTheme() switch
+                    {
+                        BaseTheme.Dark => Theme.Dark,
+                        _ => Theme.Light
+                    };
                 default: throw new InvalidOperationException();
             }
         }


### PR DESCRIPTION
Will retrieve the Windows Light/Dark theme and use that to apply the theme.

This will allow setting BaseTheme="Inherit" on the resource dictionaries. This will use the current windows theme (light or dark).