### PR TITLE
Demo cleanup

### DIFF
--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -51,7 +51,7 @@
         <StackPanel Grid.Row="1">
             <StackPanel
                 Orientation="Horizontal"
-                Margin="0 24 0 0">
+                Margin="0 16 0 0">
                 
                 <StackPanel.Resources>
                     <system:Double x:Key="IconSize">24</system:Double>
@@ -374,10 +374,10 @@
             </StackPanel>
         </StackPanel>
         
-        <Border
+        <Rectangle
             Margin="0 24 0 0"
-            BorderThickness="0 1 0 0"
-            BorderBrush="{DynamicResource MaterialDesignDivider}"
+            Height="1"
+            Fill="{DynamicResource MaterialDesignDivider}"
             Grid.Row="2" />
 
         <TextBlock
@@ -443,11 +443,12 @@
                 </Grid>
             </smtx:XamlDisplay>            
         </StackPanel>
-        
-        <Border
+
+        <Rectangle
             Margin="0 24 0 0"
-            BorderThickness="0 1 0 0"
-            BorderBrush="{DynamicResource MaterialDesignDivider}" Grid.Row="5" />
+            Height="1"
+            Fill="{DynamicResource MaterialDesignDivider}"
+            Grid.Row="5" />
 
         <TextBlock
             Style="{StaticResource MaterialDesignHeadline5TextBlock}"
@@ -583,11 +584,11 @@
                 </smtx:XamlDisplay>
             </StackPanel>
         </StackPanel>
-        
-        <Border
+
+        <Rectangle
             Margin="0 24 0 0"
-            BorderThickness="0 1 0 0"
-            BorderBrush="{DynamicResource MaterialDesignDivider}"
+            Height="1"
+            Fill="{DynamicResource MaterialDesignDivider}"
             Grid.Row="8" />
 
         <TextBlock

--- a/MainDemo.Wpf/Cards.xaml
+++ b/MainDemo.Wpf/Cards.xaml
@@ -23,7 +23,7 @@
     <WrapPanel Margin="0 0 8 8">
         <smtx:XamlDisplay
             UniqueKey="cards_1"
-            Margin="4 4 0 0"
+            Margin="4 4 0 16"
             VerticalContentAlignment="Top">
             <materialDesign:Card Width="200">
                 <Grid>
@@ -85,7 +85,7 @@
 
         <smtx:XamlDisplay
             UniqueKey="cards_2"
-            Margin="4 4 0 0"
+            Margin="4 4 0 16"
             VerticalContentAlignment="Top">
             <materialDesign:Card Width="220">
                 <Grid>
@@ -192,7 +192,7 @@
         <StackPanel>
             <smtx:XamlDisplay
                 UniqueKey="cards_3"
-                Margin="4 4 0 0"
+                Margin="4 4 0 16"
                 VerticalContentAlignment="Top">
                 <materialDesign:Card Background="#03a9f4"
                       Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}"
@@ -248,7 +248,7 @@
             
             <smtx:XamlDisplay
                 UniqueKey="cards_4"
-                Margin="4 4 0 0"
+                Margin="4 4 0 16"
                 VerticalContentAlignment="Top">
                 <materialDesign:Card Background="{DynamicResource PrimaryHueLightBrush}"
                       Foreground="{DynamicResource PrimaryHueLightForegroundBrush}"
@@ -262,7 +262,7 @@
             
             <smtx:XamlDisplay
                 UniqueKey="cards_5"
-                Margin="4 4 0 0">
+                Margin="4 4 0 16">
                 <materialDesign:Card
                     Background="{DynamicResource PrimaryHueDarkBrush}"
                     Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}"
@@ -278,7 +278,7 @@
         
         <smtx:XamlDisplay
             UniqueKey="cards_6"
-            Margin="4 4 0 0"
+            Margin="4 4 0 16"
             VerticalContentAlignment="Top">
             <materialDesign:Card
                 Background="{DynamicResource PrimaryHueDarkBrush}"

--- a/MainDemo.Wpf/Chips.xaml
+++ b/MainDemo.Wpf/Chips.xaml
@@ -14,375 +14,382 @@
         <Style
             x:Key="ChipsHeadline"
             TargetType="TextBlock"
-            BasedOn="{StaticResource MaterialDesignHeadline6TextBlock}">
+            BasedOn="{StaticResource MaterialDesignHeadline5TextBlock}">
             <Setter Property="Margin" Value="0,16,0,16"/>
         </Style>
     </UserControl.Resources>
     
-    <ScrollViewer Margin="0">
-        <Grid VerticalAlignment="Top">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
+    <Grid VerticalAlignment="Top">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
 
+        <TextBlock
+            Style="{StaticResource ChipsHeadline}"
+            Margin="0,0,0,16"
+            Text="Action Chips"/>
+        
+        <StackPanel Grid.Row="1">
+            <WrapPanel
+                Orientation="Horizontal"
+                smtx:XamlDisplay.Ignore="This">
+                <smtx:XamlDisplay UniqueKey="chips_1" Margin="0 0 6 4">
+                    <materialDesign:Chip Content="James Willock">
+                        <materialDesign:Chip.Icon>
+                            <Image Source="Resources/ProfilePic.jpg" />
+                        </materialDesign:Chip.Icon>
+                    </materialDesign:Chip>
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay UniqueKey="chips_2" Margin="0 0 4 4">
+                    <materialDesign:Chip Content="Example Chip"/>
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay UniqueKey="chips_3" Margin="0 0 4 4">
+                    <materialDesign:Chip Content="ANZ Bank" Icon="A" />
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay UniqueKey="chips_4" Margin="0 0 4 4">
+                    <materialDesign:Chip Content="ZNA Inc" Icon="Z" />
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay UniqueKey="chips_5" Margin="0 0 4 4">
+                    <materialDesign:Chip
+                        Content="Twitter"
+                        IconBackground="{DynamicResource PrimaryHueDarkBrush}"
+                        IconForeground="{DynamicResource PrimaryHueDarkForegroundBrush}">
+                        <materialDesign:Chip.Icon>
+                            <materialDesign:PackIcon Kind="Twitter"/>
+                        </materialDesign:Chip.Icon>
+                    </materialDesign:Chip>
+                </smtx:XamlDisplay>
+            </WrapPanel>
+
+            <WrapPanel
+                Margin="0 12 0 0"
+                Orientation="Horizontal"
+                smtx:XamlDisplay.Ignore="This">
+                <smtx:XamlDisplay UniqueKey="chips_6" Margin="0 0 4 4">
+                    <materialDesign:Chip
+                        Content="James Willock"
+                        IsDeletable="True"
+                        Click="ButtonsDemoChip_OnClick"
+                        DeleteClick="ButtonsDemoChip_OnDeleteClick"
+                        ToolTip="Just a tool tip"
+                        DeleteToolTip="Your friendly neighbor delete button">
+                        <materialDesign:Chip.Icon>
+                            <Image Source="Resources/ProfilePic.jpg" />
+                        </materialDesign:Chip.Icon>
+                    </materialDesign:Chip>
+                </smtx:XamlDisplay>
+
+                <smtx:XamlDisplay UniqueKey="chips_7" Margin="0 0 4 4">
+                    <materialDesign:Chip
+                        Content="Example Chip"
+                        IsDeletable="True"
+                        ToolTip="This is an example chip">
+                    </materialDesign:Chip>
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay UniqueKey="chips_8" Margin="0 0 4 4">
+                    <materialDesign:Chip
+                        Content="ANZ Bank" 
+                        Icon="A"
+                        IsDeletable="True" />
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay UniqueKey="chips_9" Margin="0 0 4 4">
+                    <materialDesign:Chip
+                        Content="ZNA Inc" 
+                        Icon="Z" 
+                        IsDeletable="True"
+                        IconBackground="{DynamicResource PrimaryHueLightBrush}"
+                        IconForeground="{DynamicResource PrimaryHueLightForegroundBrush}" />
+                </smtx:XamlDisplay>
+            </WrapPanel>
+        </StackPanel>
+
+        <StackPanel Grid.Row="2">
+            <Rectangle
+                Margin="0 24 0 0"
+                Height="1"
+                Fill="{DynamicResource MaterialDesignDivider}" />
             <TextBlock
                 Style="{StaticResource ChipsHeadline}"
-                Text="Action Chips"/>
-            
-            <StackPanel Grid.Row="1">
-                <WrapPanel
-                    Orientation="Horizontal"
-                    smtx:XamlDisplay.Ignore="This">
-                    <smtx:XamlDisplay UniqueKey="chips_1" Margin="0 0 6 4">
-                        <materialDesign:Chip Content="James Willock">
-                            <materialDesign:Chip.Icon>
-                                <Image Source="Resources/ProfilePic.jpg" />
-                            </materialDesign:Chip.Icon>
-                        </materialDesign:Chip>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay UniqueKey="chips_2" Margin="0 0 4 4">
-                        <materialDesign:Chip Content="Example Chip"/>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay UniqueKey="chips_3" Margin="0 0 4 4">
-                        <materialDesign:Chip Content="ANZ Bank" Icon="A" />
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay UniqueKey="chips_4" Margin="0 0 4 4">
-                        <materialDesign:Chip Content="ZNA Inc" Icon="Z" />
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay UniqueKey="chips_5" Margin="0 0 4 4">
-                        <materialDesign:Chip
-                            Content="Twitter"
-                            IconBackground="{DynamicResource PrimaryHueDarkBrush}"
-                            IconForeground="{DynamicResource PrimaryHueDarkForegroundBrush}">
-                            <materialDesign:Chip.Icon>
-                                <materialDesign:PackIcon Kind="Twitter"/>
-                            </materialDesign:Chip.Icon>
-                        </materialDesign:Chip>
-                    </smtx:XamlDisplay>
-                </WrapPanel>
-
-                <WrapPanel
-                    Margin="0 12 0 0"
-                    Orientation="Horizontal"
-                    smtx:XamlDisplay.Ignore="This">
-                    <smtx:XamlDisplay UniqueKey="chips_6" Margin="0 0 4 4">
-                        <materialDesign:Chip
-                            Content="James Willock"
-                            IsDeletable="True"
-                            Click="ButtonsDemoChip_OnClick"
-                            DeleteClick="ButtonsDemoChip_OnDeleteClick"
-                            ToolTip="Just a tool tip"
-                            DeleteToolTip="Your friendly neighbor delete button">
-                            <materialDesign:Chip.Icon>
-                                <Image Source="Resources/ProfilePic.jpg" />
-                            </materialDesign:Chip.Icon>
-                        </materialDesign:Chip>
-                    </smtx:XamlDisplay>
-
-                    <smtx:XamlDisplay UniqueKey="chips_7" Margin="0 0 4 4">
-                        <materialDesign:Chip
-                            Content="Example Chip"
-                            IsDeletable="True"
-                            ToolTip="This is an example chip">
-                        </materialDesign:Chip>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay UniqueKey="chips_8" Margin="0 0 4 4">
-                        <materialDesign:Chip
-                            Content="ANZ Bank" 
-                            Icon="A"
-                            IsDeletable="True" />
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay UniqueKey="chips_9" Margin="0 0 4 4">
-                        <materialDesign:Chip
-                            Content="ZNA Inc" 
-                            Icon="Z" 
-                            IsDeletable="True"
-                            IconBackground="{DynamicResource PrimaryHueLightBrush}"
-                            IconForeground="{DynamicResource PrimaryHueLightForegroundBrush}" />
-                    </smtx:XamlDisplay>
-                </WrapPanel>
-            </StackPanel>
-
-            <StackPanel Grid.Row="2">
-                <TextBlock
-                    Style="{StaticResource ChipsHeadline}"
-                    Text="Filter Chips"/>
-            </StackPanel>
-            
-            <StackPanel Grid.Row="3">
-                <WrapPanel
-                    Orientation="Horizontal"
-                    smtx:XamlDisplay.Ignore="This">
-                    <smtx:XamlDisplay UniqueKey="chips_10" Margin="0 0 4 4">
-                        <CheckBox
-                            Style="{StaticResource MaterialDesignFilterChipCheckBox}"
-                            IsChecked="True"
-                            Content="CheckBox" />
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay UniqueKey="chips_11" Margin="0 0 4 4">
-                        <CheckBox
-                            Style="{StaticResource MaterialDesignFilterChipPrimaryCheckBox}"
-                            IsChecked="True"
-                            Content="Primary" />
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay UniqueKey="chips_12" Margin="0 0 4 4">
-                        <CheckBox
-                            Style="{StaticResource MaterialDesignFilterChipAccentCheckBox}"
-                            IsChecked="True">Secondary</CheckBox>
-                    </smtx:XamlDisplay>
-                </WrapPanel>
+                Text="Filter Chips"/>
+        </StackPanel>
+        
+        <StackPanel Grid.Row="3">
+            <WrapPanel
+                Orientation="Horizontal"
+                smtx:XamlDisplay.Ignore="This">
+                <smtx:XamlDisplay UniqueKey="chips_10" Margin="0 0 4 4">
+                    <CheckBox
+                        Style="{StaticResource MaterialDesignFilterChipCheckBox}"
+                        IsChecked="True"
+                        Content="CheckBox" />
+                </smtx:XamlDisplay>
                 
-                <WrapPanel
-                    Orientation="Horizontal"
-                    smtx:XamlDisplay.Ignore="This">
-                    <smtx:XamlDisplay UniqueKey="chips_13" Margin="0 0 4 4">
-                        <CheckBox
-                            Style="{StaticResource MaterialDesignFilterChipOutlineCheckBox}"
-                            IsChecked="True"
-                            Content="Outline"/>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay UniqueKey="chips_14" Margin="0 0 4 4">
-                        <CheckBox
-                            Style="{StaticResource MaterialDesignFilterChipPrimaryOutlineCheckBox}"
-                            IsChecked="True"
-                            Content="Primary Outline"/>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay UniqueKey="chips_15" Margin="0 0 4 4">
-                        <CheckBox
-                            Style="{StaticResource MaterialDesignFilterChipAccentOutlineCheckBox}"
-                            IsChecked="True"
-                            Content="Secondary Outline"/>
-                    </smtx:XamlDisplay>
-                </WrapPanel>
-
-                <WrapPanel>
-                    <materialDesign:Card Margin="4">
-                        <smtx:XamlDisplay UniqueKey="chips_16" Margin="4">
-                            <ListBox Style="{StaticResource MaterialDesignFilterChipListBox}">
-                                <ListBoxItem Content="Mercury"/>
-                                <ListBoxItem IsSelected="True" Content="Venus"/>
-                                <ListBoxItem Content="Earth"/>
-                                <ListBoxItem IsEnabled="False" Content="Pluto"/>
-                            </ListBox>
-                        </smtx:XamlDisplay>
-                    </materialDesign:Card>
-                    
-                    <materialDesign:Card Margin="4">
-                        <smtx:XamlDisplay UniqueKey="chips_17" Margin="4">
-                            <ListBox Style="{StaticResource MaterialDesignFilterChipPrimaryListBox}">
-                                <ListBoxItem Content="Mercury"/>
-                                <ListBoxItem IsSelected="True" Content="Venus"/>
-                                <ListBoxItem Content="Earth"/>
-                                <ListBoxItem IsEnabled="False" Content="Pluto"/>
-                            </ListBox>
-                        </smtx:XamlDisplay>
-                    </materialDesign:Card>
-                    
-                    <materialDesign:Card Margin="4">
-                        <smtx:XamlDisplay UniqueKey="chips_18" Margin="4">
-                            <ListBox Style="{StaticResource MaterialDesignFilterChipAccentListBox}">
-                                <ListBoxItem Content="Mercury"/>
-                                <ListBoxItem IsSelected="True" Content="Venus"/>
-                                <ListBoxItem Content="Earth"/>
-                                <ListBoxItem IsEnabled="False" Content="Pluto"/>
-                            </ListBox>
-                        </smtx:XamlDisplay>
-                    </materialDesign:Card>
-                </WrapPanel>
+                <smtx:XamlDisplay UniqueKey="chips_11" Margin="0 0 4 4">
+                    <CheckBox
+                        Style="{StaticResource MaterialDesignFilterChipPrimaryCheckBox}"
+                        IsChecked="True"
+                        Content="Primary" />
+                </smtx:XamlDisplay>
                 
-                <WrapPanel>
-                    <materialDesign:Card Margin="4">
-                        <smtx:XamlDisplay UniqueKey="chips_19" Margin="4">
-                            <ListBox Style="{StaticResource MaterialDesignFilterChipOutlineListBox}">
-                                <ListBoxItem Content="Mercury"/>
-                                <ListBoxItem IsSelected="True" Content="Venus"/>
-                                <ListBoxItem Content="Earth"/>
-                                <ListBoxItem IsEnabled="False" Content="Pluto"/>
-                            </ListBox>
-                        </smtx:XamlDisplay>
-                    </materialDesign:Card>
-                    
-                    <materialDesign:Card Margin="4">
-                        <smtx:XamlDisplay UniqueKey="chips_20" Margin="4">
-                            <ListBox Style="{StaticResource MaterialDesignFilterChipPrimaryOutlineListBox}">
-                                <ListBoxItem Content="Mercury"/>
-                                <ListBoxItem IsSelected="True" Content="Venus"/>
-                                <ListBoxItem Content="Earth"/>
-                                <ListBoxItem IsEnabled="False" Content="Pluto"/>
-                            </ListBox>
-                        </smtx:XamlDisplay>
-                    </materialDesign:Card>
-                    
-                    <materialDesign:Card Margin="4">
-                        <smtx:XamlDisplay UniqueKey="chips_21" Margin="4">
-                            <ListBox Style="{StaticResource MaterialDesignFilterChipAccentOutlineListBox}">
-                                <ListBoxItem Content="Mercury"/>
-                                <ListBoxItem IsSelected="True" Content="Venus"/>
-                                <ListBoxItem Content="Earth"/>
-                                <ListBoxItem IsEnabled="False" Content="Pluto"/>
-                            </ListBox>
-                        </smtx:XamlDisplay>
-                    </materialDesign:Card>
-                </WrapPanel>
-            </StackPanel>
-
-            <StackPanel Grid.Row="4">
-                <TextBlock
-                    Style="{StaticResource ChipsHeadline}"
-                    Text="Choice Chips"/>
-            </StackPanel>
+                <smtx:XamlDisplay UniqueKey="chips_12" Margin="0 0 4 4">
+                    <CheckBox
+                        Style="{StaticResource MaterialDesignFilterChipAccentCheckBox}"
+                        IsChecked="True">Secondary</CheckBox>
+                </smtx:XamlDisplay>
+            </WrapPanel>
             
-            <StackPanel Grid.Row="5">
-                <WrapPanel
-                    Orientation="Horizontal"
-                    smtx:XamlDisplay.Ignore="This">
-                    <smtx:XamlDisplay UniqueKey="chips_22" Margin="0 0 4 4">
-                        <RadioButton
-                            Style="{StaticResource MaterialDesignChoiceChipRadioButton}"
-                            GroupName="GroupChoiceChip"
-                            Content="RadioButton"/>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay UniqueKey="chips_23" Margin="0 0 4 4">
-                        <RadioButton
-                            Style="{StaticResource MaterialDesignChoiceChipPrimaryRadioButton}"
-                            IsChecked="True"
-                            GroupName="GroupChoiceChip"
-                            Content="Primary"/>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay UniqueKey="chips_24" Margin="0 0 4 4">
-                        <RadioButton
-                            Style="{StaticResource MaterialDesignChoiceChipAccentRadioButton}"
-                            GroupName="GroupChoiceChip"
-                            Content="Secondary"/>
-                    </smtx:XamlDisplay>
-                </WrapPanel>
+            <WrapPanel
+                Orientation="Horizontal"
+                smtx:XamlDisplay.Ignore="This">
+                <smtx:XamlDisplay UniqueKey="chips_13" Margin="0 0 4 4">
+                    <CheckBox
+                        Style="{StaticResource MaterialDesignFilterChipOutlineCheckBox}"
+                        IsChecked="True"
+                        Content="Outline"/>
+                </smtx:XamlDisplay>
                 
-                <WrapPanel
-                    Orientation="Horizontal"
-                    smtx:XamlDisplay.Ignore="This">
-                    <smtx:XamlDisplay UniqueKey="chips_25" Margin="0 0 4 4">
-                        <RadioButton
-                            Style="{StaticResource MaterialDesignChoiceChipOutlineRadioButton}"
-                            GroupName="GroupChoiceChipOutline"
-                            Content="Outline"/>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay UniqueKey="chips_26" Margin="0 0 4 4">
-                        <RadioButton
-                            Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineRadioButton}"
-                            IsChecked="True"
-                            GroupName="GroupChoiceChipOutline"
-                            Content="Primary Outline"/>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay UniqueKey="chips_27" Margin="0 0 4 4">
-                        <RadioButton
-                            Style="{StaticResource MaterialDesignChoiceChipAccentOutlineRadioButton}"
-                            GroupName="GroupChoiceChipOutline"
-                            Content="Secondary Outline"/>
-                    </smtx:XamlDisplay>
-                </WrapPanel>
+                <smtx:XamlDisplay UniqueKey="chips_14" Margin="0 0 4 4">
+                    <CheckBox
+                        Style="{StaticResource MaterialDesignFilterChipPrimaryOutlineCheckBox}"
+                        IsChecked="True"
+                        Content="Primary Outline"/>
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay UniqueKey="chips_15" Margin="0 0 4 4">
+                    <CheckBox
+                        Style="{StaticResource MaterialDesignFilterChipAccentOutlineCheckBox}"
+                        IsChecked="True"
+                        Content="Secondary Outline"/>
+                </smtx:XamlDisplay>
+            </WrapPanel>
 
-                <WrapPanel>
-                    <materialDesign:Card Margin="4">
-                        <smtx:XamlDisplay UniqueKey="chips_28" Margin="0 0 6 4">
-                            <ListBox
-                                Style="{StaticResource MaterialDesignChoiceChipListBox}"
-                                x:Name="RadioButtonGroupChoiceChip">
-                                <ListBoxItem Content="Mercury"/>
-                                <ListBoxItem IsSelected="True" Content="Venus"/>
-                                <ListBoxItem Content="Earth"/>
-                                <ListBoxItem IsEnabled="False" Content="Pluto"/>
-                            </ListBox>
-                        </smtx:XamlDisplay>
-                    </materialDesign:Card>
-                    
-                    <materialDesign:Card Margin="4">
-                        <smtx:XamlDisplay UniqueKey="chips_29" Margin="0 0 6 4">
-                            <ListBox
-                                Style="{StaticResource MaterialDesignChoiceChipPrimaryListBox}"
-                                x:Name="RadioButtonGroupChoiceChipPrimary">
-                                <ListBoxItem Content="Mercury"/>
-                                <ListBoxItem IsSelected="True" Content="Venus"/>
-                                <ListBoxItem Content="Earth"/>
-                                <ListBoxItem IsEnabled="False" Content="Pluto"/>
-                            </ListBox>
-                        </smtx:XamlDisplay>
-                    </materialDesign:Card>
-                    
-                    <materialDesign:Card Margin="4">
-                        <smtx:XamlDisplay UniqueKey="chips_30" Margin="0 0 6 4">
-                            <ListBox
-                                Style="{StaticResource MaterialDesignChoiceChipAccentListBox}"
-                                x:Name="RadioButtonGroupChoiceChipAccent">
-                                <ListBoxItem Content="Mercury"/>
-                                <ListBoxItem IsSelected="True" Content="Venus"/>
-                                <ListBoxItem Content="Earth"/>
-                                <ListBoxItem IsEnabled="False" Content="Pluto"/>
-                            </ListBox>
-                        </smtx:XamlDisplay>
-                    </materialDesign:Card>
-                </WrapPanel>
+            <WrapPanel>
+                <materialDesign:Card Margin="4">
+                    <smtx:XamlDisplay UniqueKey="chips_16" Margin="4">
+                        <ListBox Style="{StaticResource MaterialDesignFilterChipListBox}">
+                            <ListBoxItem Content="Mercury"/>
+                            <ListBoxItem IsSelected="True" Content="Venus"/>
+                            <ListBoxItem Content="Earth"/>
+                            <ListBoxItem IsEnabled="False" Content="Pluto"/>
+                        </ListBox>
+                    </smtx:XamlDisplay>
+                </materialDesign:Card>
+                
+                <materialDesign:Card Margin="4">
+                    <smtx:XamlDisplay UniqueKey="chips_17" Margin="4">
+                        <ListBox Style="{StaticResource MaterialDesignFilterChipPrimaryListBox}">
+                            <ListBoxItem Content="Mercury"/>
+                            <ListBoxItem IsSelected="True" Content="Venus"/>
+                            <ListBoxItem Content="Earth"/>
+                            <ListBoxItem IsEnabled="False" Content="Pluto"/>
+                        </ListBox>
+                    </smtx:XamlDisplay>
+                </materialDesign:Card>
+                
+                <materialDesign:Card Margin="4">
+                    <smtx:XamlDisplay UniqueKey="chips_18" Margin="4">
+                        <ListBox Style="{StaticResource MaterialDesignFilterChipAccentListBox}">
+                            <ListBoxItem Content="Mercury"/>
+                            <ListBoxItem IsSelected="True" Content="Venus"/>
+                            <ListBoxItem Content="Earth"/>
+                            <ListBoxItem IsEnabled="False" Content="Pluto"/>
+                        </ListBox>
+                    </smtx:XamlDisplay>
+                </materialDesign:Card>
+            </WrapPanel>
+            
+            <WrapPanel>
+                <materialDesign:Card Margin="4">
+                    <smtx:XamlDisplay UniqueKey="chips_19" Margin="4">
+                        <ListBox Style="{StaticResource MaterialDesignFilterChipOutlineListBox}">
+                            <ListBoxItem Content="Mercury"/>
+                            <ListBoxItem IsSelected="True" Content="Venus"/>
+                            <ListBoxItem Content="Earth"/>
+                            <ListBoxItem IsEnabled="False" Content="Pluto"/>
+                        </ListBox>
+                    </smtx:XamlDisplay>
+                </materialDesign:Card>
+                
+                <materialDesign:Card Margin="4">
+                    <smtx:XamlDisplay UniqueKey="chips_20" Margin="4">
+                        <ListBox Style="{StaticResource MaterialDesignFilterChipPrimaryOutlineListBox}">
+                            <ListBoxItem Content="Mercury"/>
+                            <ListBoxItem IsSelected="True" Content="Venus"/>
+                            <ListBoxItem Content="Earth"/>
+                            <ListBoxItem IsEnabled="False" Content="Pluto"/>
+                        </ListBox>
+                    </smtx:XamlDisplay>
+                </materialDesign:Card>
+                
+                <materialDesign:Card Margin="4">
+                    <smtx:XamlDisplay UniqueKey="chips_21" Margin="4">
+                        <ListBox Style="{StaticResource MaterialDesignFilterChipAccentOutlineListBox}">
+                            <ListBoxItem Content="Mercury"/>
+                            <ListBoxItem IsSelected="True" Content="Venus"/>
+                            <ListBoxItem Content="Earth"/>
+                            <ListBoxItem IsEnabled="False" Content="Pluto"/>
+                        </ListBox>
+                    </smtx:XamlDisplay>
+                </materialDesign:Card>
+            </WrapPanel>
+        </StackPanel>
 
-                <WrapPanel>
-                    <materialDesign:Card Margin="4">
-                        <smtx:XamlDisplay UniqueKey="chips_31" Margin="0 0 6 4">
-                            <ListBox
-                                Style="{StaticResource MaterialDesignChoiceChipOutlineListBox}"
-                                x:Name="RadioButtonGroupChoiceChipOutline">
-                                <ListBoxItem Content="Mercury"/>
-                                <ListBoxItem IsSelected="True" Content="Venus"/>
-                                <ListBoxItem Content="Earth"/>
-                                <ListBoxItem IsEnabled="False" Content="Pluto"/>
-                            </ListBox>
-                        </smtx:XamlDisplay>
-                    </materialDesign:Card>
-                    
-                    <materialDesign:Card Margin="4">
-                        <smtx:XamlDisplay UniqueKey="chips_32" Margin="0 0 6 4">
-                            <ListBox
-                                Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineListBox}"
-                                x:Name="RadioButtonGroupChoiceChipPrimaryOutline">
-                                <ListBoxItem Content="Mercury"/>
-                                <ListBoxItem IsSelected="True" Content="Venus"/>
-                                <ListBoxItem Content="Earth"/>
-                                <ListBoxItem IsEnabled="False" Content="Pluto"/>
-                            </ListBox>
-                        </smtx:XamlDisplay>
-                    </materialDesign:Card>
-                    
-                    <materialDesign:Card Margin="4">
-                        <smtx:XamlDisplay UniqueKey="chips_33" Margin="0 0 6 4">
-                            <ListBox
-                                Style="{StaticResource MaterialDesignChoiceChipAccentOutlineListBox}"
-                                x:Name="RadioButtonGroupChoiceChipAccentOutline">
-                                <ListBoxItem Content="Mercury"/>
-                                <ListBoxItem IsSelected="True" Content="Venus"/>
-                                <ListBoxItem Content="Earth"/>
-                                <ListBoxItem IsEnabled="False" Content="Pluto"/>
-                            </ListBox>
-                        </smtx:XamlDisplay>
-                    </materialDesign:Card>
-                </WrapPanel>
-            </StackPanel>
-        </Grid>
-    </ScrollViewer>
+        <StackPanel Grid.Row="4">
+            <Rectangle
+                Margin="0 24 0 0"
+                Height="1"
+                Fill="{DynamicResource MaterialDesignDivider}" />
+            <TextBlock
+                Style="{StaticResource ChipsHeadline}"
+                Text="Choice Chips"/>
+        </StackPanel>
+        
+        <StackPanel Grid.Row="5">
+            <WrapPanel
+                Orientation="Horizontal"
+                smtx:XamlDisplay.Ignore="This">
+                <smtx:XamlDisplay UniqueKey="chips_22" Margin="0 0 4 4">
+                    <RadioButton
+                        Style="{StaticResource MaterialDesignChoiceChipRadioButton}"
+                        GroupName="GroupChoiceChip"
+                        Content="RadioButton"/>
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay UniqueKey="chips_23" Margin="0 0 4 4">
+                    <RadioButton
+                        Style="{StaticResource MaterialDesignChoiceChipPrimaryRadioButton}"
+                        IsChecked="True"
+                        GroupName="GroupChoiceChip"
+                        Content="Primary"/>
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay UniqueKey="chips_24" Margin="0 0 4 4">
+                    <RadioButton
+                        Style="{StaticResource MaterialDesignChoiceChipAccentRadioButton}"
+                        GroupName="GroupChoiceChip"
+                        Content="Secondary"/>
+                </smtx:XamlDisplay>
+            </WrapPanel>
+            
+            <WrapPanel
+                Orientation="Horizontal"
+                smtx:XamlDisplay.Ignore="This">
+                <smtx:XamlDisplay UniqueKey="chips_25" Margin="0 0 4 4">
+                    <RadioButton
+                        Style="{StaticResource MaterialDesignChoiceChipOutlineRadioButton}"
+                        GroupName="GroupChoiceChipOutline"
+                        Content="Outline"/>
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay UniqueKey="chips_26" Margin="0 0 4 4">
+                    <RadioButton
+                        Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineRadioButton}"
+                        IsChecked="True"
+                        GroupName="GroupChoiceChipOutline"
+                        Content="Primary Outline"/>
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay UniqueKey="chips_27" Margin="0 0 4 4">
+                    <RadioButton
+                        Style="{StaticResource MaterialDesignChoiceChipAccentOutlineRadioButton}"
+                        GroupName="GroupChoiceChipOutline"
+                        Content="Secondary Outline"/>
+                </smtx:XamlDisplay>
+            </WrapPanel>
+
+            <WrapPanel>
+                <materialDesign:Card Margin="4">
+                    <smtx:XamlDisplay UniqueKey="chips_28" Margin="0 0 6 4">
+                        <ListBox
+                            Style="{StaticResource MaterialDesignChoiceChipListBox}"
+                            x:Name="RadioButtonGroupChoiceChip">
+                            <ListBoxItem Content="Mercury"/>
+                            <ListBoxItem IsSelected="True" Content="Venus"/>
+                            <ListBoxItem Content="Earth"/>
+                            <ListBoxItem IsEnabled="False" Content="Pluto"/>
+                        </ListBox>
+                    </smtx:XamlDisplay>
+                </materialDesign:Card>
+                
+                <materialDesign:Card Margin="4">
+                    <smtx:XamlDisplay UniqueKey="chips_29" Margin="0 0 6 4">
+                        <ListBox
+                            Style="{StaticResource MaterialDesignChoiceChipPrimaryListBox}"
+                            x:Name="RadioButtonGroupChoiceChipPrimary">
+                            <ListBoxItem Content="Mercury"/>
+                            <ListBoxItem IsSelected="True" Content="Venus"/>
+                            <ListBoxItem Content="Earth"/>
+                            <ListBoxItem IsEnabled="False" Content="Pluto"/>
+                        </ListBox>
+                    </smtx:XamlDisplay>
+                </materialDesign:Card>
+                
+                <materialDesign:Card Margin="4">
+                    <smtx:XamlDisplay UniqueKey="chips_30" Margin="0 0 6 4">
+                        <ListBox
+                            Style="{StaticResource MaterialDesignChoiceChipAccentListBox}"
+                            x:Name="RadioButtonGroupChoiceChipAccent">
+                            <ListBoxItem Content="Mercury"/>
+                            <ListBoxItem IsSelected="True" Content="Venus"/>
+                            <ListBoxItem Content="Earth"/>
+                            <ListBoxItem IsEnabled="False" Content="Pluto"/>
+                        </ListBox>
+                    </smtx:XamlDisplay>
+                </materialDesign:Card>
+            </WrapPanel>
+
+            <WrapPanel>
+                <materialDesign:Card Margin="4">
+                    <smtx:XamlDisplay UniqueKey="chips_31" Margin="0 0 6 4">
+                        <ListBox
+                            Style="{StaticResource MaterialDesignChoiceChipOutlineListBox}"
+                            x:Name="RadioButtonGroupChoiceChipOutline">
+                            <ListBoxItem Content="Mercury"/>
+                            <ListBoxItem IsSelected="True" Content="Venus"/>
+                            <ListBoxItem Content="Earth"/>
+                            <ListBoxItem IsEnabled="False" Content="Pluto"/>
+                        </ListBox>
+                    </smtx:XamlDisplay>
+                </materialDesign:Card>
+                
+                <materialDesign:Card Margin="4">
+                    <smtx:XamlDisplay UniqueKey="chips_32" Margin="0 0 6 4">
+                        <ListBox
+                            Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineListBox}"
+                            x:Name="RadioButtonGroupChoiceChipPrimaryOutline">
+                            <ListBoxItem Content="Mercury"/>
+                            <ListBoxItem IsSelected="True" Content="Venus"/>
+                            <ListBoxItem Content="Earth"/>
+                            <ListBoxItem IsEnabled="False" Content="Pluto"/>
+                        </ListBox>
+                    </smtx:XamlDisplay>
+                </materialDesign:Card>
+                
+                <materialDesign:Card Margin="4">
+                    <smtx:XamlDisplay UniqueKey="chips_33" Margin="0 0 6 4">
+                        <ListBox
+                            Style="{StaticResource MaterialDesignChoiceChipAccentOutlineListBox}"
+                            x:Name="RadioButtonGroupChoiceChipAccentOutline">
+                            <ListBoxItem Content="Mercury"/>
+                            <ListBoxItem IsSelected="True" Content="Venus"/>
+                            <ListBoxItem Content="Earth"/>
+                            <ListBoxItem IsEnabled="False" Content="Pluto"/>
+                        </ListBox>
+                    </smtx:XamlDisplay>
+                </materialDesign:Card>
+            </WrapPanel>
+        </StackPanel>
+    </Grid>
 </UserControl>
 

--- a/MainDemo.Wpf/ColorTool.xaml
+++ b/MainDemo.Wpf/ColorTool.xaml
@@ -565,55 +565,53 @@
                             Color="{Binding SelectedColor, Delay=25}"/>
                     </Grid>
                     
-                    <ScrollViewer
+                    <StackPanel
                         Visibility="{Binding IsChecked,
                                 ElementName=MdPaletteButton,
                                 Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <StackPanel>
-                            <StackPanel Orientation="Horizontal">
-                                <StackPanel.Resources>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="Width" Value="40" />
-                                        <Setter Property="Margin" Value="1 1 0 0" />
-                                        <Setter Property="TextAlignment" Value="Center" />
-                                    </Style>
-                                </StackPanel.Resources>
-                                
-                                <Rectangle Width="80" />
-                                <TextBlock Text="50" />
-                                <TextBlock Text="100" />
-                                <TextBlock Text="200" />
-                                <TextBlock Text="300" />
-                                <TextBlock Text="400" />
-                                <TextBlock Text="500" />
-                                <TextBlock Text="600" />
-                                <TextBlock Text="700" />
-                                <TextBlock Text="800" />
-                                <TextBlock Text="900" />
-                                <TextBlock Text="A100" />
-                                <TextBlock Text="A200" />
-                                <TextBlock Text="A400" />
-                                <TextBlock Text="A700" />
-                            </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <StackPanel.Resources>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Width" Value="40" />
+                                    <Setter Property="Margin" Value="1 1 0 0" />
+                                    <Setter Property="TextAlignment" Value="Center" />
+                                </Style>
+                            </StackPanel.Resources>
                             
-                            <ItemsControl ItemsSource="{Binding Swatches}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate DataType="{x:Type materialDesignColors:ISwatch}">
-                                        <StackPanel Orientation="Horizontal">
-                                            <TextBlock Text="{Binding Name}" Width="80" VerticalAlignment="Center" />
-                                            <ItemsControl ItemsSource="{Binding Hues}" ItemTemplate="{StaticResource SwatchColorTemplate}">
-                                                <ItemsControl.ItemsPanel>
-                                                    <ItemsPanelTemplate>
-                                                        <VirtualizingStackPanel Orientation="Horizontal" />
-                                                    </ItemsPanelTemplate>
-                                                </ItemsControl.ItemsPanel>
-                                            </ItemsControl>
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
+                            <Rectangle Width="80" />
+                            <TextBlock Text="50" />
+                            <TextBlock Text="100" />
+                            <TextBlock Text="200" />
+                            <TextBlock Text="300" />
+                            <TextBlock Text="400" />
+                            <TextBlock Text="500" />
+                            <TextBlock Text="600" />
+                            <TextBlock Text="700" />
+                            <TextBlock Text="800" />
+                            <TextBlock Text="900" />
+                            <TextBlock Text="A100" />
+                            <TextBlock Text="A200" />
+                            <TextBlock Text="A400" />
+                            <TextBlock Text="A700" />
                         </StackPanel>
-                    </ScrollViewer>
+                        
+                        <ItemsControl ItemsSource="{Binding Swatches}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type materialDesignColors:ISwatch}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="{Binding Name}" Width="80" VerticalAlignment="Center" />
+                                        <ItemsControl ItemsSource="{Binding Hues}" ItemTemplate="{StaticResource SwatchColorTemplate}">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <VirtualizingStackPanel Orientation="Horizontal" />
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
                 </Grid>
             </DockPanel>
         </DockPanel>

--- a/MainDemo.Wpf/ColorZones.xaml
+++ b/MainDemo.Wpf/ColorZones.xaml
@@ -18,237 +18,227 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
-    <ScrollViewer>
-        <StackPanel Margin="0,20">
-            <StackPanel Margin="16">
-                <TextBlock
-                    Style="{StaticResource MaterialDesignHeadline5TextBlock}"
-                    Text="Colour Zones"/>
-                
-                <TextBlock
-                    TextWrapping="Wrap"
-                    MaxWidth="800"
-                    Margin="0 16 0 0"
-                    Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                    Text="The ColorZone control allows you to  easily define striking blocks of colour to give your application extra clarity and style, whilst still remaining within the bounds of your Material Design palette."/>
-            </StackPanel>
-            <TextBlock
-                Margin="0 16 0 0"
-                Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                Text="Invert the basic paper/body colours."/>
-            
-            <smtx:XamlDisplay UniqueKey="color_zones_inverted">
-                <materialDesign:ColorZone
-                    Mode="Inverted"
-                    Padding="16">
+    <StackPanel>
+        <TextBlock
+            Style="{StaticResource MaterialDesignHeadline5TextBlock}"
+            Text="Colour Zones"/>
+        
+        <TextBlock
+            TextWrapping="Wrap"
+            MaxWidth="800"
+            HorizontalAlignment="Left"
+            Margin="0 16 0 0"
+            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+            Text="The ColorZone control allows you to easily define striking blocks of colour to give your application extra clarity and style, whilst still remaining within the bounds of your Material Design palette."/>
+        <TextBlock
+            Margin="0 16 0 2"
+            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+            Text="Invert the basic paper/body colours."/>
+        
+        <smtx:XamlDisplay UniqueKey="color_zones_inverted">
+            <materialDesign:ColorZone
+                Mode="Inverted"
+                Padding="16">
 
-                    <DockPanel>
-                        <materialDesign:PopupBox
-                            DockPanel.Dock="Right"
-                            PlacementMode="BottomAndAlignRightEdges">
-                            <ListBox>
-                                <ListBoxItem Content="Hello World"/>
-                                <ListBoxItem Content="Nice Popup"/>
-                                <ListBoxItem Content="Goodbye"/>
-                            </ListBox>
-                        </materialDesign:PopupBox>
+                <DockPanel>
+                    <materialDesign:PopupBox
+                        DockPanel.Dock="Right"
+                        PlacementMode="BottomAndAlignRightEdges">
+                        <ListBox>
+                            <ListBoxItem Content="Hello World"/>
+                            <ListBoxItem Content="Nice Popup"/>
+                            <ListBoxItem Content="Goodbye"/>
+                        </ListBox>
+                    </materialDesign:PopupBox>
 
-                        <StackPanel Orientation="Horizontal">
-                            <ToggleButton
-                                Style="{DynamicResource MaterialDesignHamburgerToggleButton}"/>
-
-                            <TextBlock
-                                VerticalAlignment="Center"
-                                Margin="16 0 0 0"
-                                Text="Material Design In XAML Toolkit"/>
-                        </StackPanel>
-                    </DockPanel>
-                </materialDesign:ColorZone>
-            </smtx:XamlDisplay>
-            <TextBlock
-                Margin="0 16 0 0"
-                Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                Text="Use primary light background and foreground colours."/>
-
-            <smtx:XamlDisplay UniqueKey="color_zones_primary_light">
-                <materialDesign:ColorZone
-                    Mode="PrimaryLight"
-                    Padding="16">
                     <StackPanel Orientation="Horizontal">
                         <ToggleButton
                             Style="{DynamicResource MaterialDesignHamburgerToggleButton}"/>
-                        
+
                         <TextBlock
                             VerticalAlignment="Center"
                             Margin="16 0 0 0"
                             Text="Material Design In XAML Toolkit"/>
                     </StackPanel>
-                </materialDesign:ColorZone>
-            </smtx:XamlDisplay>
-            <TextBlock
-                Margin="0 16 0 0"
-                Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                Text="Use primary mid colours, and nest colour zones!"/>
-            
-            <smtx:XamlDisplay UniqueKey="color_zones_primary_mid">
-                <materialDesign:ColorZone
-                    Mode="PrimaryMid"
-                    Padding="16">
-                    <DockPanel>
-                        <ToggleButton
-                            Style="{DynamicResource MaterialDesignSwitchAccentToggleButton}"
-                            VerticalAlignment="Center"
-                            DockPanel.Dock="Right"/>
-                        
-                        <StackPanel
-                            Orientation="Horizontal"
-                            materialDesign:RippleAssist.IsCentered="True">
-                            <ToggleButton
-                                Style="{DynamicResource MaterialDesignHamburgerToggleButton}"/>
-                            
-                            <ComboBox
-                                SelectedIndex="0"
-                                Margin="8 0 0 0"
-                                BorderThickness="0" 
-                                materialDesign:ColorZoneAssist.Mode="Standard" 
-                                materialDesign:TextFieldAssist.UnderlineBrush="{DynamicResource MaterialDesignPaper}"
-                                BorderBrush="{DynamicResource MaterialDesignPaper}">
-                                <ComboBoxItem Content="Android"/>
-                                <ComboBoxItem Content="iOS"/>
-                                <ComboBoxItem Content="Linux"/>
-                                <ComboBoxItem Content="Windows"/>
-                            </ComboBox>
-                            
-                            <materialDesign:ColorZone
-                                Mode="Standard"
-                                Padding="8 4 8 4"
-                                CornerRadius="2"
-                                Panel.ZIndex="1"
-                                Margin="16 0 0 0"
-                                materialDesign:ShadowAssist.ShadowDepth="Depth1">
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>                                    
-                                    <Button
-                                        Style="{DynamicResource MaterialDesignToolButton}">
-                                        <materialDesign:PackIcon
-                                            Kind="Search"
-                                            Opacity=".56"/>
-                                    </Button>
+                </DockPanel>
+            </materialDesign:ColorZone>
+        </smtx:XamlDisplay>
+        <TextBlock
+            Margin="0 16 0 2"
+            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+            Text="Use primary light background and foreground colours."/>
 
-                                    <TextBox
-                                        Grid.Column="1"
-                                        Margin="8 0 0 0"
-                                        materialDesign:HintAssist.Hint="Build a search bar" 
-                                        materialDesign:TextFieldAssist.DecorationVisibility="Hidden"
-                                        BorderThickness="0"
-                                        MinWidth="200"
-                                        VerticalAlignment="Center"/>
-                                    
-                                    <Button
-                                        Style="{DynamicResource MaterialDesignToolButton}"
-                                        Grid.Column="2">
-                                        <materialDesign:PackIcon
-                                            Kind="Microphone"
-                                            Opacity=".56"
-                                            Margin="8 0 0 0"/>
-                                    </Button>
-                                </Grid>
-                            </materialDesign:ColorZone>
-                            
-                            <Button
-                                Style="{DynamicResource MaterialDesignToolForegroundButton}"
-                                Margin="8 0 0 0"
-                                Panel.ZIndex="0">
-                                <materialDesign:PackIcon Kind="Send" />
-                            </Button>
-                        </StackPanel>
-                    </DockPanel>
-                </materialDesign:ColorZone>
-            </smtx:XamlDisplay>
-            <TextBlock
-                Margin="0 16 0 0"
-                Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                Text="Add in a corner radius and shadow."/>
-            
-            <smtx:XamlDisplay UniqueKey="color_zones_primary_dark" Padding="10">
-                <materialDesign:ColorZone
-                    Mode="PrimaryDark"
-                    Padding="16"
-                    CornerRadius="10"
-                    materialDesign:ShadowAssist.ShadowDepth="Depth3"
-                    ClipToBounds="False">
-                    <StackPanel Orientation="Horizontal">
+        <smtx:XamlDisplay UniqueKey="color_zones_primary_light">
+            <materialDesign:ColorZone
+                Mode="PrimaryLight"
+                Padding="16">
+                <StackPanel Orientation="Horizontal">
+                    <ToggleButton
+                        Style="{DynamicResource MaterialDesignHamburgerToggleButton}"/>
+                    
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Margin="16 0 0 0"
+                        Text="Material Design In XAML Toolkit"/>
+                </StackPanel>
+            </materialDesign:ColorZone>
+        </smtx:XamlDisplay>
+        <TextBlock
+            Margin="0 16 0 2"
+            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+            Text="Use primary mid colours, and nest colour zones!"/>
+        
+        <smtx:XamlDisplay UniqueKey="color_zones_primary_mid">
+            <materialDesign:ColorZone
+                Mode="PrimaryMid"
+                Padding="16">
+                <DockPanel>
+                    <ToggleButton
+                        Style="{DynamicResource MaterialDesignSwitchAccentToggleButton}"
+                        VerticalAlignment="Center"
+                        DockPanel.Dock="Right"/>
+                    
+                    <StackPanel
+                        Orientation="Horizontal"
+                        materialDesign:RippleAssist.IsCentered="True">
                         <ToggleButton
                             Style="{DynamicResource MaterialDesignHamburgerToggleButton}"/>
                         
-                        <TextBlock
-                            VerticalAlignment="Center"
+                        <ComboBox
+                            SelectedIndex="0"
+                            Margin="8 0 0 0"
+                            BorderThickness="0" 
+                            materialDesign:ColorZoneAssist.Mode="Standard" 
+                            materialDesign:TextFieldAssist.UnderlineBrush="{DynamicResource MaterialDesignPaper}"
+                            BorderBrush="{DynamicResource MaterialDesignPaper}">
+                            <ComboBoxItem Content="Android"/>
+                            <ComboBoxItem Content="iOS"/>
+                            <ComboBoxItem Content="Linux"/>
+                            <ComboBoxItem Content="Windows"/>
+                        </ComboBox>
+                        
+                        <materialDesign:ColorZone
+                            Mode="Standard"
+                            Padding="8 4 8 4"
+                            CornerRadius="2"
+                            Panel.ZIndex="1"
                             Margin="16 0 0 0"
-                            Text="Material Design In XAML Toolkit"/>
-                    </StackPanel>
-                </materialDesign:ColorZone>
-            </smtx:XamlDisplay>
-            <TextBlock
-                Margin="0 16 0 0"
-                Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                Text="Use secondary mid background and foreground colours."/>
+                            materialDesign:ShadowAssist.ShadowDepth="Depth1">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>                                    
+                                <Button
+                                    Style="{DynamicResource MaterialDesignToolButton}">
+                                    <materialDesign:PackIcon
+                                        Kind="Search"
+                                        Opacity=".56"/>
+                                </Button>
 
-            <smtx:XamlDisplay UniqueKey="color_zones_secondary_mid">
-                <materialDesign:ColorZone
-                    Mode="SecondaryMid"
-                    Padding="16">
-                    <StackPanel Orientation="Horizontal">
-                        <ToggleButton
-                            Style="{DynamicResource MaterialDesignHamburgerToggleButton}"/>
+                                <TextBox
+                                    Grid.Column="1"
+                                    Margin="8 0 0 0"
+                                    materialDesign:HintAssist.Hint="Build a search bar" 
+                                    materialDesign:TextFieldAssist.DecorationVisibility="Hidden"
+                                    BorderThickness="0"
+                                    MinWidth="200"
+                                    VerticalAlignment="Center"/>
+                                
+                                <Button
+                                    Style="{DynamicResource MaterialDesignToolButton}"
+                                    Grid.Column="2">
+                                    <materialDesign:PackIcon
+                                        Kind="Microphone"
+                                        Opacity=".56"
+                                        Margin="8 0 0 0"/>
+                                </Button>
+                            </Grid>
+                        </materialDesign:ColorZone>
                         
-                        <TextBlock
-                            VerticalAlignment="Center"
-                            Margin="16 0 0 0"
-                            Text="Material Design In XAML Toolkit"/>
+                        <Button
+                            Style="{DynamicResource MaterialDesignToolForegroundButton}"
+                            Margin="8 0 0 0"
+                            Panel.ZIndex="0">
+                            <materialDesign:PackIcon Kind="Send" />
+                        </Button>
                     </StackPanel>
-                </materialDesign:ColorZone>
-            </smtx:XamlDisplay>
-            <TextBlock
-                Margin="0 16 0 0"
-                Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                Text="Use custom background and foreground colours. Disabled ClipToBounds"/>
-            
-            <smtx:XamlDisplay UniqueKey="color_zones_custom" Margin="0 16">
-                <materialDesign:ColorZone
-                    Mode="Custom"
-                    Background="Black"
-                    Foreground="White"
-                    Padding="16"
-                    ClipToBounds="False">
+                </DockPanel>
+            </materialDesign:ColorZone>
+        </smtx:XamlDisplay>
+        <TextBlock
+            Margin="0 16 0 2"
+            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+            Text="Add in a corner radius and shadow."/>
+        
+        <smtx:XamlDisplay UniqueKey="color_zones_primary_dark" Padding="10">
+            <materialDesign:ColorZone
+                Mode="PrimaryDark"
+                Padding="16"
+                CornerRadius="10"
+                materialDesign:ShadowAssist.ShadowDepth="Depth3"
+                ClipToBounds="False">
+                <StackPanel Orientation="Horizontal">
+                    <ToggleButton
+                        Style="{DynamicResource MaterialDesignHamburgerToggleButton}"/>
+                    
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Margin="16 0 0 0"
+                        Text="Material Design In XAML Toolkit"/>
+                </StackPanel>
+            </materialDesign:ColorZone>
+        </smtx:XamlDisplay>
+        <TextBlock
+            Margin="0 16 0 2"
+            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+            Text="Use secondary mid background and foreground colours."/>
 
-                    <StackPanel Orientation="Horizontal">
-                        <ToggleButton
-                            Style="{DynamicResource MaterialDesignHamburgerToggleButton}"/>
-                        
-                        <TextBlock
-                            VerticalAlignment="Center"
-                            Margin="16 0"
-                            Text="Material Design In XAML Toolkit"/>
-                        
-                        <materialDesign:Badged
-                            Badge="123"
-                            VerticalAlignment="Center">
-                            <Button Content="Some action"/>
-                        </materialDesign:Badged>
-                    </StackPanel>
-                </materialDesign:ColorZone>
-            </smtx:XamlDisplay>
-        </StackPanel>
-    </ScrollViewer>
+        <smtx:XamlDisplay UniqueKey="color_zones_secondary_mid">
+            <materialDesign:ColorZone
+                Mode="SecondaryMid"
+                Padding="16">
+                <StackPanel Orientation="Horizontal">
+                    <ToggleButton
+                        Style="{DynamicResource MaterialDesignHamburgerToggleButton}"/>
+                    
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Margin="16 0 0 0"
+                        Text="Material Design In XAML Toolkit"/>
+                </StackPanel>
+            </materialDesign:ColorZone>
+        </smtx:XamlDisplay>
+        <TextBlock
+            Margin="0 16 0 2"
+            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+            Text="Use custom background and foreground colours. Disabled ClipToBounds"/>
+        
+        <smtx:XamlDisplay UniqueKey="color_zones_custom">
+            <materialDesign:ColorZone
+                Mode="Custom"
+                Background="Black"
+                Foreground="White"
+                Padding="16"
+                ClipToBounds="False">
+
+                <StackPanel Orientation="Horizontal">
+                    <ToggleButton
+                        Style="{DynamicResource MaterialDesignHamburgerToggleButton}"/>
+                    
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Margin="16 0"
+                        Text="Material Design In XAML Toolkit"/>
+                    
+                    <materialDesign:Badged
+                        Badge="123"
+                        VerticalAlignment="Center">
+                        <Button Content="Some action"/>
+                    </materialDesign:Badged>
+                </StackPanel>
+            </materialDesign:ColorZone>
+        </smtx:XamlDisplay>
+    </StackPanel>
 </UserControl>
-
-
-
-
-
-
-

--- a/MainDemo.Wpf/ComboBoxes.xaml
+++ b/MainDemo.Wpf/ComboBoxes.xaml
@@ -15,17 +15,16 @@
     
     <UserControl.Resources>
         <Style x:Key="SectionTitle" TargetType="TextBlock" BasedOn="{StaticResource MaterialDesignHeadline5TextBlock }">
-            <Setter Property="Margin" Value="0 32 0 0" />
+            <Setter Property="Margin" Value="0 24 0 0" />
         </Style>
         
         <Style TargetType="{x:Type smtx:XamlDisplay}" BasedOn="{StaticResource {x:Type smtx:XamlDisplay}}">
-            <Setter Property="Margin" Value="16 0" />
+            <Setter Property="Margin" Value="16 0 0 0" />
             <Setter Property="VerticalAlignment" Value="Bottom" />
         </Style>
     </UserControl.Resources>
     
     <StackPanel
-        Margin="16 0"
         VerticalAlignment="Top"
         HorizontalAlignment="Left">
         <TextBlock
@@ -40,7 +39,7 @@
                 </Style>
             </StackPanel.Resources>
      
-            <smtx:XamlDisplay UniqueKey="comboboxes_1">
+            <smtx:XamlDisplay UniqueKey="comboboxes_1" Margin="0">
 
                 <ComboBox materialDesign:HintAssist.Hint="OS">
                     <ComboBoxItem Content="Android"/>
@@ -100,7 +99,7 @@
             </smtx:XamlDisplay>
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal" Margin="0 32 0 0">
+        <StackPanel Orientation="Horizontal" Margin="0 16 0 0">
             <StackPanel.Resources>
                 <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource {x:Type ComboBox}}">
                     <Setter Property="Margin" Value="0 8 0 0" />
@@ -108,7 +107,7 @@
                 </Style>
             </StackPanel.Resources>
        
-            <smtx:XamlDisplay UniqueKey="comboboxes_9">
+            <smtx:XamlDisplay UniqueKey="comboboxes_9" Margin="0">
 
                 <StackPanel>
                     <CheckBox
@@ -146,14 +145,17 @@
             </smtx:XamlDisplay>
         </StackPanel>
 
-
+        <Rectangle
+            Margin="0 32 0 0"
+            Height="1"
+            Fill="{DynamicResource MaterialDesignDivider}" />
         <TextBlock
             Style="{StaticResource SectionTitle}"
             Text="Virtualised ComboBoxes"/>
 
         <StackPanel Orientation="Horizontal">
 
-            <smtx:XamlDisplay UniqueKey="comboboxes_5">
+            <smtx:XamlDisplay UniqueKey="comboboxes_5" Margin="0">
                 <ComboBox
                     materialDesign:HintAssist.Hint="Virtualisation"
                     MinWidth="72"
@@ -240,13 +242,18 @@
             </smtx:XamlDisplay>
         </StackPanel>
 
+        <Rectangle
+            Margin="0 32 0 0"
+            Height="1"
+            Fill="{DynamicResource MaterialDesignDivider}" />
         <TextBlock
             Style="{StaticResource SectionTitle}"
             Text="Filled ComboBox"/>
         
         <smtx:XamlDisplay
             UniqueKey="comboboxes_filled_combobox"
-            HorizontalAlignment="Left">
+            HorizontalAlignment="Left"
+            Margin="0 16 0 0">
 
             <StackPanel>
                 <Grid>

--- a/MainDemo.Wpf/DataGrids.xaml
+++ b/MainDemo.Wpf/DataGrids.xaml
@@ -20,149 +20,147 @@
         </ResourceDictionary>
     </UserControl.Resources>
     
-    <ScrollViewer>
-        <StackPanel Margin="5 0 0 0">
-            <TextBlock
-                Style="{StaticResource MaterialDesignHeadline5TextBlock}"
-                Text="Custom Columns"/>
-            
-            <smtx:XamlDisplay UniqueKey="grids_1">
-                <DataGrid
-                    ItemsSource="{Binding Items1}"
-                    CanUserAddRows="False" AutoGenerateColumns="False"
-                    HeadersVisibility="All">
-                    <DataGrid.Resources>
-                        <domain:BindingProxy
-                            x:Key="DataContextProxy"
-                            Data="{Binding}" />
-                    </DataGrid.Resources>
+    <StackPanel>
+        <TextBlock
+            Style="{StaticResource MaterialDesignHeadline5TextBlock}"
+            Text="Custom Columns"/>
+        
+        <smtx:XamlDisplay UniqueKey="grids_1">
+            <DataGrid
+                ItemsSource="{Binding Items1}"
+                CanUserAddRows="False" AutoGenerateColumns="False"
+                HeadersVisibility="All">
+                <DataGrid.Resources>
+                    <domain:BindingProxy
+                        x:Key="DataContextProxy"
+                        Data="{Binding}" />
+                </DataGrid.Resources>
+                
+                <DataGrid.Columns>
+                    <DataGridCheckBoxColumn
+                        Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" 
+                        ElementStyle="{StaticResource MaterialDesignDataGridCheckBoxColumnStyle}"
+                        EditingElementStyle="{StaticResource MaterialDesignDataGridCheckBoxColumnEditingStyle}">
+                        <DataGridCheckBoxColumn.Header>
+                            <Border Background="Transparent">
+                                <CheckBox
+                                    IsChecked="{Binding Data.IsAllItems1Selected, Source={StaticResource DataContextProxy}}"/>
+                            </Border>
+                        </DataGridCheckBoxColumn.Header>
+                        
+                        <DataGridCheckBoxColumn.HeaderStyle>
+                            <Style TargetType="{x:Type DataGridColumnHeader}" BasedOn="{StaticResource MaterialDesignDataGridColumnHeader}">
+                                <Setter Property="HorizontalContentAlignment" Value="Center" />
+                            </Style>
+                        </DataGridCheckBoxColumn.HeaderStyle>
+                    </DataGridCheckBoxColumn>
                     
-                    <DataGrid.Columns>
-                        <DataGridCheckBoxColumn
-                            Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" 
-                            ElementStyle="{StaticResource MaterialDesignDataGridCheckBoxColumnStyle}"
-                            EditingElementStyle="{StaticResource MaterialDesignDataGridCheckBoxColumnEditingStyle}">
-                            <DataGridCheckBoxColumn.Header>
-                                <Border Background="Transparent">
-                                    <CheckBox
-                                        IsChecked="{Binding Data.IsAllItems1Selected, Source={StaticResource DataContextProxy}}"/>
-                                </Border>
-                            </DataGridCheckBoxColumn.Header>
-                            
-                            <DataGridCheckBoxColumn.HeaderStyle>
-                                <Style TargetType="{x:Type DataGridColumnHeader}" BasedOn="{StaticResource MaterialDesignDataGridColumnHeader}">
-                                    <Setter Property="HorizontalContentAlignment" Value="Center" />
-                                </Style>
-                            </DataGridCheckBoxColumn.HeaderStyle>
-                        </DataGridCheckBoxColumn>
+                    <DataGridTextColumn
+                        Binding="{Binding Code}"
+                        Header="Code"
+                        ElementStyle="{StaticResource MaterialDesignDataGridTextColumnStyle}"
+                        EditingElementStyle="{StaticResource MaterialDesignDataGridTextColumnEditingStyle}"/>
+                    
+                    <!-- if you want to use the pop up style (MaterialDesignDataGridTextColumnPopupEditingStyle), you must use MaterialDataGridTextColumn -->
+                    <materialDesign:DataGridTextColumn
+                        Header="Name"
+                        ElementStyle="{StaticResource MaterialDesignDataGridTextColumnStyle}"
+                        EditingElementStyle="{StaticResource MaterialDesignDataGridTextColumnPopupEditingStyle}">
+                        <materialDesign:DataGridTextColumn.Binding>
+                            <Binding Path="Name">
+                                <Binding.ValidationRules>
+                                    <domain:NotEmptyValidationRule/>
+                                </Binding.ValidationRules>
+                            </Binding>
+                        </materialDesign:DataGridTextColumn.Binding>
+                    </materialDesign:DataGridTextColumn>
+                    
+                    <!-- set a max length to get an indicator in the editor -->
+                    <DataGridTextColumn
+                        Header="Description"
+                        ElementStyle="{StaticResource MaterialDesignDataGridTextColumnStyle}"
+                        EditingElementStyle="{StaticResource MaterialDesignDataGridTextColumnEditingStyle}">
+                        <DataGridTextColumn.Binding>
+                            <Binding Path="Description">
+                                <Binding.ValidationRules>
+                                    <domain:NotEmptyValidationRule />
+                                </Binding.ValidationRules>
+                            </Binding>
+                        </DataGridTextColumn.Binding>
+                    </DataGridTextColumn>
+                    
+                    <materialDesign:DataGridTextColumn
+                        Binding="{Binding Numeric}"
+                        Header="Number with long header"
+                        Width="120"
+                        EditingElementStyle="{StaticResource MaterialDesignDataGridTextColumnPopupEditingStyle}">
+                        <DataGridTextColumn.HeaderStyle>
+                            <Style TargetType="{x:Type DataGridColumnHeader}" BasedOn="{StaticResource MaterialDesignDataGridColumnHeader}">
+                                <Setter Property="HorizontalContentAlignment" Value="Right" />
+                                <Setter Property="ContentTemplate">
+                                    <Setter.Value>
+                                        <DataTemplate>
+                                            <TextBlock
+                                                TextWrapping="Wrap"
+                                                Text="{Binding}"
+                                                TextAlignment="Right"/>
+                                        </DataTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </DataGridTextColumn.HeaderStyle>
                         
-                        <DataGridTextColumn
-                            Binding="{Binding Code}"
-                            Header="Code"
-                            ElementStyle="{StaticResource MaterialDesignDataGridTextColumnStyle}"
-                            EditingElementStyle="{StaticResource MaterialDesignDataGridTextColumnEditingStyle}"/>
-                        
-                        <!-- if you want to use the pop up style (MaterialDesignDataGridTextColumnPopupEditingStyle), you must use MaterialDataGridTextColumn -->
-                        <materialDesign:DataGridTextColumn
-                            Header="Name"
-                            ElementStyle="{StaticResource MaterialDesignDataGridTextColumnStyle}"
-                            EditingElementStyle="{StaticResource MaterialDesignDataGridTextColumnPopupEditingStyle}">
-                            <materialDesign:DataGridTextColumn.Binding>
-                                <Binding Path="Name">
-                                    <Binding.ValidationRules>
-                                        <domain:NotEmptyValidationRule/>
-                                    </Binding.ValidationRules>
-                                </Binding>
-                            </materialDesign:DataGridTextColumn.Binding>
-                        </materialDesign:DataGridTextColumn>
-                        
-                        <!-- set a max length to get an indicator in the editor -->
-                        <DataGridTextColumn
-                            Header="Description"
-                            ElementStyle="{StaticResource MaterialDesignDataGridTextColumnStyle}"
-                            EditingElementStyle="{StaticResource MaterialDesignDataGridTextColumnEditingStyle}">
-                            <DataGridTextColumn.Binding>
-                                <Binding Path="Description">
-                                    <Binding.ValidationRules>
-                                        <domain:NotEmptyValidationRule />
-                                    </Binding.ValidationRules>
-                                </Binding>
-                            </DataGridTextColumn.Binding>
-                        </DataGridTextColumn>
-                        
-                        <materialDesign:DataGridTextColumn
-                            Binding="{Binding Numeric}"
-                            Header="Number with long header"
-                            Width="120"
-                            EditingElementStyle="{StaticResource MaterialDesignDataGridTextColumnPopupEditingStyle}">
-                            <DataGridTextColumn.HeaderStyle>
-                                <Style TargetType="{x:Type DataGridColumnHeader}" BasedOn="{StaticResource MaterialDesignDataGridColumnHeader}">
-                                    <Setter Property="HorizontalContentAlignment" Value="Right" />
-                                    <Setter Property="ContentTemplate">
-                                        <Setter.Value>
-                                            <DataTemplate>
-                                                <TextBlock
-                                                    TextWrapping="Wrap"
-                                                    Text="{Binding}"
-                                                    TextAlignment="Right"/>
-                                            </DataTemplate>
-                                        </Setter.Value>
-                                    </Setter>
-                                </Style>
-                            </DataGridTextColumn.HeaderStyle>
-                            
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource MaterialDesignDataGridTextColumnStyle}">
-                                    <Setter Property="HorizontalAlignment" Value="Right" />
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </materialDesign:DataGridTextColumn>
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource MaterialDesignDataGridTextColumnStyle}">
+                                <Setter Property="HorizontalAlignment" Value="Right" />
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </materialDesign:DataGridTextColumn>
 
-                        <!-- use custom combo box column to get better combos. Use ItemsSourceBinding as your binding template to be applied to each combo -->
-                        <materialDesign:DataGridComboBoxColumn
-                            Header="Food with long header" IsEditable="True"
-                            Width="100"
-                            SelectedValueBinding="{Binding Food}"
-                            ItemsSourceBinding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type DataGrid}}, Path=DataContext.Foods}">
-                            <!--Setting the editing element style allows access to all of the combo box's properties
-                            <materialDesign:MaterialDataGridComboBoxColumn.EditingElementStyle>
-                                <Style TargetType="ComboBox" BasedOn="{StaticResource {ComponentResourceKey TypeInTargetAssembly={x:Type ComboBox}, ResourceId=MaterialDataGridComboBoxColumnEditingStyle}}" >
-                                    <Setter Property="IsEditable" Value="True" />
-                                </Style>
-                            </materialDesign:MaterialDataGridComboBoxColumn.EditingElementStyle>
-                            -->
-                        </materialDesign:DataGridComboBoxColumn>
-                    </DataGrid.Columns>
-                </DataGrid>
-            </smtx:XamlDisplay>
-            
-            <TextBlock
-                Style="{StaticResource MaterialDesignHeadline5TextBlock}"
-                Text="Auto Generated Columns"
-                Margin="0 24 0 0"/>
-            
-            <smtx:XamlDisplay UniqueKey="grids_2">
-                <DataGrid
-                    ItemsSource="{Binding Items2}"
-                    CanUserAddRows="False"
-                    SelectionUnit="Cell"
-                    SelectionMode="Extended" />
-            </smtx:XamlDisplay>
-            
-            <TextBlock
-                Style="{StaticResource MaterialDesignHeadline6TextBlock}"
-                Text="Custom Padding" Margin="0 24 0 0"/>
-            
-            <smtx:XamlDisplay UniqueKey="grids_3">
-                <DataGrid
-                    ItemsSource="{Binding Items3}"
-                    CanUserSortColumns="False"
-                    CanUserAddRows="False"
-                    materialDesign:DataGridAssist.CellPadding="4 2 2 2"
-                    materialDesign:DataGridAssist.ColumnHeaderPadding="4 2 2 2" />
+                    <!-- use custom combo box column to get better combos. Use ItemsSourceBinding as your binding template to be applied to each combo -->
+                    <materialDesign:DataGridComboBoxColumn
+                        Header="Food with long header" IsEditable="True"
+                        Width="100"
+                        SelectedValueBinding="{Binding Food}"
+                        ItemsSourceBinding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type DataGrid}}, Path=DataContext.Foods}">
+                        <!--Setting the editing element style allows access to all of the combo box's properties
+                        <materialDesign:MaterialDataGridComboBoxColumn.EditingElementStyle>
+                            <Style TargetType="ComboBox" BasedOn="{StaticResource {ComponentResourceKey TypeInTargetAssembly={x:Type ComboBox}, ResourceId=MaterialDataGridComboBoxColumnEditingStyle}}" >
+                                <Setter Property="IsEditable" Value="True" />
+                            </Style>
+                        </materialDesign:MaterialDataGridComboBoxColumn.EditingElementStyle>
+                        -->
+                    </materialDesign:DataGridComboBoxColumn>
+                </DataGrid.Columns>
+            </DataGrid>
+        </smtx:XamlDisplay>
+        
+        <TextBlock
+            Style="{StaticResource MaterialDesignHeadline5TextBlock}"
+            Text="Auto Generated Columns"
+            Margin="0 24 0 0"/>
+        
+        <smtx:XamlDisplay UniqueKey="grids_2">
+            <DataGrid
+                ItemsSource="{Binding Items2}"
+                CanUserAddRows="False"
+                SelectionUnit="Cell"
+                SelectionMode="Extended" />
+        </smtx:XamlDisplay>
+        
+        <TextBlock
+            Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+            Text="Custom Padding" Margin="0 24 0 0"/>
+        
+        <smtx:XamlDisplay UniqueKey="grids_3">
+            <DataGrid
+                ItemsSource="{Binding Items3}"
+                CanUserSortColumns="False"
+                CanUserAddRows="False"
+                materialDesign:DataGridAssist.CellPadding="4 2 2 2"
+                materialDesign:DataGridAssist.ColumnHeaderPadding="4 2 2 2" />
 
-            </smtx:XamlDisplay>
-        </StackPanel>
-    </ScrollViewer>
+        </smtx:XamlDisplay>
+    </StackPanel>
 </UserControl>
 

--- a/MainDemo.Wpf/Dialogs.xaml
+++ b/MainDemo.Wpf/Dialogs.xaml
@@ -27,344 +27,338 @@
 
         <TextBlock
             TextWrapping="Wrap"
-            Margin="32"
-            Text="Dialogs are supported via the DialogHost control which was designed to work with MVVM/binding, code-behind, routed commands, and a pure code-based API."/>
+            MaxWidth="700"
+            HorizontalAlignment="Left"
+            Text="Dialogs are supported via the DialogHost control which was designed to work with MVVM/binding, code-behind, routed commands, and a pure code-based API."
+            Style="{StaticResource MaterialDesignSubtitle1TextBlock}" />
 
-        <ScrollViewer
-            HorizontalScrollBarVisibility="Auto"
-            Grid.Row="1">
-            <Grid VerticalAlignment="Top">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
-                
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="320" />
-                    <ColumnDefinition Width="320" />
-                    <ColumnDefinition Width="320" />
-                    <ColumnDefinition Width="320" />
-                    <ColumnDefinition Width="320" />
-                </Grid.ColumnDefinitions>
+        <Grid VerticalAlignment="Top" Grid.Row="1" Margin="0 24 0 0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="320" />
+                <ColumnDefinition Width="320" />
+                <ColumnDefinition Width="320" />
+                <ColumnDefinition Width="320" />
+                <ColumnDefinition Width="320" />
+            </Grid.ColumnDefinitions>
 
-                <!--#region SAMPLE 1-->
+            <!--#region SAMPLE 1-->
 
-                <TextBlock
-                    TextWrapping="Wrap"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Top"
-                    Margin="8 0 8 0"
-                    Text="SAMPLE 1: Localized dialog encapsulating specific content, launched from a routed command, response handled in code-behind."/>
-                
-                <smtx:XamlDisplay
-                    UniqueKey="dialogs_sample1"
-                    Grid.Column="0"
-                    Grid.Row="1"
-                    Margin="5 0 0 0">
-                    <materialDesign:DialogHost
-                        DialogClosing="Sample1_DialogHost_OnDialogClosing"
-                        DialogTheme="Inherit"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center">
-                        <materialDesign:DialogHost.DialogContent>
-                            <StackPanel Margin="16">
-                                <TextBlock Text="Add a new fruit."/>
-                                
-                                <TextBox
-                                    Margin="0 8 0 0"
-                                    HorizontalAlignment="Stretch"
-                                    x:Name="FruitTextBox"/>
-                                
-                                <StackPanel
-                                    Orientation="Horizontal"
-                                    HorizontalAlignment="Right">
-                                    <Button
-                                        Style="{StaticResource MaterialDesignFlatButton}"
-                                        IsDefault="True"
-                                        Margin="0 8 8 0"
-                                        Content="ACCEPT"
-                                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
-                                        <Button.CommandParameter>
-                                            <system:Boolean>True</system:Boolean>
-                                        </Button.CommandParameter>                                        
-                                    </Button>
-                                    
-                                    <Button
-                                        Style="{StaticResource MaterialDesignFlatButton}"
-                                        IsCancel="True"
-                                        Margin="0 8 8 0"
-                                        Content="CANCEL"
-                                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
-                                        <Button.CommandParameter>
-                                            <system:Boolean>False</system:Boolean>
-                                        </Button.CommandParameter>                                        
-                                    </Button>
-                                </StackPanel>
-                            </StackPanel>
-                        </materialDesign:DialogHost.DialogContent>
-                        
-                        <Border
-                            BorderThickness="1"
-                            BorderBrush="{DynamicResource PrimaryHueMidBrush}"
-                            MinWidth="256"
-                            MinHeight="256"
-                            ClipToBounds="True">
-                            <Grid>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="*" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-                                
-                                <ListBox x:Name="FruitListBox">
-                                    <ListBoxItem Content="Apple"/>
-                                    <ListBoxItem Content="Banana"/>
-                                    <ListBoxItem Content="Pear"/>
-                                </ListBox>
-                                
-                                <materialDesign:ColorZone
-                                    Mode="PrimaryMid"
-                                    Grid.Row="1"
-                                    Effect="{DynamicResource MaterialDesignShadowDepth5}">
-                                    <TextBlock
-                                        Margin="16"
-                                        Text="Fruit Bowl"/>
-                                </materialDesign:ColorZone>
-
+            <TextBlock
+                TextWrapping="Wrap"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Top"
+                Margin="0 0 24 0"
+                Text="SAMPLE 1: Localized dialog encapsulating specific content, launched from a routed command, response handled in code-behind."/>
+            
+            <smtx:XamlDisplay
+                UniqueKey="dialogs_sample1"
+                Margin="8 8 0 0"
+                Grid.Column="0"
+                Grid.Row="1">
+                <materialDesign:DialogHost
+                    DialogClosing="Sample1_DialogHost_OnDialogClosing"
+                    DialogTheme="Inherit">
+                    <materialDesign:DialogHost.DialogContent>
+                        <StackPanel Margin="16">
+                            <TextBlock Text="Add a new fruit."/>
+                            
+                            <TextBox
+                                Margin="0 8 0 0"
+                                HorizontalAlignment="Stretch"
+                                x:Name="FruitTextBox"/>
+                            
+                            <StackPanel
+                                Orientation="Horizontal"
+                                HorizontalAlignment="Right">
                                 <Button
-                                    Style="{StaticResource MaterialDesignFloatingActionMiniAccentButton}"
-                                    Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
-                                    VerticalAlignment="Bottom"
-                                    HorizontalAlignment="Right" 
-                                    Grid.Row="0"
-                                    Margin="0 0 28 -20"
-                                    Content="{materialDesign:PackIcon Kind=Plus, Size=22}"/>
-                            </Grid>
-                        </Border>
-                    </materialDesign:DialogHost>
-                </smtx:XamlDisplay>
-                <!--#endregion -->
+                                    Style="{StaticResource MaterialDesignFlatButton}"
+                                    IsDefault="True"
+                                    Margin="0 8 8 0"
+                                    Content="ACCEPT"
+                                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
+                                    <Button.CommandParameter>
+                                        <system:Boolean>True</system:Boolean>
+                                    </Button.CommandParameter>                                        
+                                </Button>
+                                
+                                <Button
+                                    Style="{StaticResource MaterialDesignFlatButton}"
+                                    IsCancel="True"
+                                    Margin="0 8 8 0"
+                                    Content="CANCEL"
+                                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
+                                    <Button.CommandParameter>
+                                        <system:Boolean>False</system:Boolean>
+                                    </Button.CommandParameter>                                        
+                                </Button>
+                            </StackPanel>
+                        </StackPanel>
+                    </materialDesign:DialogHost.DialogContent>
+                    
+                    <Border
+                        BorderThickness="1"
+                        BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+                        MinHeight="256"
+                        ClipToBounds="True">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            
+                            <ListBox x:Name="FruitListBox">
+                                <ListBoxItem Content="Apple"/>
+                                <ListBoxItem Content="Banana"/>
+                                <ListBoxItem Content="Pear"/>
+                            </ListBox>
+                            
+                            <materialDesign:ColorZone
+                                Mode="PrimaryMid"
+                                Grid.Row="1"
+                                Effect="{DynamicResource MaterialDesignShadowDepth5}">
+                                <TextBlock
+                                    Margin="16"
+                                    Text="Fruit Bowl"/>
+                            </materialDesign:ColorZone>
 
-                <!--#region SAMPLE 2-->
-                <TextBlock
-                    Grid.Column="1"
-                    Grid.Row="0"
-                    TextWrapping="Wrap"
-                    VerticalAlignment="Top"
-                    Margin="8 0 8 0"
-                    Text="SAMPLE 2: Top level dialog,  using OpenDialog, passing content via the Parameter. You can pass a view model, provided a corresponding DataTemplate can be found in the scope of the root DialogHost."/>
-                
-                <smtx:XamlDisplay
-                    Grid.Column="1"
-                    Grid.Row="1"
-                    UniqueKey="dialogs_sample2">
-                    <StackPanel VerticalAlignment="Center">
-                        <!--the request to open the dialog will bubble up to the top-most DialogHost,
-                            but we can used the attached property based event to handle the response -->
-                        <Button
-                            Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
-                            materialDesign:DialogHost.DialogClosingAttached="Sample2_DialogHost_OnDialogClosing"
-                            Width="128"
-                            Content="PASS VIEW">
-                            <Button.CommandParameter>
-                                <StackPanel Margin="16">
-                                    <ProgressBar
-                                        Style="{DynamicResource MaterialDesignCircularProgressBar}"
-                                        HorizontalAlignment="Center" Margin="16"
-                                        IsIndeterminate="True"
-                                        Value="0" />
-                                    <Button
-                                        Style="{StaticResource MaterialDesignFlatButton}"
-                                        IsCancel="True" 
-                                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
-                                        CommandParameter="Sample2Cancel"
-                                        HorizontalAlignment="Center"
-                                        Content="CANCEL"/>
-                                </StackPanel>
-                            </Button.CommandParameter>                            
-                        </Button>
-                        
-                        <Button
-                            Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
-                            Width="128"
-                            Margin="0 32 0 0"
-                            Content="PASS MODEL">
-                            <Button.CommandParameter>
-                                <!-- the simplest view model of all, a DateTime.
-                                    the view can be found in the resources of MainWindow.xaml  -->
-                                <system:DateTime>1966-JUL-30</system:DateTime>
-                            </Button.CommandParameter>                            
-                        </Button>
-                    </StackPanel>
-                </smtx:XamlDisplay>
-                <!--#endregion-->
-
-                <!--#region SAMPLE 3-->
-                <TextBlock
-                    Grid.Column="2"
-                    Grid.Row="0"
-                    TextWrapping="Wrap"
-                    VerticalAlignment="Top"
-                    Margin="8 0 8 0"
-                    Text="SAMPLE 3: Open and listen to the dialog entirely from code in a view model."/>
-                
-                <!-- Executes a command on DialogsViewModel.cs, which will launch the dialog from code -->
-
-                <smtx:XamlDisplay
-                    Grid.Column="2"
-                    Grid.Row="1"
-                    UniqueKey="dialogs_sample3">
-
-                    <StackPanel>
-                        <Button
-                            Command="{Binding RunDialogCommand}"
-                            Width="128"
-                            Content="RUN CODE"/>
-
-                        <Button
-                            Command="{Binding RunExtendedDialogCommand}"
-                            Width="128"
-                            Margin="0 32 0 0"
-                            Content="EXTENDED"/>
-                    </StackPanel>
-                </smtx:XamlDisplay>
-                <!--#endregion-->
-
-                <!--#region SAMPLE 4-->
-                <TextBlock
-                    TextWrapping="Wrap"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Top"
-                    Grid.Column="3"
-                    Grid.Row="0"
-                    Margin="8 0 8 0"
-                    Text="SAMPLE 4: Dialog managed from view model using IsOpen and custom commands (ignoring the provided routed commands). This also uses a custom brush to dim the background."/>
-
-                <smtx:XamlDisplay
-                    UniqueKey="dialogs_sample4"
-                    Grid.Column="3"
-                    Grid.Row="1" >
-                    <materialDesign:DialogHost
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        IsOpen="{Binding IsSample4DialogOpen}"
-                        DialogContent="{Binding Sample4Content}"
-                        CloseOnClickAway="True"
-                        OverlayBackground="{DynamicResource PrimaryHueDarkBrush}"
-                        DialogTheme="Inherit">
-                        
-                        <Border
-                            BorderThickness="1"
-                            BorderBrush="{DynamicResource PrimaryHueMidBrush}"
-                            MinWidth="256"
-                            MinHeight="256"
-                            ClipToBounds="True">
                             <Button
-                                HorizontalAlignment="Center"
-                                VerticalAlignment="Center"
-                                Command="{Binding OpenSample4DialogCommand}"
-                                Content="RUN"/>
-                        </Border>
-                    </materialDesign:DialogHost>
-                </smtx:XamlDisplay>
-                <!--#endregion-->
+                                Style="{StaticResource MaterialDesignFloatingActionMiniAccentButton}"
+                                Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
+                                VerticalAlignment="Bottom"
+                                HorizontalAlignment="Right" 
+                                Grid.Row="0"
+                                Margin="0 0 28 -20"
+                                Content="{materialDesign:PackIcon Kind=Plus, Size=22}"/>
+                        </Grid>
+                    </Border>
+                </materialDesign:DialogHost>
+            </smtx:XamlDisplay>
+            <!--#endregion -->
 
-                <!--#region SAMPLE 5-->
-                <TextBlock
-                    TextWrapping="Wrap"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Top"
-                    Grid.Column="4"
-                    Grid.Row="0"
-                    Margin="8 0 8 0"
-                    Text="SAMPLE 5: Localized dialog encapsulating specific content, launched from a routed command. This dialog is contained inside of the visual tree rather than the normal dialog which uses a popup."/>
-                
-                <smtx:XamlDisplay
-                    UniqueKey="dialogs_sample5"
-                    Grid.Column="4"
-                    Grid.Row="1"
-                    Margin="10">
-                    <materialDesign:DialogHost
-                        DialogClosing="Sample5_DialogHost_OnDialogClosing"
-                        Style="{StaticResource MaterialDesignEmbeddedDialogHost}"
-                        DialogMargin="8">
-                        <materialDesign:DialogHost.DialogContent>
+            <!--#region SAMPLE 2-->
+            <TextBlock
+                Grid.Column="1"
+                Grid.Row="0"
+                TextWrapping="Wrap"
+                Margin="8 0 24 0"
+                Text="SAMPLE 2: Top level dialog,  using OpenDialog, passing content via the Parameter. You can pass a view model, provided a corresponding DataTemplate can be found in the scope of the root DialogHost."/>
+            
+            <smtx:XamlDisplay
+                Grid.Column="1"
+                Grid.Row="1"
+                UniqueKey="dialogs_sample2">
+                <StackPanel VerticalAlignment="Center">
+                    <!--the request to open the dialog will bubble up to the top-most DialogHost,
+                        but we can used the attached property based event to handle the response -->
+                    <Button
+                        Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
+                        materialDesign:DialogHost.DialogClosingAttached="Sample2_DialogHost_OnDialogClosing"
+                        Width="128"
+                        Content="PASS VIEW">
+                        <Button.CommandParameter>
                             <StackPanel Margin="16">
-                                <TextBlock Text="Add a new animal."/>
-                                
-                                <TextBox
-                                    Margin="0 8 0 0"
-                                    HorizontalAlignment="Stretch"
-                                    x:Name="AnimalTextBox"/>
-                                
-                                <StackPanel
-                                    Orientation="Horizontal"
-                                    HorizontalAlignment="Right" >
-                                    <Button
-                                        Style="{StaticResource MaterialDesignFlatButton}"
-                                        IsDefault="True"
-                                        Margin="0 8 8 0"
-                                        Content="ACCEPT"
-                                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
-                                        <Button.CommandParameter>
-                                            <system:Boolean>True</system:Boolean>
-                                        </Button.CommandParameter>                                        
-                                    </Button>
-                                    
-                                    <Button
-                                        Style="{StaticResource MaterialDesignFlatButton}"
-                                        IsCancel="True"
-                                        Margin="0 8 8 0"
-                                        Content="CANCEL"
-                                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
-                                        <Button.CommandParameter>
-                                            <system:Boolean>False</system:Boolean>
-                                        </Button.CommandParameter>                                        
-                                    </Button>
-                                </StackPanel>
-                            </StackPanel>
-                        </materialDesign:DialogHost.DialogContent>
-                        
-                        <Border
-                            BorderThickness="1"
-                            BorderBrush="{DynamicResource PrimaryHueMidBrush}"
-                            ClipToBounds="True"
-                            HorizontalAlignment="Stretch">
-                            <Grid>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="*" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-                                
-                                <ListBox x:Name="AnimalListBox">
-                                    <ListBoxItem Content="Dog"/>
-                                    <ListBoxItem Content="Cat"/>
-                                    <ListBoxItem Content="Platypus"/>
-                                </ListBox>
-                                
-                                <materialDesign:ColorZone
-                                    Mode="PrimaryMid"
-                                    Grid.Row="1"
-                                    Effect="{DynamicResource MaterialDesignShadowDepth5}">
-                                    <TextBlock
-                                        Margin="16"
-                                        Text="Petting Zoo"/>
-                                </materialDesign:ColorZone>
-
+                                <ProgressBar
+                                    Style="{DynamicResource MaterialDesignCircularProgressBar}"
+                                    HorizontalAlignment="Center" Margin="16"
+                                    IsIndeterminate="True"
+                                    Value="0" />
                                 <Button
-                                    Style="{StaticResource MaterialDesignFloatingActionMiniAccentButton}"
-                                    Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
-                                    VerticalAlignment="Bottom"
-                                    HorizontalAlignment="Right" 
-                                    Grid.Row="0"
-                                    Margin="0 0 28 -20"
-                                    Content="{materialDesign:PackIcon Kind=Plus, Size=22}"/>
-                            </Grid>
-                        </Border>
-                    </materialDesign:DialogHost>
-                </smtx:XamlDisplay>
-                <!--#endregion -->
-            </Grid>
-        </ScrollViewer>
+                                    Style="{StaticResource MaterialDesignFlatButton}"
+                                    IsCancel="True" 
+                                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                                    CommandParameter="Sample2Cancel"
+                                    HorizontalAlignment="Center"
+                                    Content="CANCEL"/>
+                            </StackPanel>
+                        </Button.CommandParameter>                            
+                    </Button>
+                    
+                    <Button
+                        Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
+                        Width="128"
+                        Margin="0 32 0 0"
+                        Content="PASS MODEL">
+                        <Button.CommandParameter>
+                            <!-- the simplest view model of all, a DateTime.
+                                the view can be found in the resources of MainWindow.xaml  -->
+                            <system:DateTime>1966-JUL-30</system:DateTime>
+                        </Button.CommandParameter>                            
+                    </Button>
+                </StackPanel>
+            </smtx:XamlDisplay>
+            <!--#endregion-->
+
+            <!--#region SAMPLE 3-->
+            <TextBlock
+                Grid.Column="2"
+                Grid.Row="0"
+                TextWrapping="Wrap"
+                VerticalAlignment="Top"
+                Margin="8 0 24 0"
+                Text="SAMPLE 3: Open and listen to the dialog entirely from code in a view model."/>
+            
+            <!-- Executes a command on DialogsViewModel.cs, which will launch the dialog from code -->
+
+            <smtx:XamlDisplay
+                Grid.Column="2"
+                Grid.Row="1"
+                UniqueKey="dialogs_sample3">
+
+                <StackPanel VerticalAlignment="Center">
+                    <Button
+                        Command="{Binding RunDialogCommand}"
+                        Width="128"
+                        Content="RUN CODE"/>
+
+                    <Button
+                        Command="{Binding RunExtendedDialogCommand}"
+                        Width="128"
+                        Margin="0 32 0 0"
+                        Content="EXTENDED"/>
+                </StackPanel>
+            </smtx:XamlDisplay>
+            <!--#endregion-->
+
+            <!--#region SAMPLE 4-->
+            <TextBlock
+                TextWrapping="Wrap"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Top"
+                Grid.Column="3"
+                Grid.Row="0"
+                Margin="8 0 24 0"
+                Text="SAMPLE 4: Dialog managed from view model using IsOpen and custom commands (ignoring the provided routed commands). This also uses a custom brush to dim the background."/>
+
+            <smtx:XamlDisplay
+                UniqueKey="dialogs_sample4"
+                Margin="8 8 0 0"
+                Grid.Column="3"
+                Grid.Row="1" >
+                <materialDesign:DialogHost
+                    VerticalAlignment="Center"
+                    IsOpen="{Binding IsSample4DialogOpen}"
+                    DialogContent="{Binding Sample4Content}"
+                    CloseOnClickAway="True"
+                    OverlayBackground="{DynamicResource PrimaryHueDarkBrush}"
+                    DialogTheme="Inherit">
+                    
+                    <Border
+                        BorderThickness="1"
+                        BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+                        MinWidth="256"
+                        MinHeight="256"
+                        ClipToBounds="True">
+                        <Button
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Command="{Binding OpenSample4DialogCommand}"
+                            Content="RUN"/>
+                    </Border>
+                </materialDesign:DialogHost>
+            </smtx:XamlDisplay>
+            <!--#endregion-->
+
+            <!--#region SAMPLE 5-->
+            <TextBlock
+                TextWrapping="Wrap"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Top"
+                Grid.Column="4"
+                Grid.Row="0"
+                Margin="8 0 24 0"
+                Text="SAMPLE 5: Localized dialog encapsulating specific content, launched from a routed command. This dialog is contained inside of the visual tree rather than the normal dialog which uses a popup."/>
+            
+            <smtx:XamlDisplay
+                UniqueKey="dialogs_sample5"
+                Grid.Column="4"
+                Grid.Row="1"
+                Margin="8 8 0 0">
+                <materialDesign:DialogHost
+                    DialogClosing="Sample5_DialogHost_OnDialogClosing"
+                    Style="{StaticResource MaterialDesignEmbeddedDialogHost}"
+                    DialogMargin="8">
+                    <materialDesign:DialogHost.DialogContent>
+                        <StackPanel Margin="16">
+                            <TextBlock Text="Add a new animal."/>
+                            
+                            <TextBox
+                                Margin="0 8 0 0"
+                                HorizontalAlignment="Stretch"
+                                x:Name="AnimalTextBox"/>
+                            
+                            <StackPanel
+                                Orientation="Horizontal"
+                                HorizontalAlignment="Right" >
+                                <Button
+                                    Style="{StaticResource MaterialDesignFlatButton}"
+                                    IsDefault="True"
+                                    Margin="0 8 8 0"
+                                    Content="ACCEPT"
+                                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
+                                    <Button.CommandParameter>
+                                        <system:Boolean>True</system:Boolean>
+                                    </Button.CommandParameter>                                        
+                                </Button>
+                                
+                                <Button
+                                    Style="{StaticResource MaterialDesignFlatButton}"
+                                    IsCancel="True"
+                                    Margin="0 8 8 0"
+                                    Content="CANCEL"
+                                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
+                                    <Button.CommandParameter>
+                                        <system:Boolean>False</system:Boolean>
+                                    </Button.CommandParameter>                                        
+                                </Button>
+                            </StackPanel>
+                        </StackPanel>
+                    </materialDesign:DialogHost.DialogContent>
+                    
+                    <Border
+                        BorderThickness="1"
+                        BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+                        ClipToBounds="True"
+                        HorizontalAlignment="Stretch">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            
+                            <ListBox x:Name="AnimalListBox">
+                                <ListBoxItem Content="Dog"/>
+                                <ListBoxItem Content="Cat"/>
+                                <ListBoxItem Content="Platypus"/>
+                            </ListBox>
+                            
+                            <materialDesign:ColorZone
+                                Mode="PrimaryMid"
+                                Grid.Row="1"
+                                Effect="{DynamicResource MaterialDesignShadowDepth5}">
+                                <TextBlock
+                                    Margin="16"
+                                    Text="Petting Zoo"/>
+                            </materialDesign:ColorZone>
+
+                            <Button
+                                Style="{StaticResource MaterialDesignFloatingActionMiniAccentButton}"
+                                Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
+                                VerticalAlignment="Bottom"
+                                HorizontalAlignment="Right" 
+                                Grid.Row="0"
+                                Margin="0 0 28 -20"
+                                Content="{materialDesign:PackIcon Kind=Plus, Size=22}"/>
+                        </Grid>
+                    </Border>
+                </materialDesign:DialogHost>
+            </smtx:XamlDisplay>
+            <!--#endregion -->
+        </Grid>
     </Grid>
 </UserControl>
 

--- a/MainDemo.Wpf/Domain/DemoItem.cs
+++ b/MainDemo.Wpf/Domain/DemoItem.cs
@@ -11,7 +11,7 @@ namespace MaterialDesignDemo.Domain
         private string _name;
         private object? _content;
         private ScrollBarVisibility _horizontalScrollBarVisibilityRequirement;
-        private ScrollBarVisibility _verticalScrollBarVisibilityRequirement;
+        private ScrollBarVisibility _verticalScrollBarVisibilityRequirement = ScrollBarVisibility.Auto;
         private Thickness _marginRequirement = new Thickness(16);
 
         public DemoItem(string name, object? content, IEnumerable<DocumentationLink> documentation)

--- a/MainDemo.Wpf/Domain/MainWindowViewModel.cs
+++ b/MainDemo.Wpf/Domain/MainWindowViewModel.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Configuration;
 using System.Linq;
+using System.Windows.Data;
 using System.Windows.Controls;
 using MaterialDesignThemes.Wpf;
 using MaterialDesignThemes.Wpf.Transitions;
@@ -13,8 +15,31 @@ namespace MaterialDesignDemo.Domain
     {
         public MainWindowViewModel(ISnackbarMessageQueue snackbarMessageQueue)
         {
-            _allItems = GenerateDemoItems(snackbarMessageQueue);
-            FilterItems(null);
+            DemoItems = new ObservableCollection<DemoItem>(new[]
+            {
+                new DemoItem(
+                    "Home",
+                    new Home(),
+                    new[]
+                    {
+                        new DocumentationLink(
+                            DocumentationLinkType.Wiki,
+                            $"{ConfigurationManager.AppSettings["GitHub"]}/wiki",
+                            "WIKI"),
+                        DocumentationLink.DemoPageLink<Home>()
+                    }
+                )
+            });
+
+            foreach (var item in GenerateDemoItems(snackbarMessageQueue).OrderBy(i => i.Name))
+            {
+                DemoItems.Add(item);
+            }
+
+            _demoItemsView = CollectionViewSource.GetDefaultView(DemoItems);
+            _demoItemsView.Filter = DemoItemsFilter;
+
+            HomeCommand = new AnotherCommandImplementation(_ => { SelectedIndex = 0; });
 
             MovePrevCommand = new AnotherCommandImplementation(
                 _ =>
@@ -34,13 +59,12 @@ namespace MaterialDesignDemo.Domain
 
                    SelectedIndex++;
                },
-               _ => SelectedIndex < _allItems.Count - 1);
+               _ => SelectedIndex < DemoItems.Count - 1);
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;
 
-        private readonly ObservableCollection<DemoItem> _allItems;
-        private ObservableCollection<DemoItem>? _demoItems;
+        private readonly ICollectionView _demoItemsView;
         private DemoItem? _selectedItem;
         private int _selectedIndex;
         private string? _searchKeyword;
@@ -52,19 +76,11 @@ namespace MaterialDesignDemo.Domain
             {
                 _searchKeyword = value;
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(SearchKeyword)));
-                FilterItems(_searchKeyword);
+                _demoItemsView.Refresh();
             }
         }
 
-        public ObservableCollection<DemoItem>? DemoItems
-        {
-            get => _demoItems;
-            set
-            {
-                _demoItems = value;
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(DemoItems)));
-            }
-        }
+        public ObservableCollection<DemoItem> DemoItems { get; }
 
         public DemoItem? SelectedItem
         {
@@ -88,252 +104,320 @@ namespace MaterialDesignDemo.Domain
             }
         }
 
+        public AnotherCommandImplementation HomeCommand { get; }
         public AnotherCommandImplementation MovePrevCommand { get; }
         public AnotherCommandImplementation MoveNextCommand { get; }
 
-        private ObservableCollection<DemoItem> GenerateDemoItems(ISnackbarMessageQueue snackbarMessageQueue)
+        private static IEnumerable<DemoItem> GenerateDemoItems(ISnackbarMessageQueue snackbarMessageQueue)
         {
             if (snackbarMessageQueue is null)
                 throw new ArgumentNullException(nameof(snackbarMessageQueue));
 
-            return new ObservableCollection<DemoItem>
-            {
-                new DemoItem("Home", new Home(),
-                    new []
-                    {
-                        new DocumentationLink(DocumentationLinkType.Wiki, $"{ConfigurationManager.AppSettings["GitHub"]}/wiki", "WIKI"),
-                        DocumentationLink.DemoPageLink<Home>()
-                    }
-                ),
-                new DemoItem("Palette", new PaletteSelector { DataContext = new PaletteSelectorViewModel() },
-                    new []
-                    {
-                        DocumentationLink.WikiLink("Brush-Names", "Brushes"),
-                        DocumentationLink.WikiLink("Custom-Palette-Hues", "Custom Palettes"),
-                        DocumentationLink.WikiLink("Swatches-and-Recommended-Colors", "Swatches"),
-                        DocumentationLink.DemoPageLink<PaletteSelector>("Demo View"),
-                        DocumentationLink.DemoPageLink<PaletteSelectorViewModel>("Demo View Model"),
-                        DocumentationLink.ApiLink<PaletteHelper>()
-                    }),
-                new DemoItem("Color Tool", new ColorTool { DataContext = new ColorToolViewModel() },
-                    new []
-                    {
-                        DocumentationLink.WikiLink("Brush-Names", "Brushes"),
-                        DocumentationLink.WikiLink("Custom-Palette-Hues", "Custom Palettes"),
-                        DocumentationLink.WikiLink("Swatches-and-Recommended-Colors", "Swatches"),
-                        DocumentationLink.DemoPageLink<ColorTool>("Demo View"),
-                        DocumentationLink.DemoPageLink<ColorToolViewModel>("Demo View Model"),
-                        DocumentationLink.ApiLink<PaletteHelper>()
-                    }),
-                new DemoItem("Buttons", new Buttons { DataContext = new ButtonsViewModel() } ,
-                    new []
-                    {
-                        DocumentationLink.WikiLink("Button-Styles", "Buttons"),
-                        DocumentationLink.DemoPageLink<Buttons>("Demo View"),
-                        DocumentationLink.DemoPageLink<ButtonsViewModel>("Demo View Model"),
-                        DocumentationLink.StyleLink("Button"),
-                        DocumentationLink.StyleLink("PopupBox"),
-                        DocumentationLink.ApiLink<PopupBox>()
-                    })
-                    {
-                        VerticalScrollBarVisibilityRequirement = ScrollBarVisibility.Auto
-                    },
-                new DemoItem("Toggles", new Toggles(), 
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<Toggles>(),
-                        DocumentationLink.StyleLink("ToggleButton"),
-                        DocumentationLink.StyleLink("CheckBox"),
-                        DocumentationLink.ApiLink<Toggles>()
-                    })
-                    {
-                        VerticalScrollBarVisibilityRequirement = ScrollBarVisibility.Auto
-                    },
-                new DemoItem("Rating Bar", new RatingBar(), new []
+            yield return new DemoItem(
+                "Palette",
+                new PaletteSelector { DataContext = new PaletteSelectorViewModel() },
+                new[]
+                {
+                    DocumentationLink.WikiLink("Brush-Names", "Brushes"),
+                    DocumentationLink.WikiLink("Custom-Palette-Hues", "Custom Palettes"),
+                    DocumentationLink.WikiLink("Swatches-and-Recommended-Colors", "Swatches"),
+                    DocumentationLink.DemoPageLink<PaletteSelector>("Demo View"),
+                    DocumentationLink.DemoPageLink<PaletteSelectorViewModel>("Demo View Model"),
+                    DocumentationLink.ApiLink<PaletteHelper>()
+                });
+
+            yield return new DemoItem(
+                "Color Tool",
+                new ColorTool { DataContext = new ColorToolViewModel() },
+                new[]
+                {
+                    DocumentationLink.WikiLink("Brush-Names", "Brushes"),
+                    DocumentationLink.WikiLink("Custom-Palette-Hues", "Custom Palettes"),
+                    DocumentationLink.WikiLink("Swatches-and-Recommended-Colors", "Swatches"),
+                    DocumentationLink.DemoPageLink<ColorTool>("Demo View"),
+                    DocumentationLink.DemoPageLink<ColorToolViewModel>("Demo View Model"),
+                    DocumentationLink.ApiLink<PaletteHelper>()
+                });
+
+            yield return new DemoItem(
+                "Buttons",
+                new Buttons { DataContext = new ButtonsViewModel() },
+                new[]
+                {
+                    DocumentationLink.WikiLink("Button-Styles", "Buttons"),
+                    DocumentationLink.DemoPageLink<Buttons>("Demo View"),
+                    DocumentationLink.DemoPageLink<ButtonsViewModel>("Demo View Model"),
+                    DocumentationLink.StyleLink("Button"),
+                    DocumentationLink.StyleLink("PopupBox"),
+                    DocumentationLink.ApiLink<PopupBox>()
+                });
+
+            yield return new DemoItem(
+                "Toggles",
+                new Toggles(),
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<Toggles>(),
+                    DocumentationLink.StyleLink("ToggleButton"),
+                    DocumentationLink.StyleLink("CheckBox"),
+                    DocumentationLink.ApiLink<Toggles>()
+                });
+
+            yield return new DemoItem(
+                "Rating Bar",
+                new RatingBar(),
+                new[]
                 {
                     DocumentationLink.DemoPageLink<RatingBar>(),
                     DocumentationLink.StyleLink("RatingBar"),
                     DocumentationLink.ApiLink<RatingBar>()
-                }),
-                new DemoItem("Fields", new Fields(),
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<Fields>(),
-                        DocumentationLink.StyleLink("TextBox")
-                    })
-                    {
-                        VerticalScrollBarVisibilityRequirement = ScrollBarVisibility.Auto
-                    },
-                new DemoItem("Fields line up", new FieldsLineUp(), new []
+                });
+
+            yield return new DemoItem(
+                "Fields",
+                new Fields(),
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<Fields>(),
+                    DocumentationLink.StyleLink("TextBox")
+                });
+
+            yield return new DemoItem(
+                "Fields line up",
+                new FieldsLineUp(),
+                new[]
                 {
                     DocumentationLink.DemoPageLink<FieldsLineUp>()
-                }),
-                new DemoItem("ComboBoxes", new ComboBoxes(),
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<ComboBoxes>(),
-                        DocumentationLink.StyleLink("ComboBox")
-                    })
-                    {
-                        VerticalScrollBarVisibilityRequirement = ScrollBarVisibility.Auto
-                    },
-                new DemoItem("Pickers", new Pickers { DataContext = new PickersViewModel()},
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<Pickers>(),
-                        DocumentationLink.StyleLink("Clock"),
-                        DocumentationLink.StyleLink("DatePicker"),
-                        DocumentationLink.ApiLink<TimePicker>()
-                    }),
-                new DemoItem("Sliders", new Sliders(), new []
-                    {
-                        DocumentationLink.DemoPageLink<Sliders>(),
-                        DocumentationLink.StyleLink("Slider")
-                    }),
-                new DemoItem("Chips", new Chips(), new []
-                    {
-                        DocumentationLink.DemoPageLink<Chips>(),
-                        DocumentationLink.StyleLink("Chip"),
-                        DocumentationLink.ApiLink<Chip>()
-                    }),
-                new DemoItem("Typography", new Typography(), new []
-                    {
-                        DocumentationLink.DemoPageLink<Typography>(),
-                        DocumentationLink.StyleLink("TextBlock")
-                    })
-                    {
-                        VerticalScrollBarVisibilityRequirement = ScrollBarVisibility.Auto,
-                        HorizontalScrollBarVisibilityRequirement = ScrollBarVisibility.Auto
-                    },
-                new DemoItem("Cards", new Cards(), new []
-                    {
-                        DocumentationLink.DemoPageLink<Cards>(),
-                        DocumentationLink.StyleLink("Card"),
-                        DocumentationLink.ApiLink<Card>()
-                    })
+                });
+
+            yield return new DemoItem(
+                "ComboBoxes",
+                new ComboBoxes(),
+                new[]
                 {
-                    VerticalScrollBarVisibilityRequirement = ScrollBarVisibility.Auto
-                },
-                new DemoItem("Icon Pack", new IconPack { DataContext = new IconPackViewModel(snackbarMessageQueue) },
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<IconPack>("Demo View"),
-                        DocumentationLink.DemoPageLink<IconPackViewModel>("Demo View Model"),
-                        DocumentationLink.ApiLink<PackIcon>()
-                    }),
-                new DemoItem("Colour Zones", new ColorZones(),
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<ColorZones>(),
-                        DocumentationLink.ApiLink<ColorZone>()
-                    }),
-                new DemoItem("Lists", new Lists { DataContext = new ListsAndGridsViewModel()},
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<Lists>("Demo View"),
-                        DocumentationLink.DemoPageLink<ListsAndGridsViewModel>("Demo View Model", "Domain"),
-                        DocumentationLink.StyleLink("ListBox"),
-                        DocumentationLink.StyleLink("ListView")
-                    })
+                    DocumentationLink.DemoPageLink<ComboBoxes>(),
+                    DocumentationLink.StyleLink("ComboBox")
+                });
+
+            yield return new DemoItem(
+                "Pickers",
+                new Pickers { DataContext = new PickersViewModel() },
+                new[]
                 {
-                    VerticalScrollBarVisibilityRequirement = ScrollBarVisibility.Auto
-                },
-                new DemoItem("Trees", new Trees { DataContext = new TreesViewModel() },
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<Trees>("Demo View"),
-                        DocumentationLink.DemoPageLink<TreesViewModel>("Demo View Model"),
-                        DocumentationLink.StyleLink("TreeView")
-                    }),
-                new DemoItem("Data Grids", new DataGrids { DataContext = new ListsAndGridsViewModel()},
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<DataGrids>("Demo View"),
-                        DocumentationLink.DemoPageLink<ListsAndGridsViewModel>("Demo View Model", "Domain"),
-                        DocumentationLink.StyleLink("DataGrid")
-                    }),
-                new DemoItem("Expander", new Expander(),
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<Expander>(),
-                        DocumentationLink.StyleLink("Expander")
-                    }),
-                new DemoItem("Group Boxes", new GroupBoxes(),
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<GroupBoxes>(),
-                        DocumentationLink.StyleLink("GroupBox")
-                    }),
-                new DemoItem("Menus & Tool Bars", new MenusAndToolBars(),
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<MenusAndToolBars>(),
-                        DocumentationLink.StyleLink("Menu"),
-                        DocumentationLink.StyleLink("ToolBar")
-                    }),
-                new DemoItem("Progress Indicators", new Progress(),
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<Progress>(),
-                        DocumentationLink.StyleLink("ProgressBar")
-                    }),
-                new DemoItem("Navigation Rail", new NavigationRail { DataContext = null},
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<NavigationRail>("Demo View"),
-                        DocumentationLink.StyleLink("TabControl"),
-                    })
+                    DocumentationLink.DemoPageLink<Pickers>(),
+                    DocumentationLink.StyleLink("Clock"),
+                    DocumentationLink.StyleLink("DatePicker"),
+                    DocumentationLink.ApiLink<TimePicker>()
+                });
+
+            yield return new DemoItem(
+                "Sliders",
+                new Sliders(),
+                new[]
                 {
-                    VerticalScrollBarVisibilityRequirement = ScrollBarVisibility.Auto
-                },
-                new DemoItem("Dialogs", new Dialogs { DataContext = new DialogsViewModel()},
-                    new []
-                    {
-                        DocumentationLink.WikiLink("Dialogs", "Dialogs"),
-                        DocumentationLink.DemoPageLink<Dialogs>("Demo View"),
-                        DocumentationLink.DemoPageLink<DialogsViewModel>("Demo View Model", "Domain"),
-                        DocumentationLink.ApiLink<DialogHost>()
-                    }),
-                new DemoItem("Drawer", new Drawers(),
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<Drawers>("Demo View"),
-                        DocumentationLink.ApiLink<DrawerHost>()
-                    }),
-                new DemoItem("Snackbar", new Snackbars(),
-                    new []
-                    {
-                        DocumentationLink.WikiLink("Snackbar", "Snackbar"),
-                        DocumentationLink.DemoPageLink<Snackbars>(),
-                        DocumentationLink.StyleLink("Snackbar"),
-                        DocumentationLink.ApiLink<Snackbar>(),
-                        DocumentationLink.ApiLink<ISnackbarMessageQueue>()
-                    }),
-                new DemoItem("Transitions", new Transitions(),
-                    new []
-                    {
-                        DocumentationLink.WikiLink("Transitions", "Transitions"),
-                        DocumentationLink.DemoPageLink<Transitions>(),
-                        DocumentationLink.ApiLink<Transitioner>("Transitions"),
-                        DocumentationLink.ApiLink<TransitionerSlide>("Transitions"),
-                        DocumentationLink.ApiLink<TransitioningContent>("Transitions"),
-                    }),
-                new DemoItem("Shadows", new Shadows(),
-                    new []
-                    {
-                        DocumentationLink.DemoPageLink<Shadows>(),
-                    })
+                    DocumentationLink.DemoPageLink<Sliders>(),
+                    DocumentationLink.StyleLink("Slider")
+                });
+
+            yield return new DemoItem(
+                "Chips",
+                new Chips(),
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<Chips>(),
+                    DocumentationLink.StyleLink("Chip"),
+                    DocumentationLink.ApiLink<Chip>()
+                });
+
+            yield return new DemoItem(
+                "Typography",
+                new Typography(),
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<Typography>(),
+                    DocumentationLink.StyleLink("TextBlock")
+                })
+            {
+                HorizontalScrollBarVisibilityRequirement = ScrollBarVisibility.Auto
             };
+
+            yield return new DemoItem(
+                "Cards",
+                new Cards(),
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<Cards>(),
+                    DocumentationLink.StyleLink("Card"),
+                    DocumentationLink.ApiLink<Card>()
+                });
+
+            yield return new DemoItem(
+                "Icon Pack",
+                new IconPack { DataContext = new IconPackViewModel(snackbarMessageQueue) },
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<IconPack>("Demo View"),
+                    DocumentationLink.DemoPageLink<IconPackViewModel>("Demo View Model"),
+                    DocumentationLink.ApiLink<PackIcon>()
+                })
+            {
+                VerticalScrollBarVisibilityRequirement = ScrollBarVisibility.Disabled
+            };
+
+            yield return new DemoItem(
+                "Colour Zones",
+                new ColorZones(),
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<ColorZones>(),
+                    DocumentationLink.ApiLink<ColorZone>()
+                });
+
+            yield return new DemoItem(
+                "Lists",
+                new Lists { DataContext = new ListsAndGridsViewModel() },
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<Lists>("Demo View"),
+                    DocumentationLink.DemoPageLink<ListsAndGridsViewModel>("Demo View Model", "Domain"),
+                    DocumentationLink.StyleLink("ListBox"),
+                    DocumentationLink.StyleLink("ListView")
+                });
+
+            yield return new DemoItem(
+                "Trees",
+                new Trees { DataContext = new TreesViewModel() },
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<Trees>("Demo View"),
+                    DocumentationLink.DemoPageLink<TreesViewModel>("Demo View Model"),
+                    DocumentationLink.StyleLink("TreeView")
+                });
+
+            yield return new DemoItem(
+                "Data Grids",
+                new DataGrids { DataContext = new ListsAndGridsViewModel() },
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<DataGrids>("Demo View"),
+                    DocumentationLink.DemoPageLink<ListsAndGridsViewModel>("Demo View Model", "Domain"),
+                    DocumentationLink.StyleLink("DataGrid")
+                });
+
+            yield return new DemoItem(
+                "Expander",
+                new Expander(),
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<Expander>(),
+                    DocumentationLink.StyleLink("Expander")
+                });
+
+            yield return new DemoItem(
+                "Group Boxes",
+                new GroupBoxes(),
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<GroupBoxes>(),
+                    DocumentationLink.StyleLink("GroupBox")
+                });
+
+            yield return new DemoItem(
+                "Menus & Tool Bars",
+                new MenusAndToolBars(),
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<MenusAndToolBars>(),
+                    DocumentationLink.StyleLink("Menu"),
+                    DocumentationLink.StyleLink("ToolBar")
+                });
+
+            yield return new DemoItem(
+                "Progress Indicators",
+                new Progress(),
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<Progress>(),
+                    DocumentationLink.StyleLink("ProgressBar")
+                });
+
+            yield return new DemoItem(
+                "Navigation Rail",
+                new NavigationRail(),
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<NavigationRail>("Demo View"),
+                    DocumentationLink.StyleLink("TabControl"),
+                });
+
+            yield return new DemoItem(
+                "Dialogs",
+                new Dialogs { DataContext = new DialogsViewModel() },
+                new[]
+                {
+                    DocumentationLink.WikiLink("Dialogs", "Dialogs"),
+                    DocumentationLink.DemoPageLink<Dialogs>("Demo View"),
+                    DocumentationLink.DemoPageLink<DialogsViewModel>("Demo View Model", "Domain"),
+                    DocumentationLink.ApiLink<DialogHost>()
+                })
+            {
+                HorizontalScrollBarVisibilityRequirement = ScrollBarVisibility.Auto
+            };
+
+            yield return new DemoItem(
+                "Drawer",
+                new Drawers(),
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<Drawers>("Demo View"),
+                    DocumentationLink.ApiLink<DrawerHost>()
+                });
+
+            yield return new DemoItem(
+                "Snackbar",
+                new Snackbars(),
+                new[]
+                {
+                    DocumentationLink.WikiLink("Snackbar", "Snackbar"),
+                    DocumentationLink.DemoPageLink<Snackbars>(),
+                    DocumentationLink.StyleLink("Snackbar"),
+                    DocumentationLink.ApiLink<Snackbar>(),
+                    DocumentationLink.ApiLink<ISnackbarMessageQueue>()
+                })
+            {
+                HorizontalScrollBarVisibilityRequirement = ScrollBarVisibility.Auto
+            };
+
+            yield return new DemoItem(
+                "Transitions",
+                new Transitions(),
+                new[]
+                {
+                    DocumentationLink.WikiLink("Transitions", "Transitions"),
+                    DocumentationLink.DemoPageLink<Transitions>(),
+                    DocumentationLink.ApiLink<Transitioner>("Transitions"),
+                    DocumentationLink.ApiLink<TransitionerSlide>("Transitions"),
+                    DocumentationLink.ApiLink<TransitioningContent>("Transitions"),
+                });
+
+            yield return new DemoItem(
+                "Shadows",
+                new Shadows(),
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<Shadows>(),
+                });
         }
 
-        private void FilterItems(string? keyword)
+        private bool DemoItemsFilter(object obj)
         {
-            var filteredItems =
-                string.IsNullOrWhiteSpace(keyword) ?
-                _allItems :
-                _allItems.Where(i => i.Name.ToLower().Contains(keyword!.ToLower()));
+            if (string.IsNullOrWhiteSpace(_searchKeyword))
+            {
+                return true;
+            }
 
-            DemoItems = new ObservableCollection<DemoItem>(filteredItems);
+            return obj is DemoItem item
+                   && item.Name.ToLower().Contains(_searchKeyword!.ToLower());
         }
     }
 }

--- a/MainDemo.Wpf/FieldsLineUp.xaml
+++ b/MainDemo.Wpf/FieldsLineUp.xaml
@@ -6,239 +6,237 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="300">
-    <ScrollViewer>
-        <GroupBox
-            materialDesign:ColorZoneAssist.Mode="Custom"
-            materialDesign:ColorZoneAssist.Background="{DynamicResource PrimaryHueLightBrush}"
-            materialDesign:ColorZoneAssist.Foreground="{DynamicResource PrimaryHueLightForegroundBrush}"
-            Margin="10"
-            HorizontalAlignment="Left"
-            VerticalAlignment="Top">
-            <GroupBox.Header>
-                <StackPanel
-                    Orientation="Horizontal">
-                    <StackPanel>
-                        <StackPanel.Resources>
-                            <Style TargetType="Slider" BasedOn="{StaticResource MaterialDesignSlider}">
-                                <Setter Property="Width" Value="130" />
-                                <Setter Property="Margin" Value="10 0" />
-                                <Setter Property="IsSnapToTickEnabled" Value="True" />
-                                <Setter Property="VerticalAlignment" Value="Center" />
-                            </Style>
-                            <Style TargetType="TextBlock" BasedOn="{StaticResource MaterialDesignCaptionTextBlock}">
-                                <Setter Property="Margin" Value="10 0" />
-                                <Setter Property="HorizontalAlignment" Value="Left" />
-                            </Style>
-                        </StackPanel.Resources>
-                        <TextBlock>
-                            <Run Text="FontSize" FontFamily="Consolas" />
-                            <Run Text="{Binding Value, ElementName=FontSizeSlider, Mode=OneWay}" FontStyle="Italic" />
-                        </TextBlock>
-                        <Slider
-                            x:Name="FontSizeSlider"
-                            Minimum="8"
-                            Maximum="24"
-                            Value="14" />
-                        <TextBlock>
-                            <Run Text="Padding" FontFamily="Consolas" />
-                            <LineBreak />
-                            <Run Text="horizontal" />
-                            <Run Text="{Binding Value, ElementName=HorizontalPaddingSlider, Mode=OneWay}" FontStyle="Italic" />
-                        </TextBlock>
-                        <Slider
-                            x:Name="HorizontalPaddingSlider"
-                            Minimum="0"
-                            Maximum="16"
-                            Value="0" />
-                        <TextBlock>
-                            <Run Text="Padding" FontFamily="Consolas" />
-                            <LineBreak />
-                            <Run Text="vertical" />
-                            <Run Text="{Binding Value, ElementName=VerticalPaddingSlider, Mode=OneWay}" FontStyle="Italic" />
-                        </TextBlock>
-                        <Slider
-                            x:Name="VerticalPaddingSlider"
-                            Minimum="0"
-                            Maximum="16"
-                            Value="4" />
-                        <TextBlock>
-                            <Run Text="TextFieldAssist.TextBoxViewMargin" FontFamily="Consolas" />
-                            <LineBreak />
-                            <Run Text="horizontal" />
-                            <Run Text="{Binding Value, ElementName=HorizontalTextBoxViewMarginSlider, Mode=OneWay}" FontStyle="Italic" />
-                        </TextBlock>
-                        <Slider
-                            x:Name="HorizontalTextBoxViewMarginSlider"
-                            Minimum="0"
-                            Maximum="16"
-                            Value="4" />
-                    </StackPanel>
-                    <StackPanel>
-                        <StackPanel.Resources>
-                            <Style TargetType="TextBox" BasedOn="{StaticResource MaterialDesignTextBox}">
-                                <Setter Property="FontFamily" Value="Consolas" />
-                                <Setter Property="MinWidth" Value="200" />
-                                <Setter Property="materialDesign:HintAssist.IsFloating" Value="True" />
-                                <Setter Property="Margin" Value="10 2" />
-                                <Setter Property="HorizontalAlignment" Value="Left" />
-                                <Setter Property="VerticalAlignment" Value="Center" />
-                            </Style>
-                        </StackPanel.Resources>
-                        <TextBox x:Name="HintTextBox" materialDesign:HintAssist.Hint="HintAssist.Hint" Text="Hint" />
-                        <TextBox x:Name="HelperTextBox" materialDesign:HintAssist.Hint="HintAssist.HelperText" />
-                        <TextBox x:Name="ValidationErrorTextBox" materialDesign:HintAssist.Hint="Validation error" />
-                        <TextBox x:Name="PrefixTextBox" materialDesign:HintAssist.Hint="TextFieldAssist.PrefixText" />
-                        <TextBox x:Name="SuffixTextBox" materialDesign:HintAssist.Hint="TextFieldAssist.SuffixText" />
-                    </StackPanel>
-                    <StackPanel>
-                        <StackPanel.Resources>
-                            <Style TargetType="CheckBox" BasedOn="{StaticResource MaterialDesignCheckBox}">
-                                <Setter Property="FontFamily" Value="Consolas" />
-                                <Setter Property="Margin" Value="10 4" />
-                                <Setter Property="HorizontalAlignment" Value="Left" />
-                            </Style>
-                        </StackPanel.Resources>
-                        <CheckBox x:Name="IsEnabledCheckBox" Content="IsEnabled" IsChecked="True" />
-                        <CheckBox x:Name="HasClearButtonCheckBox" Content="TextFieldAssist.HasClearButton" />
-                        <CheckBox x:Name="IsEditableCheckBox" Content="ComboBox.IsEditable" />
-                    </StackPanel>
-                </StackPanel>
-            </GroupBox.Header>
-            <StackPanel>
-                <Grid
-                    x:Name="FieldsLineUpGrid"
-                    TextElement.FontSize="{Binding Value, ElementName=FontSizeSlider}"
-                    IsEnabled="{Binding IsChecked, ElementName=IsEnabledCheckBox}"
-                    HorizontalAlignment="Left">
-                    <Grid.Resources>
-                        <Style x:Key="StyleHeader" TargetType="TextBlock" BasedOn="{StaticResource MaterialDesignCaptionTextBlock}">
-                            <Setter Property="VerticalAlignment" Value="Center" />
-                            <Setter Property="HorizontalAlignment" Value="Left" />
+    <GroupBox
+        materialDesign:ColorZoneAssist.Mode="Custom"
+        materialDesign:ColorZoneAssist.Background="{DynamicResource PrimaryHueLightBrush}"
+        materialDesign:ColorZoneAssist.Foreground="{DynamicResource PrimaryHueLightForegroundBrush}"
+        Margin="10"
+        HorizontalAlignment="Left"
+        VerticalAlignment="Top">
+        <GroupBox.Header>
+            <StackPanel
+                Orientation="Horizontal">
+                <StackPanel>
+                    <StackPanel.Resources>
+                        <Style TargetType="Slider" BasedOn="{StaticResource MaterialDesignSlider}">
+                            <Setter Property="Width" Value="130" />
                             <Setter Property="Margin" Value="10 0" />
-                            <Setter Property="Opacity" Value="0.56" />
-                        </Style>
-                        <Style x:Key="FieldHeader" TargetType="TextBlock" BasedOn="{StaticResource MaterialDesignCaptionTextBlock}">
-                            <Setter Property="VerticalAlignment" Value="Top" />
-                            <Setter Property="HorizontalAlignment" Value="Center" />
-                            <Setter Property="Margin" Value="0 6" />
-                            <Setter Property="Opacity" Value="0.56" />
-                        </Style>
-                        <Style x:Key="NotAvailable" TargetType="TextBlock" BasedOn="{StaticResource MaterialDesignCaptionTextBlock}">
-                            <Setter Property="Text" Value="N/A" />
-                            <Setter Property="Opacity" Value="0.24" />
+                            <Setter Property="IsSnapToTickEnabled" Value="True" />
                             <Setter Property="VerticalAlignment" Value="Center" />
-                            <Setter Property="HorizontalAlignment" Value="Center" />
                         </Style>
-                    </Grid.Resources>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition MinWidth="100" />
-                        <ColumnDefinition MinWidth="100" />
-                        <ColumnDefinition MinWidth="100" />
-                        <ColumnDefinition MinWidth="100" />
-                        <ColumnDefinition MinWidth="100" />
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock Grid.Column="0" Grid.Row="1" Style="{StaticResource StyleHeader}" Text="Default" />
-                    <TextBlock Grid.Column="0" Grid.Row="2" Style="{StaticResource StyleHeader}" Text="Floating" />
-                    <TextBlock Grid.Column="0" Grid.Row="3" Style="{StaticResource StyleHeader}" Text="Filled" />
-                    <TextBlock Grid.Column="0" Grid.Row="4" Style="{StaticResource StyleHeader}" Text="Outlined" />
-
-                    <TextBlock Grid.Column="1" Grid.Row="0" Style="{StaticResource FieldHeader}" Text="TextField" />
-                    <TextBlock Grid.Column="2" Grid.Row="0" Style="{StaticResource FieldHeader}" Text="PasswordBox" />
-                    <TextBlock Grid.Column="3" Grid.Row="0" Style="{StaticResource FieldHeader}" Text="ComboBox" />
-                    <TextBlock Grid.Column="4" Grid.Row="0" Style="{StaticResource FieldHeader}" Text="DatePicker" />
-                    <TextBlock Grid.Column="5" Grid.Row="0" Style="{StaticResource FieldHeader}" Text="TimePicker" />
-
-                    <TextBox
-                        Grid.Column="1"
-                        Grid.Row="1" />
-                    <TextBox
-                        Grid.Column="1"
-                        Grid.Row="2"
-                        materialDesign:HintAssist.IsFloating="True" />
-                    <TextBox
-                        Grid.Column="1"
-                        Grid.Row="3"
-                        Style="{StaticResource MaterialDesignFilledTextBox}" />
-                    <TextBox
-                        Grid.Column="1"
-                        Grid.Row="4"
-                        Style="{StaticResource MaterialDesignOutlinedTextBox}" />
-
-                    <PasswordBox
-                        Grid.Column="2"
-                        Grid.Row="1" />
-                    <PasswordBox
-                        Grid.Column="2"
-                        Grid.Row="2"
-                        materialDesign:HintAssist.IsFloating="True" />
-                    <PasswordBox
-                        Grid.Column="2"
-                        Grid.Row="3"
-                        Style="{StaticResource MaterialDesignFilledPasswordBox}" />
-                    <PasswordBox
-                        Grid.Column="2"
-                        Grid.Row="4"
-                        Style="{StaticResource MaterialDesignOutlinedPasswordBox}" />
-
-                    <ComboBox
-                        Grid.Column="3"
-                        Grid.Row="1" />
-                    <ComboBox
-                        Grid.Column="3"
-                        Grid.Row="2"
-                        materialDesign:HintAssist.IsFloating="true" />
-                    <ComboBox
-                        Grid.Column="3"
-                        Grid.Row="3"
-                        Style="{StaticResource MaterialDesignFilledComboBox}" />
-                    <TextBlock
-                        Grid.Column="3"
-                        Grid.Row="4"
-                        Style="{StaticResource NotAvailable}" />
-
-                    <DatePicker
-                        Grid.Column="4"
-                        Grid.Row="1" />
-                    <DatePicker
-                        Grid.Column="4"
-                        Grid.Row="2"
-                        materialDesign:HintAssist.IsFloating="True" />
-                    <DatePicker
-                        Grid.Column="4"
-                        Grid.Row="3"
-                        Style="{StaticResource MaterialDesignFilledDatePicker}" />
-                    <DatePicker
-                        Grid.Column="4"
-                        Grid.Row="4"
-                        Style="{StaticResource MaterialDesignOutlinedDatePicker}" />
-
-                    <materialDesign:TimePicker
-                        Grid.Column="5"
-                        Grid.Row="1" />
-                    <materialDesign:TimePicker
-                        Grid.Column="5"
-                        Grid.Row="2"
-                        Style="{StaticResource MaterialDesignFloatingHintTimePicker}" />
-                    <materialDesign:TimePicker
-                        Grid.Column="5"
-                        Grid.Row="3"
-                        Style="{StaticResource MaterialDesignFilledTimePicker}" />
-                    <materialDesign:TimePicker
-                        Grid.Column="5"
-                        Grid.Row="4"
-                        Style="{StaticResource MaterialDesignOutlinedTimePicker}" />
-
-                </Grid>
+                        <Style TargetType="TextBlock" BasedOn="{StaticResource MaterialDesignCaptionTextBlock}">
+                            <Setter Property="Margin" Value="10 0" />
+                            <Setter Property="HorizontalAlignment" Value="Left" />
+                        </Style>
+                    </StackPanel.Resources>
+                    <TextBlock>
+                        <Run Text="FontSize" FontFamily="Consolas" />
+                        <Run Text="{Binding Value, ElementName=FontSizeSlider, Mode=OneWay}" FontStyle="Italic" />
+                    </TextBlock>
+                    <Slider
+                        x:Name="FontSizeSlider"
+                        Minimum="8"
+                        Maximum="24"
+                        Value="14" />
+                    <TextBlock>
+                        <Run Text="Padding" FontFamily="Consolas" />
+                        <LineBreak />
+                        <Run Text="horizontal" />
+                        <Run Text="{Binding Value, ElementName=HorizontalPaddingSlider, Mode=OneWay}" FontStyle="Italic" />
+                    </TextBlock>
+                    <Slider
+                        x:Name="HorizontalPaddingSlider"
+                        Minimum="0"
+                        Maximum="16"
+                        Value="0" />
+                    <TextBlock>
+                        <Run Text="Padding" FontFamily="Consolas" />
+                        <LineBreak />
+                        <Run Text="vertical" />
+                        <Run Text="{Binding Value, ElementName=VerticalPaddingSlider, Mode=OneWay}" FontStyle="Italic" />
+                    </TextBlock>
+                    <Slider
+                        x:Name="VerticalPaddingSlider"
+                        Minimum="0"
+                        Maximum="16"
+                        Value="4" />
+                    <TextBlock>
+                        <Run Text="TextFieldAssist.TextBoxViewMargin" FontFamily="Consolas" />
+                        <LineBreak />
+                        <Run Text="horizontal" />
+                        <Run Text="{Binding Value, ElementName=HorizontalTextBoxViewMarginSlider, Mode=OneWay}" FontStyle="Italic" />
+                    </TextBlock>
+                    <Slider
+                        x:Name="HorizontalTextBoxViewMarginSlider"
+                        Minimum="0"
+                        Maximum="16"
+                        Value="4" />
+                </StackPanel>
+                <StackPanel>
+                    <StackPanel.Resources>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource MaterialDesignTextBox}">
+                            <Setter Property="FontFamily" Value="Consolas" />
+                            <Setter Property="MinWidth" Value="200" />
+                            <Setter Property="materialDesign:HintAssist.IsFloating" Value="True" />
+                            <Setter Property="Margin" Value="10 2" />
+                            <Setter Property="HorizontalAlignment" Value="Left" />
+                            <Setter Property="VerticalAlignment" Value="Center" />
+                        </Style>
+                    </StackPanel.Resources>
+                    <TextBox x:Name="HintTextBox" materialDesign:HintAssist.Hint="HintAssist.Hint" Text="Hint" />
+                    <TextBox x:Name="HelperTextBox" materialDesign:HintAssist.Hint="HintAssist.HelperText" />
+                    <TextBox x:Name="ValidationErrorTextBox" materialDesign:HintAssist.Hint="Validation error" />
+                    <TextBox x:Name="PrefixTextBox" materialDesign:HintAssist.Hint="TextFieldAssist.PrefixText" />
+                    <TextBox x:Name="SuffixTextBox" materialDesign:HintAssist.Hint="TextFieldAssist.SuffixText" />
+                </StackPanel>
+                <StackPanel>
+                    <StackPanel.Resources>
+                        <Style TargetType="CheckBox" BasedOn="{StaticResource MaterialDesignCheckBox}">
+                            <Setter Property="FontFamily" Value="Consolas" />
+                            <Setter Property="Margin" Value="10 4" />
+                            <Setter Property="HorizontalAlignment" Value="Left" />
+                        </Style>
+                    </StackPanel.Resources>
+                    <CheckBox x:Name="IsEnabledCheckBox" Content="IsEnabled" IsChecked="True" />
+                    <CheckBox x:Name="HasClearButtonCheckBox" Content="TextFieldAssist.HasClearButton" />
+                    <CheckBox x:Name="IsEditableCheckBox" Content="ComboBox.IsEditable" />
+                </StackPanel>
             </StackPanel>
-        </GroupBox>
-    </ScrollViewer>
+        </GroupBox.Header>
+        <StackPanel>
+            <Grid
+                x:Name="FieldsLineUpGrid"
+                TextElement.FontSize="{Binding Value, ElementName=FontSizeSlider}"
+                IsEnabled="{Binding IsChecked, ElementName=IsEnabledCheckBox}"
+                HorizontalAlignment="Left">
+                <Grid.Resources>
+                    <Style x:Key="StyleHeader" TargetType="TextBlock" BasedOn="{StaticResource MaterialDesignCaptionTextBlock}">
+                        <Setter Property="VerticalAlignment" Value="Center" />
+                        <Setter Property="HorizontalAlignment" Value="Left" />
+                        <Setter Property="Margin" Value="10 0" />
+                        <Setter Property="Opacity" Value="0.56" />
+                    </Style>
+                    <Style x:Key="FieldHeader" TargetType="TextBlock" BasedOn="{StaticResource MaterialDesignCaptionTextBlock}">
+                        <Setter Property="VerticalAlignment" Value="Top" />
+                        <Setter Property="HorizontalAlignment" Value="Center" />
+                        <Setter Property="Margin" Value="0 6" />
+                        <Setter Property="Opacity" Value="0.56" />
+                    </Style>
+                    <Style x:Key="NotAvailable" TargetType="TextBlock" BasedOn="{StaticResource MaterialDesignCaptionTextBlock}">
+                        <Setter Property="Text" Value="N/A" />
+                        <Setter Property="Opacity" Value="0.24" />
+                        <Setter Property="VerticalAlignment" Value="Center" />
+                        <Setter Property="HorizontalAlignment" Value="Center" />
+                    </Style>
+                </Grid.Resources>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition MinWidth="100" />
+                    <ColumnDefinition MinWidth="100" />
+                    <ColumnDefinition MinWidth="100" />
+                    <ColumnDefinition MinWidth="100" />
+                    <ColumnDefinition MinWidth="100" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Column="0" Grid.Row="1" Style="{StaticResource StyleHeader}" Text="Default" />
+                <TextBlock Grid.Column="0" Grid.Row="2" Style="{StaticResource StyleHeader}" Text="Floating" />
+                <TextBlock Grid.Column="0" Grid.Row="3" Style="{StaticResource StyleHeader}" Text="Filled" />
+                <TextBlock Grid.Column="0" Grid.Row="4" Style="{StaticResource StyleHeader}" Text="Outlined" />
+
+                <TextBlock Grid.Column="1" Grid.Row="0" Style="{StaticResource FieldHeader}" Text="TextField" />
+                <TextBlock Grid.Column="2" Grid.Row="0" Style="{StaticResource FieldHeader}" Text="PasswordBox" />
+                <TextBlock Grid.Column="3" Grid.Row="0" Style="{StaticResource FieldHeader}" Text="ComboBox" />
+                <TextBlock Grid.Column="4" Grid.Row="0" Style="{StaticResource FieldHeader}" Text="DatePicker" />
+                <TextBlock Grid.Column="5" Grid.Row="0" Style="{StaticResource FieldHeader}" Text="TimePicker" />
+
+                <TextBox
+                    Grid.Column="1"
+                    Grid.Row="1" />
+                <TextBox
+                    Grid.Column="1"
+                    Grid.Row="2"
+                    materialDesign:HintAssist.IsFloating="True" />
+                <TextBox
+                    Grid.Column="1"
+                    Grid.Row="3"
+                    Style="{StaticResource MaterialDesignFilledTextBox}" />
+                <TextBox
+                    Grid.Column="1"
+                    Grid.Row="4"
+                    Style="{StaticResource MaterialDesignOutlinedTextBox}" />
+
+                <PasswordBox
+                    Grid.Column="2"
+                    Grid.Row="1" />
+                <PasswordBox
+                    Grid.Column="2"
+                    Grid.Row="2"
+                    materialDesign:HintAssist.IsFloating="True" />
+                <PasswordBox
+                    Grid.Column="2"
+                    Grid.Row="3"
+                    Style="{StaticResource MaterialDesignFilledPasswordBox}" />
+                <PasswordBox
+                    Grid.Column="2"
+                    Grid.Row="4"
+                    Style="{StaticResource MaterialDesignOutlinedPasswordBox}" />
+
+                <ComboBox
+                    Grid.Column="3"
+                    Grid.Row="1" />
+                <ComboBox
+                    Grid.Column="3"
+                    Grid.Row="2"
+                    materialDesign:HintAssist.IsFloating="true" />
+                <ComboBox
+                    Grid.Column="3"
+                    Grid.Row="3"
+                    Style="{StaticResource MaterialDesignFilledComboBox}" />
+                <TextBlock
+                    Grid.Column="3"
+                    Grid.Row="4"
+                    Style="{StaticResource NotAvailable}" />
+
+                <DatePicker
+                    Grid.Column="4"
+                    Grid.Row="1" />
+                <DatePicker
+                    Grid.Column="4"
+                    Grid.Row="2"
+                    materialDesign:HintAssist.IsFloating="True" />
+                <DatePicker
+                    Grid.Column="4"
+                    Grid.Row="3"
+                    Style="{StaticResource MaterialDesignFilledDatePicker}" />
+                <DatePicker
+                    Grid.Column="4"
+                    Grid.Row="4"
+                    Style="{StaticResource MaterialDesignOutlinedDatePicker}" />
+
+                <materialDesign:TimePicker
+                    Grid.Column="5"
+                    Grid.Row="1" />
+                <materialDesign:TimePicker
+                    Grid.Column="5"
+                    Grid.Row="2"
+                    Style="{StaticResource MaterialDesignFloatingHintTimePicker}" />
+                <materialDesign:TimePicker
+                    Grid.Column="5"
+                    Grid.Row="3"
+                    Style="{StaticResource MaterialDesignFilledTimePicker}" />
+                <materialDesign:TimePicker
+                    Grid.Column="5"
+                    Grid.Row="4"
+                    Style="{StaticResource MaterialDesignOutlinedTimePicker}" />
+
+            </Grid>
+        </StackPanel>
+    </GroupBox>
 </UserControl>

--- a/MainDemo.Wpf/IconPack.xaml
+++ b/MainDemo.Wpf/IconPack.xaml
@@ -53,7 +53,10 @@
             Grid.Row="1"
             Margin="0 8 0 0"
             ItemsSource="{Binding Kinds}"
-            SelectedItem="{Binding Group}">
+            SelectedItem="{Binding Group}"
+            VirtualizingPanel.IsVirtualizing="True"
+            VirtualizingPanel.ScrollUnit="Pixel"
+            VirtualizingPanel.VirtualizationMode="Recycling">
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
                     <virtualCollection:VirtualizingWrapPanel />

--- a/MainDemo.Wpf/Lists.xaml
+++ b/MainDemo.Wpf/Lists.xaml
@@ -20,184 +20,180 @@
         </ResourceDictionary>
     </UserControl.Resources>
     
-    <ScrollViewer
-        VerticalScrollBarVisibility="Auto"
-        HorizontalScrollBarVisibility="Auto">
-        <Grid Margin="8" >
+    <Grid Margin="8" >
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock
+            Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+            Text="ListBox"/>
+        
+        <Grid Grid.Row="1">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
+                <RowDefinition/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-
-            <TextBlock
-                Style="{StaticResource MaterialDesignHeadline6TextBlock}"
-                Text="ListBox"/>
             
-            <Grid Grid.Row="1">
-                <Grid.RowDefinitions>
-                    <RowDefinition/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="1*"/>
-                    <ColumnDefinition Width="1*"/>
-                    <ColumnDefinition Width="1*"/>
-                </Grid.ColumnDefinitions>      
-                <smtx:XamlDisplay
-                    UniqueKey="list_1"
-                    Grid.Column="0">
-                    <ListBox IsEnabled="{Binding IsChecked, ElementName=EnableListBox}">
-                        <TextBlock Text="Plain"/>
-                        <TextBlock Text="Old"/>
-                        <TextBlock Text="ListBox"/>
-                        <TextBlock Text="Full of junk"/>
-                    </ListBox>
-                </smtx:XamlDisplay>
-
-                <CheckBox
-                    Name="EnableListBox"
-                    Grid.Column="0"
-                    Grid.Row="1"
-                    IsChecked="True"
-                    Content="Enabled"/>
-
-                <smtx:XamlDisplay
-                    UniqueKey="list_2"
-                    Grid.Column="1"
-                    Grid.Row="0">
-                    <!-- piece together your own items control to create some nice stuff that will make everyone think you are cool. and rightly so, because you are cool.  you might even be a hipster for all I know -->
-                    <ItemsControl
-                        ItemsSource="{Binding Items1}"
-                        Grid.IsSharedSizeScope="True"
-                        Margin="12 0 12 0">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate DataType="{x:Type domain:SelectableViewModel}">
-                                <Border
-                                    x:Name="Border"
-                                    Padding="8">
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition SharedSizeGroup="Checkerz"/>
-                                            <ColumnDefinition/>
-                                        </Grid.ColumnDefinitions>                                        
-                                        <CheckBox
-                                            VerticalAlignment="Center"
-                                            IsChecked="{Binding IsSelected}"/>
-                                        
-                                        <StackPanel
-                                            Margin="8 0 0 0"
-                                            Grid.Column="1">
-                                            <TextBlock Text="{Binding Name}" FontWeight="Bold"/>
-                                            <TextBlock Text="{Binding Description}"/>
-                                        </StackPanel>
-                                    </Grid>
-                                </Border>
-                                
-                                <DataTemplate.Triggers>
-                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
-                                        <Setter TargetName="Border" Property="Background" Value="{DynamicResource MaterialDesignSelection}"/>
-                                    </DataTrigger>
-                                </DataTemplate.Triggers>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                </smtx:XamlDisplay>
-
-                <smtx:XamlDisplay
-                    UniqueKey="list_3"
-                    Grid.Column="2"
-                    Grid.Row="0">
-                    <!-- and here's another -->
-                    <ItemsControl
-                        ItemsSource="{Binding Items2}"
-                        Grid.IsSharedSizeScope="True">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate DataType="{x:Type domain:SelectableViewModel}">
-                                <Border
-                                    x:Name="Border"
-                                    Padding="8"
-                                    BorderThickness="0 0 0 1"
-                                    BorderBrush="{DynamicResource MaterialDesignDivider}">
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition SharedSizeGroup="Checkerz"/>
-                                            <ColumnDefinition/>
-                                        </Grid.ColumnDefinitions>
-                                        
-                                        <ToggleButton
-                                            VerticalAlignment="Center" IsChecked="{Binding IsSelected}"
-                                            Style="{StaticResource MaterialDesignActionLightToggleButton}"
-                                            Content="{Binding Code}"/>
-                                        <StackPanel
-                                            Margin="8 0 0 0"
-                                            Grid.Column="1">
-                                            <TextBlock Text="{Binding Name}" FontWeight="Bold"/>
-                                            <TextBlock Text="{Binding Description}"/>
-                                        </StackPanel>
-                                    </Grid>
-                                </Border>
-                                
-                                <DataTemplate.Triggers>
-                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
-                                        <Setter TargetName="Border" Property="Background" Value="{DynamicResource MaterialDesignSelection}"/>
-                                    </DataTrigger>
-                                </DataTemplate.Triggers>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                </smtx:XamlDisplay>
-            </Grid>
-            <TextBlock
-                Style="{StaticResource MaterialDesignHeadline6TextBlock}"
-                Grid.Row="2"
-                Margin="0 32 0 0"
-                Text="ListView"/>
-            
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="1*"/>
+            </Grid.ColumnDefinitions>      
             <smtx:XamlDisplay
-                UniqueKey="lists_4"
-                Grid.Row="3">
-                <ListView>
-                    <ListViewItem Content="Hello"/>
-                    <ListViewItem Content="World"/>
-                    <ListViewItem Content=":)"/>
-                </ListView>
+                UniqueKey="list_1"
+                Grid.Column="0">
+                <ListBox IsEnabled="{Binding IsChecked, ElementName=EnableListBox}">
+                    <TextBlock Text="Plain"/>
+                    <TextBlock Text="Old"/>
+                    <TextBlock Text="ListBox"/>
+                    <TextBlock Text="Full of junk"/>
+                </ListBox>
             </smtx:XamlDisplay>
-            <TextBlock
-                Style="{StaticResource MaterialDesignHeadline6TextBlock}"
-                Grid.Row="4"
-                Margin="0 32 0 0"
-                Text="ListView.GridView"/>
-            
+
+            <CheckBox
+                Name="EnableListBox"
+                Grid.Column="0"
+                Grid.Row="1"
+                IsChecked="True"
+                Content="Enabled"/>
+
             <smtx:XamlDisplay
-                UniqueKey="lists_5"
-                Grid.Row="5">
-                <ListView ItemsSource="{Binding Items1}">
-                    <ListView.View>
-                        <GridView>
-                            <GridViewColumn DisplayMemberBinding="{Binding Code}" Header="Code"/>
-                            <GridViewColumn DisplayMemberBinding="{Binding Name}" Header="Name"/>
-                            <GridViewColumn DisplayMemberBinding="{Binding Description}" Header="Description"/>
-                            <GridViewColumn Header="Options">
-                                <GridViewColumn.CellTemplate>
-                                    <DataTemplate>
-                                        <ComboBox Width="100">
-                                            <ComboBoxItem Content="Test"/>
-                                            <ComboBoxItem Content="Test2"/>
-                                            <ComboBoxItem Content="Test3"/>
-                                        </ComboBox>
-                                    </DataTemplate>
-                                </GridViewColumn.CellTemplate>
-                            </GridViewColumn>
-                        </GridView>
-                    </ListView.View>
-                </ListView>
+                UniqueKey="list_2"
+                Grid.Column="1"
+                Grid.Row="0">
+                <!-- piece together your own items control to create some nice stuff that will make everyone think you are cool. and rightly so, because you are cool.  you might even be a hipster for all I know -->
+                <ItemsControl
+                    ItemsSource="{Binding Items1}"
+                    Grid.IsSharedSizeScope="True"
+                    Margin="12 0 12 0">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type domain:SelectableViewModel}">
+                            <Border
+                                x:Name="Border"
+                                Padding="8">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition SharedSizeGroup="Checkerz"/>
+                                        <ColumnDefinition/>
+                                    </Grid.ColumnDefinitions>                                        
+                                    <CheckBox
+                                        VerticalAlignment="Center"
+                                        IsChecked="{Binding IsSelected}"/>
+                                    
+                                    <StackPanel
+                                        Margin="8 0 0 0"
+                                        Grid.Column="1">
+                                        <TextBlock Text="{Binding Name}" FontWeight="Bold"/>
+                                        <TextBlock Text="{Binding Description}"/>
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+                            
+                            <DataTemplate.Triggers>
+                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                    <Setter TargetName="Border" Property="Background" Value="{DynamicResource MaterialDesignSelection}"/>
+                                </DataTrigger>
+                            </DataTemplate.Triggers>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
+                UniqueKey="list_3"
+                Grid.Column="2"
+                Grid.Row="0">
+                <!-- and here's another -->
+                <ItemsControl
+                    ItemsSource="{Binding Items2}"
+                    Grid.IsSharedSizeScope="True">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type domain:SelectableViewModel}">
+                            <Border
+                                x:Name="Border"
+                                Padding="8"
+                                BorderThickness="0 0 0 1"
+                                BorderBrush="{DynamicResource MaterialDesignDivider}">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition SharedSizeGroup="Checkerz"/>
+                                        <ColumnDefinition/>
+                                    </Grid.ColumnDefinitions>
+                                    
+                                    <ToggleButton
+                                        VerticalAlignment="Center" IsChecked="{Binding IsSelected}"
+                                        Style="{StaticResource MaterialDesignActionLightToggleButton}"
+                                        Content="{Binding Code}"/>
+                                    <StackPanel
+                                        Margin="8 0 0 0"
+                                        Grid.Column="1">
+                                        <TextBlock Text="{Binding Name}" FontWeight="Bold"/>
+                                        <TextBlock Text="{Binding Description}"/>
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+                            
+                            <DataTemplate.Triggers>
+                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                    <Setter TargetName="Border" Property="Background" Value="{DynamicResource MaterialDesignSelection}"/>
+                                </DataTrigger>
+                            </DataTemplate.Triggers>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
             </smtx:XamlDisplay>
         </Grid>
-    </ScrollViewer>
+        <TextBlock
+            Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+            Grid.Row="2"
+            Margin="0 32 0 0"
+            Text="ListView"/>
+        
+        <smtx:XamlDisplay
+            UniqueKey="lists_4"
+            Grid.Row="3">
+            <ListView>
+                <ListViewItem Content="Hello"/>
+                <ListViewItem Content="World"/>
+                <ListViewItem Content=":)"/>
+            </ListView>
+        </smtx:XamlDisplay>
+        <TextBlock
+            Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+            Grid.Row="4"
+            Margin="0 32 0 0"
+            Text="ListView.GridView"/>
+        
+        <smtx:XamlDisplay
+            UniqueKey="lists_5"
+            Grid.Row="5">
+            <ListView ItemsSource="{Binding Items1}">
+                <ListView.View>
+                    <GridView>
+                        <GridViewColumn DisplayMemberBinding="{Binding Code}" Header="Code"/>
+                        <GridViewColumn DisplayMemberBinding="{Binding Name}" Header="Name"/>
+                        <GridViewColumn DisplayMemberBinding="{Binding Description}" Header="Description"/>
+                        <GridViewColumn Header="Options">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <ComboBox Width="100">
+                                        <ComboBoxItem Content="Test"/>
+                                        <ComboBoxItem Content="Test2"/>
+                                        <ComboBoxItem Content="Test3"/>
+                                    </ComboBox>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                    </GridView>
+                </ListView.View>
+            </ListView>
+        </smtx:XamlDisplay>
+    </Grid>
 </UserControl>
 

--- a/MainDemo.Wpf/MainWindow.xaml
+++ b/MainDemo.Wpf/MainWindow.xaml
@@ -2,10 +2,13 @@
     x:Class="MaterialDesignDemo.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:domain="clr-namespace:MaterialDesignDemo.Domain"
     xmlns:system="clr-namespace:System;assembly=mscorlib"
     xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-    xmlns:domain1="clr-namespace:MaterialDesignDemo.Domain"
+    mc:Ignorable="d"
+    d:DataContext="{d:DesignInstance domain:MainWindowViewModel}"
     WindowStartupLocation="CenterScreen"
     Title="Material Design in XAML" 
     AutomationProperties.Name="{Binding Title, RelativeSource={RelativeSource Self}}"
@@ -106,21 +109,30 @@
                                 IsChecked="False"
                                 Click="MenuToggleButton_OnClick"
                                 AutomationProperties.Name="HamburgerToggleButton"/>
-                            
+
                             <Button
-                                Margin="24,0,12,0"
+                                Margin="24,0,0,0"
                                 ToolTip="Previous Item"
                                 Command="{Binding MovePrevCommand}"
                                 Content="{materialDesign:PackIcon Kind=ArrowLeft, Size=24}"
                                 Style="{DynamicResource MaterialDesignToolButton}"
                                 Foreground="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"
                                 materialDesign:RippleAssist.Feedback="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Converter={StaticResource BrushRoundConverter}}"/>
-                            
+
                             <Button 
-                                Margin="8,0,0,0"
+                                Margin="16,0,0,0"
                                 ToolTip="Next Item"
                                 Command="{Binding MoveNextCommand}"
                                 Content="{materialDesign:PackIcon Kind=ArrowRight, Size=24}"
+                                Style="{DynamicResource MaterialDesignToolButton}"
+                                Foreground="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"
+                                materialDesign:RippleAssist.Feedback="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Converter={StaticResource BrushRoundConverter}}"/>
+
+                            <Button
+                                Margin="16,0,0,0"
+                                ToolTip="Home"
+                                Command="{Binding HomeCommand}"
+                                Content="{materialDesign:PackIcon Kind=Home, Size=24}"
                                 Style="{DynamicResource MaterialDesignToolButton}"
                                 Foreground="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"
                                 materialDesign:RippleAssist.Feedback="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Converter={StaticResource BrushRoundConverter}}"/>
@@ -183,18 +195,19 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     
-                    <domain1:DocumentationLinks
-                        DataContext="{Binding ElementName=DemoItemsListBox, Path=SelectedItem}"
-                        Margin="0 0 0 16"/>
+                    <domain:DocumentationLinks DataContext="{Binding SelectedItem}"/>
                     
                     <ScrollViewer
-                        Grid.Row="1" 
+                        x:Name="MainScrollViewer"
+                        Grid.Row="1"
                         materialDesign:ScrollViewerAssist.IsAutoHideEnabled="True"
-                        HorizontalScrollBarVisibility="{Binding ElementName=DemoItemsListBox, Path=SelectedItem.HorizontalScrollBarVisibilityRequirement}"
-                        VerticalScrollBarVisibility="{Binding ElementName=DemoItemsListBox, Path=SelectedItem.VerticalScrollBarVisibilityRequirement}" 
-                        Padding="{Binding ElementName=DemoItemsListBox, Path=SelectedItem.MarginRequirement}">
+                        HorizontalScrollBarVisibility="{Binding SelectedItem.HorizontalScrollBarVisibilityRequirement, FallbackValue=Disabled}"
+                        VerticalScrollBarVisibility="{Binding SelectedItem.VerticalScrollBarVisibilityRequirement, FallbackValue=Disabled}" >
                         <ContentControl
-                            Content="{Binding SelectedItem.Content, UpdateSourceTrigger=PropertyChanged}"/>
+                            DataContextChanged="OnSelectedItemChanged"
+                            DataContext="{Binding SelectedItem}"
+                            Margin="{Binding MarginRequirement, FallbackValue=16}"
+                            Content="{Binding Content, UpdateSourceTrigger=PropertyChanged, FallbackValue={x:Null}}"/>
                     </ScrollViewer>
 
                     <materialDesign:Snackbar

--- a/MainDemo.Wpf/MainWindow.xaml.cs
+++ b/MainDemo.Wpf/MainWindow.xaml.cs
@@ -94,5 +94,8 @@ namespace MaterialDesignDemo
             theme.SetBaseTheme(isDarkTheme ? Theme.Dark : Theme.Light);
             paletteHelper.SetTheme(theme);
         }
+
+        private void OnSelectedItemChanged(object sender, DependencyPropertyChangedEventArgs e)
+            => MainScrollViewer.ScrollToHome();
     }
 }

--- a/MainDemo.Wpf/PaletteSelector.xaml
+++ b/MainDemo.Wpf/PaletteSelector.xaml
@@ -144,19 +144,16 @@
                     Text="Dark"/>
             </StackPanel>
 
-            <ScrollViewer
+            <ItemsControl
                 Grid.Row="1"
-                VerticalScrollBarVisibility="Auto"
-                HorizontalScrollBarVisibility="Disabled"
-                Margin="0 12 0 0">
-                <ItemsControl ItemsSource="{Binding Swatches, Mode=OneTime}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <WrapPanel/>
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                </ItemsControl>
-            </ScrollViewer>
+                Margin="0 12 0 0"
+                ItemsSource="{Binding Swatches, Mode=OneTime}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+            </ItemsControl>
         </Grid>
     </DockPanel>
 </UserControl>

--- a/MainDemo.Wpf/Pickers.xaml
+++ b/MainDemo.Wpf/Pickers.xaml
@@ -12,377 +12,375 @@
     d:DesignWidth="300">
     <!-- for some reason to get the validation templates to show on this page need an extra decorator. haven't figure out why yet -->
     <AdornerDecorator>
-        <ScrollViewer>
-            <Grid Margin="32">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition/>                    
-                </Grid.ColumnDefinitions>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition/>                    
+            </Grid.ColumnDefinitions>
 
-                <TextBlock
-                    Grid.ColumnSpan="3"
-                    Text="Classic WPF DatePicker control with Material Design theme, and new TimePicker control:"/>
+            <TextBlock
+                Grid.ColumnSpan="3"
+                Text="Classic WPF DatePicker control with Material Design theme, and new TimePicker control:"/>
+            
+            <StackPanel
+                Grid.Row="1"
+                Grid.Column="0">
+                <smtx:XamlDisplay
+                    UniqueKey="pickers_1"
+                    HorizontalAlignment="Left"
+                    Margin="0 16 0 0">
+                    <DatePicker
+                        Width="100"
+                        materialDesign:HintAssist.Hint="Pick Date"
+                        Style="{StaticResource MaterialDesignFloatingHintDatePicker}"/>
+                </smtx:XamlDisplay>
                 
-                <StackPanel
-                    Grid.Row="1"
-                    Grid.Column="0">
+                <smtx:XamlDisplay
+                    UniqueKey="pickers_2"
+                    HorizontalAlignment="Left"
+                    Margin="0 16 0 0" >
+                    <DatePicker
+                        x:Name="FutureDatePicker"
+                        Width="100"
+                        materialDesign:HintAssist.Hint="Future Date"
+                        materialDesign:CalendarAssist.IsHeaderVisible="False">
+                        <DatePicker.SelectedDate>
+                            <Binding Path="FutureValidatingDate" UpdateSourceTrigger="PropertyChanged">
+                                <Binding.ValidationRules>
+                                    <domain:FutureDateValidationRule ValidatesOnTargetUpdated="True"/>
+                                </Binding.ValidationRules>
+                            </Binding>
+                        </DatePicker.SelectedDate>
+                    </DatePicker>
+                </smtx:XamlDisplay>
+                
                     <smtx:XamlDisplay
-                        UniqueKey="pickers_1"
-                        HorizontalAlignment="Left"
-                        Margin="0 16 0 0">
-                        <DatePicker
-                            Width="100"
-                            materialDesign:HintAssist.Hint="Pick Date"
-                            Style="{StaticResource MaterialDesignFloatingHintDatePicker}"/>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay
-                        UniqueKey="pickers_2"
+                        UniqueKey="pickers_2_disabled"
                         HorizontalAlignment="Left"
                         Margin="0 16 0 0" >
                         <DatePicker
-                            x:Name="FutureDatePicker"
-                            Width="100"
-                            materialDesign:HintAssist.Hint="Future Date"
-                            materialDesign:CalendarAssist.IsHeaderVisible="False">
-                            <DatePicker.SelectedDate>
-                                <Binding Path="FutureValidatingDate" UpdateSourceTrigger="PropertyChanged">
-                                    <Binding.ValidationRules>
-                                        <domain:FutureDateValidationRule ValidatesOnTargetUpdated="True"/>
-                                    </Binding.ValidationRules>
-                                </Binding>
-                            </DatePicker.SelectedDate>
-                        </DatePicker>
-                    </smtx:XamlDisplay>
-                    
-                        <smtx:XamlDisplay
-                            UniqueKey="pickers_2_disabled"
-                            HorizontalAlignment="Left"
-                            Margin="0 16 0 0" >
-                            <DatePicker
-                                IsEnabled="False"
-                                Width="100"
-                                materialDesign:HintAssist.Hint="Disabled"/>
-                        </smtx:XamlDisplay>
-                    
-                        <smtx:XamlDisplay
-                            UniqueKey="pickers_3"
-                            HorizontalAlignment="Left"
-                            Margin="0 32 0 0">
-                        <ComboBox
-                            Name="LocaleCombo"
-                            Width="50">
-                            <ComboBox.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <VirtualizingStackPanel/>
-                                </ItemsPanelTemplate>
-                            </ComboBox.ItemsPanel>
-                        </ComboBox>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay
-                        UniqueKey="pickers_4"
-                        HorizontalAlignment="Left"
-                        Margin="0 16 0 0">
-                        <DatePicker
-                            Name="LocaleDatePicker"
-                            Width="120"
-                            materialDesign:HintAssist.Hint="Locale Date"/>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay
-                        UniqueKey="pickers_5"
-                        HorizontalAlignment="Left"
-                        Margin="0 16 0 0">
-                        <DatePicker
-                            Name="LocaleDatePickerRTL"
-                            Width="120"
-                            FlowDirection="RightToLeft"
-                            materialDesign:HintAssist.Hint="RTL Locale Date"/>
-                    </smtx:XamlDisplay>
-                </StackPanel>
-                
-                <StackPanel
-                    Grid.Row="1"
-                    Grid.Column="1" >
-                    <smtx:XamlDisplay
-                        UniqueKey="pickers_6"
-                        HorizontalAlignment="Left"
-                        Margin="0 16 0 0"
-                        VerticalAlignment="Top">
-                        <materialDesign:TimePicker
-                            Width="100" 
-                            Style="{StaticResource MaterialDesignFloatingHintTimePicker}"
-                            materialDesign:HintAssist.Hint="Custom hint"/>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay
-                        UniqueKey="pickers_6_disabled"
-                        HorizontalAlignment="Left"
-                        Margin="0 16 0 0"
-                        VerticalAlignment="Top">
-                        <materialDesign:TimePicker
-                            Width="100"
                             IsEnabled="False"
-                            Style="{StaticResource MaterialDesignFloatingHintTimePicker}"
+                            Width="100"
                             materialDesign:HintAssist.Hint="Disabled"/>
                     </smtx:XamlDisplay>
-                    
+                
                     <smtx:XamlDisplay
-                        UniqueKey="pickers_13"
+                        UniqueKey="pickers_3"
                         HorizontalAlignment="Left"
                         Margin="0 32 0 0">
-                        <DatePicker
-                            Width="140"
-                            materialDesign:HintAssist.Hint="Pick Date"
-                            Style="{StaticResource MaterialDesignFilledDatePicker}"/>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay
-                        UniqueKey="pickers_14"
-                        HorizontalAlignment="Left"
-                        Margin="0 16 0 0">
-                        <DatePicker
-                            Width="140"
-                            materialDesign:HintAssist.Hint="Pick Date"
-                            Style="{StaticResource MaterialDesignOutlinedDatePicker}"/>
-                    </smtx:XamlDisplay>
-                </StackPanel>
-
+                    <ComboBox
+                        Name="LocaleCombo"
+                        Width="50">
+                        <ComboBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel/>
+                            </ItemsPanelTemplate>
+                        </ComboBox.ItemsPanel>
+                    </ComboBox>
+                </smtx:XamlDisplay>
+                
                 <smtx:XamlDisplay
-                    UniqueKey="pickers_7"
-                    Grid.Row="1"
-                    Grid.Column="2"
-                    VerticalAlignment="Top"
+                    UniqueKey="pickers_4"
                     HorizontalAlignment="Left"
                     Margin="0 16 0 0">
-                    <materialDesign:TimePicker
-                        x:Name="PresetTimePicker"
-                        Is24Hours="True"
-                        Width="100"
-                        SelectedTimeChanged="PresetTimePicker_SelectedTimeChanged"/>
+                    <DatePicker
+                        Name="LocaleDatePicker"
+                        Width="120"
+                        materialDesign:HintAssist.Hint="Locale Date"/>
                 </smtx:XamlDisplay>
-                
-                <StackPanel
-                    Grid.Row="1"
-                    Grid.Column="3"
-                    VerticalAlignment="Top"
-                    HorizontalAlignment="Left">
-                    <smtx:XamlDisplay
-                        UniqueKey="pickers_8"
-                        Margin="0 16 0 0">
-                        <materialDesign:TimePicker 
-                            materialDesign:HintAssist.Hint="Validates"
-                            IsInvalidTextAllowed="True"
-                            Is24Hours="{Binding IsChecked, ElementName=Is24HourCheckbox}"
-                            Width="100">
-                            <materialDesign:TimePicker.Text>
-                                <Binding Path="ValidatingTime" UpdateSourceTrigger="PropertyChanged">
-                                    <Binding.ValidationRules>
-                                        <domain:SimpleDateValidationRule ValidatesOnTargetUpdated="True"/>
-                                    </Binding.ValidationRules>
-                                </Binding>
-                            </materialDesign:TimePicker.Text>
-                        </materialDesign:TimePicker>
-                    </smtx:XamlDisplay>
-                    
-                    <CheckBox
-                        x:Name="Is24HourCheckbox"
-                        Content="Is 24 Hour"
-                        IsChecked="True"
-                        Margin="0,10,0,0"
-                        VerticalAlignment="Top"/>
-                </StackPanel>
-                
-                <smtx:XamlDisplay UniqueKey="pickers_11" Grid.Row="1" Grid.Column="4" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0 16 0 0">
-                    <materialDesign:TimePicker
-                        materialDesign:HintAssist.Hint="With Seconds"
-                        Is24Hours="{Binding IsChecked, ElementName=Is24HourCheckbox}"
-                        x:Name="WithSecondsTimePicker"
-                        WithSeconds="True"
-                        Width="100"/>
-                </smtx:XamlDisplay>
-
-                <TextBlock
-                    Grid.Row="2"
-                    Grid.Column="0"
-                    Grid.ColumnSpan="4"
-                    Margin="0 128 0 0"
-                    Text="By combining the DialogHost (see MainWindow.xaml) and the Calendar and Clock controls, custom popups can be built."/>
                 
                 <smtx:XamlDisplay
-                    UniqueKey="pickers_9"
-                    Grid.Row="3"
-                    Grid.Column="0"
-                    Margin="0 32 0 0"
-                    HorizontalAlignment="Left">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock
-                            Text="{Binding Date, StringFormat=d}"
-                            VerticalAlignment="Center"
-                            FontSize="24"/>
-                        
-                        <Button
-                            Margin="8 0 0 0"
-                            Content="..." 
-                            Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
-                            materialDesign:DialogHost.DialogOpenedAttached="CalendarDialogOpenedEventHandler"
-                            materialDesign:DialogHost.DialogClosingAttached="CalendarDialogClosingEventHandler">
-                            <Button.CommandParameter>
-                                <Grid>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>                                    
+                    UniqueKey="pickers_5"
+                    HorizontalAlignment="Left"
+                    Margin="0 16 0 0">
+                    <DatePicker
+                        Name="LocaleDatePickerRTL"
+                        Width="120"
+                        FlowDirection="RightToLeft"
+                        materialDesign:HintAssist.Hint="RTL Locale Date"/>
+                </smtx:XamlDisplay>
+            </StackPanel>
+            
+            <StackPanel
+                Grid.Row="1"
+                Grid.Column="1" >
+                <smtx:XamlDisplay
+                    UniqueKey="pickers_6"
+                    HorizontalAlignment="Left"
+                    Margin="0 16 0 0"
+                    VerticalAlignment="Top">
+                    <materialDesign:TimePicker
+                        Width="100" 
+                        Style="{StaticResource MaterialDesignFloatingHintTimePicker}"
+                        materialDesign:HintAssist.Hint="Custom hint"/>
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay
+                    UniqueKey="pickers_6_disabled"
+                    HorizontalAlignment="Left"
+                    Margin="0 16 0 0"
+                    VerticalAlignment="Top">
+                    <materialDesign:TimePicker
+                        Width="100"
+                        IsEnabled="False"
+                        Style="{StaticResource MaterialDesignFloatingHintTimePicker}"
+                        materialDesign:HintAssist.Hint="Disabled"/>
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay
+                    UniqueKey="pickers_13"
+                    HorizontalAlignment="Left"
+                    Margin="0 32 0 0">
+                    <DatePicker
+                        Width="140"
+                        materialDesign:HintAssist.Hint="Pick Date"
+                        Style="{StaticResource MaterialDesignFilledDatePicker}"/>
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay
+                    UniqueKey="pickers_14"
+                    HorizontalAlignment="Left"
+                    Margin="0 16 0 0">
+                    <DatePicker
+                        Width="140"
+                        materialDesign:HintAssist.Hint="Pick Date"
+                        Style="{StaticResource MaterialDesignOutlinedDatePicker}"/>
+                </smtx:XamlDisplay>
+            </StackPanel>
+
+            <smtx:XamlDisplay
+                UniqueKey="pickers_7"
+                Grid.Row="1"
+                Grid.Column="2"
+                VerticalAlignment="Top"
+                HorizontalAlignment="Left"
+                Margin="0 16 0 0">
+                <materialDesign:TimePicker
+                    x:Name="PresetTimePicker"
+                    Is24Hours="True"
+                    Width="100"
+                    SelectedTimeChanged="PresetTimePicker_SelectedTimeChanged"/>
+            </smtx:XamlDisplay>
+            
+            <StackPanel
+                Grid.Row="1"
+                Grid.Column="3"
+                VerticalAlignment="Top"
+                HorizontalAlignment="Left">
+                <smtx:XamlDisplay
+                    UniqueKey="pickers_8"
+                    Margin="0 16 0 0">
+                    <materialDesign:TimePicker 
+                        materialDesign:HintAssist.Hint="Validates"
+                        IsInvalidTextAllowed="True"
+                        Is24Hours="{Binding IsChecked, ElementName=Is24HourCheckbox}"
+                        Width="100">
+                        <materialDesign:TimePicker.Text>
+                            <Binding Path="ValidatingTime" UpdateSourceTrigger="PropertyChanged">
+                                <Binding.ValidationRules>
+                                    <domain:SimpleDateValidationRule ValidatesOnTargetUpdated="True"/>
+                                </Binding.ValidationRules>
+                            </Binding>
+                        </materialDesign:TimePicker.Text>
+                    </materialDesign:TimePicker>
+                </smtx:XamlDisplay>
+                
+                <CheckBox
+                    x:Name="Is24HourCheckbox"
+                    Content="Is 24 Hour"
+                    IsChecked="True"
+                    Margin="0,10,0,0"
+                    VerticalAlignment="Top"/>
+            </StackPanel>
+            
+            <smtx:XamlDisplay UniqueKey="pickers_11" Grid.Row="1" Grid.Column="4" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0 16 0 0">
+                <materialDesign:TimePicker
+                    materialDesign:HintAssist.Hint="With Seconds"
+                    Is24Hours="{Binding IsChecked, ElementName=Is24HourCheckbox}"
+                    x:Name="WithSecondsTimePicker"
+                    WithSeconds="True"
+                    Width="100"/>
+            </smtx:XamlDisplay>
+
+            <TextBlock
+                Grid.Row="2"
+                Grid.Column="0"
+                Grid.ColumnSpan="4"
+                Margin="0 64 0 0"
+                Text="By combining the DialogHost (see MainWindow.xaml) and the Calendar and Clock controls, custom popups can be built."/>
+            
+            <smtx:XamlDisplay
+                UniqueKey="pickers_9"
+                Grid.Row="3"
+                Grid.Column="0"
+                Margin="0 32 0 0"
+                HorizontalAlignment="Left">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock
+                        Text="{Binding Date, StringFormat=d}"
+                        VerticalAlignment="Center"
+                        FontSize="24"/>
+                    
+                    <Button
+                        Margin="8 0 0 0"
+                        Content="..." 
+                        Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
+                        materialDesign:DialogHost.DialogOpenedAttached="CalendarDialogOpenedEventHandler"
+                        materialDesign:DialogHost.DialogClosingAttached="CalendarDialogClosingEventHandler">
+                        <Button.CommandParameter>
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>                                    
+                                <Calendar
+                                    x:Name="Calendar"
+                                    Margin="-1 -4 -1 0"/>
+                                
+                                <StackPanel
+                                    Grid.Row="1"
+                                    Margin="8"
+                                    HorizontalAlignment="Right"
+                                    Orientation="Horizontal">
+                                    <Button
+                                        Style="{DynamicResource MaterialDesignFlatButton}"
+                                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                                        CommandParameter="0"
+                                        Content="CANCEL"/>
+                                    
+                                    <Button
+                                        Style="{DynamicResource MaterialDesignFlatButton}"
+                                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                                        CommandParameter="1"
+                                        Content="OK"/>
+                                </StackPanel>
+                            </Grid>
+                        </Button.CommandParameter>
+                    </Button>
+                </StackPanel>
+            </smtx:XamlDisplay>
+            
+            <smtx:XamlDisplay
+                UniqueKey="pickers_10"
+                Grid.Row="3"
+                Grid.Column="1"
+                Margin="0 32 0 0"
+                HorizontalAlignment="Left">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock
+                        Text="{Binding Time, StringFormat=t}"
+                        VerticalAlignment="Center"
+                        FontSize="24"/>
+                    
+                    <Button
+                        Margin="8 0 0 0"
+                        Content="..." 
+                        Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
+                        materialDesign:DialogHost.DialogOpenedAttached="ClockDialogOpenedEventHandler"
+                        materialDesign:DialogHost.DialogClosingAttached="ClockDialogClosingEventHandler">
+                        <Button.CommandParameter>
+                            <Grid Margin="-1">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>                                    
+                                <materialDesign:Clock
+                                    DisplayAutomation="ToSeconds"
+                                    x:Name="Clock"/>
+                                
+                                <StackPanel
+                                    Grid.Row="1"
+                                    Margin="8"
+                                    HorizontalAlignment="Right"
+                                    Orientation="Horizontal">
+                                    <Button
+                                        Style="{DynamicResource MaterialDesignFlatButton}"
+                                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                                        CommandParameter="0"
+                                        Content="CANCEL"/>
+
+                                    <Button
+                                        Style="{DynamicResource MaterialDesignFlatButton}"
+                                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                                        CommandParameter="1"
+                                        Content="OK"/>
+                                </StackPanel>
+                            </Grid>
+                        </Button.CommandParameter>
+                    </Button>
+                </StackPanel>
+            </smtx:XamlDisplay>
+            
+            <smtx:XamlDisplay
+                UniqueKey="pickers_12"
+                Grid.Row="3"
+                Grid.Column="2"
+                Margin="0 32 0 0"
+                HorizontalAlignment="Left">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock
+                        Text="{Binding Date, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"
+                        VerticalAlignment="Center"
+                        FontSize="24"/>
+                    <Button
+                        Margin="8 0 0 0"
+                        Content="..."
+                        Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
+                        materialDesign:DialogHost.DialogOpenedAttached="CombinedDialogOpenedEventHandler"
+                        materialDesign:DialogHost.DialogClosingAttached="CombinedDialogClosingEventHandler">
+                        <Button.CommandParameter>
+                            <Grid Margin="-1">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                
+                                <StackPanel
+                                    Grid.Row="0"
+                                    Orientation="Horizontal">
                                     <Calendar
-                                        x:Name="Calendar"
+                                        x:Name="CombinedCalendar"
                                         Margin="-1 -4 -1 0"/>
                                     
-                                    <StackPanel
-                                        Grid.Row="1"
-                                        Margin="8"
-                                        HorizontalAlignment="Right"
-                                        Orientation="Horizontal">
-                                        <Button
-                                            Style="{DynamicResource MaterialDesignFlatButton}"
-                                            Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
-                                            CommandParameter="0"
-                                            Content="CANCEL"/>
-                                        
-                                        <Button
-                                            Style="{DynamicResource MaterialDesignFlatButton}"
-                                            Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
-                                            CommandParameter="1"
-                                            Content="OK"/>
-                                    </StackPanel>
-                                </Grid>
-                            </Button.CommandParameter>
-                        </Button>
-                    </StackPanel>
-                </smtx:XamlDisplay>
-                
-                <smtx:XamlDisplay
-                    UniqueKey="pickers_10"
-                    Grid.Row="3"
-                    Grid.Column="1"
-                    Margin="0 32 0 0"
-                    HorizontalAlignment="Left">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock
-                            Text="{Binding Time, StringFormat=t}"
-                            VerticalAlignment="Center"
-                            FontSize="24"/>
-                        
-                        <Button
-                            Margin="8 0 0 0"
-                            Content="..." 
-                            Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
-                            materialDesign:DialogHost.DialogOpenedAttached="ClockDialogOpenedEventHandler"
-                            materialDesign:DialogHost.DialogClosingAttached="ClockDialogClosingEventHandler">
-                            <Button.CommandParameter>
-                                <Grid Margin="-1">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>                                    
                                     <materialDesign:Clock
-                                        DisplayAutomation="ToSeconds"
-                                        x:Name="Clock"/>
-                                    
-                                    <StackPanel
-                                        Grid.Row="1"
-                                        Margin="8"
-                                        HorizontalAlignment="Right"
-                                        Orientation="Horizontal">
-                                        <Button
-                                            Style="{DynamicResource MaterialDesignFlatButton}"
-                                            Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
-                                            CommandParameter="0"
-                                            Content="CANCEL"/>
+                                        x:Name="CombinedClock"
+                                        DisplayAutomation="CycleWithSeconds"
+                                        Is24Hours="True"/>
+                                </StackPanel>
+                                
+                                <StackPanel
+                                    Grid.Row="1"
+                                    Margin="8"
+                                    HorizontalAlignment="Right"
+                                    Orientation="Horizontal">
+                                    <Button
+                                        Style="{DynamicResource MaterialDesignFlatButton}"
+                                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                                        CommandParameter="0"
+                                        Content="CANCEL"/>
 
-                                        <Button
-                                            Style="{DynamicResource MaterialDesignFlatButton}"
-                                            Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
-                                            CommandParameter="1"
-                                            Content="OK"/>
-                                    </StackPanel>
-                                </Grid>
-                            </Button.CommandParameter>
-                        </Button>
-                    </StackPanel>
-                </smtx:XamlDisplay>
-                
-                <smtx:XamlDisplay
-                    UniqueKey="pickers_12"
-                    Grid.Row="3"
-                    Grid.Column="2"
-                    Margin="0 32 0 0"
-                    HorizontalAlignment="Left">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock
-                            Text="{Binding Date, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"
-                            VerticalAlignment="Center"
-                            FontSize="24"/>
-                        <Button
-                            Margin="8 0 0 0"
-                            Content="..."
-                            Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
-                            materialDesign:DialogHost.DialogOpenedAttached="CombinedDialogOpenedEventHandler"
-                            materialDesign:DialogHost.DialogClosingAttached="CombinedDialogClosingEventHandler">
-                            <Button.CommandParameter>
-                                <Grid Margin="-1">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="*"/>
-                                        <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>
-                                    
-                                    <StackPanel
-                                        Grid.Row="0"
-                                        Orientation="Horizontal">
-                                        <Calendar
-                                            x:Name="CombinedCalendar"
-                                            Margin="-1 -4 -1 0"/>
-                                        
-                                        <materialDesign:Clock
-                                            x:Name="CombinedClock"
-                                            DisplayAutomation="CycleWithSeconds"
-                                            Is24Hours="True"/>
-                                    </StackPanel>
-                                    
-                                    <StackPanel
-                                        Grid.Row="1"
-                                        Margin="8"
-                                        HorizontalAlignment="Right"
-                                        Orientation="Horizontal">
-                                        <Button
-                                            Style="{DynamicResource MaterialDesignFlatButton}"
-                                            Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
-                                            CommandParameter="0"
-                                            Content="CANCEL"/>
-
-                                        <Button
-                                            Style="{DynamicResource MaterialDesignFlatButton}"
-                                            Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
-                                            CommandParameter="1"
-                                            Content="OK"/>
-                                    </StackPanel>
-                                </Grid>
-                            </Button.CommandParameter>
-                        </Button>
-                    </StackPanel>
-                </smtx:XamlDisplay>
-            </Grid>
-        </ScrollViewer>
+                                    <Button
+                                        Style="{DynamicResource MaterialDesignFlatButton}"
+                                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                                        CommandParameter="1"
+                                        Content="OK"/>
+                                </StackPanel>
+                            </Grid>
+                        </Button.CommandParameter>
+                    </Button>
+                </StackPanel>
+            </smtx:XamlDisplay>
+        </Grid>
     </AdornerDecorator>
 </UserControl>
 

--- a/MainDemo.Wpf/Sliders.xaml
+++ b/MainDemo.Wpf/Sliders.xaml
@@ -137,7 +137,7 @@
             Grid.Row="4"
             Grid.Column="0"
             HorizontalAlignment="Left"
-            Margin="24 8 0 0">
+            Margin="8 8 0 0">
             <StackPanel
                     Orientation="Horizontal"
                     Margin="0 16 0 0">

--- a/MainDemo.Wpf/Snackbars.xaml
+++ b/MainDemo.Wpf/Snackbars.xaml
@@ -9,416 +9,412 @@
     mc:Ignorable="d"
     d:DesignHeight="300"
     d:DesignWidth="300">
-    <ScrollViewer
-        HorizontalScrollBarVisibility="Auto"
-        VerticalScrollBarVisibility="Hidden">
-        <Grid Margin="0 0 0 4">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="340"/>
-                <ColumnDefinition Width="340"/>
-                <ColumnDefinition Width="340"/>
-                <ColumnDefinition Width="340"/>
-            </Grid.ColumnDefinitions>
-            
-            <Grid.RowDefinitions>
-                <RowDefinition/>
-                <RowDefinition/>
-            </Grid.RowDefinitions>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="340"/>
+            <ColumnDefinition Width="340"/>
+            <ColumnDefinition Width="340"/>
+            <ColumnDefinition Width="340"/>
+        </Grid.ColumnDefinitions>
+        
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
 
-            <!-- example 1 -->
-            <Border
-                Background="{DynamicResource MaterialDesignSelection}"
-                Padding="8 0 8 0">
-                <Grid>
-                    <StackPanel
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center">
-                        <TextBlock
-                            TextWrapping="WrapWithOverflow"
-                            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                            Text="Example 1."/>
-
-                        <TextBlock
-                            TextWrapping="WrapWithOverflow"
-                            Text="Simple definition within XAML. Use the toggle to display the message."/>
-                        
-                        <ToggleButton
-                            IsChecked="{Binding ElementName=SnackbarOne, Path=IsActive, Mode=TwoWay}"
-                            Margin="0 8 0 0"/>
-                    </StackPanel>
-
-                    <smtx:XamlDisplay UniqueKey="snackbar_1">
-                        <!-- simplest form -->
-                        <materialDesign:Snackbar
-                            x:Name="SnackbarOne"
-                            Message="hello 1"
-                            IsActive="False"/>
-                    </smtx:XamlDisplay>
-                </Grid>
-            </Border>
-
-            <!-- example 2 -->
-            <Border
-                Background="{DynamicResource MaterialDesignPaper}"
-                Padding="8 0 8 0"
-                Grid.Column="1"
-                Grid.Row="0">
-                <Grid>
-                    <StackPanel
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center">
-                        <StackPanel.Resources>
-                            <Style TargetType="{x:Type TextBlock}">
-                                <Setter Property="TextWrapping" Value="WrapWithOverflow"/>
-                            </Style>
-                        </StackPanel.Resources>                        
-                        <TextBlock
-                            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                            Text="Example 2."/>
-
-                        <TextBlock
-                            Text="View source to see message defined in long hand, allowing action button content to be set."/>
-                        
-                        <ToggleButton
-                            IsChecked="{Binding ElementName=SnackbarTwo, Path=IsActive, Mode=TwoWay}"
-                            Margin="0 8 0 0"/>
-                    </StackPanel>
-
-                    <smtx:XamlDisplay UniqueKey="snackbar_2">
-                        <!-- long hand form for setting the message -->
-                        <materialDesign:Snackbar
-                            x:Name="SnackbarTwo"
-                            IsActive="False">
-                            <materialDesign:SnackbarMessage
-                                Content="Hello 2"
-                                ActionContent="UNDO"/>
-                        </materialDesign:Snackbar>
-                    </smtx:XamlDisplay>
-                </Grid>
-            </Border>
-
-            <!-- example 3 -->
-            <!--
-                    * using a message queue to manage queuing of messages, and getting onto correct thread
-                    * notice the shorthand syntax {materialDesign:MessageQueue} for creating a new message 
-                    queue without expanded XAML. useful in code-behind scenarios if you do not want to bind 
-                    a message queue in to the snackbar.
-            -->
-            <Border
-                Background="{DynamicResource MaterialDesignSelection}"
-                Padding="8 0 8 0"
-                Grid.Row="0"
-                Grid.Column="2">
-                <Grid>
-                    <StackPanel
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center">
-                        <StackPanel.Resources>
-                            <Style TargetType="{x:Type TextBlock}">
-                                <Setter Property="TextWrapping" Value="WrapWithOverflow"/>
-                            </Style>
-                        </StackPanel.Resources>
-                        <TextBlock
-                            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                            Text="Example 3."/>
-                        
-                        <TextBlock
-                            Text="In many real world scenario, notification display must deal with threading, queuing, and potentially heavy usage. A MessageQueue can be set to handle much of this for you, gicing the following benefits:"/>
-                        
-                        <TextBlock
-                            Margin="0 8 0 0"
-                            Text=" • Messages can be queued from any thread"/>
-                        
-                        <TextBlock
-                            Text=" • Message will auto hide after a time out period"/>
-                        
-                        <TextBlock
-                            Text=" • Notification will not time out if mouse is over it"/>
-                        
-                        <TextBlock
-                            Text=" • Can be paired with a DialogHost so timeout will pause if a active dialog"/>
-                        
-                        <TextBlock
-                            Text=" • Duplicate within a short period will be discarded"/>
-                        
-                        <TextBlock
-                            Text=" • A single message queue can be shared acros multiple Windows"/>
-                        
-                        <TextBlock
-                            Text=" • Works with code-behind and MVVM"/>
-                        
-                        <Grid Margin="0 16 0 0">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-
-                            <TextBox
-                                x:Name="MessageTextBox"
-                                VerticalAlignment="Top"
-                                Grid.Column="0"
-                                Text="Hello World"/>
-
-                            <Button
-                                Click="SnackBar3_OnClick"
-                                Margin="16 0 0 0"
-                                Grid.Column="1"
-                                Content="Send"/>
-                        </Grid>
-                    </StackPanel>
-                    
-                    <smtx:XamlDisplay
-                        UniqueKey="snackbar_3"
-                        VerticalContentAlignment="Top">
-                        <materialDesign:Snackbar
-                            x:Name="SnackbarThree"
-                            MessageQueue="{materialDesign:MessageQueue}"/>
-                    </smtx:XamlDisplay>
-                </Grid>
-            </Border>
-
-            <!-- example 4 -->
-            <!-- illustrates queueing uses some action command call backs -->
-            <Border
-                Background="{DynamicResource MaterialDesignPaper}"
-                Padding="8 0 8 0"
-                Grid.Column="3"
-                Grid.Row="0">
-                <Grid>
-                    <StackPanel
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center">
-                        <StackPanel.Resources>
-                            <Style TargetType="{x:Type TextBlock}">
-                                <Setter Property="TextWrapping" Value="WrapWithOverflow"/>
-                            </Style>
-                        </StackPanel.Resources>
-                        <TextBlock
-                            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                            Text="Example 4."/>
-
-                        <TextBlock
-                            Text="Illustrates queueing (including discarding of duplicates), and handling of commands. Action a notification to see a System.Trace response.."/>
-                        
-                        <CheckBox
-                            Name="DiscardDuplicateCheckBox"
-                            IsChecked="True"
-                            Content="Discard duplicates"/>
-                        
-                        <Grid Margin="0 16 0 0">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-                            
-                            <TextBox
-                                x:Name="ExampleFourTextBox"
-                                AcceptsReturn="True"
-                                TextWrapping="Wrap"
-                                Text="Message One&#x0d;&#x0a;Message Two&#x0d;&#x0a;Message Three&#x0d;&#x0a;Duplicate&#x0d;&#x0a;Duplicate&#x0d;&#x0a;Duplicate&#x0d;&#x0a;Start Fresh&#x0d;&#x0a;Goodbye"/>
-                            
-                            <StackPanel
-                                Grid.Column="1"
-                                VerticalAlignment="Center">
-                                <Button
-                                    Click="SnackBar4_OnClick"
-                                    HorizontalAlignment="Center"
-                                    Content="Send"/>
-
-                                <Button
-                                    Click="SnackBar4_OnClearClick"
-                                    HorizontalAlignment="Center"
-                                    Margin="0 8"
-                                    Content="Clear"/>
-                            </StackPanel>
-                        </Grid>
-                    </StackPanel>
-                    <smtx:XamlDisplay UniqueKey="snackbar_4">
-                        <materialDesign:Snackbar
-                            x:Name="SnackbarFour"
-                            MessageQueue="{materialDesign:MessageQueue}"/>
-                    </smtx:XamlDisplay>
-                </Grid>
-            </Border>
-
-            <!-- example 5 -->
-            <!-- full width snack bar -->
-            <Border
-                Background="{DynamicResource MaterialDesignChipBackground}"
-                Grid.ColumnSpan="2"
-                Grid.Row="1"
-                Grid.Column="0">
-                <StackPanel VerticalAlignment="Bottom">
-                    <StackPanel
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        Margin="0 0 0 32">
-                        <StackPanel.Resources>
-                            <Style TargetType="{x:Type TextBlock}">
-                                <Setter Property="TextWrapping" Value="WrapWithOverflow"/>
-                            </Style>
-                        </StackPanel.Resources>
-                        <TextBlock
-                            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                            Text="Example 5."/>
-
-                        <TextBlock Text="Illustrates a full width Snackbar."/>
-                       
-                        <ToggleButton
-                            IsChecked="{Binding ElementName=SnackbarFive, Path=IsActive, Mode=TwoWay}"
-                            Margin="0 8 0 0"/>
-                    </StackPanel>                 
-                    <smtx:XamlDisplay
-                        UniqueKey="snackbar_5"
-                        HorizontalAlignment="Stretch">
-                        <materialDesign:Snackbar
-                            x:Name="SnackbarFive"
-                            HorizontalAlignment="Stretch">
-                            <materialDesign:SnackbarMessage
-                                Content="This Snackbar is stretched horizontally. Consider allowing your content to push up."
-                                ActionContent="OK"/>
-                        </materialDesign:Snackbar>
-                    </smtx:XamlDisplay>
-                </StackPanel>
-            </Border>
-
-            <!-- example 6 -->
-            <!-- colour variations -->
-            <Border
-                Grid.Column="2"
-                Grid.Row="1">
-                <Border.Resources>
-                    <ResourceDictionary>
-                        <ResourceDictionary.MergedDictionaries>
-                            <!-- here is where you can get additional snackbar button styles from -->
-                            <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Snackbar.xaml"/>
-                        </ResourceDictionary.MergedDictionaries>
-                        
-                        <Style TargetType="materialDesign:Snackbar" BasedOn="{StaticResource {x:Type materialDesign:Snackbar}}">
-                            <Setter Property="Width" Value="288"/>
-                        </Style>
-                        
-                        <Style TargetType="{x:Type TextBlock}">
-                            <Setter Property="TextWrapping" Value="WrapWithOverflow"/>
-                        </Style>
-                    </ResourceDictionary>
-                </Border.Resources>
+        <!-- example 1 -->
+        <Border
+            Background="{DynamicResource MaterialDesignSelection}"
+            Padding="8 0 8 0">
+            <Grid>
                 <StackPanel
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center">
                     <TextBlock
+                        TextWrapping="WrapWithOverflow"
                         Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                        Text="Example 6."/>
+                        Text="Example 1."/>
 
                     <TextBlock
-                        Text="Action button colour variations."/>
+                        TextWrapping="WrapWithOverflow"
+                        Text="Simple definition within XAML. Use the toggle to display the message."/>
                     
-                    <smtx:XamlDisplay
-                        UniqueKey="snackbar_6"
-                        Margin="0 8 0 0">
-                        <materialDesign:Snackbar IsActive="True">
-                            <materialDesign:SnackbarMessage
-                                Content="Default - accent"
-                                ActionContent="ACCENT"/>
-                        </materialDesign:Snackbar>
-                    </smtx:XamlDisplay>      
-                    <smtx:XamlDisplay
-                        UniqueKey="snackbar_7"
-                        Margin="0 8 0 0">
-                        <materialDesign:Snackbar
-                            IsActive="True"
-                            ActionButtonStyle="{StaticResource MaterialDesignSnackbarActionLightButton}">
-                            <materialDesign:SnackbarMessage
-                                Content="Primary Light - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-                                ActionContent="LIGHT - very long text"/>
-                        </materialDesign:Snackbar>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay
-                        UniqueKey="snackbar_8"
-                        Margin="0 8 0 0">
-                        <materialDesign:Snackbar
-                            IsActive="True"
-                            ActionButtonStyle="{StaticResource MaterialDesignSnackbarActionMidButton}"
-                            ActionButtonPlacement="Inline">
-                            <materialDesign:SnackbarMessage
-                                Content="Primary Mid - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-                                ActionContent="MID"/>
-                        </materialDesign:Snackbar>
-                    </smtx:XamlDisplay>
-                    
-                    <smtx:XamlDisplay
-                        UniqueKey="snackbar_9"
-                        Margin="0 8 0 0">
-                        <materialDesign:Snackbar
-                            IsActive="True"
-                            ActionButtonStyle="{StaticResource MaterialDesignSnackbarActionDarkButton}"
-                            ActionButtonPlacement="SeparateLine">
-                            <materialDesign:SnackbarMessage
-                                Content="Primary Dark"
-                                ActionContent="DARK"/>
-                        </materialDesign:Snackbar>
-                    </smtx:XamlDisplay>
+                    <ToggleButton
+                        IsChecked="{Binding ElementName=SnackbarOne, Path=IsActive, Mode=TwoWay}"
+                        Margin="0 8 0 0"/>
                 </StackPanel>
-            </Border>
 
-            <!-- example 7 -->
-            <!-- message duration override -->
-            <Border
-                Background="{DynamicResource MaterialDesignPaper}"
-                Padding="8 0 8 0"
-                Grid.Column="3"
-                Grid.Row="1">
-                <Grid>
-                    <StackPanel
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center">
-                        <StackPanel.Resources>
-                            <Style TargetType="{x:Type TextBlock}">
-                                <Setter Property="TextWrapping" Value="WrapWithOverflow"/>
-                            </Style>
-                        </StackPanel.Resources>
-                        <TextBlock
-                            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                            Text="Example 7."/>
-                        
-                        <TextBlock
-                            Text="The message show duration is controlled by the message queue. But this can be overridden for a specific message."/>
-                        
-                        <Grid Margin="0 16 0 0">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>                            
-                            <Slider
-                                x:Name="MessageDurationOverrideSlider"
-                                Minimum="1"
-                                Maximum="10"
-                                Value="5"
-                                IsSnapToTickEnabled="True"
-                                TickFrequency="0.1"
-                                VerticalAlignment="Center"/>
-                            
-                            <TextBlock
-                                Text="{Binding ElementName=MessageDurationOverrideSlider, Path=Value, StringFormat={}{0:F1}}"
-                                Margin="10,0" Grid.Column="1" VerticalAlignment="Center"/>
-                            
-                            <Button
-                                Click="SnackBar7_OnClick"
-                                HorizontalAlignment="Center"
-                                Grid.Column="2"
-                                Content="Send"/>
-                        </Grid>
-                    </StackPanel>
+                <smtx:XamlDisplay UniqueKey="snackbar_1">
+                    <!-- simplest form -->
+                    <materialDesign:Snackbar
+                        x:Name="SnackbarOne"
+                        Message="hello 1"
+                        IsActive="False"/>
+                </smtx:XamlDisplay>
+            </Grid>
+        </Border>
+
+        <!-- example 2 -->
+        <Border
+            Background="{DynamicResource MaterialDesignPaper}"
+            Padding="8 0 8 0"
+            Grid.Column="1"
+            Grid.Row="0">
+            <Grid>
+                <StackPanel
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center">
+                    <StackPanel.Resources>
+                        <Style TargetType="{x:Type TextBlock}">
+                            <Setter Property="TextWrapping" Value="WrapWithOverflow"/>
+                        </Style>
+                    </StackPanel.Resources>                        
+                    <TextBlock
+                        Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                        Text="Example 2."/>
+
+                    <TextBlock
+                        Text="View source to see message defined in long hand, allowing action button content to be set."/>
                     
-                    <smtx:XamlDisplay UniqueKey="snackbar_10">
-                        <materialDesign:Snackbar
-                            x:Name="SnackbarSeven"
-                            MessageQueue="{materialDesign:MessageQueue}"/>
-                    </smtx:XamlDisplay>
-                </Grid>
-            </Border>
-        </Grid>
-    </ScrollViewer>
+                    <ToggleButton
+                        IsChecked="{Binding ElementName=SnackbarTwo, Path=IsActive, Mode=TwoWay}"
+                        Margin="0 8 0 0"/>
+                </StackPanel>
+
+                <smtx:XamlDisplay UniqueKey="snackbar_2">
+                    <!-- long hand form for setting the message -->
+                    <materialDesign:Snackbar
+                        x:Name="SnackbarTwo"
+                        IsActive="False">
+                        <materialDesign:SnackbarMessage
+                            Content="Hello 2"
+                            ActionContent="UNDO"/>
+                    </materialDesign:Snackbar>
+                </smtx:XamlDisplay>
+            </Grid>
+        </Border>
+
+        <!-- example 3 -->
+        <!--
+                * using a message queue to manage queuing of messages, and getting onto correct thread
+                * notice the shorthand syntax {materialDesign:MessageQueue} for creating a new message 
+                queue without expanded XAML. useful in code-behind scenarios if you do not want to bind 
+                a message queue in to the snackbar.
+        -->
+        <Border
+            Background="{DynamicResource MaterialDesignSelection}"
+            Padding="8 0 8 0"
+            Grid.Row="0"
+            Grid.Column="2">
+            <Grid>
+                <StackPanel
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center">
+                    <StackPanel.Resources>
+                        <Style TargetType="{x:Type TextBlock}">
+                            <Setter Property="TextWrapping" Value="WrapWithOverflow"/>
+                        </Style>
+                    </StackPanel.Resources>
+                    <TextBlock
+                        Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                        Text="Example 3."/>
+                    
+                    <TextBlock
+                        Text="In many real world scenario, notification display must deal with threading, queuing, and potentially heavy usage. A MessageQueue can be set to handle much of this for you, gicing the following benefits:"/>
+                    
+                    <TextBlock
+                        Margin="0 8 0 0"
+                        Text=" • Messages can be queued from any thread"/>
+                    
+                    <TextBlock
+                        Text=" • Message will auto hide after a time out period"/>
+                    
+                    <TextBlock
+                        Text=" • Notification will not time out if mouse is over it"/>
+                    
+                    <TextBlock
+                        Text=" • Can be paired with a DialogHost so timeout will pause if a active dialog"/>
+                    
+                    <TextBlock
+                        Text=" • Duplicate within a short period will be discarded"/>
+                    
+                    <TextBlock
+                        Text=" • A single message queue can be shared acros multiple Windows"/>
+                    
+                    <TextBlock
+                        Text=" • Works with code-behind and MVVM"/>
+                    
+                    <Grid Margin="0 16 0 0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBox
+                            x:Name="MessageTextBox"
+                            VerticalAlignment="Top"
+                            Grid.Column="0"
+                            Text="Hello World"/>
+
+                        <Button
+                            Click="SnackBar3_OnClick"
+                            Margin="16 0 0 0"
+                            Grid.Column="1"
+                            Content="Send"/>
+                    </Grid>
+                </StackPanel>
+                
+                <smtx:XamlDisplay
+                    UniqueKey="snackbar_3"
+                    VerticalContentAlignment="Top">
+                    <materialDesign:Snackbar
+                        x:Name="SnackbarThree"
+                        MessageQueue="{materialDesign:MessageQueue}"/>
+                </smtx:XamlDisplay>
+            </Grid>
+        </Border>
+
+        <!-- example 4 -->
+        <!-- illustrates queueing uses some action command call backs -->
+        <Border
+            Background="{DynamicResource MaterialDesignPaper}"
+            Padding="8 0 8 0"
+            Grid.Column="3"
+            Grid.Row="0">
+            <Grid>
+                <StackPanel
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center">
+                    <StackPanel.Resources>
+                        <Style TargetType="{x:Type TextBlock}">
+                            <Setter Property="TextWrapping" Value="WrapWithOverflow"/>
+                        </Style>
+                    </StackPanel.Resources>
+                    <TextBlock
+                        Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                        Text="Example 4."/>
+
+                    <TextBlock
+                        Text="Illustrates queueing (including discarding of duplicates), and handling of commands. Action a notification to see a System.Trace response.."/>
+                    
+                    <CheckBox
+                        Name="DiscardDuplicateCheckBox"
+                        IsChecked="True"
+                        Content="Discard duplicates"/>
+                    
+                    <Grid Margin="0 16 0 0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        
+                        <TextBox
+                            x:Name="ExampleFourTextBox"
+                            AcceptsReturn="True"
+                            TextWrapping="Wrap"
+                            Text="Message One&#x0d;&#x0a;Message Two&#x0d;&#x0a;Message Three&#x0d;&#x0a;Duplicate&#x0d;&#x0a;Duplicate&#x0d;&#x0a;Duplicate&#x0d;&#x0a;Start Fresh&#x0d;&#x0a;Goodbye"/>
+                        
+                        <StackPanel
+                            Grid.Column="1"
+                            VerticalAlignment="Center">
+                            <Button
+                                Click="SnackBar4_OnClick"
+                                HorizontalAlignment="Center"
+                                Content="Send"/>
+
+                            <Button
+                                Click="SnackBar4_OnClearClick"
+                                HorizontalAlignment="Center"
+                                Margin="0 8"
+                                Content="Clear"/>
+                        </StackPanel>
+                    </Grid>
+                </StackPanel>
+                <smtx:XamlDisplay UniqueKey="snackbar_4">
+                    <materialDesign:Snackbar
+                        x:Name="SnackbarFour"
+                        MessageQueue="{materialDesign:MessageQueue}"/>
+                </smtx:XamlDisplay>
+            </Grid>
+        </Border>
+
+        <!-- example 5 -->
+        <!-- full width snack bar -->
+        <Border
+            Background="{DynamicResource MaterialDesignChipBackground}"
+            Grid.ColumnSpan="2"
+            Grid.Row="1"
+            Grid.Column="0">
+            <StackPanel VerticalAlignment="Bottom">
+                <StackPanel
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Margin="0 0 0 32">
+                    <StackPanel.Resources>
+                        <Style TargetType="{x:Type TextBlock}">
+                            <Setter Property="TextWrapping" Value="WrapWithOverflow"/>
+                        </Style>
+                    </StackPanel.Resources>
+                    <TextBlock
+                        Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                        Text="Example 5."/>
+
+                    <TextBlock Text="Illustrates a full width Snackbar."/>
+                   
+                    <ToggleButton
+                        IsChecked="{Binding ElementName=SnackbarFive, Path=IsActive, Mode=TwoWay}"
+                        Margin="0 8 0 0"/>
+                </StackPanel>                 
+                <smtx:XamlDisplay
+                    UniqueKey="snackbar_5"
+                    HorizontalAlignment="Stretch">
+                    <materialDesign:Snackbar
+                        x:Name="SnackbarFive"
+                        HorizontalAlignment="Stretch">
+                        <materialDesign:SnackbarMessage
+                            Content="This Snackbar is stretched horizontally. Consider allowing your content to push up."
+                            ActionContent="OK"/>
+                    </materialDesign:Snackbar>
+                </smtx:XamlDisplay>
+            </StackPanel>
+        </Border>
+
+        <!-- example 6 -->
+        <!-- colour variations -->
+        <Border
+            Grid.Column="2"
+            Grid.Row="1">
+            <Border.Resources>
+                <ResourceDictionary>
+                    <ResourceDictionary.MergedDictionaries>
+                        <!-- here is where you can get additional snackbar button styles from -->
+                        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Snackbar.xaml"/>
+                    </ResourceDictionary.MergedDictionaries>
+                    
+                    <Style TargetType="materialDesign:Snackbar" BasedOn="{StaticResource {x:Type materialDesign:Snackbar}}">
+                        <Setter Property="Width" Value="288"/>
+                    </Style>
+                    
+                    <Style TargetType="{x:Type TextBlock}">
+                        <Setter Property="TextWrapping" Value="WrapWithOverflow"/>
+                    </Style>
+                </ResourceDictionary>
+            </Border.Resources>
+            <StackPanel
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+                <TextBlock
+                    Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                    Text="Example 6."/>
+
+                <TextBlock
+                    Text="Action button colour variations."/>
+                
+                <smtx:XamlDisplay
+                    UniqueKey="snackbar_6"
+                    Margin="0 8 0 0">
+                    <materialDesign:Snackbar IsActive="True">
+                        <materialDesign:SnackbarMessage
+                            Content="Default - accent"
+                            ActionContent="ACCENT"/>
+                    </materialDesign:Snackbar>
+                </smtx:XamlDisplay>      
+                <smtx:XamlDisplay
+                    UniqueKey="snackbar_7"
+                    Margin="0 8 0 0">
+                    <materialDesign:Snackbar
+                        IsActive="True"
+                        ActionButtonStyle="{StaticResource MaterialDesignSnackbarActionLightButton}">
+                        <materialDesign:SnackbarMessage
+                            Content="Primary Light - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+                            ActionContent="LIGHT - very long text"/>
+                    </materialDesign:Snackbar>
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay
+                    UniqueKey="snackbar_8"
+                    Margin="0 8 0 0">
+                    <materialDesign:Snackbar
+                        IsActive="True"
+                        ActionButtonStyle="{StaticResource MaterialDesignSnackbarActionMidButton}"
+                        ActionButtonPlacement="Inline">
+                        <materialDesign:SnackbarMessage
+                            Content="Primary Mid - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+                            ActionContent="MID"/>
+                    </materialDesign:Snackbar>
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay
+                    UniqueKey="snackbar_9"
+                    Margin="0 8 0 0">
+                    <materialDesign:Snackbar
+                        IsActive="True"
+                        ActionButtonStyle="{StaticResource MaterialDesignSnackbarActionDarkButton}"
+                        ActionButtonPlacement="SeparateLine">
+                        <materialDesign:SnackbarMessage
+                            Content="Primary Dark"
+                            ActionContent="DARK"/>
+                    </materialDesign:Snackbar>
+                </smtx:XamlDisplay>
+            </StackPanel>
+        </Border>
+
+        <!-- example 7 -->
+        <!-- message duration override -->
+        <Border
+            Background="{DynamicResource MaterialDesignPaper}"
+            Padding="8 0 8 0"
+            Grid.Column="3"
+            Grid.Row="1">
+            <Grid>
+                <StackPanel
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center">
+                    <StackPanel.Resources>
+                        <Style TargetType="{x:Type TextBlock}">
+                            <Setter Property="TextWrapping" Value="WrapWithOverflow"/>
+                        </Style>
+                    </StackPanel.Resources>
+                    <TextBlock
+                        Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                        Text="Example 7."/>
+                    
+                    <TextBlock
+                        Text="The message show duration is controlled by the message queue. But this can be overridden for a specific message."/>
+                    
+                    <Grid Margin="0 16 0 0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>                            
+                        <Slider
+                            x:Name="MessageDurationOverrideSlider"
+                            Minimum="1"
+                            Maximum="10"
+                            Value="5"
+                            IsSnapToTickEnabled="True"
+                            TickFrequency="0.1"
+                            VerticalAlignment="Center"/>
+                        
+                        <TextBlock
+                            Text="{Binding ElementName=MessageDurationOverrideSlider, Path=Value, StringFormat={}{0:F1}}"
+                            Margin="10,0" Grid.Column="1" VerticalAlignment="Center"/>
+                        
+                        <Button
+                            Click="SnackBar7_OnClick"
+                            HorizontalAlignment="Center"
+                            Grid.Column="2"
+                            Content="Send"/>
+                    </Grid>
+                </StackPanel>
+                
+                <smtx:XamlDisplay UniqueKey="snackbar_10">
+                    <materialDesign:Snackbar
+                        x:Name="SnackbarSeven"
+                        MessageQueue="{materialDesign:MessageQueue}"/>
+                </smtx:XamlDisplay>
+            </Grid>
+        </Border>
+    </Grid>
 </UserControl>

--- a/MainDemo.Wpf/Typography.xaml
+++ b/MainDemo.Wpf/Typography.xaml
@@ -15,7 +15,7 @@
         </Style>
     </UserControl.Resources>
     
-    <Grid Margin="32">
+    <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="64"/>

--- a/MaterialDesignToolkit.Full.sln.DotSettings
+++ b/MaterialDesignToolkit.Full.sln.DotSettings
@@ -1,6 +1,10 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=adorner/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Controlz/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Meridiem/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Snackbar/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Templated/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Transitioner/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
## What changed?
- Sorted demo pages alphabetically (except for Home page, which remains on top)
- Optimized demo page search (view filter, instead of creating new collections)
- Added `MainWindowViewModel` `DesignInstance` to `MainWindow`, to help tools like ReSharper detect usings
- Added Home button to top navigation bar
- Removed nested `ScrollViewer`s in demo pages and improved margins
- Fixed file name of `DotSettings` file so ReSharper detects it
- Added naming rules to `DotSettings` that matches current code style
## Notes
This PR appears to change a lot more than it really does, due to indentation change in XAML when removing nested `ScrollViewer`s.
If it's desirable to minimize line changes, I can revert the indentation changes.