### PR TITLE
Fix the caret does not appear

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -196,19 +196,26 @@
                             <Setter TargetName="passwordFieldBoxBorder" Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
                             <Setter TargetName="passwordFieldBoxBorder" Property="Padding" Value="0,8,0,0" />
                             <Setter TargetName="passwordFieldBoxBorder" Property="Margin" Value="-1" />
-                            <Setter TargetName="passwordFieldGrid" Property="Margin" Value="12,0,12,0" />
+                            <Setter TargetName="passwordFieldGrid" Property="Margin" Value="16,0,16,0" />
                             <Setter TargetName="border" Property="BorderThickness" Value="0" />
                             <Setter TargetName="border" Property="Cursor" Value="IBeam" />
                             <Setter TargetName="border" Property="Margin" Value="0 0 0 0" />
                             <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="PART_ContentHost" Property="Margin" Value="0,0,0,8" />
-                            <Setter TargetName="Hint" Property="Margin" Value="0,0,0,0" />
+                            <Setter TargetName="Hint" Property="Margin" Value="1,0,0,0" />
                             <Setter TargetName="Hint" Property="FloatingOffset" Value="{Binding FontSize, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FontSizeToHintOffsetConverter}}" />
                             <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
                             <Setter TargetName="HintWrapper" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+                            </MultiTrigger.Conditions>
                             <Setter TargetName="HintBackgroundBorder" Property="Padding" Value="4, 0" />
                             <Setter Property="wpf:HintAssist.Background" Value="{DynamicResource MaterialDesignPaper}" />
-                        </Trigger>
+                        </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -232,19 +232,26 @@
                             <Setter TargetName="textFieldBoxBorder" Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
                             <Setter TargetName="textFieldBoxBorder" Property="Padding" Value="0,8,0,0" />
                             <Setter TargetName="textFieldBoxBorder" Property="Margin" Value="-1" />
-                            <Setter TargetName="textFieldGrid" Property="Margin" Value="12,0,12,0" />
+                            <Setter TargetName="textFieldGrid" Property="Margin" Value="16,0,16,0" />
                             <Setter TargetName="border" Property="BorderThickness" Value="0" />
                             <Setter TargetName="border" Property="Cursor" Value="IBeam" />
                             <Setter TargetName="border" Property="Margin" Value="0 0 0 0" />
                             <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="PART_ContentHost" Property="Margin" Value="0,0,0,8" />
-                            <Setter TargetName="Hint" Property="Margin" Value="0,0,0,0" />
+                            <Setter TargetName="Hint" Property="Margin" Value="1,0,0,0" />
                             <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
                             <Setter TargetName="Hint" Property="FloatingOffset" Value="{Binding FontSize, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FontSizeToHintOffsetConverter}}" />
                             <Setter TargetName="HintWrapper" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+                            </MultiTrigger.Conditions>
                             <Setter TargetName="HintBackgroundBorder" Property="Padding" Value="4, 0" />
                             <Setter Property="wpf:HintAssist.Background" Value="{DynamicResource MaterialDesignPaper}" />
-                        </Trigger>
+                        </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />


### PR DESCRIPTION
Fixed the caret does not appear when the text content is empty, in `MaterialDesignOutlinedTextFieldTextBox` with `HintAssist.IsFloating="False"` as below.

```xml
    <TextBox Style="{StaticResource MaterialDesignOutlinedTextFieldTextBox}"
             materialDesign:HintAssist.IsFloating="False"
             materialDesign:HintAssist.Hint="Hint Text" />
```