### PR TITLE
TextField.PrefixText spec update

### DIFF
--- a/MaterialDesignThemes.Wpf/Converters/TextFieldPrefixTextVisibilityConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/TextFieldPrefixTextVisibilityConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace MaterialDesignThemes.Wpf.Converters
+{
+    public class TextFieldPrefixTextVisibilityConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            string prefixText = (string)values[1];
+            if(string.IsNullOrEmpty(prefixText))
+            {
+                return Visibility.Collapsed;
+            }
+
+            bool isHintInFloatingPosition = (bool)values[0];
+            return isHintInFloatingPosition ? Visibility.Visible : Visibility.Hidden;            
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    }
+}

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -9,6 +9,7 @@
 
     <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearButtonVisibilityConverter" />
+    <converters:TextFieldPrefixTextVisibilityConverter x:Key="PrefixTextVisibilityConverter" />
     <converters:NotConverter x:Key="NotConverter" />
     <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
     <converters:FloatingHintOffsetCalculationConverter x:Key="FloatingHintOffsetCalculationConverter" />
@@ -102,25 +103,35 @@
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
-                                        <TextBlock
-                                            x:Name="PrefixTextBlock"
-                                            Grid.Column="0"
-                                            FontSize="{TemplateBinding FontSize}"
-                                            Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                                            Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}" />
-                                        <ScrollViewer
-                                            x:Name="PART_ContentHost"
-                                            Grid.Column="1"
-                                            Panel.ZIndex="1"
-                                            Focusable="false"
-                                            HorizontalScrollBarVisibility="Hidden"
-                                            VerticalScrollBarVisibility="Hidden"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                            UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
-                                            wpf:ScrollViewerAssist.IgnorePadding="True" />
+                                        <WrapPanel
+                                            Grid.Column="0">
+                                            <TextBlock
+                                                x:Name="PrefixTextBlock"
+                                                Margin="0 0 2 0"
+                                                FontSize="{TemplateBinding FontSize}"
+                                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                                                Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}">
+                                                <TextBlock.Visibility>
+                                                    <MultiBinding Converter="{StaticResource PrefixTextVisibilityConverter}">
+                                                        <Binding ElementName="Hint" Path="IsHintInFloatingPosition" />
+                                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.PrefixText)" />
+                                                    </MultiBinding>
+                                                </TextBlock.Visibility>
+                                            </TextBlock>
+                                            
+                                            <ScrollViewer
+                                                x:Name="PART_ContentHost"
+                                                Panel.ZIndex="1"
+                                                Focusable="false"
+                                                HorizontalScrollBarVisibility="Hidden"
+                                                VerticalScrollBarVisibility="Hidden"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
+                                                wpf:ScrollViewerAssist.IgnorePadding="True" />
+                                        </WrapPanel>
                                         <wpf:SmartHint
                                             x:Name="Hint"
-                                            Grid.Column="1"
+                                            Grid.Column="0"
                                             HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                             FontSize="{TemplateBinding FontSize}"
                                             FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"


### PR DESCRIPTION
The specification for the prefix text is different from the current implementation from #1894 . 
The changes in this PR fix following thing:
* PrefixText is now invisible on inactive state (see spec). This uses a new converter `TextFieldPrefixTextVisibilityConverter`  which depends on the value of PrefixText and IsHintInFloatingPosition.
* The Hint is aligned with the PrefixText instead of the input text
* Small margin of `Margin="0 0 2 0"` added to the PrefixText so it doesn't sit so tight against the input text. This is not in the spec, but it seems they also have some margin in the spec

![image](https://user-images.githubusercontent.com/6505319/105572930-62be2380-5d5a-11eb-80ca-58e974a78410.png)

However, this PR introduces a small bug on a TextBox without floating hint. 
![image](https://user-images.githubusercontent.com/6505319/105572957-78cbe400-5d5a-11eb-9cd9-136f4e1c45bc.png)

The cursor sits behind the PrefixText, but the text isn't visible yet because the hint is not in floating mode. When you start typing, the hint dissapears and the PrefixText shows. I didn't want to touch this, because imo in a TextBox without floating hint, the hint should dissapear on focus.

Specification followed:
![image](https://user-images.githubusercontent.com/6505319/105572766-7b7a0980-5d59-11eb-8fda-0ccc65426561.png)
