### PR TITLE
Properly set ItemContainerStyle for ListBox #922

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
@@ -330,6 +330,7 @@
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}"/>
+        <Setter Property="ItemContainerStyle" Value="{StaticResource MaterialDesignListBoxItem}" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
         <Setter Property="ScrollViewer.CanContentScroll" Value="true"/>


### PR DESCRIPTION
Fixes #922

One can check that the issue described in #922 does not exist when using `ListView` in place of `ListBox`.  I compared the default styles set by MDinXAML for [`ListBox`](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/d75bac11b6d25ad34c78e416b26727344da8c487/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml#L328) and [`ListView`](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/d75bac11b6d25ad34c78e416b26727344da8c487/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml#L228).  I concluded that the problem does not exist for `ListView` because [it sets the `ItemContainerStyle` property](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/d75bac11b6d25ad34c78e416b26727344da8c487/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml#L234) while `ListBox` does not.  That property setter uses a converter, which makes things a bit more complicated, but in the cases I tested, the converter always returned [the style with key `MaterialDesignListBoxItem`](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/d75bac11b6d25ad34c78e416b26727344da8c487/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml#L217), which is the default style set by MDinXAML for `ListBoxItem`.

This PR sets the `ItemContainerStyle` property to the style with key `MaterialDesignListBoxItem` on the default style for `ListBox`.  I verified locally that this fixes #922.

I am willing to also add a test for this if someone can provide me a bit of assistance by showing me what such a test should look like.