### PR TITLE
Fixing copy-paste typo in description of theme NuGet package

### DIFF
--- a/MaterialDesignThemes.nuspec
+++ b/MaterialDesignThemes.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit</projectUrl>
     <iconUrl>http://materialdesigninxaml.net/images/MD4XAML32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>ResourceDictionary instances containing Material Design templates and styles for WPF controls in the MahApps library.</description>
+    <description>ResourceDictionary instances containing Material Design templates and styles for WPF controls in .NET.</description>
     <releaseNotes>https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/releases</releaseNotes>
     <copyright>$copyright$</copyright>
     <tags>WPF XAML Material Design Theme Colour Color UI UX</tags>


### PR DESCRIPTION
In the files `MaterialDesignThemes.nuspec` and `MaterialDesignThemes.MahApps.nuspec`, the descriptions are the same.  In particular, they both end by saying
> ...for WPF controls in the MahApps library.

https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/e799b0cbcef70f5d9be2e502223244bdb2d58783/MaterialDesignThemes.nuspec#L13
https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/e799b0cbcef70f5d9be2e502223244bdb2d58783/MaterialDesignThemes.MahApps.nuspec#L13

Of course `MaterialDesignThemes.nuspec` is not about MahApps.  I changed that line to end this way.
> ...for WPF controls in .NET.