### PR TITLE
Fix TimePicker issue

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/TimePicker/MaterialDesignTimePicker.cs
+++ b/MaterialDesignThemes.UITests/WPF/TimePicker/MaterialDesignTimePicker.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Threading.Tasks;
+using MaterialDesignThemes.Wpf;
+using XamlTest;
+
+namespace MaterialDesignThemes.UITests.WPF.TimePicker
+{
+    static class MaterialDesignTimePicker
+    {
+        private static async Task<T>GetNullableProperty<T>(this IVisualElement element, string propertyName)
+        {
+            try
+            {
+                return await element.GetProperty<T>(propertyName);
+            }
+            catch
+            {
+                return default!;
+            }
+        }
+
+        public static async Task<DateTime?>GetSelectedTime(this IVisualElement timePicker)
+            => await timePicker.GetNullableProperty<DateTime?>(nameof(Wpf.TimePicker.SelectedTime));
+
+        public static async Task SetSelectedTime(this IVisualElement timePicker, DateTime value)
+            => await timePicker.SetProperty(nameof(Wpf.TimePicker.SelectedTime), (DateTime?)value);
+
+        public static async Task PickClock(this IVisualElement timePicker, int hour, int minute)
+        {
+            var button = await timePicker.GetElement("PART_Button");
+            await button.Click();
+
+            var popup = await timePicker.GetElement("PART_Popup");
+            await popup.ClickHour(hour);
+            await popup.ClickMinute(minute);
+        }
+
+        private static async Task ClickHour(this IVisualElement popup, int hour)
+            => await popup.ClickButton(Clock.HoursCanvasPartName, (hour + 11) % 12);
+
+        private static async Task ClickMinute(this IVisualElement popup, int minute)
+            => await popup.ClickButton(Clock.MinutesCanvasPartName, (minute % 5 == 0 ? (minute / 5 + 11) % 12 : minute - minute / 5 + 11));
+
+        private static async Task ClickButton(this IVisualElement popup, string partName, int index)
+        {
+            const int delay = 200;
+
+            await Task.Delay(delay);
+            var canvas = await Wait.For(async () => await popup.GetElement(partName));
+            var button = await canvas.GetElement($"/ClockItemButton[{index}]");
+            await Task.Delay(delay);
+            await Wait.For(async () =>
+            {
+                await button.Click();
+                await Task.Delay(delay);
+                return await button.GetNullableProperty<bool?>(nameof(ClockItemButton.IsChecked)) == true;
+            });
+        }
+    }
+}

--- a/MaterialDesignThemes.UITests/WPF/TimePicker/TimePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TimePicker/TimePickerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using XamlTest;
 using Xunit;
 using Xunit.Abstractions;
@@ -163,5 +164,166 @@ namespace MaterialDesignThemes.UITests.WPF.TimePicker
             }
             return today;
         }
+
+#if false // These tests cannot be compiled until IVisualElement.SendInput and IVisualElement.SendKey are supported.
+        [Theory]
+        [InlineData("1:2")]
+        [InlineData("1:02")]
+        [InlineData("1:02 AM")]
+        public async Task OnLostFocusIfTimeHasBeenChanged_TextWillbeFormated(string text)
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <materialDesign:TimePicker/>
+    <TextBox/>
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/TimePicker");
+            var timePickerTextBox = await timePicker.GetElement("/TimePickerTextBox");
+            var textBox = await stackPanel.GetElement("/TextBox");
+
+            await timePickerTextBox.MoveKeyboardFocus();
+            await timePickerTextBox.SendInput(text);
+            await textBox.MoveKeyboardFocus();
+
+            var actual = await timePickerTextBox.GetText();
+            Assert.Equal("1:02 AM", actual);
+
+            recorder.Success();
+        }
+
+        [Theory]
+        [InlineData("1:2")]
+        [InlineData("1:02")]
+        [InlineData("1:02 AM")]
+        public async Task OnLostFocusIfTimeHasNotBeenChanged_TextWillbeFormated(string text)
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <materialDesign:TimePicker/>
+    <TextBox/>
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/TimePicker");
+            var timePickerTextBox = await timePicker.GetElement("/TimePickerTextBox");
+            var textBox = await stackPanel.GetElement("/TextBox");
+
+            await timePicker.SetSelectedTime(new DateTime (2020, 8, 10, 1, 2, 0)); 
+            await timePickerTextBox.MoveKeyboardFocus();
+            await timePickerTextBox.SendInput(text);
+            await textBox.MoveKeyboardFocus();
+
+            var actual = await timePickerTextBox.GetText();
+            Assert.Equal("1:02 AM", actual);
+
+            recorder.Success();
+        }
+
+        [Theory]
+        [InlineData("1:2")]
+        [InlineData("1:02")]
+        [InlineData("1:02 AM")]
+        public async Task OnEnterKeyDownIfTimeHasNotBeenChanged_TextWillbeFormated(string text)
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <materialDesign:TimePicker/>
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/TimePicker");
+            var timePickerTextBox = await timePicker.GetElement("/TimePickerTextBox");
+
+            await timePicker.SetSelectedTime(new DateTime (2020, 8, 10, 1, 2, 0)); 
+            await timePickerTextBox.MoveKeyboardFocus();
+            await timePickerTextBox.SendInput(text);
+            await timePickerTextBox.SendKey(Key.Enter);
+
+            var actual = await timePickerTextBox.GetText();
+            Assert.Equal("1:02 AM", actual);
+
+            recorder.Success();
+        }
+
+        [Theory]
+        [InlineData("1:2")]
+        [InlineData("1:02")]
+        [InlineData("1:02 AM")]
+        public async Task OnEnterKeyDownIfTimeHasBeenChanged_TextWillbeFormated(string text)
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <materialDesign:TimePicker/>
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/TimePicker");
+            var timePickerTextBox = await timePicker.GetElement("/TimePickerTextBox");
+
+            await timePicker.SetSelectedTime(new DateTime (2020, 8, 10, 1, 3, 0)); 
+            await timePickerTextBox.MoveKeyboardFocus();
+            await timePickerTextBox.SendInput(text);
+            await timePickerTextBox.SendKey(Key.Enter);
+
+            var actual = await timePickerTextBox.GetText();
+            Assert.Equal("1:02 AM", actual);
+
+            recorder.Success();
+        }
+
+        [Theory]
+        [InlineData("1:2")]
+        [InlineData("1:02")]
+        [InlineData("1:02 AM")]
+        public async Task OnTimePickedIfTimeHasBeenChanged_TextWillbeFormated(string text)
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <materialDesign:TimePicker/>
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/TimePicker");
+            var timePickerTextBox = await timePicker.GetElement("/TimePickerTextBox");
+
+            await timePicker.SetSelectedTime(new DateTime(2020, 8, 10, 1, 2, 0));
+            await timePickerTextBox.MoveKeyboardFocus();
+            await timePickerTextBox.SendInput(text);
+            await timePicker.PickClock(1, 3);
+
+            var actual = await timePickerTextBox.GetText();
+            Assert.Equal("1:03 AM", actual);
+
+            recorder.Success();
+        }
+
+        [Theory]
+        [InlineData("1:2")]
+        [InlineData("1:02")]
+        [InlineData("1:02 AM")]
+        public async Task OnTimePickedIfTimeHasNotBeenChanged_TextWillbeFormated(string text)
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <materialDesign:TimePicker/>
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/TimePicker");
+            var timePickerTextBox = await timePicker.GetElement("/TimePickerTextBox");
+
+            await timePicker.SetSelectedTime(new DateTime(2020, 8, 10, 1, 2, 0));
+            await timePickerTextBox.MoveKeyboardFocus();
+            await timePickerTextBox.SendInput(text);
+            await timePicker.PickClock(1, 2);
+
+            var actual = await timePickerTextBox.GetText();
+            Assert.Equal("1:02 AM", actual);
+
+            recorder.Success();
+        }
+#endif
     }
 }

--- a/MaterialDesignThemes.UITests/WPF/TimePicker/TimePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TimePicker/TimePickerTests.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Threading.Tasks;
+using XamlTest;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MaterialDesignThemes.UITests.WPF.TimePicker
+{
+    public class TimePickerTests : TestBase
+    {
+        public TimePickerTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Theory]
+        [InlineData(1, 1, 1)]
+        [InlineData(2020, 8, 10)]
+        public async Task OnTextChangedIfSelectedTimeIsNonNull_DatePartDoesNotChange(int year, int month, int day)
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <materialDesign:TimePicker Language=""en-US"" />
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/TimePicker");
+            var timePickerTextBox = await timePicker.GetElement("/TimePickerTextBox");
+
+            await timePicker.SetSelectedTime(new DateTime(year, month, day));
+            await timePickerTextBox.MoveKeyboardFocus();
+            await timePickerTextBox.SetText("1:10 AM");
+
+            var actual = await timePicker.GetSelectedTime();
+            Assert.Equal(new DateTime(year, month, day, 1, 10, 0), actual);
+
+            recorder.Success();
+        }
+
+        [Theory]
+        [InlineData(1, 1, 1)]
+        [InlineData(2020, 8, 10)]
+        public async Task OnLostFocusIfSelectedTimeIsNonNull_DatePartDoesNotChange(int year, int month, int day)
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <materialDesign:TimePicker Language=""en-US"" />
+    <TextBox />
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/TimePicker");
+            var timePickerTextBox = await timePicker.GetElement("/TimePickerTextBox");
+            var textBox = await stackPanel.GetElement("/TextBox");
+
+            await timePicker.SetSelectedTime(new DateTime(year, month, day));
+            await timePickerTextBox.MoveKeyboardFocus();
+            await timePickerTextBox.SetText("1:10");
+            await textBox.MoveKeyboardFocus();
+
+            var actual = await timePicker.GetSelectedTime();
+            Assert.Equal(new DateTime(year, month, day, 1, 10, 0), actual);
+
+            recorder.Success();
+        }
+
+        [Theory]
+        [InlineData(1, 1, 1)]
+        [InlineData(2020, 8, 2)]
+        public async Task OnClockPickedIfSelectedTimeIsNonNull_DatePartDoesNotChange(int year, int month, int day)
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <materialDesign:TimePicker/>
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/TimePicker");
+
+            await timePicker.SetSelectedTime(new DateTime(year, month, day));
+            await timePicker.PickClock(1, 10);
+
+            var actual = await timePicker.GetSelectedTime();
+            Assert.Equal(new DateTime(year, month, day, 1, 10, 0), actual);
+
+            recorder.Success();
+        }
+
+        [Fact]
+        public async Task OnTextChangedIfSelectedTimeIsNull_DatePartWillBeToday()
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <materialDesign:TimePicker Language=""en-US"" />
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/TimePicker");
+            var timePickerTextBox = await timePicker.GetElement("/TimePickerTextBox");
+
+            var today = DateTime.Today;
+            await timePickerTextBox.MoveKeyboardFocus();
+            await timePickerTextBox.SetText("1:23 AM");
+
+            var actual = await timePicker.GetSelectedTime();
+            Assert.Equal(AdjustToday(today, actual).Add(new TimeSpan(1, 23, 0)), actual);
+
+            recorder.Success();
+        }
+
+        [Fact]
+        public async Task OnLostFocusIfSelectedTimeIsNull_DatePartWillBeToday()
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <materialDesign:TimePicker Language=""en-US"" />
+    <TextBox />
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/TimePicker");
+            var timePickerTextBox = await timePicker.GetElement("/TimePickerTextBox");
+            var textBox = await stackPanel.GetElement("/TextBox");
+
+            var today = DateTime.Today;
+            await timePickerTextBox.MoveKeyboardFocus();
+            await timePickerTextBox.SetText("1:23");
+            await textBox.MoveKeyboardFocus();
+
+            var actual = await timePicker.GetSelectedTime();
+            Assert.Equal(AdjustToday(today, actual).Add(new TimeSpan(1, 23, 0)), actual);
+
+            recorder.Success();
+        }
+
+        [Fact]
+        public async Task OnClockPickedIfSelectedTimeIsNull_DatePartWillBeToday()
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <materialDesign:TimePicker/>
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/TimePicker");
+
+            var today = DateTime.Today;
+            await timePicker.PickClock(1, 23);
+
+            var actual = await timePicker.GetSelectedTime();
+            Assert.Equal(AdjustToday(today, actual).Add(new TimeSpan(1, 23, 0)), actual);
+
+            recorder.Success();
+        }
+
+        private static DateTime AdjustToday(DateTime today, DateTime? adjustTo)
+        {
+            if (adjustTo.HasValue && today != adjustTo.Value.Date)
+            {
+                var tomorrow = today.AddDays(1);
+                if (tomorrow == adjustTo.Value.Date)
+                    today = tomorrow;
+            }
+            return today;
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf.Tests/TimePickerUnitTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/TimePickerUnitTests.cs
@@ -54,6 +54,7 @@ namespace MaterialDesignThemes.Wpf.Tests
             _timePicker.SelectedTimeFormat = format;
             _timePicker.Is24Hours = is24Hour;
             _timePicker.WithSeconds = withSeconds;
+            _timePicker.SelectedTime = DateTime.MinValue;
 
             var textBox = _timePicker.FindVisualChild<TextBox>(TimePicker.TextBoxPartName);
             textBox.Text = timeString;

--- a/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -80,10 +80,7 @@ namespace MaterialDesignThemes.Wpf
                 timePicker.SetSelectedTime();
             if (timePicker._textBox != null)
             {
-                // Save and restore the cursor position
-                var caretIndex = timePicker._textBox.CaretIndex;
-                timePicker._textBox.Text = dependencyPropertyChangedEventArgs.NewValue as string ?? "";
-                timePicker._textBox.CaretIndex = caretIndex;
+                timePicker.UpdateTextBoxText(dependencyPropertyChangedEventArgs.NewValue as string ?? "");
             }
         }
 
@@ -322,8 +319,12 @@ namespace MaterialDesignThemes.Wpf
                 return;
             }
 
-            if (IsTimeValid(_textBox.Text, out DateTime time))
+            var currentText = _textBox.Text;
+            if (IsTimeValid(currentText, out DateTime time))
+            {
                 SetSelectedTime(time);
+                UpdateTextBoxTextIfNeeded(currentText);
+            }
             else // Invalid time, jump back to previous good time
                 SetInvalidTime();
         }
@@ -394,6 +395,24 @@ namespace MaterialDesignThemes.Wpf
                 SetSelectedTime(true);
         }
 
+        private void UpdateTextBoxText(string text)
+        {
+            // Save and restore the cursor position
+            var caretIndex = _textBox.CaretIndex;
+            _textBox.Text = text;
+            _textBox.CaretIndex = caretIndex;
+        }
+
+        private void UpdateTextBoxTextIfNeeded(string lastText)
+        {
+            if (_textBox.Text == lastText)
+            {
+                var formattedText = DateTimeToString(SelectedTime);
+                if (formattedText != lastText)
+                    UpdateTextBoxText(formattedText);
+            }
+        }
+
         private void SetSelectedTime(in DateTime time)
         {
             SetCurrentValue(SelectedTimeProperty, (SelectedTime?.Date ?? DateTime.Today).Add(time.TimeOfDay));
@@ -401,12 +420,15 @@ namespace MaterialDesignThemes.Wpf
 
         private void SetSelectedTime(bool beCautious = false)
         {
-            if (!string.IsNullOrEmpty(_textBox?.Text))
+            var currentText = _textBox?.Text;
+            if (!string.IsNullOrEmpty(currentText))
             {
-                ParseTime(_textBox.Text, t =>
+                ParseTime(currentText, t =>
                 {
-                    if (!beCautious || DateTimeToString(t) == _textBox.Text)
+                    if (!beCautious || DateTimeToString(t) == currentText)
                         SetSelectedTime(t);
+                    if (!beCautious)
+                        UpdateTextBoxTextIfNeeded(currentText);
                 });
             }
             else

--- a/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -323,8 +323,7 @@ namespace MaterialDesignThemes.Wpf
             }
 
             if (IsTimeValid(_textBox.Text, out DateTime time))
-                SetCurrentValue(SelectedTimeProperty, SelectedTime?.Date.Add(time.TimeOfDay) ?? time);
-
+                SetSelectedTime(time);
             else // Invalid time, jump back to previous good time
                 SetInvalidTime();
         }
@@ -395,6 +394,11 @@ namespace MaterialDesignThemes.Wpf
                 SetSelectedTime(true);
         }
 
+        private void SetSelectedTime(in DateTime time)
+        {
+            SetCurrentValue(SelectedTimeProperty, (SelectedTime?.Date ?? DateTime.Today).Add(time.TimeOfDay));
+        }
+
         private void SetSelectedTime(bool beCautious = false)
         {
             if (!string.IsNullOrEmpty(_textBox?.Text))
@@ -402,7 +406,7 @@ namespace MaterialDesignThemes.Wpf
                 ParseTime(_textBox.Text, t =>
                 {
                     if (!beCautious || DateTimeToString(t) == _textBox.Text)
-                        SetCurrentValue(SelectedTimeProperty, SelectedTime?.Date.Add(t.TimeOfDay) ?? t);
+                        SetSelectedTime(t);
                 });
             }
             else


### PR DESCRIPTION
Fixed the following issues.

- When type the time text if `SelectedTime` is null, the date part of `SelectedTime` will be `DateTime.MinValue.Date`. It should be today (Fixes #1998).

- If the time text is "9:00 AM", edit the text to "9:0 AM" then press Enter or move the keyboard focus, the text remains "9:0 AM". It should be "9:00 AM". Whereas, if edit the text to "9:1 AM", it will be properly "9:01 AM".

- If the time text is "9:00 AM", edit the text to "9:0 AM" then select "9:00 AM" on clock popup, the text remains "9:0 AM". It should be "9:00 AM". Whereas, if select "9:01 AM" on clock popup, the text will be properly "9:01 AM".
