### PR TITLE
Fixes validation message remains visible

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
@@ -18,7 +18,8 @@
             </DataTemplate>
         </ControlTemplate.Resources>
         <StackPanel>
-            <AdornedElementPlaceholder Name="Placeholder" />
+            <AdornedElementPlaceholder Name="Placeholder"
+                                       wpf:ValidationAssist.Validatee="{Binding ElementName=Placeholder, Path=AdornedElement}"/>
             <Border x:Name="DefaultErrorViewer"
                     Visibility="Collapsed"
                     Background="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.Background)}">
@@ -29,6 +30,7 @@
                            Margin="0 2"
                            TextWrapping="Wrap"
                            Text="{Binding CurrentItem.ErrorContent}"
+                           Opacity="{Binding Path=(wpf:ValidationAssist.ValidateeOpacity), ElementName=Placeholder}"
                            UseLayoutRounding="false" />
             </Border>
             <controlzEx:PopupEx x:Name="ValidationPopup"
@@ -43,6 +45,7 @@
                                Margin="0 2"
                                TextWrapping="Wrap"
                                Text="{Binding CurrentItem.ErrorContent}"
+                               Opacity="{Binding Path=(wpf:ValidationAssist.ValidateeOpacity), ElementName=Placeholder}"
                                UseLayoutRounding="false" />
                 </Border>
             </controlzEx:PopupEx>

--- a/MaterialDesignThemes.Wpf/Transitions/TransitionerSlide.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/TransitionerSlide.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 
 namespace MaterialDesignThemes.Wpf.Transitions
 {
@@ -10,6 +11,7 @@ namespace MaterialDesignThemes.Wpf.Transitions
         static TransitionerSlide()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(TransitionerSlide), new FrameworkPropertyMetadata(typeof(TransitionerSlide)));
+            OpacityProperty.OverrideMetadata(typeof(TransitionerSlide), new UIPropertyMetadata(OpacityChangedCallback));
         }
 
         public static readonly DependencyProperty TransitionOriginProperty = DependencyProperty.Register(
@@ -66,6 +68,13 @@ namespace MaterialDesignThemes.Wpf.Transitions
             if (State != TransitionerSlideState.Current) return;
 
             RunOpeningEffects();
+        }
+
+        public event EventHandler OpacityChanged;
+
+        private static void OpacityChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((TransitionerSlide)d).OpacityChanged?.Invoke(d, EventArgs.Empty);
         }
     }
 }


### PR DESCRIPTION
Fixes #1969.

Made the `Opacity` of the validation error message has same value as the `Opacity` of `TransitionerSlide`, if the validatee is on the `Transitioner`.
