### PR TITLE
Fix Calendar to use ClearType

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
@@ -318,8 +318,8 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <wpf:Card UniformCornerRadius="2"  Background="{TemplateBinding Background}" wpf:ShadowAssist.ShadowDepth="Depth0">
-                            <Grid>
+                        <wpf:Card UniformCornerRadius="2" wpf:ShadowAssist.ShadowDepth="Depth0">
+                            <Grid Background="{TemplateBinding Background}" RenderOptions.ClearTypeHint="Enabled">
                                 <Grid.Resources>
                                     <ControlTemplate x:Key="PreviousButtonTemplate" TargetType="{x:Type Button}">
                                         <Grid Cursor="Hand">


### PR DESCRIPTION
ClearType is now enabled in the `Calendar` like this.

![use-clear-type](https://user-images.githubusercontent.com/66123786/86019030-0e232600-ba61-11ea-962b-15b83b19b2ee.png)

But this cannot resolve DPI Awareness Issue (#1714). Set display scaling setting to 150%, it appears blurry. This is because `AdornerDecorator.CacheMode` is specified in `MaterialDesignDatePickerCalendarPortrait`. Without `CacheMode`, it appears clearly.
![CacheMode](https://user-images.githubusercontent.com/66123786/86019114-2a26c780-ba61-11ea-8477-b9b70f8bc8a3.png)

If `BitmapCache.RenderAtScale` is set to 2.0, it also appears clearly.
![RenderAtScale](https://user-images.githubusercontent.com/66123786/86019163-3ad73d80-ba61-11ea-9c9d-88b757586cec.png)

This issue is not only with `Calendar`, but also with elements that use `CacheMode` (e.g. `Menu`).

![menu](https://user-images.githubusercontent.com/66123786/86019236-53dfee80-ba61-11ea-963e-5bd8ad9224b5.png)

Anyone has a good idea?
