### PR TITLE
Fixed the hint background color of OutlinedTextBox to always be opaque

### DIFF
--- a/MaterialDesignThemes.UITests/MaterialDesignThemes.UITests.csproj
+++ b/MaterialDesignThemes.UITests/MaterialDesignThemes.UITests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="XAMLTest" Version="0.0.4-ci45" />
+    <PackageReference Include="XAMLTest" Version="0.0.4-ci47" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/MaterialDesignThemes.UITests/WPF/TextBox/TextBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TextBox/TextBoxTests.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Media;
 using XamlTest;
 using Xunit;
 using Xunit.Abstractions;
@@ -119,6 +120,34 @@ namespace MaterialDesignThemes.UITests.WPF.TextBox
             await Wait.For(async () => Assert.Equal(initialHeight, await textBox.GetActualHeight()));
             Rect rect = await textBox.GetCoordinates();
             Assert.Equal(initialRect, rect);
+            recorder.Success();
+        }
+
+        [Fact]
+        [Description("Issue 2002")]
+        public async Task OnTextBoxDisabled_FloatingHintBackgroundIsOpaque()
+        {
+            await using var recorder = new TestRecorder(App);
+
+            IVisualElement grid = await LoadXaml(@"
+<Grid Background=""Red"">
+    <TextBox
+        Style=""{StaticResource MaterialDesignOutlinedTextFieldTextBox}""
+        VerticalAlignment=""Top""
+        Height=""100""
+        Text=""Some content to force hint to float""
+        IsEnabled=""false""
+        Margin=""30""
+        materialDesign:HintAssist.Hint=""This is a text area""/>
+</Grid>");
+            IVisualElement textBox = await grid.GetElement("/TextBox");
+            //textFieldGrid is the element just inside of the border
+            IVisualElement textFieldGrid = await textBox.GetElement("textFieldGrid");
+            IVisualElement hintBackground = await textBox.GetElement("HintBackgroundBorder");
+
+            Color background = await hintBackground.GetEffectiveBackground(textFieldGrid);
+
+            Assert.Equal(255, background.A);
             recorder.Success();
         }
     }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -13,6 +13,7 @@
     <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearTextConverter" />
     <converters:NotConverter x:Key="NotConverter" />
     <converters:FontSizeToHintOffsetConverter x:Key="FontSizeToHintOffsetConverter" />
+    <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
 
     <Style x:Key="MaterialDesignPasswordBox" TargetType="{x:Type PasswordBox}">
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
@@ -225,7 +226,6 @@
                             <Setter TargetName="HintWrapper" Property="Opacity" Value="1" />
                         </MultiTrigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Opacity" TargetName="border" Value="0.42"/>
                             <Setter TargetName="border" Property="BorderBrush" Value="Transparent" />
                         </Trigger>
                         <MultiTrigger>
@@ -242,6 +242,23 @@
                             </MultiTrigger.Conditions>
                             <Setter Property="Opacity" TargetName="border" Value="0.42"/>
                             <Setter TargetName="border" Property="BorderBrush" Value="Transparent" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsEnabled" Value="true" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="HintWrapper" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsEnabled" Value="false" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_ContentHost" Property="Opacity" Value="0.42"/>
+                            <Setter TargetName="HintWrapper" Property="Opacity"
+                                    Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MathMultiplyConverter}, ConverterParameter=0.42}"/>
+                            <Setter TargetName="PART_ClearButton" Property="Opacity" Value="0.42"/>
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -123,12 +123,12 @@
                                             FloatingOffset="{Binding Path=(wpf:HintAssist.FloatingOffset), RelativeSource={RelativeSource TemplatedParent}}">
                                                 <wpf:SmartHint.Hint>
                                                     <Border
-                                                    x:Name="HintBackgroundBorder"
-                                                    Background="{TemplateBinding wpf:HintAssist.Background}"
-                                                    CornerRadius="2">
+                                                        x:Name="HintBackgroundBorder"
+                                                        Background="{TemplateBinding wpf:HintAssist.Background}"
+                                                        CornerRadius="2">
                                                         <ContentPresenter
-                                                        x:Name="HintWrapper"
-                                                        Content="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource TemplatedParent}}" />
+                                                            x:Name="HintWrapper"
+                                                            Content="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource TemplatedParent}}" />
                                                     </Border>
                                                 </wpf:SmartHint.Hint>
                                             </wpf:SmartHint>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -15,6 +15,7 @@
     <converters:NotConverter x:Key="NotConverter" />
     <converters:FontSizeToHintOffsetConverter x:Key="FontSizeToHintOffsetConverter" />
     <converters:FontToLineHeightConverter x:Key="FontToLineHeightConverter" />
+    <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
 
     <Style x:Key="MaterialDesignTextBoxBase" TargetType="{x:Type TextBoxBase}">
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
@@ -274,7 +275,6 @@
                             <Setter Property="VerticalContentAlignment" Value="Top" />
                         </MultiTrigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter TargetName="border" Property="Opacity" Value="0.42" />
                             <Setter TargetName="textFieldBoxBottomLine" Property="Height" Value="0" />
                         </Trigger>
                         <MultiTrigger>
@@ -291,6 +291,25 @@
                             </MultiTrigger.Conditions>
                             <Setter Property="Opacity" TargetName="border" Value="0.42"/>
                             <Setter TargetName="border" Property="BorderBrush" Value="Transparent" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsEnabled" Value="true" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="HintWrapper" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsEnabled" Value="false" />
+                                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="0.42"/>
+                            <Setter TargetName="PART_ContentHost" Property="Opacity" Value="0.42"/>
+                            <Setter TargetName="HintWrapper" Property="Opacity"
+                                    Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource MathMultiplyConverter}, ConverterParameter=0.42}"/>
+                            <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="0.42"/>
+                            <Setter TargetName="PART_ClearButton" Property="Opacity" Value="0.42"/>
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>


### PR DESCRIPTION
Fixes #2002.

Fixed the hint background color of `MaterialDesignOutlinedTextFieldTextBox` to always be opaque so that the underlying border cannot be seen through.