### PR TITLE
MaterialDesignOutlinedTextBox floating hint position bug fix + Refactor FloatingHintOffsetCalculationConverter

### DIFF
--- a/MaterialDesignThemes.Wpf/Converters/FloatingHintOffsetCalculationConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/FloatingHintOffsetCalculationConverter.cs
@@ -10,25 +10,35 @@ namespace MaterialDesignThemes.Wpf.Converters
     {
         public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
         {
-            var hintHeight = ((FontFamily)values[0]).LineSpacing
-                             * (double)values[1]; // fontSize
-            var floatingHintHeight = hintHeight
-                                     * (double)values[2]; // floatingScale
+            var fontFamily = (FontFamily)values[0];
+            double fontSize = (double)values[1];
+            double floatingScale = (double)values[2];
 
-            var offset = (values.Length > 3 ? values[3] : null) switch
+            double hintHeight = fontFamily.LineSpacing * fontSize;
+            double floatingHintHeight = hintHeight * floatingScale;
+
+            double offset = (values.Length > 3 ? values[3] : null) switch
             {
                 Thickness padding => floatingHintHeight / 2 + padding.Top,
                 double parentHeight => (parentHeight - hintHeight + floatingHintHeight) / 2,
                 _ => floatingHintHeight
             };
 
-            if (targetType == typeof(Point)) // offset
+            if (IsType<Point>(targetType))
+            {
                 return new Point(0, -offset);
-            if (targetType == typeof(Thickness)) // margin
+            }
+
+            if (IsType<Thickness>(targetType))
+            {
                 return new Thickness(0, offset, 0, 0);
+            }
+
             throw new NotSupportedException(targetType.FullName);
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => throw new NotSupportedException();
+
+        private bool IsType<T>(Type type) => type == typeof(T);
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -242,7 +242,7 @@
                                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="FontFamily" />
                                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="FontSize" />
                                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.FloatingScale)" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualHeight" />
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Padding" />
                                     </MultiBinding>
                                 </Setter.Value>
                             </Setter>


### PR DESCRIPTION
This PR fixes issue #2203. I also refactored the converter class a bit, as it was hard to figure out what it exactly did. Feel free to edit/remove anything if it's not following the guidelines.