### PR TITLE
Fix a wrong awaiter configuration.

### DIFF
--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
@@ -277,7 +277,7 @@ namespace MaterialDesignThemes.Wpf
                         break;
 
                     Trace.TraceWarning("A snackbar message as waiting, but no snackbar instances are assigned to the message queue.");
-                    await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                    await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(true);
                 }
 
                 LinkedListNode<SnackbarMessageQueueItem> messageNode;


### PR DESCRIPTION
`FindSnackbar()` must be called on the dispatcher context, so should back to the original context here.