### PR TITLE
Removed the old SecondaryAccent resource with updated resource

### DIFF
--- a/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs
+++ b/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.cs
@@ -32,8 +32,8 @@ namespace MaterialDesignThemes.Wpf
 
             //NB: These are here for backwards compatibility, and will be removed in a future version.
             //These will be removed in version 4.0.0
-            SetSolidColorBrush(resourceDictionary, "SecondaryAccentBrush", theme.SecondaryMid.Color);
-            SetSolidColorBrush(resourceDictionary, "SecondaryAccentForegroundBrush", theme.SecondaryMid.ForegroundColor ?? theme.SecondaryMid.Color.ContrastingForegroundColor());
+            SetSolidColorBrush(resourceDictionary, "SecondaryHueMidBrush", theme.SecondaryMid.Color);
+            SetSolidColorBrush(resourceDictionary, "SecondaryHueMidForegroundBrush", theme.SecondaryMid.ForegroundColor ?? theme.SecondaryMid.Color.ContrastingForegroundColor());
 
             SetSolidColorBrush(resourceDictionary, "ValidationErrorBrush", theme.ValidationError);
             resourceDictionary["ValidationErrorColor"] = theme.ValidationError;


### PR DESCRIPTION
Creating a pull request related to #2080. While I was searching for the resource mentioned in the issue, I couldn't find `SecondaryHueMidForegroundBrushColor` and `SecondaryAccentBrushColor`. I updated and removed the rest of the old `SecondaryAccent*` resources. 

Please let me know if I missed anything.

Thank you for letting me work on this issue!