### PR TITLE
Added null check to DialogHost.ShowInternal

### DIFF
--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -190,7 +190,10 @@ namespace MaterialDesignThemes.Wpf
             _dialogTaskCompletionSource = new TaskCompletionSource<object>();
 
             AssertTargetableContent();
-            DialogContent = content;
+
+            if (content != null)
+                DialogContent = content;
+
             _asyncShowOpenedEventHandler = openedEventHandler;
             _asyncShowClosingEventHandler = closingEventHandler;
             SetCurrentValue(IsOpenProperty, true);


### PR DESCRIPTION
There are scenarios when you would like to Show the DialogHost but not change it's content. I came across this problem when working with Prism Library. I wanted to asynchronously show a Dialog but keep the existing Dialoghost.DialogContent control (which I defined as a Prism region). By setting content to null in Window.ShowDialog(), the content will not be changed.

I am open to discussion if there is a better way of implementing this and I'm happy to provide a sample project if it helps clarify this use case.