### PR TITLE
Fix blurry text in context menus

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
@@ -55,6 +55,7 @@
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}"/>
         <Setter Property="TextBlock.FontSize" Value="15"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type MenuBase}">
@@ -75,11 +76,11 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type MenuBase}">
                     <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
-                        <Border Background="{TemplateBinding Background}"
-                                Effect="{DynamicResource MaterialDesignShadowDepth1}"
-                                Margin="3"
-                                CornerRadius="2">
-                            <Border Background="Transparent">
+                        <Grid>
+                            <Border Background="{TemplateBinding Background}" Margin="3"
+                                    CornerRadius="2" Effect="{DynamicResource MaterialDesignShadowDepth1}"></Border>
+                        
+                            <Border Margin="3" Background="Transparent">
                                 <ScrollViewer x:Name="SubMenuScrollViewer" Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
                                     <Grid RenderOptions.ClearTypeHint="Enabled" Margin="0 16">
                                         <ItemsPresenter x:Name="ItemsPresenter"
@@ -90,7 +91,7 @@
                                     </Grid>
                                 </ScrollViewer>
                             </Border>
-                        </Border>
+                        </Grid>
                     </AdornerDecorator>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
When using High DPI screen with text scaling at 125% the text in context menu is blurry. The culprit is the effect that is used to have a drop shadow.

This is discussed on many places : https://stackoverflow.com/questions/805677/why-everything-in-wpf-is-blurry

- Adding `UseLayoutRounding=true`  did fix the sub menus
- For the root menus I did not find any other solution than using a trick. A grid is used with two child borders on top of each other, one is only for the drop shadow and does not affect the other border.

Before:  
![image](https://user-images.githubusercontent.com/15875066/92644312-71dc9180-f2e3-11ea-858e-c8cf146d6512.png)

After:  
![image](https://user-images.githubusercontent.com/15875066/92644252-583b4a00-f2e3-11ea-8134-a5822c6c37e3.png)


