### PR TITLE
TextField LeadingIcon

### DIFF
--- a/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -180,7 +180,9 @@ namespace MaterialDesignThemes.Wpf
         public static bool GetHasClearButton(DependencyObject element)
             => (bool)element.GetValue(HasClearButtonProperty);
 
-        // Controls visibility of the leading icon
+        /// <summary>
+        /// Controls visibility of the leading icon
+        /// </summary>
         public static readonly DependencyProperty HasLeadingIconProperty = DependencyProperty.RegisterAttached(
             "HasLeadingIcon", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(default(bool)));
 
@@ -201,6 +203,18 @@ namespace MaterialDesignThemes.Wpf
 
         public static PackIconKind GetLeadingIcon(DependencyObject element)
             => (PackIconKind)element.GetValue(LeadingIconProperty);
+
+        /// <summary>
+        /// Controls the size of the leading icon
+        /// </summary>
+        public static readonly DependencyProperty LeadingIconSizeProperty = DependencyProperty.RegisterAttached(
+            "LeadingIconSize", typeof(double), typeof(TextFieldAssist), new PropertyMetadata(20.0));
+
+        public static void SetLeadingIconSize(DependencyObject element, double value)
+            => element.SetValue(LeadingIconSizeProperty, value);
+
+        public static double GetLeadingIconSize(DependencyObject element)
+            => (double)element.GetValue(LeadingIconSizeProperty);
 
         #region Methods
 

--- a/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -144,6 +144,66 @@ namespace MaterialDesignThemes.Wpf
 
         public static bool GetIncludeSpellingSuggestions(TextBoxBase element) => (bool)element.GetValue(IncludeSpellingSuggestionsProperty);
 
+        /// <summary>
+        /// SuffixText dependency property
+        /// </summary>
+        public static readonly DependencyProperty SuffixTextProperty = DependencyProperty.RegisterAttached(
+            "SuffixText", typeof(string), typeof(TextFieldAssist), new PropertyMetadata(default(string?)));
+
+        public static void SetSuffixText(DependencyObject element, string? value)
+            => element.SetValue(SuffixTextProperty, value);
+
+        public static string? GetSuffixText(DependencyObject element)
+            => (string?)element.GetValue(SuffixTextProperty);
+
+        /// <summary>
+        /// PrefixText dependency property
+        /// </summary>
+        public static readonly DependencyProperty PrefixTextProperty = DependencyProperty.RegisterAttached(
+            "PrefixText", typeof(string), typeof(TextFieldAssist), new PropertyMetadata(default(string?)));
+
+        public static void SetPrefixText(DependencyObject element, string? value)
+            => element.SetValue(PrefixTextProperty, value);
+
+        public static string? GetPrefixText(DependencyObject element)
+            => (string?)element.GetValue(PrefixTextProperty);
+
+        /// <summary>
+        /// Controls the visbility of the clear button.
+        /// </summary>
+        public static readonly DependencyProperty HasClearButtonProperty = DependencyProperty.RegisterAttached(
+            "HasClearButton", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(false, HasClearButtonChanged));
+
+        public static void SetHasClearButton(DependencyObject element, bool value)
+            => element.SetValue(HasClearButtonProperty, value);
+
+        public static bool GetHasClearButton(DependencyObject element)
+            => (bool)element.GetValue(HasClearButtonProperty);
+
+        // Controls visibility of the leading icon
+        public static readonly DependencyProperty HasLeadingIconProperty = DependencyProperty.RegisterAttached(
+            "HasLeadingIcon", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(default(bool)));
+
+        public static void SetHasLeadingIcon(DependencyObject element, bool value)
+            => element.SetValue(HasLeadingIconProperty, value);
+
+        public static bool GetHasLeadingIcon(DependencyObject element)
+            => (bool)element.GetValue(HasLeadingIconProperty);
+
+        /// <summary>
+        /// Controls the leading icon
+        /// </summary>
+        public static readonly DependencyProperty LeadingIconProperty = DependencyProperty.RegisterAttached(
+            "LeadingIcon", typeof(PackIconKind), typeof(TextFieldAssist), new PropertyMetadata());
+
+        public static void SetLeadingIcon(DependencyObject element, PackIconKind value)
+            => element.SetValue(LeadingIconProperty, value);
+
+        public static PackIconKind GetLeadingIcon(DependencyObject element)
+            => (PackIconKind)element.GetValue(LeadingIconProperty);
+
+        #region Methods
+
         private static void IncludeSpellingSuggestionsChanged(DependencyObject element, DependencyPropertyChangedEventArgs e)
         {
             if (element is TextBoxBase textBox)
@@ -255,13 +315,7 @@ namespace MaterialDesignThemes.Wpf
             {
                 menu.Items.Remove(item);
             }
-        }
-
-        /// <summary>
-        /// Controls the visbility of the clear button.
-        /// </summary>
-        public static readonly DependencyProperty HasClearButtonProperty = DependencyProperty.RegisterAttached(
-            "HasClearButton", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(false, HasClearButtonChanged));
+        }        
 
         private static void HasClearButtonChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -299,39 +353,7 @@ namespace MaterialDesignThemes.Wpf
                     clearButton.Click -= handler;
             }
         }
-
-        public static void SetHasClearButton(DependencyObject element, bool value)
-            => element.SetValue(HasClearButtonProperty, value);
-
-        public static bool GetHasClearButton(DependencyObject element)
-            => (bool)element.GetValue(HasClearButtonProperty);
-
-        /// <summary>
-        /// SuffixText dependency property
-        /// </summary>
-        public static readonly DependencyProperty SuffixTextProperty = DependencyProperty.RegisterAttached(
-            "SuffixText", typeof(string), typeof(TextFieldAssist), new PropertyMetadata(default(string?)));
-
-        public static void SetSuffixText(DependencyObject element, string? value)
-            => element.SetValue(SuffixTextProperty, value);
-
-        public static string? GetSuffixText(DependencyObject element)
-            => (string?)element.GetValue(SuffixTextProperty);
-
-        /// <summary>
-        /// PrefixText dependency property
-        /// </summary>
-        public static readonly DependencyProperty PrefixTextProperty = DependencyProperty.RegisterAttached(
-            "PrefixText", typeof(string), typeof(TextFieldAssist), new PropertyMetadata(default(string?)));
-
-        public static void SetPrefixText(DependencyObject element, string? value)
-            => element.SetValue(PrefixTextProperty, value);
-
-        public static string? GetPrefixText(DependencyObject element)
-            => (string?)element.GetValue(PrefixTextProperty);
-
-        #region Methods
-
+       
         /// <summary>
         /// Applies the text box view margin.
         /// </summary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -91,27 +91,33 @@
                                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}">
                                     <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
                                         <ColumnDefinition />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
+                                    <wpf:PackIcon
+                                        Grid.Column="0"
+                                        x:Name="LeadingPackIcon"
+                                        Margin="0 0 8 0"
+                                        Height="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
+                                        Width="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
+                                        VerticalAlignment="Bottom"
+                                        Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                                        Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}" />
+
                                     <Grid
+                                        Grid.Column="1"
                                         x:Name="grid"                                        
                                         MinWidth="1">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
-                                            <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
-                                        <wpf:PackIcon
-                                            x:Name="LeadingPackIcon"
-                                            Margin="0 0 12 0"
-                                            Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                                            Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                            Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}" />
-
+                                        
                                         <WrapPanel
-                                            Grid.Column="1">
+                                            Grid.Column="0">
                                             <TextBlock
                                                 x:Name="PrefixTextBlock"
                                                 Margin="0 0 2 0"
@@ -138,7 +144,7 @@
                                         </WrapPanel>
                                         <wpf:SmartHint
                                             x:Name="Hint"
-                                            Grid.Column="1"
+                                            Grid.Column="0"
                                             HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                             FontSize="{TemplateBinding FontSize}"
                                             FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
@@ -160,13 +166,13 @@
                                         </wpf:SmartHint>
                                         <TextBlock
                                             x:Name="SuffixTextBlock"
-                                            Grid.Column="3"
+                                            Grid.Column="2"
                                             FontSize="{TemplateBinding FontSize}"
                                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                             Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />
                                     </Grid>
                                     <Button
-                                        Grid.Column="1"
+                                        Grid.Column="2"
                                         x:Name="PART_ClearButton"
                                         Height="Auto"
                                         Padding="2 0 0 0"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -95,16 +95,23 @@
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
                                     <Grid
-                                        x:Name="grid"
-                                        VerticalAlignment="Center"
+                                        x:Name="grid"                                        
                                         MinWidth="1">
                                         <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
+                                        <wpf:PackIcon
+                                            x:Name="LeadingPackIcon"
+                                            Margin="0 0 12 0"
+                                            Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                                            Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                            Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}" />
+
                                         <WrapPanel
-                                            Grid.Column="0">
+                                            Grid.Column="1">
                                             <TextBlock
                                                 x:Name="PrefixTextBlock"
                                                 Margin="0 0 2 0"
@@ -131,7 +138,7 @@
                                         </WrapPanel>
                                         <wpf:SmartHint
                                             x:Name="Hint"
-                                            Grid.Column="0"
+                                            Grid.Column="1"
                                             HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                             FontSize="{TemplateBinding FontSize}"
                                             FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
@@ -153,7 +160,7 @@
                                         </wpf:SmartHint>
                                         <TextBlock
                                             x:Name="SuffixTextBlock"
-                                            Grid.Column="2"
+                                            Grid.Column="3"
                                             FontSize="{TemplateBinding FontSize}"
                                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                             Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />


### PR DESCRIPTION
This PR implements a LeadingIcon in the TextBox control.

New properties on TextFieldAssist:
* `HasLeadingIcon` (`bool`): Controls the visibility of the icon
* `LeadingIcon` (`PackIconKind`): Controls which icon is shown
* `LeadingIconSize` (`double`, default 20): Controls the size of the icon

This PR builds further upon PR #2220 and is a solution for #1984 

The TextBox template was changed to accomodate these changes. I'm not sure about the WrapPanel, so I'd like somebody to review that change before this gets merged.