### PR TITLE
now avoiding some missing resource warnings #2040

### DIFF
--- a/MaterialDesignThemes.Wpf/Snackbar.cs
+++ b/MaterialDesignThemes.Wpf/Snackbar.cs
@@ -31,16 +31,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty MessageProperty = DependencyProperty.Register(
-            nameof(Message), typeof(SnackbarMessage), typeof(Snackbar), new PropertyMetadata(default(SnackbarMessage), MessagePropertyChangedCallback));
-
-        private static void MessagePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
-        {
-            var snackbar = (Snackbar)dependencyObject;
-            //this prevents missing resource warnings after the message is removed from the Snackbar
-            //see https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2040
-            if (snackbar.Message != null)
-                snackbar.Message.Resources = SnackbarMessage.defaultResources;
-        }
+            nameof(Message), typeof(SnackbarMessage), typeof(Snackbar), new PropertyMetadata(default(SnackbarMessage)));
 
         public SnackbarMessage Message
         {

--- a/MaterialDesignThemes.Wpf/Snackbar.cs
+++ b/MaterialDesignThemes.Wpf/Snackbar.cs
@@ -31,7 +31,16 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty MessageProperty = DependencyProperty.Register(
-            nameof(Message), typeof(SnackbarMessage), typeof(Snackbar), new PropertyMetadata(default(SnackbarMessage)));
+            nameof(Message), typeof(SnackbarMessage), typeof(Snackbar), new PropertyMetadata(default(SnackbarMessage), MessagePropertyChangedCallback));
+
+        private static void MessagePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            var snackbar = (Snackbar)dependencyObject;
+            //this prevents missing resource warnings after the message is removed from the Snackbar
+            //see https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2040
+            if (snackbar.Message != null)
+                snackbar.Message.Resources = SnackbarMessage.defaultResources;
+        }
 
         public SnackbarMessage Message
         {

--- a/MaterialDesignThemes.Wpf/SnackbarMessage.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessage.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Media;
 using MaterialDesignThemes.Wpf.Converters;
 
 namespace MaterialDesignThemes.Wpf
@@ -18,6 +19,12 @@ namespace MaterialDesignThemes.Wpf
     [TemplatePart(Name = ActionButtonPartName, Type = typeof(ButtonBase))]
     public class SnackbarMessage : ContentControl
     {
+        internal static readonly ResourceDictionary defaultResources = new ResourceDictionary
+        {
+            { "SecondaryHueMidBrush", Brushes.Transparent },
+            { "MaterialDesignSnackbarRipple", Brushes.Transparent },
+        };
+
         public const string ActionButtonPartName = "PART_ActionButton";
         private Action _templateCleanupAction = () => { };
 

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
@@ -352,6 +352,11 @@ namespace MaterialDesignThemes.Wpf
             //this for now...at least it is prevent extra call back hell
             await Task.Delay(snackbar.DeactivateStoryboardDuration);
 
+            //this prevents missing resource warnings after the message is removed from the Snackbar
+            //see https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2040
+            if (snackbar.Message != null)
+                snackbar.Message.Resources = SnackbarMessage.defaultResources;
+
             //remove message on snackbar
             snackbar.SetCurrentValue(Snackbar.MessageProperty, null);
 

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
@@ -338,7 +338,10 @@ namespace MaterialDesignThemes.Wpf
         private async Task ShowAsync(Snackbar snackbar, SnackbarMessageQueueItem messageQueueItem, ManualResetEvent actionClickWaitHandle)
         {
             //create and show the message, setting up all the handles we need to wait on
-            var mouseNotOverManagedWaitHandle = CreateAndShowMessage(snackbar, messageQueueItem, actionClickWaitHandle);
+            var tuple = CreateAndShowMessage(snackbar, messageQueueItem, actionClickWaitHandle);
+            var snackbarMessage = tuple.Item1;
+            var mouseNotOverManagedWaitHandle = tuple.Item2;
+
             var durationPassedWaitHandle = new ManualResetEvent(false);
             StartDuration(messageQueueItem.Duration.Add(snackbar.ActivateStoryboardDuration), durationPassedWaitHandle);
 
@@ -354,8 +357,7 @@ namespace MaterialDesignThemes.Wpf
 
             //this prevents missing resource warnings after the message is removed from the Snackbar
             //see https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2040
-            if (snackbar.Message != null)
-                snackbar.Message.Resources = SnackbarMessage.defaultResources;
+            snackbarMessage.Resources = SnackbarMessage.defaultResources;
 
             //remove message on snackbar
             snackbar.SetCurrentValue(Snackbar.MessageProperty, null);
@@ -364,7 +366,7 @@ namespace MaterialDesignThemes.Wpf
             durationPassedWaitHandle.Dispose();
         }
 
-        private static MouseNotOverManagedWaitHandle CreateAndShowMessage(UIElement snackbar,
+        private static Tuple<SnackbarMessage, MouseNotOverManagedWaitHandle> CreateAndShowMessage(UIElement snackbar,
             SnackbarMessageQueueItem messageQueueItem, EventWaitHandle actionClickWaitHandle)
         {
             var clickCount = 0;
@@ -381,7 +383,7 @@ namespace MaterialDesignThemes.Wpf
             };
             snackbar.SetCurrentValue(Snackbar.MessageProperty, snackbarMessage);
             snackbar.SetCurrentValue(Snackbar.IsActiveProperty, true);
-            return new MouseNotOverManagedWaitHandle(snackbar);
+            return Tuple.Create(snackbarMessage, new MouseNotOverManagedWaitHandle(snackbar));
         }
 
         private static async Task WaitForCompletionAsync(

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
@@ -352,11 +352,6 @@ namespace MaterialDesignThemes.Wpf
             //this for now...at least it is prevent extra call back hell
             await Task.Delay(snackbar.DeactivateStoryboardDuration);
 
-            //this prevents missing resource warnings after the message is removed from the Snackbar
-            //see https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2040
-            if (snackbar.Message != null)
-                snackbar.Message.Resources = SnackbarMessage.defaultResources;
-
             //remove message on snackbar
             snackbar.SetCurrentValue(Snackbar.MessageProperty, null);
 

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -351,6 +351,11 @@ namespace MaterialDesignThemes.Wpf
             //we could wait for the animation event, but just doing 
             //this for now...at least it is prevent extra call back hell
             await Task.Delay(snackbar.DeactivateStoryboardDuration);
+
+            //this prevents missing resource warnings after the message is removed from the Snackbar
+            //see https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2040
+            if (snackbar.Message != null)
+                snackbar.Message.Resources = SnackbarMessage.defaultResources;
 
             //remove message on snackbar
             snackbar.SetCurrentValue(Snackbar.MessageProperty, null);


### PR DESCRIPTION
Fixes #2040

This PR is based on the fix @bombipappoo suggested in https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2040#issuecomment-683248221.

To test that it works, try [this branch](https://github.com/bender2k14/MaterialDesignInXamlToolkit/tree/testing/2040_default_SnackbarMessage_resources), which adds an executable project in the first commit and then cherry picks the commit from the branch for this PR to create its second commit.  In this way, testing on the first commit exhibits the issue while testing on the second commit shows that the issue is fixed.

As I said in https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2040#issuecomment-687867884, I tried and failed to create an automated test for this issue.  I created this PR because I ran out of ideas for creating such an automated test.  If someone wants to suggest any more though, I will definitely look into them.