### PR TITLE
Fix clicks not registering on DataGridTemplateColumn

### DIFF
--- a/MaterialDesignThemes.Wpf/DataGridAssist.cs
+++ b/MaterialDesignThemes.Wpf/DataGridAssist.cs
@@ -3,6 +3,8 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Media3D;
 
 namespace MaterialDesignThemes.Wpf
 {
@@ -219,6 +221,13 @@ namespace MaterialDesignThemes.Wpf
                 var elementHitBox = new Rect(element.RenderSize);
                 if (elementHitBox.Contains(mousePosition))
                 {
+
+                    if (dataGridCell.Column.GetType() == typeof(DataGridTemplateColumn))
+                    {
+                        AllowDirectEditWithoutFocusTemplateColumn(sender, mouseArgs);
+                        return;
+                    }
+
                     dataGrid.CurrentCell = new DataGridCellInfo(dataGridCell);
                     dataGrid.BeginEdit();
 
@@ -253,6 +262,24 @@ namespace MaterialDesignThemes.Wpf
                             }
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Allows editing of components inside of a datagrid cell template with a single left click.
+        /// </summary>
+        private static void AllowDirectEditWithoutFocusTemplateColumn(object sender, MouseButtonEventArgs mouseArgs)
+        {
+            var dataGrid = (DataGrid)sender;
+
+            var inputHitTest =
+                dataGrid.InputHitTest(mouseArgs.GetPosition((DataGrid)sender)) as DependencyObject;
+
+            while (inputHitTest != null)
+            {
+                inputHitTest = (inputHitTest is Visual || inputHitTest is Visual3D)
+                    ? VisualTreeHelper.GetParent(inputHitTest)
+                    : null;
             }
         }
     }

--- a/MaterialDesignThemes.Wpf/DataGridAssist.cs
+++ b/MaterialDesignThemes.Wpf/DataGridAssist.cs
@@ -221,10 +221,10 @@ namespace MaterialDesignThemes.Wpf
                 var elementHitBox = new Rect(element.RenderSize);
                 if (elementHitBox.Contains(mousePosition))
                 {
-
+                    //if it is a DataGridTemplateColumn we want the
+                    //click to react however it would naturally on the control
                     if (dataGridCell.Column.GetType() == typeof(DataGridTemplateColumn))
                     {
-                        AllowDirectEditWithoutFocusTemplateColumn(sender, mouseArgs);
                         return;
                     }
 
@@ -262,24 +262,6 @@ namespace MaterialDesignThemes.Wpf
                             }
                     }
                 }
-            }
-        }
-
-        /// <summary>
-        /// Allows editing of components inside of a datagrid cell template with a single left click.
-        /// </summary>
-        private static void AllowDirectEditWithoutFocusTemplateColumn(object sender, MouseButtonEventArgs mouseArgs)
-        {
-            var dataGrid = (DataGrid)sender;
-
-            var inputHitTest =
-                dataGrid.InputHitTest(mouseArgs.GetPosition((DataGrid)sender)) as DependencyObject;
-
-            while (inputHitTest != null)
-            {
-                inputHitTest = (inputHitTest is Visual || inputHitTest is Visual3D)
-                    ? VisualTreeHelper.GetParent(inputHitTest)
-                    : null;
             }
         }
     }


### PR DESCRIPTION
Following the refactoring in #1927 the new AllowDirectEditWithoutFocus method does not allow clicks to pass through onto controls that were contained within a DataGridCellTemplate when not in focus.  These needed two clicks to register.

I have attempted a rather crude fix to use the older code in the event the click is on a DataGridTemplateColumn but I suspect there is a better way to do it!