### PR TITLE
Fixing BrushOpacityConverter to always parse consistently

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/Converters/BrushOpacityConverterTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/Converters/BrushOpacityConverterTests.cs
@@ -1,0 +1,23 @@
+﻿using System.Globalization;
+using System.Windows.Media;
+using MaterialDesignThemes.Wpf.Converters;
+using Xunit;
+
+namespace MaterialDesignThemes.Wpf.Tests.Converters
+{
+    public class BrushOpacityConverterTests
+    {
+        [Theory]
+        [InlineData("0.16", 0.16)]
+        public void AllCultureParseParameterCorrectly(object parameter, double expectedOpacity)
+        {
+            var converter = new BrushOpacityConverter();
+            foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures))
+            {
+                var inputBrush = new SolidColorBrush { Color = Colors.Red };
+                var brush = (SolidColorBrush)converter.Convert(inputBrush, typeof(Brush), parameter, culture);
+                Assert.Equal(expectedOpacity, brush.Opacity);
+            }
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/Converters/BrushOpacityConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/BrushOpacityConverter.cs
@@ -11,7 +11,7 @@ namespace MaterialDesignThemes.Wpf.Converters
         {
             if (value is SolidColorBrush brush)
             {
-                var opacity = System.Convert.ToDouble(parameter, culture);
+                var opacity = System.Convert.ToDouble(parameter, CultureInfo.InvariantCulture);
                 return new SolidColorBrush(brush.Color)
                 {
                     Opacity = opacity


### PR DESCRIPTION
Fixes #2159 