### PR TITLE
TextField TrailingIcon added (built upon #2221 and previous)

### DIFF
--- a/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -217,7 +217,7 @@ namespace MaterialDesignThemes.Wpf
             => (double)element.GetValue(LeadingIconSizeProperty);
 
         /// <summary>
-        /// Controls visibility of the leading icon
+        /// Controls visibility of the trailing icon
         /// </summary>
         public static readonly DependencyProperty HasTrailingIconProperty = DependencyProperty.RegisterAttached(
             "HasTrailingIcon", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(default(bool)));
@@ -229,7 +229,7 @@ namespace MaterialDesignThemes.Wpf
             => (bool)element.GetValue(HasTrailingIconProperty);
 
         /// <summary>
-        /// Controls the leading icon
+        /// Controls the trailing icon
         /// </summary>
         public static readonly DependencyProperty TrailingIconProperty = DependencyProperty.RegisterAttached(
             "TrailingIcon", typeof(PackIconKind), typeof(TextFieldAssist), new PropertyMetadata());
@@ -241,7 +241,7 @@ namespace MaterialDesignThemes.Wpf
             => (PackIconKind)element.GetValue(TrailingIconProperty);
 
         /// <summary>
-        /// Controls the size of the leading icon
+        /// Controls the size of the trailing icon
         /// </summary>
         public static readonly DependencyProperty TrailingIconSizeProperty = DependencyProperty.RegisterAttached(
             "TrailingIconSize", typeof(double), typeof(TextFieldAssist), new PropertyMetadata(20.0));

--- a/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -180,7 +180,9 @@ namespace MaterialDesignThemes.Wpf
         public static bool GetHasClearButton(DependencyObject element)
             => (bool)element.GetValue(HasClearButtonProperty);
 
-        // Controls visibility of the leading icon
+        /// <summary>
+        /// Controls visibility of the leading icon
+        /// </summary>
         public static readonly DependencyProperty HasLeadingIconProperty = DependencyProperty.RegisterAttached(
             "HasLeadingIcon", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(default(bool)));
 
@@ -201,6 +203,18 @@ namespace MaterialDesignThemes.Wpf
 
         public static PackIconKind GetLeadingIcon(DependencyObject element)
             => (PackIconKind)element.GetValue(LeadingIconProperty);
+
+        /// <summary>
+        /// Controls the size of the leading icon
+        /// </summary>
+        public static readonly DependencyProperty LeadingIconSizeProperty = DependencyProperty.RegisterAttached(
+            "LeadingIconSize", typeof(double), typeof(TextFieldAssist), new PropertyMetadata(20.0));
+
+        public static void SetLeadingIconSize(DependencyObject element, double value)
+            => element.SetValue(LeadingIconSizeProperty, value);
+
+        public static double GetLeadingIconSize(DependencyObject element)
+            => (double)element.GetValue(LeadingIconSizeProperty);
 
         #region Methods
 

--- a/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -216,6 +216,42 @@ namespace MaterialDesignThemes.Wpf
         public static double GetLeadingIconSize(DependencyObject element)
             => (double)element.GetValue(LeadingIconSizeProperty);
 
+        /// <summary>
+        /// Controls visibility of the leading icon
+        /// </summary>
+        public static readonly DependencyProperty HasTrailingIconProperty = DependencyProperty.RegisterAttached(
+            "HasTrailingIcon", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(default(bool)));
+
+        public static void SetHasTrailingIcon(DependencyObject element, bool value)
+            => element.SetValue(HasTrailingIconProperty, value);
+
+        public static bool GetHasTrailingIcon(DependencyObject element)
+            => (bool)element.GetValue(HasTrailingIconProperty);
+
+        /// <summary>
+        /// Controls the leading icon
+        /// </summary>
+        public static readonly DependencyProperty TrailingIconProperty = DependencyProperty.RegisterAttached(
+            "TrailingIcon", typeof(PackIconKind), typeof(TextFieldAssist), new PropertyMetadata());
+
+        public static void SetTrailingIcon(DependencyObject element, PackIconKind value)
+            => element.SetValue(TrailingIconProperty, value);
+
+        public static PackIconKind GetTrailingIcon(DependencyObject element)
+            => (PackIconKind)element.GetValue(TrailingIconProperty);
+
+        /// <summary>
+        /// Controls the size of the leading icon
+        /// </summary>
+        public static readonly DependencyProperty TrailingIconSizeProperty = DependencyProperty.RegisterAttached(
+            "TrailingIconSize", typeof(double), typeof(TextFieldAssist), new PropertyMetadata(20.0));
+
+        public static void SetTrailingIconSize(DependencyObject element, double value)
+            => element.SetValue(TrailingIconSizeProperty, value);
+
+        public static double GetTrailingIconSize(DependencyObject element)
+            => (double)element.GetValue(TrailingIconSizeProperty);
+
         #region Methods
 
         private static void IncludeSpellingSuggestionsChanged(DependencyObject element, DependencyPropertyChangedEventArgs e)

--- a/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -180,9 +180,7 @@ namespace MaterialDesignThemes.Wpf
         public static bool GetHasClearButton(DependencyObject element)
             => (bool)element.GetValue(HasClearButtonProperty);
 
-        /// <summary>
-        /// Controls visibility of the leading icon
-        /// </summary>
+        // Controls visibility of the leading icon
         public static readonly DependencyProperty HasLeadingIconProperty = DependencyProperty.RegisterAttached(
             "HasLeadingIcon", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(default(bool)));
 
@@ -203,18 +201,6 @@ namespace MaterialDesignThemes.Wpf
 
         public static PackIconKind GetLeadingIcon(DependencyObject element)
             => (PackIconKind)element.GetValue(LeadingIconProperty);
-
-        /// <summary>
-        /// Controls the size of the leading icon
-        /// </summary>
-        public static readonly DependencyProperty LeadingIconSizeProperty = DependencyProperty.RegisterAttached(
-            "LeadingIconSize", typeof(double), typeof(TextFieldAssist), new PropertyMetadata(20.0));
-
-        public static void SetLeadingIconSize(DependencyObject element, double value)
-            => element.SetValue(LeadingIconSizeProperty, value);
-
-        public static double GetLeadingIconSize(DependencyObject element)
-            => (double)element.GetValue(LeadingIconSizeProperty);
 
         #region Methods
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -107,16 +107,23 @@
                                         Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}" />
 
                                     <Grid
-                                        Grid.Column="1"
                                         x:Name="grid"                                        
                                         MinWidth="1">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
+                                        <wpf:PackIcon
+                                            x:Name="LeadingPackIcon"
+                                            Margin="0 0 12 0"
+                                            Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                                            Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                            Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}" />
+
                                         <WrapPanel
-                                            Grid.Column="0">
+                                            Grid.Column="1">
                                             <TextBlock
                                                 x:Name="PrefixTextBlock"
                                                 Margin="0 0 2 0"
@@ -143,7 +150,7 @@
                                         </WrapPanel>
                                         <wpf:SmartHint
                                             x:Name="Hint"
-                                            Grid.Column="0"
+                                            Grid.Column="1"
                                             HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                             FontSize="{TemplateBinding FontSize}"
                                             FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
@@ -165,7 +172,7 @@
                                         </wpf:SmartHint>
                                         <TextBlock
                                             x:Name="SuffixTextBlock"
-                                            Grid.Column="2"
+                                            Grid.Column="3"
                                             FontSize="{TemplateBinding FontSize}"
                                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                             Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -98,10 +98,10 @@
                                     <wpf:PackIcon
                                         Grid.Column="0"
                                         x:Name="LeadingPackIcon"
-                                        Margin="0 0 8 0"
+                                        Margin="0 0 6 0"
+                                        VerticalAlignment="Center"
                                         Height="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
                                         Width="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
-                                        VerticalAlignment="Bottom"
                                         Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                         Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}"
                                         Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}" />
@@ -171,6 +171,17 @@
                                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                             Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />
                                     </Grid>
+                                    <wpf:PackIcon
+                                        Grid.Column="2"
+                                        x:Name="TrailingPackIcon"
+                                        Margin="4 0 0 0"
+                                        VerticalAlignment="Center"
+                                        Height="{TemplateBinding wpf:TextFieldAssist.TrailingIconSize}"
+                                        Width="{TemplateBinding wpf:TextFieldAssist.TrailingIconSize}"
+                                        Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                                        Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        Kind="{TemplateBinding wpf:TextFieldAssist.TrailingIcon}" />
+
                                     <Button
                                         Grid.Column="2"
                                         x:Name="PART_ClearButton"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -107,23 +107,17 @@
                                         Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}" />
 
                                     <Grid
+                                        Grid.Column="1"
                                         x:Name="grid"                                        
                                         MinWidth="1">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
-                                            <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
-                                        <wpf:PackIcon
-                                            x:Name="LeadingPackIcon"
-                                            Margin="0 0 12 0"
-                                            Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                                            Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                            Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}" />
-
+                                        
                                         <WrapPanel
-                                            Grid.Column="1">
+                                            Grid.Column="0">
                                             <TextBlock
                                                 x:Name="PrefixTextBlock"
                                                 Margin="0 0 2 0"
@@ -150,7 +144,7 @@
                                         </WrapPanel>
                                         <wpf:SmartHint
                                             x:Name="Hint"
-                                            Grid.Column="1"
+                                            Grid.Column="0"
                                             HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                             FontSize="{TemplateBinding FontSize}"
                                             FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
@@ -172,7 +166,7 @@
                                         </wpf:SmartHint>
                                         <TextBlock
                                             x:Name="SuffixTextBlock"
-                                            Grid.Column="3"
+                                            Grid.Column="2"
                                             FontSize="{TemplateBinding FontSize}"
                                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                             Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -115,7 +115,6 @@
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
-                                        
                                         <WrapPanel
                                             Grid.Column="0">
                                             <TextBlock


### PR DESCRIPTION
TrailingIcon implemented on TextBox like the LeadingIcon (see PR #2221 )

![image](https://user-images.githubusercontent.com/6505319/105607460-2f51b800-5d9f-11eb-8ad3-6aed4c50bf86.png)
