### PR TITLE
Removed deprecated resource dictionary keys

### DIFF
--- a/MahMaterialDragablzMashUp/App.xaml
+++ b/MahMaterialDragablzMashUp/App.xaml
@@ -119,7 +119,7 @@
                                 </materialDesign:PopupBox>
                                 <Grid>
                                     <AdornerDecorator>
-                                        <Border BorderBrush="{DynamicResource SecondaryAccentBrush}" Opacity=".4" Margin="-5">
+                                        <Border BorderBrush="{DynamicResource SecondaryHueMidBrush}" Opacity=".4" Margin="-5">
                                             <Border.Style>
                                                 <Style TargetType="Border">
                                                     <Setter Property="BorderThickness" Value="0" />

--- a/MainDemo.Wpf/App.xaml
+++ b/MainDemo.Wpf/App.xaml
@@ -96,7 +96,7 @@
                                 </materialDesign:PopupBox>
                                 <Grid>
                                     <AdornerDecorator>
-                                        <Border BorderBrush="{DynamicResource SecondaryAccentBrush}" Opacity=".4" Margin="-5">
+                                        <Border BorderBrush="{DynamicResource SecondaryHueMidBrush}" Opacity=".4" Margin="-5">
                                             <Border.Style>
                                                 <Style TargetType="Border">
                                                     <Setter Property="BorderThickness" Value="0" />

--- a/MainDemo.Wpf/ColorTool.xaml
+++ b/MainDemo.Wpf/ColorTool.xaml
@@ -234,7 +234,7 @@
                                         <TextBlock DataContext="{DynamicResource SecondaryHueMidBrush}" 
                                                    Text="{Binding Converter={StaticResource BrushToHexConverter}}" 
                                                    Style="{StaticResource HexLabelTextBlock}" 
-                                                   Foreground="{DynamicResource SecondaryAccentForegroundBrush}" />
+                                                   Foreground="{DynamicResource SecondaryHueMidForegroundBrush}" />
                                         <Border Width="30" Height="30" CornerRadius="15">
                                             <Border.Style>
                                                 <Style TargetType="Border">
@@ -354,16 +354,16 @@
                                     <TextBlock Style="{StaticResource LabelTextBox}">Text on S</TextBlock>
                                     <Border Background="{DynamicResource SecondaryHueMidBrush}" Grid.Row="1">
                                         <Grid>
-                                            <TextBlock DataContext="{DynamicResource SecondaryAccentForegroundBrush}" 
+                                            <TextBlock DataContext="{DynamicResource SecondaryHueMidForegroundBrush}" 
                                                        Text="{Binding Converter={StaticResource BrushToHexConverter}}" 
                                                        Style="{StaticResource HexLabelTextBlock}" 
-                                                       Foreground="{DynamicResource SecondaryAccentForegroundBrush}" />
+                                                       Foreground="{DynamicResource SecondaryHueMidForegroundBrush}" />
                                             <Border Width="30" Height="30" CornerRadius="15">
                                                 <Border.Style>
                                                     <Style TargetType="Border">
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding ActiveScheme}" Value="SecondaryForeground">
-                                                                <Setter Property="Background" Value="{DynamicResource SecondaryAccentForegroundBrush}" />
+                                                                <Setter Property="Background" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
                                                             </DataTrigger>
                                                         </Style.Triggers>
                                                     </Style>
@@ -372,7 +372,7 @@
                                                            Text="T">
                                                     <TextBlock.Style>
                                                         <Style TargetType="TextBlock">
-                                                            <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}" />
+                                                            <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
                                                             <Style.Triggers>
                                                                 <DataTrigger Binding="{Binding ActiveScheme}" Value="SecondaryForeground">
                                                                     <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidBrush}" />

--- a/MainDemo.Wpf/ColorTool.xaml
+++ b/MainDemo.Wpf/ColorTool.xaml
@@ -229,7 +229,7 @@
                                 </Grid.RowDefinitions>
                                 <TextBlock Style="{StaticResource LabelTextBox}">Secondary</TextBlock>
                                 <!-- Secondary mid section -->
-                                <Border Background="{DynamicResource SecondaryAccentBrush}" Grid.Row="1">
+                                <Border Background="{DynamicResource SecondaryHueMidBrush}" Grid.Row="1">
                                     <Grid>
                                         <TextBlock DataContext="{DynamicResource SecondaryHueMidBrush}" 
                                                    Text="{Binding Converter={StaticResource BrushToHexConverter}}" 
@@ -352,7 +352,7 @@
                                         <RowDefinition Height="*" />
                                     </Grid.RowDefinitions>
                                     <TextBlock Style="{StaticResource LabelTextBox}">Text on S</TextBlock>
-                                    <Border Background="{DynamicResource SecondaryAccentBrush}" Grid.Row="1">
+                                    <Border Background="{DynamicResource SecondaryHueMidBrush}" Grid.Row="1">
                                         <Grid>
                                             <TextBlock DataContext="{DynamicResource SecondaryAccentForegroundBrush}" 
                                                        Text="{Binding Converter={StaticResource BrushToHexConverter}}" 
@@ -375,7 +375,7 @@
                                                             <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}" />
                                                             <Style.Triggers>
                                                                 <DataTrigger Binding="{Binding ActiveScheme}" Value="SecondaryForeground">
-                                                                    <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentBrush}" />
+                                                                    <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidBrush}" />
                                                                 </DataTrigger>
                                                             </Style.Triggers>
                                                         </Style>

--- a/MainDemo.Wpf/ComboBoxes.xaml
+++ b/MainDemo.Wpf/ComboBoxes.xaml
@@ -59,7 +59,7 @@
                 <ComboBox Style="{StaticResource MaterialDesignFloatingHintComboBox}"
                           materialDesign:TextFieldAssist.HasClearButton="True"
                           materialDesign:TextFieldAssist.SuffixText="sw"
-                          materialDesign:TextFieldAssist.UnderlineBrush="{DynamicResource SecondaryAccentBrush}"
+                          materialDesign:TextFieldAssist.UnderlineBrush="{DynamicResource SecondaryHueMidBrush}"
                           materialDesign:ColorZoneAssist.Mode="Inverted"
                           materialDesign:HintAssist.Hint="OS"
                           materialDesign:HintAssist.HelperText="Select one OS"

--- a/MainDemo.Wpf/Home.xaml
+++ b/MainDemo.Wpf/Home.xaml
@@ -160,7 +160,7 @@
                 </Button>
                 <Button ToolTip="Email" Click="EmailButton_OnClick"
                         Background="{DynamicResource SecondaryHueMidBrush}"
-                        Foreground="{DynamicResource SecondaryAccentForegroundBrush}"
+                        Foreground="{DynamicResource SecondaryHueMidForegroundBrush}"
                         >
                     <materialDesign:PackIcon Kind="Email" />
                 </Button>

--- a/MainDemo.Wpf/Home.xaml
+++ b/MainDemo.Wpf/Home.xaml
@@ -159,7 +159,7 @@
                     <materialDesign:PackIcon Kind="Message" />
                 </Button>
                 <Button ToolTip="Email" Click="EmailButton_OnClick"
-                        Background="{DynamicResource SecondaryAccentBrush}"
+                        Background="{DynamicResource SecondaryHueMidBrush}"
                         Foreground="{DynamicResource SecondaryAccentForegroundBrush}"
                         >
                     <materialDesign:PackIcon Kind="Email" />

--- a/MainDemo.Wpf/Palette.xaml
+++ b/MainDemo.Wpf/Palette.xaml
@@ -38,7 +38,7 @@
                 Grid.Row="1" Grid.Column="2">
             <TextBlock Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}">Dark</TextBlock>
         </Border>
-        <Border Background="{DynamicResource SecondaryAccentBrush}"
+        <Border Background="{DynamicResource SecondaryHueMidBrush}"
                 Grid.Row="2" Grid.ColumnSpan="3" Grid.Column="0">
             <TextBlock Foreground="{DynamicResource SecondaryAccentForegroundBrush}">Accent</TextBlock>
         </Border>

--- a/MainDemo.Wpf/Palette.xaml
+++ b/MainDemo.Wpf/Palette.xaml
@@ -40,7 +40,7 @@
         </Border>
         <Border Background="{DynamicResource SecondaryHueMidBrush}"
                 Grid.Row="2" Grid.ColumnSpan="3" Grid.Column="0">
-            <TextBlock Foreground="{DynamicResource SecondaryAccentForegroundBrush}">Accent</TextBlock>
+            <TextBlock Foreground="{DynamicResource SecondaryHueMidForegroundBrush}">Accent</TextBlock>
         </Border>
     </Grid>
 </UserControl>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Amber.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Amber.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Amber.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Amber.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.Amber.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Blue.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Blue.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Blue.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Blue.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.Blue.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Cyan.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Cyan.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.Cyan.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Cyan.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Cyan.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.DeepOrange.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.DeepOrange.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.DeepOrange.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.DeepOrange.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.DeepOrange.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.DeepPurple.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.DeepPurple.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.DeepPurple.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.DeepPurple.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.DeepPurple.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Green.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Green.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Green.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Green.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.Green.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Indigo.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Indigo.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Indigo.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Indigo.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.Indigo.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.LightBlue.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.LightBlue.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.LightBlue.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.LightBlue.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.LightBlue.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.LightGreen.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.LightGreen.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.LightGreen.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.LightGreen.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.LightGreen.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.Lime.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Orange.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Orange.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.Orange.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Orange.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Orange.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Pink.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Pink.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.Pink.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Pink.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Pink.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Purple.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Purple.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Purple.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Purple.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.Purple.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Red.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Red.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Red.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Red.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.Red.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Teal.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Teal.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Teal.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Teal.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.Teal.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Yellow.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Yellow.xaml
@@ -7,6 +7,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
-    <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
+    <SolidColorBrush x:Key="SecondaryHueMidForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Yellow.xaml
+++ b/MaterialDesignColors.Wpf/Themes/Recommended/Accent/MaterialDesignColor.Yellow.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.Yellow.Accent.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
+    <SolidColorBrush x:Key="SecondaryHueMidBrush" Color="{StaticResource Accent700}" po:Freeze="True" />
     <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{StaticResource Accent700Foreground}" po:Freeze="True" />  
     
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs
+++ b/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
@@ -32,7 +32,6 @@ namespace MaterialDesignThemes.Wpf
 
 
             //NB: These are here for backwards compatibility, and will be removed in a future version.
-            SetSolidColorBrush(resourceDictionary, "SecondaryAccentBrush", theme.SecondaryMid.Color);
             SetSolidColorBrush(resourceDictionary, "SecondaryAccentForegroundBrush", theme.SecondaryMid.ForegroundColor ?? theme.SecondaryMid.Color.ContrastingForegroundColor());
 
             SetSolidColorBrush(resourceDictionary, "ValidationErrorBrush", theme.ValidationError);

--- a/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs
+++ b/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
@@ -83,7 +83,7 @@ namespace MaterialDesignThemes.Wpf
                 return theme;
             }
 
-            Color secondaryMid = GetColor("SecondaryHueMidBrush", "SecondaryAccentBrush");
+            Color secondaryMid = GetColor("SecondaryHueMidBrush");
             Color secondaryMidForeground = GetColor("SecondaryHueMidForegroundBrush", "SecondaryAccentForegroundBrush");
 
             if (!TryGetColor("SecondaryHueLightBrush", out Color secondaryLight))

--- a/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs
+++ b/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs
@@ -30,6 +30,11 @@ namespace MaterialDesignThemes.Wpf
             SetSolidColorBrush(resourceDictionary, "SecondaryHueDarkBrush", theme.SecondaryDark.Color);
             SetSolidColorBrush(resourceDictionary, "SecondaryHueDarkForegroundBrush", theme.SecondaryDark.ForegroundColor ?? theme.SecondaryDark.Color.ContrastingForegroundColor());
 
+            //NB: These are here for backwards compatibility, and will be removed in a future version.
+            //These will be removed in version 4.0.0
+            SetSolidColorBrush(resourceDictionary, "SecondaryAccentBrush", theme.SecondaryMid.Color);
+            SetSolidColorBrush(resourceDictionary, "SecondaryAccentForegroundBrush", theme.SecondaryMid.ForegroundColor ?? theme.SecondaryMid.Color.ContrastingForegroundColor());
+
             SetSolidColorBrush(resourceDictionary, "ValidationErrorBrush", theme.ValidationError);
             resourceDictionary["ValidationErrorColor"] = theme.ValidationError;
 

--- a/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs
+++ b/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
@@ -29,10 +29,6 @@ namespace MaterialDesignThemes.Wpf
             SetSolidColorBrush(resourceDictionary, "SecondaryHueMidForegroundBrush", theme.SecondaryMid.ForegroundColor ?? theme.SecondaryMid.Color.ContrastingForegroundColor());
             SetSolidColorBrush(resourceDictionary, "SecondaryHueDarkBrush", theme.SecondaryDark.Color);
             SetSolidColorBrush(resourceDictionary, "SecondaryHueDarkForegroundBrush", theme.SecondaryDark.ForegroundColor ?? theme.SecondaryDark.Color.ContrastingForegroundColor());
-
-
-            //NB: These are here for backwards compatibility, and will be removed in a future version.
-            SetSolidColorBrush(resourceDictionary, "SecondaryAccentForegroundBrush", theme.SecondaryMid.ForegroundColor ?? theme.SecondaryMid.Color.ContrastingForegroundColor());
 
             SetSolidColorBrush(resourceDictionary, "ValidationErrorBrush", theme.ValidationError);
             resourceDictionary["ValidationErrorColor"] = theme.ValidationError;

--- a/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs
+++ b/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
@@ -80,7 +80,7 @@ namespace MaterialDesignThemes.Wpf
             }
 
             Color secondaryMid = GetColor("SecondaryHueMidBrush");
-            Color secondaryMidForeground = GetColor("SecondaryHueMidForegroundBrush", "SecondaryAccentForegroundBrush");
+            Color secondaryMidForeground = GetColor("SecondaryHueMidForegroundBrush");
 
             if (!TryGetColor("SecondaryHueLightBrush", out Color secondaryLight))
             {

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -479,7 +479,7 @@
                 <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkForegroundBrush}" />
             </Trigger>
             <Trigger Property="Mode" Value="Accent">
-                <Setter Property="Background" Value="{DynamicResource SecondaryAccentBrush}" />
+                <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
                 <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}" />
             </Trigger>
             <Trigger Property="Mode" Value="Light">

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -480,7 +480,7 @@
             </Trigger>
             <Trigger Property="Mode" Value="Accent">
                 <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
-                <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
             </Trigger>
             <Trigger Property="Mode" Value="Light">
                 <Setter Property="Background" Value="{DynamicResource MaterialDesignLightBackground}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Badged.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Badged.xaml
@@ -123,7 +123,7 @@
             </Trigger>
             <Trigger Property="BadgeColorZoneMode" Value="Accent">
                 <Setter Property="BadgeBackground" Value="{DynamicResource SecondaryHueMidBrush}" />
-                <Setter Property="BadgeForeground" Value="{DynamicResource SecondaryAccentForegroundBrush}" />
+                <Setter Property="BadgeForeground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
             </Trigger>
             <Trigger Property="BadgeColorZoneMode" Value="Light">
                 <Setter Property="BadgeBackground" Value="{DynamicResource MaterialDesignLightBackground}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Badged.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Badged.xaml
@@ -122,7 +122,7 @@
                 <Setter Property="BadgeForeground" Value="{DynamicResource PrimaryHueDarkForegroundBrush}" />
             </Trigger>
             <Trigger Property="BadgeColorZoneMode" Value="Accent">
-                <Setter Property="BadgeBackground" Value="{DynamicResource SecondaryAccentBrush}" />
+                <Setter Property="BadgeBackground" Value="{DynamicResource SecondaryHueMidBrush}" />
                 <Setter Property="BadgeForeground" Value="{DynamicResource SecondaryAccentForegroundBrush}" />
             </Trigger>
             <Trigger Property="BadgeColorZoneMode" Value="Light">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
@@ -126,7 +126,7 @@
     <Style x:Key="MaterialDesignRaisedAccentButton" TargetType="{x:Type ButtonBase}" BasedOn="{StaticResource MaterialDesignRaisedButton}">
         <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}"/>
     </Style>
 
     <Style x:Key="MaterialDesignFlatButton" TargetType="{x:Type ButtonBase}">
@@ -401,7 +401,7 @@
     <Style x:Key="MaterialDesignFloatingActionMiniAccentButton" TargetType="{x:Type ButtonBase}" BasedOn="{StaticResource MaterialDesignFloatingActionMiniButton}">
         <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}"/>
         <Setter Property="wpf:ButtonProgressAssist.IndicatorForeground" Value="{DynamicResource PrimaryHueMidBrush}" />
     </Style>
 
@@ -422,7 +422,7 @@
     <Style x:Key="MaterialDesignFloatingActionAccentButton" TargetType="{x:Type ButtonBase}" BasedOn="{StaticResource MaterialDesignFloatingActionButton}">
         <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}"/>
         <Setter Property="wpf:ButtonProgressAssist.IndicatorForeground" Value="{DynamicResource PrimaryHueMidBrush}" />
     </Style>
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
@@ -124,8 +124,8 @@
     </Style>
 
     <Style x:Key="MaterialDesignRaisedAccentButton" TargetType="{x:Type ButtonBase}" BasedOn="{StaticResource MaterialDesignRaisedButton}">
-        <Setter Property="Background" Value="{DynamicResource SecondaryAccentBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryAccentBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}"/>
     </Style>
 
@@ -188,7 +188,7 @@
     </Style>
 
     <Style x:Key="MaterialDesignFlatAccentButton" TargetType="{x:Type ButtonBase}" BasedOn="{StaticResource MaterialDesignFlatButton}">
-        <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidBrush}"/>
     </Style>
 
     <Style x:Key="MaterialDesignFlatAccentBgButton" TargetType="{x:Type ButtonBase}" BasedOn="{StaticResource MaterialDesignRaisedAccentButton}">
@@ -289,7 +289,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}"/>
         <Setter Property="wpf:RippleAssist.Feedback" Value="White" />
-        <Setter Property="wpf:ButtonProgressAssist.IndicatorForeground" Value="{DynamicResource SecondaryAccentBrush}" />
+        <Setter Property="wpf:ButtonProgressAssist.IndicatorForeground" Value="{DynamicResource SecondaryHueMidBrush}" />
         <Setter Property="wpf:ButtonProgressAssist.IndicatorBackground" Value="{DynamicResource MaterialDesignDivider}" />
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Cursor" Value="Hand"/>
@@ -399,8 +399,8 @@
     </Style>
 
     <Style x:Key="MaterialDesignFloatingActionMiniAccentButton" TargetType="{x:Type ButtonBase}" BasedOn="{StaticResource MaterialDesignFloatingActionMiniButton}">
-        <Setter Property="Background" Value="{DynamicResource SecondaryAccentBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryAccentBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}"/>
         <Setter Property="wpf:ButtonProgressAssist.IndicatorForeground" Value="{DynamicResource PrimaryHueMidBrush}" />
     </Style>
@@ -420,8 +420,8 @@
     </Style>
 
     <Style x:Key="MaterialDesignFloatingActionAccentButton" TargetType="{x:Type ButtonBase}" BasedOn="{StaticResource MaterialDesignFloatingActionButton}">
-        <Setter Property="Background" Value="{DynamicResource SecondaryAccentBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryAccentBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}"/>
         <Setter Property="wpf:ButtonProgressAssist.IndicatorForeground" Value="{DynamicResource PrimaryHueMidBrush}" />
     </Style>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
@@ -47,7 +47,7 @@
     <Style x:Key="MaterialDesignActionAccentCheckBox" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource MaterialDesignActionCheckBox}">
         <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}"/>
     </Style>
 
     <Style x:Key="MaterialDesignCheckBox" TargetType="{x:Type CheckBox}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
@@ -45,8 +45,8 @@
     </Style>
 
     <Style x:Key="MaterialDesignActionAccentCheckBox" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource MaterialDesignActionCheckBox}">
-        <Setter Property="Background" Value="{DynamicResource SecondaryAccentBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryAccentBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}"/>
     </Style>
 
@@ -155,8 +155,8 @@
     </Style>
 
     <Style x:Key="MaterialDesignAccentCheckBox" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource MaterialDesignCheckBox}">
-        <Setter Property="Background" Value="{DynamicResource SecondaryAccentBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryAccentBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
     </Style>
 
     <Style x:Key="MaterialDesignUserForegroundCheckBox" TargetType="{x:Type CheckBox}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -678,7 +678,7 @@
                 <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource SecondaryHueMidBrush}" />
                 <Setter TargetName="PART_Popup" Property="Background" 
                         Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
-                <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
@@ -984,7 +984,7 @@
                 <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource SecondaryHueMidBrush}" />
                 <Setter TargetName="PART_Popup" Property="Background" 
                         Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
-                <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -675,7 +675,7 @@
                     <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
                     <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Accent"/>
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource SecondaryAccentBrush}" />
+                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource SecondaryHueMidBrush}" />
                 <Setter TargetName="PART_Popup" Property="Background" 
                         Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
                 <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}" />
@@ -981,7 +981,7 @@
                     <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
                     <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Accent"/>
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource SecondaryAccentBrush}" />
+                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource SecondaryHueMidBrush}" />
                 <Setter TargetName="PART_Popup" Property="Background" 
                         Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
                 <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -417,8 +417,8 @@
     <Style TargetType="{x:Type wpf:PopupBox}" 
            x:Key="MaterialDesignMultiFloatingActionAccentPopupBox"
            BasedOn="{StaticResource MaterialDesignMultiFloatingActionPopupBox}">
-        <Setter Property="Background" Value="{DynamicResource SecondaryAccentBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryAccentBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}"/>
     </Style>
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -419,7 +419,7 @@
            BasedOn="{StaticResource MaterialDesignMultiFloatingActionPopupBox}">
         <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}"/>
     </Style>
 
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
@@ -131,8 +131,8 @@
     </Style>
 
     <Style x:Key="MaterialDesignAccentRadioButton" TargetType="{x:Type RadioButton}" BasedOn="{StaticResource MaterialDesignRadioButton}">
-        <Setter Property="Background" Value="{DynamicResource SecondaryAccentBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryAccentBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
     </Style>
 
     <Style x:Key="MaterialDesignUserForegroundRadioButton" TargetType="{x:Type RadioButton}">
@@ -225,7 +225,7 @@
         <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
         <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryAccentBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
         <Setter Property="Padding" Value="16 4 16 4"/>
         <Setter Property="Height" Value="32" />
         <Setter Property="MinWidth" Value="80" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Snackbar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Snackbar.xaml
@@ -15,7 +15,7 @@
 
     <Style x:Key="MaterialDesignSnackbarActionButton" TargetType="Button">
         <Setter Property="VerticalAlignment" Value="Stretch" />
-        <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidBrush}" />
         <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="Transparent" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
@@ -165,7 +165,7 @@
     <Style x:Key="MaterialDesignActionAccentToggleButton" TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource MaterialDesignActionToggleButton}">
         <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}"/>
     </Style>
 
     <Style x:Key="MaterialDesignFlatToggleButton" TargetType="{x:Type ToggleButton}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
@@ -163,8 +163,8 @@
     </Style>
 
     <Style x:Key="MaterialDesignActionAccentToggleButton" TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource MaterialDesignActionToggleButton}">
-        <Setter Property="Background" Value="{DynamicResource SecondaryAccentBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryAccentBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}"/>
     </Style>
 
@@ -430,7 +430,7 @@
     </Style>
 
     <Style x:Key="MaterialDesignSwitchAccentToggleButton" TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource MaterialDesignSwitchToggleButton}">
-        <Setter Property="Background" Value="{DynamicResource SecondaryAccentBrush}" />
+        <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
     </Style>
 
     <Style x:Key="MaterialDesignHamburgerToggleButton" TargetType="{x:Type ToggleButton}">


### PR DESCRIPTION
Resolves #2039

The plan was to make these four replacements...
* `SecondaryAccentBrush` with `SecondaryHueMidBrush`
* `SecondaryAccentBrushColor` with `SecondaryHueMidBrushColor`
* `SecondaryAccentForegroundBrush` with `SecondaryHueMidForegroundBrush`
* `SecondaryAccentForegroundBrushColor` with `SecondaryHueMidForegroundBrushColor`

...since the function `SetSolidColorBrush` both [sets a value for the string it is given](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/5f972ca97b7adf4c83ca3a7f6703070e9a75d5e8/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs#L205) and also [sets a value for the string it is given when suffixed with `Color`](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/5f972ca97b7adf4c83ca3a7f6703070e9a75d5e8/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs#L184).  However, neither of the keys with the `Color` suffix had any references.

Therefore, I only made these replacements:
* `SecondaryAccentBrush` with `SecondaryHueMidBrush`
* `SecondaryAccentForegroundBrush` with `SecondaryHueMidForegroundBrush`

I split the work into six commits to make it easier to follow the changes.  There are now zero references to each of `SecondaryAccentBrush` and `SecondaryAccentForegroundBrush`.