### PR TITLE
Fix for "DatePicker with Floating Hint Style's Top Margin/Padding: Issue # 1966

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -151,7 +151,7 @@
                             <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
                         </MultiTrigger>
                         <Trigger Property="wpf:HintAssist.IsFloating" Value="True">
-                            <Setter TargetName="border" Property="Margin" Value="0 12 0 0" />
+                            <Setter TargetName="border" Property="Margin" Value="0 18 0 0" />
                         </Trigger>
                         <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
                             <Setter Property="VerticalContentAlignment" Value="Top" />


### PR DESCRIPTION
Matching from **Trigger** _Property_="wpf:HintAssist.IsFloating" _Value_="True" from **MaterialDesignTheme.TextBox.xaml** :

                        <Trigger Property="wpf:HintAssist.IsFloating" Value="True">
                            <Setter TargetName="border" Property="Margin" Value="0 18 0 0" />
                            <Setter TargetName="HintBackgroundBorder" Property="Background" Value="{Binding Path=(wpf:HintAssist.Background), RelativeSource={RelativeSource TemplatedParent}}" />
                        </Trigger>