### PR TITLE
Refactored SnackbarMessageQueue to use Dispatcher

### DIFF
--- a/MaterialDesignThemes.Wpf/Snackbar.cs
+++ b/MaterialDesignThemes.Wpf/Snackbar.cs
@@ -45,7 +45,7 @@ namespace MaterialDesignThemes.Wpf
         private static void MessageQueuePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
             var snackbar = (Snackbar) dependencyObject;
-            (snackbar._messageQueueRegistrationCleanUp ?? (() => { }))();
+            snackbar._messageQueueRegistrationCleanUp?.Invoke();
             var messageQueue = dependencyPropertyChangedEventArgs.NewValue as SnackbarMessageQueue;
             snackbar._messageQueueRegistrationCleanUp = messageQueue?.Pair(snackbar);
         }

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
@@ -60,7 +60,7 @@ namespace MaterialDesignThemes.Wpf
                         /* we are we suppressing this? 
                          * as we have switched out wait onto another thread, so we don't block the UI thread, the
                          * _cleanUp/Dispose() action might also happen, and the _disposedWaitHandle might get disposed
-                         * just before we WaitOne. We want add a lock in the _cleanUp because it might block for 2 seconds.
+                         * just before we WaitOne. We won't add a lock in the _cleanUp because it might block for 2 seconds.
                          * We could use a Monitor.TryEnter in _cleanUp and run clean up after but oh my gosh it's just getting
                          * too complicated for this use case, so for the rare times this happens, we can swallow safely
                          */
@@ -141,7 +141,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         //oh if only I had Disposable.Create in this lib :)  tempted to copy it in like dragablz, 
-        //but this is an internal method so no one will know my direct Action disposer...
+        //but this is an internal method so no one will know my dirty Action disposer...
         internal Action Pair(Snackbar snackbar)
         {
             if (snackbar == null) throw new ArgumentNullException(nameof(snackbar));

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
@@ -19,7 +19,6 @@ namespace MaterialDesignThemes.Wpf
         private readonly object _snackbarMessagesLock = new object();
         private readonly ManualResetEvent _disposedEvent = new ManualResetEvent(false);
         private readonly ManualResetEvent _pausedEvent = new ManualResetEvent(false);
-        private readonly ManualResetEvent _messageWaitingEvent = new ManualResetEvent(false);
         private readonly SemaphoreSlim _showMessageSemaphore = new SemaphoreSlim(1,1);
         private int _pauseCounter;
         private bool _isDisposed;
@@ -223,8 +222,6 @@ namespace MaterialDesignThemes.Wpf
             var snackbarMessageQueueItem = new SnackbarMessageQueueItem(content, durationOverride ?? _messageDuration,
                 actionContent, actionHandler, actionArgument, promote, neverConsiderToBeDuplicate);
             InsertItem(snackbarMessageQueueItem);
-
-            _messageWaitingEvent.Set();
         }
 
         private void InsertItem(SnackbarMessageQueueItem item)

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
@@ -376,7 +376,11 @@ namespace MaterialDesignThemes.Wpf
             SnackbarMessageQueueItem messageQueueItem, EventWaitHandle actionClickWaitHandle)
         {
             var clickCount = 0;
-            var snackbarMessage = Create(messageQueueItem);
+            var snackbarMessage = new SnackbarMessage
+            {
+                Content = messageQueueItem.Content,
+                ActionContent = messageQueueItem.ActionContent
+            };
             snackbarMessage.ActionClick += (sender, args) =>
             {
                 if (++clickCount == 1)
@@ -426,15 +430,6 @@ namespace MaterialDesignThemes.Wpf
 
                 throw;
             }
-        }
-
-        private static SnackbarMessage Create(SnackbarMessageQueueItem messageQueueItem)
-        {
-            return new SnackbarMessage
-            {
-                Content = messageQueueItem.Content,
-                ActionContent = messageQueueItem.ActionContent
-            };
         }
 
         public void Dispose()


### PR DESCRIPTION
I reworked the `SnackbarMessageQueue` to no longer start its own long running task. Instead it uses the `Dispatcher` to _pull_ for next item.

That makes it necessary that a new instance of `SnackbarMessageQueue` must be created from within a `Dispatcher`-thread. But this should be the standard case any way. But it is a new limitation.

This relates to #1878. Although I could not reproduce it. But I personally did not like it anyway, that the `SnackbarMessageQueue` requires its own thread.