### PR TITLE
Fixed typo in test project

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/Converters/ExpanderDirectionConverterTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/Converters/ExpanderDirectionConverterTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace MaterialDesignThemes.Wpf.Tests.Converters
 {
 
-    public class ExpanderDirectinConverterTests
+    public class ExpanderDirectionConverterTests
     {
         [Theory]
         [InlineData(null, null, null)]


### PR DESCRIPTION
Fixed typo in file name in `MaterialDesignThemes.Wpf.Tests` test project.

File name was `ExpanderDirectinConverterTests`, should be `ExpanderDirectionConverterTests`.