### PR TITLE
Add HintAssist.HelperTextFontSize (#2170)

### DIFF
--- a/MainDemo.Wpf/Fields.xaml
+++ b/MainDemo.Wpf/Fields.xaml
@@ -12,30 +12,30 @@
     d:DesignHeight="300"
     d:DesignWidth="600"
     d:DataContext="{d:DesignInstance domain:FieldsViewModel, IsDesignTimeCreatable=False}">
-    
+
     <UserControl.Resources>
         <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignTextBox}">
             <Setter Property="Margin" Value="0,8"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
         </Style>
-        
+
         <Style TargetType="{x:Type PasswordBox}" BasedOn="{StaticResource MaterialDesignPasswordBox}">
             <Setter Property="Margin" Value="0,8"/>
         </Style>
-        
+
         <Style TargetType="{x:Type Viewbox}">
             <Setter Property="Width" Value="18"/>
             <Setter Property="Height" Value="18"/>
             <Setter Property="Margin" Value="0 0 8 0"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
         </Style>
-        
+
         <Style TargetType="{x:Type materialDesign:PackIcon}" BasedOn="{StaticResource {x:Type materialDesign:PackIcon}}">
             <Setter Property="VerticalAlignment" Value="Center"/>
             <Setter Property="Margin" Value="4 0 4 0"/>
         </Style>
     </UserControl.Resources>
-    
+
     <StackPanel Margin="16 0 16 16">
         <Grid VerticalAlignment="Top">
             <Grid.ColumnDefinitions>
@@ -45,14 +45,14 @@
                 <ColumnDefinition Width="155"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            
+
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <TextBlock
@@ -61,13 +61,13 @@
                 Grid.ColumnSpan="2"
                 Style="{StaticResource MaterialDesignHeadline5TextBlock}"
                 Text="Common Fields"/>
-            
+
             <materialDesign:PackIcon
                 Grid.Row="1"
                 Grid.Column="0"
                 Kind="Account"
                 Foreground="{Binding ElementName=NameTextBox, Path=BorderBrush}"/>
-            
+
             <smtx:XamlDisplay
                 UniqueKey="fields_1"
                 Grid.Column="1"
@@ -86,13 +86,13 @@
                     </TextBox.Text>
                 </TextBox>
             </smtx:XamlDisplay>
-            
+
             <materialDesign:PackIcon
                 Grid.Row="2"
                 Grid.Column="0"
                 Kind="Phone"
                 Foreground="{Binding ElementName=PhoneTextBox, Path=BorderBrush}"/>
-            
+
             <smtx:XamlDisplay
                 UniqueKey="fields_4"
                 Grid.Row="2"
@@ -101,13 +101,13 @@
                     x:Name="PhoneTextBox"
                     materialDesign:TransitionAssist.DisableTransitions="True"/>
             </smtx:XamlDisplay>
-            
+
             <materialDesign:PackIcon
                 Grid.Row="3"
                 Grid.Column="0"
                 Kind="Comment"
                 Foreground="{Binding ElementName=CommentTextBox, Path=BorderBrush}"/>
-            
+
             <smtx:XamlDisplay
                 UniqueKey="fields_6"
                 Grid.Row="3"
@@ -115,9 +115,10 @@
                 <TextBox
                     x:Name="CommentTextBox"
                     materialDesign:HintAssist.Hint="Comment"
-                    materialDesign:HintAssist.HelperText="Insert your comment here"/>
+                    materialDesign:HintAssist.HelperText="Bigger Helper Text"
+                    materialDesign:HintAssist.HelperTextFontSize="16"/>
             </smtx:XamlDisplay>
-            
+
             <smtx:XamlDisplay
                 UniqueKey="fields_8"
                 Grid.Row="4"
@@ -134,7 +135,7 @@
                 Kind="Key"
                 Foreground="{Binding ElementName=PasswordBox, Path=BorderBrush}"
                 HorizontalAlignment="Right"/>
-            
+
             <smtx:XamlDisplay
                 UniqueKey="fields_7"
                 Grid.Row="1"
@@ -145,14 +146,14 @@
                     materialDesign:TextFieldAssist.HasClearButton="True"
                     materialDesign:HintAssist.HelperText="At least 8 characters"/>
             </smtx:XamlDisplay>
-            
+
             <materialDesign:PackIcon
                 Grid.Row="2"
                 Grid.Column="2"
                 Kind="Key"
                 Margin="0 12 0 0"
                 Foreground="{Binding ElementName=FloatingPasswordBox, Path=BorderBrush}"/>
-            
+
             <smtx:XamlDisplay
                 UniqueKey="fields_18"
                 Grid.Row="2"
@@ -165,7 +166,7 @@
                     materialDesign:TextFieldAssist.UnderlineBrush="Green"
                     Style="{StaticResource MaterialDesignFloatingHintPasswordBox}"/>
             </smtx:XamlDisplay>
-            
+
             <smtx:XamlDisplay
                 UniqueKey="fields_19"
                 Grid.Row="3"
@@ -179,7 +180,7 @@
                     Style="{StaticResource MaterialDesignFloatingHintTextBox}"
                     FontSize="24"/>
             </smtx:XamlDisplay>
-            
+
             <smtx:XamlDisplay
                 UniqueKey="fields_13"
                 Grid.Row="4"
@@ -189,7 +190,7 @@
                     IsEnabled="False"
                     MinWidth="72"/>
             </smtx:XamlDisplay>
-            
+
             <smtx:XamlDisplay
                 UniqueKey="fields_15"
                 Grid.Row="5"
@@ -206,7 +207,7 @@
                 Style="{StaticResource MaterialDesignHeadline5TextBlock}"
                 Margin="32 0 0 0"
                 Text="Multi-line"/>
-            
+
             <smtx:XamlDisplay
                 UniqueKey="fields_3"
                 Grid.Row="1"
@@ -224,7 +225,7 @@
                     Height="80"
                     Text="Multiline. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. The quick brown fox jumps over the lazy dog. War and peace. Keep going. Go on. For how long? Not long. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."/>
             </smtx:XamlDisplay>
-            
+
             <smtx:XamlDisplay
                 UniqueKey="fields_32"
                 Grid.Row="3"
@@ -236,12 +237,12 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition/>
                     </Grid.RowDefinitions>
-                    
+
                     <CheckBox
                         Content="Rich Text Box: IsReadOnly"
                         IsChecked="True"
                         x:Name="RichTextBoxIsReadOnlyCheckBox"/>
-                    
+
                     <RichTextBox
                         MinWidth="280" AcceptsReturn="True" IsDocumentEnabled="True"
                         IsReadOnly="{Binding IsChecked, ElementName=RichTextBoxIsReadOnlyCheckBox}"
@@ -296,21 +297,21 @@
                 <RowDefinition/>
                 <RowDefinition/>
             </Grid.RowDefinitions>
-            
+
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            
+
             <Grid.Resources>
                 <Style TargetType="{x:Type smtx:XamlDisplay}" BasedOn="{StaticResource {x:Type smtx:XamlDisplay}}">
                     <Setter Property="Width" Value="200"/>
                     <Setter Property="VerticalAlignment" Value="Top"/>
                     <Setter Property="Margin" Value="0 0 16 0"/>
                 </Style>
-                
+
                 <Style TargetType="CheckBox" BasedOn="{StaticResource {x:Type CheckBox}}">
                     <Setter Property="Margin" Value="0 8"/>
                     <Setter Property="IsChecked" Value="True"/>
@@ -321,14 +322,14 @@
                 Grid.ColumnSpan="2"
                 Style="{StaticResource MaterialDesignHeadline5TextBlock}"
                 Text="Filled fields"/>
-            
+
             <TextBlock
                 Grid.Column="2"
                 Grid.Row="0"
                 Grid.ColumnSpan="2"
                 Style="{StaticResource MaterialDesignHeadline5TextBlock}"
                 Text="Outlined fields"/>
-            
+
             <smtx:XamlDisplay
                 Grid.Row="1"
                 Grid.Column="0"
@@ -337,7 +338,7 @@
                     <CheckBox
                         x:Name="MaterialDesignFilledTextBoxEnabledComboBox"
                         Content="Enabled"/>
-                    
+
                     <TextBox
                         Style="{StaticResource MaterialDesignFilledTextBox}"
                         VerticalAlignment="Top"
@@ -348,7 +349,7 @@
                         IsEnabled="{Binding Path=IsChecked, ElementName=MaterialDesignFilledTextBoxEnabledComboBox}"/>
                 </StackPanel>
             </smtx:XamlDisplay>
-   
+
             <smtx:XamlDisplay
                 Grid.Row="1"
                 Grid.Column="1"
@@ -357,7 +358,7 @@
                     <CheckBox
                         x:Name="MaterialDesignFilledPasswordFieldPasswordBoxEnabledComboBox"
                         Content="Enabled"/>
-                    
+
                     <PasswordBox
                         Style="{StaticResource MaterialDesignFilledPasswordBox}"
                         VerticalAlignment="Top"
@@ -365,7 +366,7 @@
                         materialDesign:HintAssist.Hint="Password"/>
                 </StackPanel>
             </smtx:XamlDisplay>
-   
+
             <smtx:XamlDisplay
                 Grid.Row="1"
                 Grid.Column="2"
@@ -375,7 +376,7 @@
                     <CheckBox
                         x:Name="MaterialDesignOutlinedTextBoxEnabledComboBox"
                         Content="Enabled"/>
-                    
+
                     <TextBox
                         Style="{StaticResource MaterialDesignOutlinedTextBox}"
                         VerticalAlignment="Top"
@@ -386,7 +387,7 @@
                         materialDesign:HintAssist.Hint="This is a text area"
                         IsEnabled="{Binding Path=IsChecked, ElementName=MaterialDesignOutlinedTextBoxEnabledComboBox}"/>
                 </StackPanel>
-            </smtx:XamlDisplay>    
+            </smtx:XamlDisplay>
             <smtx:XamlDisplay
                 Grid.Row="1"
                 Grid.Column="3"
@@ -395,7 +396,7 @@
                     <CheckBox
                         x:Name="MaterialDesignOutlinedPasswordFieldPasswordBoxEnabledComboBox"
                         Content="Enabled"/>
-                    
+
                     <PasswordBox
                         Style="{StaticResource MaterialDesignOutlinedPasswordBox}"
                         VerticalAlignment="Top"
@@ -414,7 +415,7 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            
+
             <Grid.RowDefinitions>
                 <RowDefinition/>
                 <RowDefinition/>
@@ -422,7 +423,7 @@
             <TextBlock
                 Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
                 Text="DataTemplate"/>
-            
+
             <smtx:XamlDisplay
                 UniqueKey="fields_20"
                 Grid.Row="1"
@@ -436,13 +437,13 @@
                                     Text="{Binding Name}"
                                     Margin="0 0 0 0"
                                     VerticalAlignment="Bottom"/>
-                                
+
                                 <TextBox
                                     materialDesign:HintAssist.Hint="Content"
                                     Text="{Binding Content}"
                                     Margin="8 0 0 0"
                                     VerticalAlignment="Bottom"/>
-                                
+
                                 <TextBox
                                     Style="{StaticResource MaterialDesignFloatingHintTextBox}"
                                     materialDesign:HintAssist.Hint="Name"
@@ -466,7 +467,7 @@
                 Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
                 Margin="32 0 0 0"
                 Text="DataTemplateSelector"/>
-            
+
             <smtx:XamlDisplay
                 Grid.Row="1"
                 Grid.Column="1"
@@ -484,20 +485,20 @@
                                             Text="{Binding Name}"
                                             Margin="0 0 0 0"
                                             VerticalAlignment="Bottom"/>
-                                        
+
                                         <TextBox
                                             materialDesign:HintAssist.Hint="Content"
                                             Text="{Binding Content}"
                                             Margin="8 0 0 0"
                                             VerticalAlignment="Bottom"/>
-                                        
+
                                         <TextBox
                                             Style="{StaticResource MaterialDesignFloatingHintTextBox}"
                                             materialDesign:HintAssist.Hint="Name"
                                             Text="{Binding Name}"
                                             Margin="8 0 0 0"
                                             VerticalAlignment="Bottom"/>
-                                        
+
                                         <TextBox
                                             Style="{StaticResource MaterialDesignFloatingHintTextBox}"
                                             materialDesign:HintAssist.Hint="Content"
@@ -517,7 +518,7 @@
                 Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
                 Margin="32 0 0 0"
                 Text="Validation"/>
-            
+
             <StackPanel
                 Orientation="Horizontal"
                 Grid.Row="1"
@@ -539,7 +540,7 @@
                             </Binding>
                         </TextBox.Text>
                     </TextBox>
-                </smtx:XamlDisplay>               
+                </smtx:XamlDisplay>
                 <smtx:XamlDisplay
                     UniqueKey="fields_validation_2"
                     Width="120">
@@ -557,7 +558,7 @@
                             </Binding>
                         </TextBox.Text>
                     </TextBox>
-                </smtx:XamlDisplay>    
+                </smtx:XamlDisplay>
                 <smtx:XamlDisplay
                     UniqueKey="fields_validation_3"
                     Width="120">

--- a/MaterialDesignThemes.UITests/MaterialDesignThemes.UITests.csproj
+++ b/MaterialDesignThemes.UITests/MaterialDesignThemes.UITests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="XAMLTest" />
-    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/MaterialDesignThemes.UITests/WPF/ComboBox/ComboBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/ComboBox/ComboBoxTests.cs
@@ -1,0 +1,58 @@
+﻿using System.ComponentModel;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using XamlTest;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MaterialDesignThemes.UITests.WPF.ComboBox
+{
+    public class ComboBoxTests : TestBase
+    {
+        public ComboBoxTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact]
+        [Description("Pull Request 2192")]
+        public async Task OnComboBoxHelperTextFontSize_ChangesHelperTextFontSize()
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <ComboBox
+        materialDesign:HintAssist.HelperTextFontSize=""20""/>
+</StackPanel>");
+            var comboBox = await stackPanel.GetElement("/ComboBox");
+            IVisualElement helpTextBlock = await comboBox.GetElement("/Grid/Canvas/TextBlock");
+
+            double fontSize = await helpTextBlock.GetProperty<double>(TextBlock.FontSizeProperty.Name);
+
+            Assert.Equal(20, fontSize);
+            recorder.Success();
+        }
+
+        [Fact]
+        [Description("Pull Request 2192")]
+        public async Task OnFilledComboBoxHelperTextFontSize_ChangesHelperTextFontSize()
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <ComboBox
+        Style=""{StaticResource MaterialDesignFilledComboBox}""
+        materialDesign:HintAssist.HelperTextFontSize=""20""/>
+</StackPanel>");
+            var comboBox = await stackPanel.GetElement("/ComboBox");
+            IVisualElement helpTextBlock = await comboBox.GetElement("/Grid/Canvas/TextBlock");
+
+            double fontSize = await helpTextBlock.GetProperty<double>(TextBlock.FontSizeProperty.Name);
+
+            Assert.Equal(20, fontSize);
+            recorder.Success();
+        }
+    }
+}

--- a/MaterialDesignThemes.UITests/WPF/DatePicker/DatePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DatePicker/DatePickerTests.cs
@@ -1,0 +1,37 @@
+﻿using System.ComponentModel;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using XamlTest;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MaterialDesignThemes.UITests.WPF.DatePicker
+{
+    public class DatePickerTests : TestBase
+    {
+        public DatePickerTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact]
+        [Description("Pull Request 2192")]
+        public async Task OnDatePickerHelperTextFontSize_ChangesHelperTextFontSize()
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <DatePicker materialDesign:HintAssist.HelperTextFontSize=""20""/>
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/DatePicker");
+            IVisualElement datePickerTextBox = await timePicker.GetElement("PART_TextBox");
+            IVisualElement helpTextBlock = await datePickerTextBox.GetElement("/Grid/Canvas/TextBlock");
+
+            double fontSize = await helpTextBlock.GetProperty<double>(TextBlock.FontSizeProperty.Name);
+
+            Assert.Equal(20, fontSize);
+            recorder.Success();
+        }
+    }
+}

--- a/MaterialDesignThemes.UITests/WPF/PasswordBox/PasswordBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/PasswordBox/PasswordBoxTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.ComponentModel;
+using System.Threading.Tasks;
+using System.Windows.Controls;
 using XamlTest;
 using Xunit;
 using Xunit.Abstractions;
@@ -28,12 +30,31 @@ namespace MaterialDesignThemes.UITests.WPF.PasswordBox
             var initialRect = await passwordBox.GetCoordinates();
 
             //Act
-            await passwordBox.SetProperty<string>(nameof(Controls.PasswordBox.Password), "x");
+            await passwordBox.SetProperty(nameof(Controls.PasswordBox.Password), "x");
 
             //Assert
             var rect = await passwordBox.GetCoordinates();
             Assert.Equal(initialRect, rect);
 
+            recorder.Success();
+        }
+
+        [Fact]
+        [Description("Pull Request 2192")]
+        public async Task OnPasswordBoxHelperTextFontSize_ChangesHelperTextFontSize()
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <PasswordBox materialDesign:HintAssist.HelperTextFontSize=""20""/>
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/PasswordBox");
+            IVisualElement helpTextBlock = await timePicker.GetElement("/Grid/Canvas/TextBlock");
+
+            double fontSize = await helpTextBlock.GetProperty<double>(TextBlock.FontSizeProperty.Name);
+
+            Assert.Equal(20, fontSize);
             recorder.Success();
         }
     }

--- a/MaterialDesignThemes.UITests/WPF/TextBox/TextBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TextBox/TextBoxTests.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Media;
 using XamlTest;
 using Xunit;
@@ -50,7 +51,6 @@ namespace MaterialDesignThemes.UITests.WPF.TextBox
 
             recorder.Success();
         }
-
 
         [Fact]
         [Description("Issue 1883")]
@@ -148,6 +148,28 @@ namespace MaterialDesignThemes.UITests.WPF.TextBox
             Color background = await hintBackground.GetEffectiveBackground(textFieldGrid);
 
             Assert.Equal(255, background.A);
+            recorder.Success();
+        }
+
+        [Fact]
+        [Description("Pull Request 2192")]
+        public async Task OnTextBoxHelperTextFontSize_ChangesHelperTextFontSize()
+        {
+            await using var recorder = new TestRecorder(App);
+
+            IVisualElement grid = await LoadXaml(@"
+<Grid Margin=""30"">
+    <TextBox VerticalAlignment=""Top""
+             Text=""Some Text""
+             materialDesign:HintAssist.HelperTextFontSize=""20"">
+    </TextBox>
+</Grid>");
+            IVisualElement textBox = await grid.GetElement("/TextBox");
+            IVisualElement helpTextBlock = await textBox.GetElement("/Grid/Canvas/TextBlock");
+            
+            double fontSize = await helpTextBlock.GetProperty<double>(TextBlock.FontSizeProperty.Name);
+
+            Assert.Equal(20, fontSize);
             recorder.Success();
         }
     }

--- a/MaterialDesignThemes.UITests/WPF/TimePicker/TimePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TimePicker/TimePickerTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
+using System.Windows.Controls;
 using System.Windows.Input;
 using XamlTest;
 using Xunit;
@@ -319,6 +321,26 @@ namespace MaterialDesignThemes.UITests.WPF.TimePicker
             var actual = await timePickerTextBox.GetText();
             Assert.Equal("1:02 AM", actual);
 
+            recorder.Success();
+        }
+
+        [Fact]
+        [Description("Pull Request 2192")]
+        public async Task OnTimePickerHelperTextFontSize_ChangesHelperTextFontSize()
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml(@"
+<StackPanel>
+    <materialDesign:TimePicker
+        materialDesign:HintAssist.HelperTextFontSize=""20""/>
+</StackPanel>");
+            var timePicker = await stackPanel.GetElement("/TimePicker");
+            IVisualElement helpTextBlock = await timePicker.GetElement("/Grid/Canvas/TextBlock");
+
+            double fontSize = await helpTextBlock.GetProperty<double>(TextBlock.FontSizeProperty.Name);
+
+            Assert.Equal(20, fontSize);
             recorder.Success();
         }
     }

--- a/MaterialDesignThemes.Wpf/HintAssist.cs
+++ b/MaterialDesignThemes.Wpf/HintAssist.cs
@@ -9,6 +9,7 @@ namespace MaterialDesignThemes.Wpf
         private const double DefaultHintOpacity = 0.56;
         private static readonly Point DefaultFloatingOffset = new Point(0, -16);
         private static readonly Brush DefaultBackground = new SolidColorBrush(Colors.Transparent);
+        private static readonly double DefaultHelperTextFontSize = 10;
 
         #region AttachedProperty : IsFloatingProperty
         public static readonly DependencyProperty IsFloatingProperty
@@ -57,7 +58,7 @@ namespace MaterialDesignThemes.Wpf
 
         #region AttachedProperty : HintOpacityProperty
         public static readonly DependencyProperty HintOpacityProperty
-            = DependencyProperty.RegisterAttached("HintOpacity", typeof(double), typeof(HintAssist), 
+            = DependencyProperty.RegisterAttached("HintOpacity", typeof(double), typeof(HintAssist),
                 new PropertyMetadata(DefaultHintOpacity));
 
         public static double GetHintOpacityProperty(DependencyObject element)
@@ -90,7 +91,7 @@ namespace MaterialDesignThemes.Wpf
         #region AttachedProperty : BackgroundProperty
         public static readonly DependencyProperty BackgroundProperty
             = DependencyProperty.RegisterAttached("Background", typeof(Brush), typeof(HintAssist), new PropertyMetadata(DefaultBackground));
-        
+
         public static Brush GetBackground(DependencyObject element)
             => (Brush)element.GetValue(BackgroundProperty);
         public static void SetBackground(DependencyObject element, Brush value)
@@ -106,6 +107,18 @@ namespace MaterialDesignThemes.Wpf
              => element.GetValue(HelperTextProperty);
         public static void SetHelperText(DependencyObject element, object value)
             => element.SetValue(HelperTextProperty, value);
+        #endregion
+
+        #region AttachedProperty : HelperTextFontSizeProperty
+        public static readonly DependencyProperty HelperTextFontSizeProperty
+            = DependencyProperty.RegisterAttached("HelperTextFontSize", typeof(double), typeof(HintAssist),
+                new FrameworkPropertyMetadata(DefaultHelperTextFontSize, FrameworkPropertyMetadataOptions.Inherits));
+
+        public static double GetHelperTextFontSize(DependencyObject element) =>
+            (double)element.GetValue(HelperTextFontSizeProperty);
+        public static void SetHelperTextFontSize(DependencyObject element, double value) =>
+            element.SetValue(HelperTextFontSizeProperty, value);
+
         #endregion
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -170,7 +170,7 @@
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <Border Grid.Row="0" 
+                <Border Grid.Row="0"
                         Height="{StaticResource PopupTopBottomMargin}"
                         Background="{Binding ElementName=PART_Popup, Path=Background}" />
                 <ContentPresenter Grid.Row="1"/>
@@ -291,7 +291,7 @@
                                                    Converter={StaticResource BrushRoundConverter}}"
                         Focusable="False"
                         Padding="{TemplateBinding Padding}"
-                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
+                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                         RecognizesAccessKey="False" />
         </Grid>
         <ControlTemplate.Triggers>
@@ -515,7 +515,7 @@
             <Canvas VerticalAlignment="Bottom">
                 <TextBlock
                     Canvas.Top="2"
-                    FontSize="10"
+                    FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                     MaxWidth="{Binding ActualWidth, ElementName=toggleButton}"
                     Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                     Text="{TemplateBinding wpf:HintAssist.HelperText}" />
@@ -866,7 +866,7 @@
             <Canvas VerticalAlignment="Bottom">
                 <TextBlock
                     Canvas.Top="2"
-                    FontSize="10"
+                    FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                     MaxWidth="{Binding ActualWidth, ElementName=toggleButton}"
                     Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                     Text="{TemplateBinding wpf:HintAssist.HelperText}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -216,7 +216,7 @@
                         <Canvas VerticalAlignment="Bottom">
                             <TextBlock
                                 Canvas.Top="2"
-                                FontSize="10"
+                                FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                                 MaxWidth="{Binding ActualWidth, ElementName=border}"
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                 Text="{TemplateBinding wpf:HintAssist.HelperText}" />
@@ -296,7 +296,7 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="HintWrapper" Property="Opacity" Value="1" />
                         </MultiTrigger>
-                        
+
                         <!-- IsEnabled -->
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -344,7 +344,7 @@
                                 </Setter.Value>
                             </Setter>
                         </MultiTrigger>
-                        
+
                         <!-- IsKeyboardFocused -->
                         <Trigger Property="IsKeyboardFocused" Value="True">
                             <Setter TargetName="Underline" Property="IsActive" Value="True"/>
@@ -365,7 +365,7 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="borderUnderline" Property="Height" Value="2" />
                         </MultiTrigger>
-                        
+
                         <!-- IsMouseOver -->
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -398,7 +398,7 @@
                             <Setter TargetName="border" Property="Margin" Value="-1" />
                             <Setter Property="BorderThickness" Value="2" />
                         </MultiTrigger>
-                        
+
                         <!-- Validation.HasError -->
                         <Trigger Property="Validation.HasError" Value="true">
                             <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignValidationErrorBrush}"/>
@@ -486,6 +486,7 @@
                             wpf:HintAssist.HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                             wpf:HintAssist.Foreground="{TemplateBinding wpf:HintAssist.Foreground}"
                             wpf:HintAssist.HelperText="{TemplateBinding wpf:HintAssist.HelperText}"
+                            wpf:HintAssist.HelperTextFontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                             wpf:TextFieldAssist.TextBoxViewMargin="{TemplateBinding wpf:TextFieldAssist.TextBoxViewMargin}"
                             wpf:TextFieldAssist.DecorationVisibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}"
                             wpf:TextFieldAssist.HasFilledTextField="{TemplateBinding wpf:TextFieldAssist.HasFilledTextField}"
@@ -591,7 +592,7 @@
                                 </Setter.Value>
                             </Setter>
                         </Trigger>
-                        
+
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="IsMouseOver" Value="True" />
@@ -599,7 +600,7 @@
                             </MultiTrigger.Conditions>
                             <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxHoverBackground}" />
                         </MultiTrigger>
-                        
+
                         <Trigger Property="Validation.HasError" Value="True">
                             <Setter TargetName="PART_TextBox" Property="wpf:ValidationAssist.HasError" Value="True" />
                             <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignValidationErrorBrush}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -185,7 +185,7 @@
                         <Canvas VerticalAlignment="Bottom">
                             <TextBlock
                                 Canvas.Top="2"
-                                FontSize="10"
+                                FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                                 MaxWidth="{Binding ActualWidth, ElementName=border}"
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                 Text="{TemplateBinding wpf:HintAssist.HelperText}" />
@@ -267,7 +267,7 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="HintWrapper" Property="Opacity" Value="1" />
                         </MultiTrigger>
-                        
+
                         <!-- IsEnabled -->
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -315,7 +315,7 @@
                                 </Setter.Value>
                             </Setter>
                         </MultiTrigger>
-                        
+
                         <!-- IsKeyboardFocused -->
                         <Trigger Property="IsKeyboardFocused" Value="True">
                             <Setter TargetName="Underline" Property="IsActive" Value="True" />
@@ -336,7 +336,7 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="borderUnderline" Property="Height" Value="2" />
                         </MultiTrigger>
-                        
+
                         <!-- IsMouseOver -->
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -373,7 +373,7 @@
                             <Setter TargetName="border" Property="Margin" Value="-1" />
                             <Setter Property="BorderThickness" Value="2" />
                         </MultiTrigger>
-                        
+
                         <!-- Validation.HasError -->
                         <Trigger Property="Validation.HasError" Value="true">
                             <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignValidationErrorBrush}"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -186,7 +186,7 @@
                         <Canvas VerticalAlignment="Bottom">
                             <TextBlock
                                 Canvas.Top="2"
-                                FontSize="10"
+                                FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                                 MaxWidth="{Binding ActualWidth, ElementName=border}"
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                 Text="{TemplateBinding wpf:HintAssist.HelperText}" />
@@ -268,7 +268,7 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="HintWrapper" Property="Opacity" Value="1" />
                         </MultiTrigger>
-                        
+
                         <!-- IsEnabled -->
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -316,7 +316,7 @@
                                 </Setter.Value>
                             </Setter>
                         </MultiTrigger>
-                        
+
                         <!-- IsKeyboardFocused -->
                         <Trigger Property="IsKeyboardFocused" Value="True">
                             <Setter TargetName="Underline" Property="IsActive" Value="True" />
@@ -337,7 +337,7 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="borderUnderline" Property="Height" Value="2" />
                         </MultiTrigger>
-                        
+
                         <!-- IsMouseOver -->
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -374,7 +374,7 @@
                             <Setter TargetName="border" Property="Margin" Value="-1" />
                             <Setter Property="BorderThickness" Value="2" />
                         </MultiTrigger>
-                        
+
                         <!-- Validation.HasError -->
                         <Trigger Property="Validation.HasError" Value="true">
                             <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignValidationErrorBrush}"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Menu.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
+
     <converters:TextFieldHintVisibilityConverter x:Key="TextFieldHintVisibilityConverter" />
     <converters:MathConverter Operation="Divide" x:Key="DivisionMathConverter" />
     <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearTextConverter" />
@@ -15,7 +15,7 @@
     <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
     <converters:FloatingHintOffsetCalculationConverter x:Key="FloatingHintOffsetCalculationConverter" />
     <converters:PickerInnerPaddingConverter x:Key="PickerInnerPaddingConverter" />
-    
+
     <Style x:Key="MaterialDesignTimePickerTextBox" TargetType="{x:Type wpf:TimePickerTextBox}">
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
         <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextBoxBorder}" />
@@ -213,7 +213,7 @@
                         <Canvas VerticalAlignment="Bottom">
                             <TextBlock
                                 Canvas.Top="2"
-                                FontSize="10"
+                                FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                                 MaxWidth="{Binding ActualWidth, ElementName=border}"
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                 Text="{TemplateBinding wpf:HintAssist.HelperText}" />
@@ -293,7 +293,7 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="HintWrapper" Property="Opacity" Value="1" />
                         </MultiTrigger>
-                        
+
                         <!-- IsEnabled -->
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -341,7 +341,7 @@
                                 </Setter.Value>
                             </Setter>
                         </MultiTrigger>
-                        
+
                         <!-- IsKeyboardFocused -->
                         <Trigger Property="IsKeyboardFocused" Value="True">
                             <Setter TargetName="Underline" Property="IsActive" Value="True"/>
@@ -362,7 +362,7 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="borderUnderline" Property="Height" Value="2" />
                         </MultiTrigger>
-                        
+
                         <!-- IsMouseOver -->
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -395,7 +395,7 @@
                             <Setter TargetName="border" Property="Margin" Value="-1" />
                             <Setter Property="BorderThickness" Value="2" />
                         </MultiTrigger>
-                        
+
                         <!-- Validation.HasError -->
                         <Trigger Property="Validation.HasError" Value="true">
                             <Setter Property="BorderBrush" Value="{DynamicResource ValidationErrorBrush}"/>
@@ -478,6 +478,7 @@
                             wpf:HintAssist.HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                             wpf:HintAssist.Foreground="{TemplateBinding wpf:HintAssist.Foreground}"
                             wpf:HintAssist.HelperText="{TemplateBinding wpf:HintAssist.HelperText}"
+                            wpf:HintAssist.HelperTextFontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                             wpf:TextFieldAssist.TextBoxViewMargin="{TemplateBinding wpf:TextFieldAssist.TextBoxViewMargin}"
                             wpf:TextFieldAssist.DecorationVisibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}"
                             wpf:TextFieldAssist.HasFilledTextField="{TemplateBinding wpf:TextFieldAssist.HasFilledTextField}"
@@ -573,7 +574,7 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="PART_TextBox" Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
                         </MultiTrigger>
-                        
+
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="IsMouseOver" Value="True" />
@@ -581,7 +582,7 @@
                             </MultiTrigger.Conditions>
                             <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxHoverBackground}" />
                         </MultiTrigger>
-                        
+
                         <Trigger Property="Validation.HasError" Value="True">
                             <Setter TargetName="PART_TextBox" Property="wpf:ValidationAssist.HasError" Value="True" />
                             <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignValidationErrorBrush}"/>
@@ -595,7 +596,7 @@
     <Style x:Key="MaterialDesignFloatingHintTimePicker" TargetType="{x:Type wpf:TimePicker}" BasedOn="{StaticResource MaterialDesignTimePicker}">
         <Setter Property="wpf:HintAssist.IsFloating" Value="True"/>
     </Style>
-    
+
     <Style x:Key="MaterialDesignFilledTimePicker" TargetType="{x:Type wpf:TimePicker}" BasedOn="{StaticResource MaterialDesignFloatingHintTimePicker}">
         <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
         <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />


### PR DESCRIPTION
I've added the attached property `HintAssist.HelperTextFontSize` and its default value `DefaultHelperTextFontSize`.
Then I proceeded to update the styles where `HintAssist.HelperText` was used.

Lastly I've edited a TextBox inside page `Fileds.xaml` in the demo to demonstrate its use.