### PR TITLE
Make sure that SnackbarMessageQueue has the same dispatcher as Snackbar.

### DIFF
--- a/MaterialDesignThemes.Wpf/Snackbar.cs
+++ b/MaterialDesignThemes.Wpf/Snackbar.cs
@@ -53,7 +53,12 @@ namespace MaterialDesignThemes.Wpf
         public SnackbarMessageQueue MessageQueue
         {
             get => (SnackbarMessageQueue) GetValue(MessageQueueProperty);
-            set => SetValue(MessageQueueProperty, value);
+            set
+            {
+                if (!(value is null) && value.Dispatcher != Dispatcher)
+                    throw new InvalidOperationException("Objects must be created by the same thread.");
+                SetValue(MessageQueueProperty, value);
+            }
         }
 
         public static readonly DependencyProperty IsActiveProperty = DependencyProperty.Register(

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
@@ -23,6 +23,11 @@ namespace MaterialDesignThemes.Wpf
         private int _pauseCounter;
         private bool _isDisposed;
 
+        /// <summary>
+        /// Gets the <see cref="System.Windows.Threading.Dispatcher"/> this <see cref="SnackbarMessageQueue"/> is associated with.
+        /// </summary>
+        internal Dispatcher Dispatcher => _dispatcher;
+
         #region MouseNotOverManagedWaitHandle
 
         private class MouseNotOverManagedWaitHandle : IDisposable


### PR DESCRIPTION
Prevent SnackbarMessageQueue from being assigned to a Snackbar created on different thread.