### PR TITLE
Changed MaterialDesignToolToggleListBoxItem MouseOverBorder Opacity to prevent confusion with checked state

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
@@ -53,7 +53,7 @@
                                 <VisualState Name="MouseOver">
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetName="MouseOverBorder" Storyboard.TargetProperty="Opacity"
-                                                         To="0.1" Duration="0"/>
+                                                         To="0.03" Duration="0"/>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState Name="Disabled"/>


### PR DESCRIPTION
Made the style more compliant with https://material.io/components/buttons#toggle-button where the hover is also less strong.

Ratio: The current style causes confusion between hovered and checked state. This is especially confusing in touch base applications, where the mouse is kept on the last touched position. When you deselect the button using touch it still looks checked.