### PR TITLE
Add the DialogHost close method.

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
@@ -126,7 +126,7 @@ namespace MaterialDesignThemes.Wpf.Tests
 
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => DialogHost.Show("Content", id));
 
-            Assert.Equal($"No loaded DialogHost have an {nameof(DialogHost.Identifier)} property matching dialogIdentifier argument.", ex.Message);
+            Assert.Equal($"No loaded DialogHost have an {nameof(DialogHost.Identifier)} property matching dialogIdentifier ('{id}') argument.", ex.Message);
         }
 
         [StaFact]
@@ -142,7 +142,7 @@ namespace MaterialDesignThemes.Wpf.Tests
             otherDialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
 
 
-            Assert.Equal("Multiple viable DialogHosts.  Specify a unique Identifier on each DialogHost, especially where multiple Windows are a concern.", ex.Message);
+            Assert.Equal("Multiple viable DialogHosts. Specify a unique Identifier on each DialogHost, especially where multiple Windows are a concern.", ex.Message);
         }
 
         [StaFact]

--- a/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
@@ -70,7 +70,7 @@ namespace MaterialDesignThemes.Wpf.Tests
             Task<object> showTask = _dialogHost.ShowDialog("Content");
             DialogSession session = _dialogHost.CurrentSession;
             Assert.False(session.IsEnded);
-            
+
             DialogHost.CloseDialogCommand.Execute(closeParameter, _dialogHost);
 
             Assert.False(_dialogHost.IsOpen);
@@ -255,5 +255,69 @@ namespace MaterialDesignThemes.Wpf.Tests
 
             Assert.Equal(closeParameter, await showTask);
         }
+
+        [StaFact]
+        [Description("Pull Request 2029")]
+        public void WhenClosingDialogItThrowsWhenNoInstancesLoaded()
+        {
+            _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
+
+            var ex = Assert.Throws<InvalidOperationException>(() => DialogHost.Close(null));
+            Assert.Equal("No loaded DialogHost instances.", ex.Message);
+        }
+
+        [StaFact]
+        [Description("Pull Request 2029")]
+        public void WhenClosingDialogWithInvalidIdentifierItThrowsWhenNoMatchingInstances()
+        {
+            object id = Guid.NewGuid();
+            var ex = Assert.Throws<InvalidOperationException>(() => DialogHost.Close(id));
+            Assert.Equal($"No loaded DialogHost have an Identifier property matching dialogIdentifier ('{id}') argument.", ex.Message);
+        }
+
+        [StaFact]
+        [Description("Pull Request 2029")]
+        public void WhenClosingDialogWithMultipleDialogHostsItThrowsTooManyMatchingInstances()
+        {
+            var secondInstance = new DialogHost();
+            try
+            {
+                secondInstance.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+                var ex = Assert.Throws<InvalidOperationException>(() => DialogHost.Close(null));
+                Assert.Equal("Multiple viable DialogHosts. Specify a unique Identifier on each DialogHost, especially where multiple Windows are a concern.", ex.Message);
+            }
+            finally
+            {
+                secondInstance.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
+            }
+        }
+
+        [StaFact]
+        [Description("Pull Request 2029")]
+        public void WhenClosingDialogThatIsNotOpenItThrowsDialogNotOpen()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() => DialogHost.Close(null));
+            Assert.Equal("DialogHost is not open.", ex.Message);
+        }
+
+        [StaFact]
+        [Description("Pull Request 2029")]
+        public void WhenClosingDialogWithParameterItPassesParameterToHandlers()
+        {
+            object parameter = Guid.NewGuid();
+            object closingParameter = null;
+            _dialogHost.DialogClosing += DialogClosing;
+            _dialogHost.IsOpen = true;
+
+            DialogHost.Close(null, parameter);
+
+            Assert.Equal(parameter, closingParameter);
+
+            void DialogClosing(object sender, DialogClosingEventArgs eventArgs)
+            {
+                closingParameter = eventArgs.Parameter;
+            }
+        }
+
     }
 }

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -174,15 +174,15 @@ namespace MaterialDesignThemes.Wpf
         ///  Close a modal dialog.
         /// </summary>
         /// <param name="dialogIdentifier"> of the instance where the dialog should be closed. Typically this will match an identifer set in XAML. </param>
-        public static void CloseDialog(object dialogIdentifier)
-            => CloseDialog(dialogIdentifier, null);
+        public static void Close(object dialogIdentifier)
+            => Close(dialogIdentifier, null);
 
         /// <summary>
         ///  Close a modal dialog.
         /// </summary>
         /// <param name="dialogIdentifier"> of the instance where the dialog should be closed. Typically this will match an identifer set in XAML. </param>
         /// <param name="parameter"> to provide to close handler</param>
-        public static void CloseDialog(object dialogIdentifier, object parameter)
+        public static void Close(object dialogIdentifier, object parameter)
         {
             DialogHost dialogHost = GetInstance(dialogIdentifier);
             if (dialogHost.CurrentSession is { } currentSession)
@@ -606,7 +606,7 @@ namespace MaterialDesignThemes.Wpf
                     "Content cannot be passed to a dialog via the OpenDialog if DialogContent already has a binding.");
         }
 
-        internal void Close(object parameter)
+        internal void InternalClose(object parameter)
         {
             var dialogClosingEventArgs = new DialogClosingEventArgs(CurrentSession, DialogClosingEvent);
 
@@ -663,7 +663,7 @@ namespace MaterialDesignThemes.Wpf
         private void ContentCoverGridOnMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
             if (CloseOnClickAway && CurrentSession != null)
-                Close(CloseOnClickAwayParameter);
+                InternalClose(CloseOnClickAwayParameter);
         }
 
         private void OpenDialogHandler(object sender, ExecutedRoutedEventArgs executedRoutedEventArgs)
@@ -716,7 +716,7 @@ namespace MaterialDesignThemes.Wpf
         {
             if (executedRoutedEventArgs.Handled) return;
 
-            Close(executedRoutedEventArgs.Parameter);
+            InternalClose(executedRoutedEventArgs.Parameter);
 
             executedRoutedEventArgs.Handled = true;
         }

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -185,7 +185,7 @@ namespace MaterialDesignThemes.Wpf
         ///  Close a modal dialog.
         /// </summary>
         /// <param name="dialogIdentifier"> of the instance where the dialog should be shown. Typically this will match an identifer set in XAML. </param>
-        public static void Close(object dialogIdentifier)
+        public static void CloseDailog(object dialogIdentifier)
         {
             if (dialogIdentifier == null) throw new ArgumentNullException(nameof(dialogIdentifier));
 
@@ -595,7 +595,7 @@ namespace MaterialDesignThemes.Wpf
                     "Content cannot be passed to a dialog via the OpenDialog if DialogContent already has a binding.");
         }
 
-        internal void dialogClose(object parameter)
+        internal void Close(object parameter)
         {
             var dialogClosingEventArgs = new DialogClosingEventArgs(CurrentSession, DialogClosingEvent);
 
@@ -652,7 +652,7 @@ namespace MaterialDesignThemes.Wpf
         private void ContentCoverGridOnMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
             if (CloseOnClickAway && CurrentSession != null)
-                dialogClose(CloseOnClickAwayParameter);
+                Close(CloseOnClickAwayParameter);
         }
 
         private void OpenDialogHandler(object sender, ExecutedRoutedEventArgs executedRoutedEventArgs)
@@ -705,7 +705,7 @@ namespace MaterialDesignThemes.Wpf
         {
             if (executedRoutedEventArgs.Handled) return;
 
-            dialogClose(executedRoutedEventArgs.Parameter);
+            Close(executedRoutedEventArgs.Parameter);
 
             executedRoutedEventArgs.Handled = true;
         }

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -185,7 +185,7 @@ namespace MaterialDesignThemes.Wpf
         ///  Close a modal dialog.
         /// </summary>
         /// <param name="dialogIdentifier"> of the instance where the dialog should be shown. Typically this will match an identifer set in XAML. </param>
-        public static void CloseDailog(object dialogIdentifier)
+        public static void CloseDialog(object dialogIdentifier)
         {
             if (dialogIdentifier == null) throw new ArgumentNullException(nameof(dialogIdentifier));
 

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -181,6 +181,22 @@ namespace MaterialDesignThemes.Wpf
             return await targets[0].ShowInternal(content, openedEventHandler, closingEventHandler);
         }
 
+        /// <summary>
+        ///  Close a modal dialog.
+        /// </summary>
+        /// <param name="dialogIdentifier"> of the instance where the dialog should be shown. Typically this will match an identifer set in XAML. </param>
+        public static void Close(object dialogIdentifier)
+        {
+            if (dialogIdentifier == null) throw new ArgumentNullException(nameof(dialogIdentifier));
+
+            if (LoadedInstances.Count == 0)
+                throw new InvalidOperationException("No loaded DialogHost instances.");
+
+            var targets = LoadedInstances.FirstOrDefault(dh => dialogIdentifier == null || Equals(dh.Identifier, dialogIdentifier));
+            if (targets != null)
+                CloseDialogCommand.Execute(false, null);
+        }
+
         internal async Task<object> ShowInternal(object content, DialogOpenedEventHandler openedEventHandler, DialogClosingEventHandler closingEventHandler)
         {
             if (IsOpen)
@@ -579,7 +595,7 @@ namespace MaterialDesignThemes.Wpf
                     "Content cannot be passed to a dialog via the OpenDialog if DialogContent already has a binding.");
         }
 
-        internal void Close(object parameter)
+        internal void dialogClose(object parameter)
         {
             var dialogClosingEventArgs = new DialogClosingEventArgs(CurrentSession, DialogClosingEvent);
 
@@ -636,7 +652,7 @@ namespace MaterialDesignThemes.Wpf
         private void ContentCoverGridOnMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
             if (CloseOnClickAway && CurrentSession != null)
-                Close(CloseOnClickAwayParameter);
+                dialogClose(CloseOnClickAwayParameter);
         }
 
         private void OpenDialogHandler(object sender, ExecutedRoutedEventArgs executedRoutedEventArgs)
@@ -689,7 +705,7 @@ namespace MaterialDesignThemes.Wpf
         {
             if (executedRoutedEventArgs.Handled) return;
 
-            Close(executedRoutedEventArgs.Parameter);
+            dialogClose(executedRoutedEventArgs.Parameter);
 
             executedRoutedEventArgs.Handled = true;
         }

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -184,7 +184,7 @@ namespace MaterialDesignThemes.Wpf
         /// <summary>
         ///  Close a modal dialog.
         /// </summary>
-        /// <param name="dialogIdentifier"> of the instance where the dialog should be shown. Typically this will match an identifer set in XAML. </param>
+        /// <param name="dialogIdentifier"> of the instance where the dialog should be closed. Typically this will match an identifer set in XAML. </param>
         public static void CloseDialog(object dialogIdentifier)
         {
             if (dialogIdentifier == null) throw new ArgumentNullException(nameof(dialogIdentifier));

--- a/MaterialDesignThemes.Wpf/DialogSession.cs
+++ b/MaterialDesignThemes.Wpf/DialogSession.cs
@@ -55,7 +55,7 @@ namespace MaterialDesignThemes.Wpf
         {
             if (IsEnded) throw new InvalidOperationException("Dialog session has ended.");
 
-            _owner.Close(null);
+            _owner.InternalClose(null);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace MaterialDesignThemes.Wpf
         {
             if (IsEnded) throw new InvalidOperationException("Dialog session has ended.");
 
-            _owner.Close(parameter);
+            _owner.InternalClose(parameter);
         }
     }
 }


### PR DESCRIPTION
Add a manual method of closing the window, and in order to keep the syntax uniform, the original Close method updates the alias.
