### PR TITLE
Fix MaterialDesignOutlinedTextFieldTextBox to use HintAssist.FloatingOffset

### DIFF
--- a/MaterialDesignThemes.Wpf/Converters/FontSizeToHintOffsetConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/FontSizeToHintOffsetConverter.cs
@@ -5,16 +5,38 @@ using System.Windows.Data;
 
 namespace MaterialDesignThemes.Wpf.Converters
 {
-    public class FontSizeToHintOffsetConverter : IValueConverter
+    public class FontSizeToHintOffsetConverter : IValueConverter, IMultiValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        private static Point ToHintOffset(object value)
         {
             var fontSize = System.Convert.ToDouble(value);
             var hintOffset = fontSize / 2 + 12;
             return new Point(0, -hintOffset);
         }
 
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return ToHintOffset(value);
+        }
+
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            var hintOffset = values.Length > 0 ? ToHintOffset(values[0]) : new Point(0, 0);
+            if (values.Length >= 2 && values[1] is Point offset)
+            {
+                if (!(parameter is Point defaultOffset))
+                    defaultOffset = new Point(0, 0);
+                hintOffset += offset - defaultOffset;
+            }
+            return hintOffset;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -16,6 +16,8 @@
     <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />    
     <converters:FontToLineHeightConverter x:Key="FontToLineHeightConverter" />
 
+    <Point x:Key="DefaultFloatingOffset">1,-16</Point>
+
     <Style x:Key="MaterialDesignPasswordBox" TargetType="{x:Type PasswordBox}">
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
         <Setter Property="FontFamily" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.FontFamily)}"/>
@@ -211,7 +213,15 @@
                             <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="PART_ContentHost" Property="Margin" Value="0,0,0,8" />
                             <Setter TargetName="Hint" Property="Margin" Value="1,0,0,0" />
-                            <Setter TargetName="Hint" Property="FloatingOffset" Value="{Binding FontSize, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FontSizeToHintOffsetConverter}}" />
+                            <Setter TargetName="Hint" Property="FloatingOffset">
+                                <Setter.Value>
+                                    <MultiBinding Converter="{StaticResource FontSizeToHintOffsetConverter}"
+                                                  ConverterParameter="{StaticResource DefaultFloatingOffset}">
+                                        <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                        <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    </MultiBinding>
+                                </Setter.Value>
+                            </Setter>
                             <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
                             <Setter TargetName="HintWrapper" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
                         </Trigger>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -17,6 +17,8 @@
     <converters:FontToLineHeightConverter x:Key="FontToLineHeightConverter" />
     <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
 
+    <Point x:Key="DefaultFloatingOffset">1,-16</Point>
+
     <Style x:Key="MaterialDesignTextBoxBase" TargetType="{x:Type TextBoxBase}">
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextBoxBorder}" />
@@ -246,7 +248,15 @@
                             <Setter TargetName="PART_ContentHost" Property="Margin" Value="0,0,0,8" />
                             <Setter TargetName="Hint" Property="Margin" Value="1,0,0,0" />
                             <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
-                            <Setter TargetName="Hint" Property="FloatingOffset" Value="{Binding FontSize, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource FontSizeToHintOffsetConverter}}" />
+                            <Setter TargetName="Hint" Property="FloatingOffset">
+                                <Setter.Value>
+                                    <MultiBinding Converter="{StaticResource FontSizeToHintOffsetConverter}"
+                                                  ConverterParameter="{StaticResource DefaultFloatingOffset}">
+                                        <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                        <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}"/>
+                                    </MultiBinding>
+                                </Setter.Value>
+                            </Setter>
                             <Setter TargetName="HintWrapper" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
                         </Trigger>
                         <MultiTrigger>


### PR DESCRIPTION
Fixes #2022.

Cannot distinguish whether `HintAssist.FloatingOffset` is provided or not, so the same offset as before is used when *DefaultFloatingOffset* is given.
