### PR TITLE
Rename outlined text style to remove "TextField"

### DIFF
--- a/MainDemo.Wpf/Fields.xaml
+++ b/MainDemo.Wpf/Fields.xaml
@@ -209,11 +209,11 @@
             </smtx:XamlDisplay>
             <smtx:XamlDisplay Grid.Row="1" Grid.Column="2" Key="fields_26">
                 <StackPanel>
-                    <CheckBox x:Name="MaterialDesignOutlinedTextFieldTextBoxEnabledComboBox">Enabled</CheckBox>
-                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextFieldTextBox}"
+                    <CheckBox x:Name="MaterialDesignOutlinedTextBoxEnabledComboBox">Enabled</CheckBox>
+                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
                              VerticalAlignment="Top" Height="100" AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"
                              materialDesign:HintAssist.Hint="This is a text area"
-                             IsEnabled="{Binding Path=IsChecked, ElementName=MaterialDesignOutlinedTextFieldTextBoxEnabledComboBox}" />
+                             IsEnabled="{Binding Path=IsChecked, ElementName=MaterialDesignOutlinedTextBoxEnabledComboBox}" />
                 </StackPanel>
             </smtx:XamlDisplay>
             <smtx:XamlDisplay Grid.Row="1" Grid.Column="3" Key="fields_29">

--- a/MaterialDesignThemes.UITests/WPF/TextBox/TextBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TextBox/TextBoxTests.cs
@@ -132,7 +132,7 @@ namespace MaterialDesignThemes.UITests.WPF.TextBox
             IVisualElement grid = await LoadXaml(@"
 <Grid Background=""Red"">
     <TextBox
-        Style=""{StaticResource MaterialDesignOutlinedTextFieldTextBox}""
+        Style=""{StaticResource MaterialDesignOutlinedTextBox}""
         VerticalAlignment=""Top""
         Height=""100""
         Text=""Some content to force hint to float""

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -424,7 +424,7 @@
         <Setter Property="wpf:TextFieldAssist.UnderlineCornerRadius" Value="0" />
     </Style>
 
-    <Style x:Key="MaterialDesignOutlinedTextFieldTextBox" TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}">
+    <Style x:Key="MaterialDesignOutlinedTextBox" TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}">
         <Setter Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
         <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />
     </Style>


### PR DESCRIPTION
`MaterialDesignOutlinedTextFieldTextBox` is renamed to
`MaterialDesignOutlinedTextBox`.

Closes #2078