### PR TITLE
Rename ColorHelper to ColorAssist in ColorManipulation

### DIFF
--- a/MaterialDesignColors.Wpf/ColorManipulation/ColorAssist.cs
+++ b/MaterialDesignColors.Wpf/ColorManipulation/ColorAssist.cs
@@ -3,7 +3,7 @@ using System.Windows.Media;
 
 namespace MaterialDesignColors.ColorManipulation
 {
-    public static class ColorHelper
+    public static class ColorAssist
     {
         public static Color ContrastingForegroundColor(this Color color)
         {


### PR DESCRIPTION
Hey there,
The ColorHelper class has renamed to ColorAssist in ColorManipulation folder.