### PR TITLE
Allowing the DrawerHost to be in either standard or modal

### DIFF
--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -18,7 +18,7 @@
             <TextBlock
                 VerticalAlignment="Center"
                 Text="Black Overlay Background"/>
-            
+
             <ToggleButton
                 Margin="8 0 16 0"
                 x:Name="BackgroundToggle" />
@@ -26,6 +26,13 @@
             <TextBlock
                 VerticalAlignment="Center"
                 Text="Primary Overlay Background"/>
+
+            <TextBlock Text="Open Mode" Margin="30,0,16,0" VerticalAlignment="Center"/>
+            <ComboBox SelectedValue="{Binding OpenMode, ElementName=DrawerHost}"
+                          SelectedValuePath="Content">
+                <ComboBoxItem Content="{x:Static materialDesign:DrawerHostOpenMode.Model}" />
+                <ComboBoxItem Content="{x:Static materialDesign:DrawerHostOpenMode.Standard}" />
+            </ComboBox>
         </StackPanel>
 
         <smtx:XamlDisplay
@@ -33,10 +40,11 @@
             MaxHeight="{x:Static system:Double.MaxValue}"
             Margin="5">
             <materialDesign:DrawerHost
-                Margin="32" 
+                x:Name="DrawerHost"
+                Margin="32"
                 HorizontalAlignment="Center" 
                 VerticalAlignment="Center" 
-                BorderThickness="2" 
+                BorderThickness="2"
                 BorderBrush="{DynamicResource MaterialDesignDivider}">
 
                 <materialDesign:DrawerHost.Style>
@@ -48,14 +56,14 @@
                         </Style.Triggers>
                     </Style>
                 </materialDesign:DrawerHost.Style>
-                
+
                 <materialDesign:DrawerHost.LeftDrawerContent>
                     <StackPanel Margin="16">
                         <TextBlock
                             Margin="4"
                             HorizontalAlignment="Center"
                             Text="LEFT FIELD"/>
-                        
+
                         <Button
                             Command="{x:Static materialDesign:DrawerHost.CloseDrawerCommand}"
                             CommandParameter="{x:Static Dock.Left}"
@@ -72,7 +80,7 @@
                             Content="CLOSE ALL"/>
                     </StackPanel>
                 </materialDesign:DrawerHost.LeftDrawerContent>
-                
+
                 <materialDesign:DrawerHost.TopDrawerContent>
                     <StackPanel
                         Margin="16"
@@ -99,14 +107,14 @@
                             Content="CLOSE THIS"/>
                     </StackPanel>
                 </materialDesign:DrawerHost.TopDrawerContent>
-                
+
                 <materialDesign:DrawerHost.RightDrawerContent>
                     <StackPanel Margin="16">
                         <TextBlock
                             Margin="4"
                             HorizontalAlignment="Center"
                             Text="THE RIGHT STUFF"/>
-                        
+
                         <Button
                             Command="{x:Static materialDesign:DrawerHost.CloseDrawerCommand}"
                             CommandParameter="{x:Static Dock.Right}"
@@ -114,7 +122,7 @@
                             HorizontalAlignment="Center"
                             Style="{DynamicResource MaterialDesignFlatButton}"
                             Content="CLOSE THIS"/>
-                        
+
                         <Button
                             Command="{x:Static materialDesign:DrawerHost.CloseDrawerCommand}"
                             Margin="4"
@@ -123,7 +131,7 @@
                             Content="CLOSE ALL"/>
                     </StackPanel>
                 </materialDesign:DrawerHost.RightDrawerContent>
-                
+
                 <materialDesign:DrawerHost.BottomDrawerContent>
                     <StackPanel
                         Margin="16"
@@ -150,7 +158,7 @@
                             Content="CLOSE THIS"/>
                     </StackPanel>
                 </materialDesign:DrawerHost.BottomDrawerContent>
-                
+
                 <Grid
                     MinWidth="480"
                     MinHeight="480">
@@ -162,7 +170,7 @@
                             <RowDefinition />
                             <RowDefinition />
                         </Grid.RowDefinitions>
-                        
+
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition />
                             <ColumnDefinition />

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -86,6 +86,15 @@ namespace MaterialDesignThemes.Wpf
             set => SetValue(OverlayBackgroundProperty, value);
         }
 
+        public DrawerHostOpenMode OpenMode
+        {
+            get => (DrawerHostOpenMode)GetValue(OpenModeProperty);
+            set => SetValue(OpenModeProperty, value);
+        }
+
+        public static readonly DependencyProperty OpenModeProperty =
+            DependencyProperty.Register("OpenMode", typeof(DrawerHostOpenMode), typeof(DrawerHost), new PropertyMetadata(DrawerHostOpenMode.Default));
+
         #region top drawer
 
         public static readonly DependencyProperty TopDrawerContentProperty = DependencyProperty.Register(
@@ -424,10 +433,7 @@ namespace MaterialDesignThemes.Wpf
             remove { RemoveHandler(DrawerOpenedEvent, value); }
         }
 
-        protected void OnDrawerOpened(DrawerOpenedEventArgs eventArgs)
-        {
-            RaiseEvent(eventArgs);
-        }
+        protected void OnDrawerOpened(DrawerOpenedEventArgs eventArgs) => RaiseEvent(eventArgs);
 
         #endregion
 
@@ -449,10 +455,7 @@ namespace MaterialDesignThemes.Wpf
             remove { RemoveHandler(DrawerClosingEvent, value); }
         }
 
-        protected void OnDrawerClosing(DrawerClosingEventArgs eventArgs)
-        {
-            RaiseEvent(eventArgs);
-        }
+        protected void OnDrawerClosing(DrawerClosingEventArgs eventArgs) => RaiseEvent(eventArgs);
 
         #endregion
 
@@ -529,40 +532,32 @@ namespace MaterialDesignThemes.Wpf
             var anyOpen = IsTopDrawerOpen || IsLeftDrawerOpen || IsBottomDrawerOpen || IsRightDrawerOpen;
 
             VisualStateManager.GoToState(this,
-                !anyOpen ? TemplateAllDrawersAllClosedStateName : TemplateAllDrawersAnyOpenStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
+                !anyOpen ? TemplateAllDrawersAllClosedStateName : TemplateAllDrawersAnyOpenStateName, useTransitions ?? !TransitionAssist.GetDisableTransitions(this));
 
             VisualStateManager.GoToState(this,
-                IsLeftDrawerOpen ? TemplateLeftOpenStateName : TemplateLeftClosedStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
+                IsLeftDrawerOpen ? TemplateLeftOpenStateName : TemplateLeftClosedStateName, useTransitions ?? !TransitionAssist.GetDisableTransitions(this));
 
             VisualStateManager.GoToState(this,
-                IsTopDrawerOpen ? TemplateTopOpenStateName : TemplateTopClosedStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
+                IsTopDrawerOpen ? TemplateTopOpenStateName : TemplateTopClosedStateName, useTransitions ?? !TransitionAssist.GetDisableTransitions(this));
 
             VisualStateManager.GoToState(this,
-                IsRightDrawerOpen ? TemplateRightOpenStateName : TemplateRightClosedStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
+                IsRightDrawerOpen ? TemplateRightOpenStateName : TemplateRightClosedStateName, useTransitions ?? !TransitionAssist.GetDisableTransitions(this));
 
             VisualStateManager.GoToState(this,
-                IsBottomDrawerOpen ? TemplateBottomOpenStateName : TemplateBottomClosedStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
+                IsBottomDrawerOpen ? TemplateBottomOpenStateName : TemplateBottomClosedStateName, useTransitions ?? !TransitionAssist.GetDisableTransitions(this));
         }
 
         private static void IsTopDrawerOpenPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
-        {
-            IsDrawerOpenPropertyChanged(dependencyObject, dependencyPropertyChangedEventArgs, Dock.Top);
-        }
+            => IsDrawerOpenPropertyChanged(dependencyObject, dependencyPropertyChangedEventArgs, Dock.Top);
 
         private static void IsLeftDrawerOpenPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
-        {
-            IsDrawerOpenPropertyChanged(dependencyObject, dependencyPropertyChangedEventArgs, Dock.Left);
-        }
+            => IsDrawerOpenPropertyChanged(dependencyObject, dependencyPropertyChangedEventArgs, Dock.Left);
 
         private static void IsRightDrawerOpenPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
-        {
-            IsDrawerOpenPropertyChanged(dependencyObject, dependencyPropertyChangedEventArgs, Dock.Right);
-        }
+            => IsDrawerOpenPropertyChanged(dependencyObject, dependencyPropertyChangedEventArgs, Dock.Right);
 
         private static void IsBottomDrawerOpenPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
-        {
-            IsDrawerOpenPropertyChanged(dependencyObject, dependencyPropertyChangedEventArgs, Dock.Bottom);
-        }
+            => IsDrawerOpenPropertyChanged(dependencyObject, dependencyPropertyChangedEventArgs, Dock.Bottom);
 
         private static void IsDrawerOpenPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs, Dock dock)
         {
@@ -630,9 +625,9 @@ namespace MaterialDesignThemes.Wpf
 
         private void SetOpenFlag(ExecutedRoutedEventArgs executedRoutedEventArgs, bool value)
         {
-            if (executedRoutedEventArgs.Parameter is Dock)
+            if (executedRoutedEventArgs.Parameter is Dock dock)
             {
-                switch ((Dock)executedRoutedEventArgs.Parameter)
+                switch (dock)
                 {
                     case Dock.Left:
                         SetCurrentValue(IsLeftDrawerOpenProperty, value);

--- a/MaterialDesignThemes.Wpf/DrawerHostOpenMode.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHostOpenMode.cs
@@ -1,0 +1,9 @@
+﻿namespace MaterialDesignThemes.Wpf
+{
+    public enum DrawerHostOpenMode
+    {
+        Default = 0,
+        Model = 0,
+        Standard = 1
+    }
+}

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -529,7 +529,7 @@
                                             <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_ContentCover" Storyboard.TargetProperty="IsHitTestVisible">
                                                 <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
                                             </BooleanAnimationUsingKeyFrames>
-                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="IsEnabled">
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Tag">
                                                 <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
                                             </BooleanAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_ContentCover" Storyboard.TargetProperty="Opacity">
@@ -558,11 +558,11 @@
                                 <VisualState x:Name="AnyOpen">
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetName="PART_ContentCover" Storyboard.TargetProperty="Opacity"
-                                                             To=".56" Duration="0" />
+                                                         To=".56" Duration="0" />
                                         <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_ContentCover" Storyboard.TargetProperty="IsHitTestVisible">
                                             <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
                                         </BooleanAnimationUsingKeyFrames>
-                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="IsEnabled">
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Tag">
                                             <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
                                         </BooleanAnimationUsingKeyFrames>
                                     </Storyboard>
@@ -759,15 +759,51 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                         <Grid x:Name="RootGrid">
-                            <AdornerDecorator>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <AdornerDecorator Grid.Column="1" Grid.Row="1">
                                 <ContentPresenter 
-                                        x:Name="ContentPresenter" Opacity="1"
-                                        Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" ContentStringFormat="{TemplateBinding ContentStringFormat}" />
+                                    x:Name="ContentPresenter"
+                                    Content="{TemplateBinding Content}"
+                                    ContentTemplate="{TemplateBinding ContentTemplate}"
+                                    ContentStringFormat="{TemplateBinding ContentStringFormat}">
+                                    <ContentPresenter.Tag>
+                                        <system:Boolean>False</system:Boolean>
+                                    </ContentPresenter.Tag>
+                                    <ContentPresenter.Style>
+                                        <Style TargetType="ContentPresenter">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding OpenMode, RelativeSource={RelativeSource TemplatedParent}}" Value="Modal">
+                                                    <Setter Property="IsEnabled" Value="{Binding Tag, RelativeSource={RelativeSource Self}}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </ContentPresenter.Style>
+                                </ContentPresenter>
                             </AdornerDecorator>
-                            <Grid x:Name="PART_ContentCover" Background="{TemplateBinding OverlayBackground}" Opacity="0" IsHitTestVisible="False" Focusable="False">
+                            <Grid x:Name="PART_ContentCover"
+                                  Opacity="0"
+                                  IsHitTestVisible="False"
+                                  Focusable="False"
+                                  Grid.Column="0"
+                                  Grid.Row="0"
+                                  Grid.ColumnSpan="3"
+                                  Grid.RowSpan="3">
                                 <Grid.Style>
                                     <Style TargetType="Grid">
+                                        <Setter Property="Background" Value="{Binding OverlayBackground, RelativeSource={RelativeSource TemplatedParent}}" />
                                         <Style.Triggers>
+                                            <DataTrigger Binding="{Binding OpenMode, RelativeSource={RelativeSource TemplatedParent}}" Value="Standard">
+                                                <Setter Property="Background" Value="{x:Null}" />
+                                            </DataTrigger>
                                             <Trigger Property="Opacity" Value="0">
                                                 <Setter Property="Visibility" Value="Hidden" />
                                             </Trigger>
@@ -775,64 +811,119 @@
                                     </Style>
                                 </Grid.Style>
                             </Grid>
-                            <Grid>
-                                <Grid HorizontalAlignment="Left" VerticalAlignment="Stretch"
-                                      x:Name="PART_LeftDrawer"
-                                      Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualWidth, Converter={StaticResource DrawerOffsetConverter}, ConverterParameter={x:Static Dock.Left}}"
-                                      Panel.ZIndex="{TemplateBinding LeftDrawerZIndex}">
-                                    <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(local:ShadowAssist.CacheMode)}">
-                                        <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
-                                                Opacity="0"
-                                                Background="{TemplateBinding LeftDrawerBackground}"
-                                                x:Name="LeftDrawerShadow">
-                                        </Border>
-                                    </AdornerDecorator>
-                                    <ContentPresenter Content="{TemplateBinding LeftDrawerContent}" ContentTemplate="{TemplateBinding LeftDrawerContentTemplate}" ContentStringFormat="{TemplateBinding LeftDrawerContentStringFormat}"
-                                                      IsEnabled="{TemplateBinding IsLeftDrawerOpen}"
-                                                      />
+                            <Grid HorizontalAlignment="Left" VerticalAlignment="Stretch"
+                                  x:Name="PART_LeftDrawer"
+                                  Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualWidth, Converter={StaticResource DrawerOffsetConverter}, ConverterParameter={x:Static Dock.Left}}"
+                                  Panel.ZIndex="{TemplateBinding LeftDrawerZIndex}">
+                                <Grid.Style>
+                                    <Style TargetType="Grid">
+                                        <Setter Property="Grid.Column" Value="1" />
+                                        <Setter Property="Grid.Row" Value="1" />
+                                        <Setter Property="Grid.RowSpan" Value="1" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding OpenMode, RelativeSource={RelativeSource TemplatedParent}}" Value="Standard">
+                                                <Setter Property="Grid.Column" Value="0" />
+                                                <Setter Property="Grid.Row" Value="0" />
+                                                <Setter Property="Grid.RowSpan" Value="3" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Grid.Style>
+                                
+                                <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(local:ShadowAssist.CacheMode)}">
+                                    <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
+                                            Opacity="0"
+                                            Background="{TemplateBinding LeftDrawerBackground}"
+                                            x:Name="LeftDrawerShadow">
+                                    </Border>
+                                </AdornerDecorator>
+                                <ContentPresenter Content="{TemplateBinding LeftDrawerContent}" ContentTemplate="{TemplateBinding LeftDrawerContentTemplate}" ContentStringFormat="{TemplateBinding LeftDrawerContentStringFormat}"
+                                                    IsEnabled="{TemplateBinding IsLeftDrawerOpen}"
+                                                    />
+                            </Grid>
+                            <Grid VerticalAlignment="Stretch" HorizontalAlignment="Right"
+                                  x:Name="PART_RightDrawer"
+                                  Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualWidth, Converter={StaticResource DrawerOffsetConverter}, ConverterParameter={x:Static Dock.Right}}"
+                                  Panel.ZIndex="{TemplateBinding RightDrawerZIndex}">
+                                <Grid.Style>
+                                    <Style TargetType="Grid">
+                                        <Setter Property="Grid.Column" Value="1" />
+                                        <Setter Property="Grid.Row" Value="1" />
+                                        <Setter Property="Grid.RowSpan" Value="1" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding OpenMode, RelativeSource={RelativeSource TemplatedParent}}" Value="Standard">
+                                                <Setter Property="Grid.Column" Value="2" />
+                                                <Setter Property="Grid.Row" Value="0" />
+                                                <Setter Property="Grid.RowSpan" Value="3" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Grid.Style>
+                                <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(local:ShadowAssist.CacheMode)}">
+                                    <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
+                                            Opacity="0"
+                                            Background="{TemplateBinding RightDrawerBackground}"
+                                            x:Name="RightDrawerShadow">
+                                    </Border>
+                                </AdornerDecorator>
+                                <ContentPresenter Content="{TemplateBinding RightDrawerContent}" ContentTemplate="{TemplateBinding RightDrawerContentTemplate}" ContentStringFormat="{TemplateBinding RightDrawerContentStringFormat}"
+                                                  IsEnabled="{TemplateBinding IsRightDrawerOpen}" />
                                 </Grid>
-                                <Grid VerticalAlignment="Stretch" HorizontalAlignment="Right"
-                                      x:Name="PART_RightDrawer"
-                                      Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualWidth, Converter={StaticResource DrawerOffsetConverter}, ConverterParameter={x:Static Dock.Right}}"
-                                      Panel.ZIndex="{TemplateBinding RightDrawerZIndex}">
-                                    <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(local:ShadowAssist.CacheMode)}">
-                                        <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
-                                                Opacity="0"
-                                                Background="{TemplateBinding RightDrawerBackground}"
-                                                x:Name="RightDrawerShadow">
-                                        </Border>
-                                    </AdornerDecorator>
-                                    <ContentPresenter Content="{TemplateBinding RightDrawerContent}" ContentTemplate="{TemplateBinding RightDrawerContentTemplate}" ContentStringFormat="{TemplateBinding RightDrawerContentStringFormat}"
-                                                      IsEnabled="{TemplateBinding IsRightDrawerOpen}" />
+                            <Grid HorizontalAlignment="Stretch" VerticalAlignment="Top"
+                                  x:Name="PART_TopDrawer"
+                                  Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualHeight, Converter={StaticResource DrawerOffsetConverter}, ConverterParameter={x:Static Dock.Top}}"
+                                  Panel.ZIndex="{TemplateBinding TopDrawerZIndex}">
+                                <Grid.Style>
+                                    <Style TargetType="Grid">
+                                        <Setter Property="Grid.Column" Value="1" />
+                                        <Setter Property="Grid.Row" Value="1" />
+                                        <Setter Property="Grid.RowSpan" Value="1" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding OpenMode, RelativeSource={RelativeSource TemplatedParent}}" Value="Standard">
+                                                <Setter Property="Grid.Column" Value="0" />
+                                                <Setter Property="Grid.Row" Value="0" />
+                                                <Setter Property="Grid.ColumnSpan" Value="3" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Grid.Style>
+                                <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(local:ShadowAssist.CacheMode)}">
+                                    <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
+                                            Opacity="0"
+                                            Background="{TemplateBinding TopDrawerBackground}"
+                                            x:Name="TopDrawerShadow">
+                                    </Border>
+                                </AdornerDecorator>
+                                <ContentPresenter Content="{TemplateBinding TopDrawerContent}" ContentTemplate="{TemplateBinding TopDrawerContentTemplate}" ContentStringFormat="{TemplateBinding TopDrawerContentStringFormat}"
+                                                  IsEnabled="{TemplateBinding IsTopDrawerOpen}" />
                                 </Grid>
-                                <Grid HorizontalAlignment="Stretch" VerticalAlignment="Top"
-                                      x:Name="PART_TopDrawer"
-                                      Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualHeight, Converter={StaticResource DrawerOffsetConverter}, ConverterParameter={x:Static Dock.Top}}"
-                                      Panel.ZIndex="{TemplateBinding TopDrawerZIndex}">
-                                    <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(local:ShadowAssist.CacheMode)}">
-                                        <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
-                                                Opacity="0"
-                                                Background="{TemplateBinding TopDrawerBackground}"
-                                                x:Name="TopDrawerShadow">
-                                        </Border>
-                                    </AdornerDecorator>
-                                    <ContentPresenter Content="{TemplateBinding TopDrawerContent}" ContentTemplate="{TemplateBinding TopDrawerContentTemplate}" ContentStringFormat="{TemplateBinding TopDrawerContentStringFormat}"
-                                                      IsEnabled="{TemplateBinding IsTopDrawerOpen}" />
-                                </Grid>
-                                <Grid VerticalAlignment="Bottom" HorizontalAlignment="Stretch"
-                                      x:Name="PART_BottomDrawer"
-                                      Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualHeight, Converter={StaticResource DrawerOffsetConverter}, ConverterParameter={x:Static Dock.Bottom}}"
-                                      Panel.ZIndex="{TemplateBinding BottomDrawerZIndex}">
-                                    <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(local:ShadowAssist.CacheMode)}">
-                                        <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
+                            <Grid VerticalAlignment="Bottom" HorizontalAlignment="Stretch"
+                                  x:Name="PART_BottomDrawer"
+                                  Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualHeight, Converter={StaticResource DrawerOffsetConverter}, ConverterParameter={x:Static Dock.Bottom}}"
+                                  Panel.ZIndex="{TemplateBinding BottomDrawerZIndex}">
+                                <Grid.Style>
+                                    <Style TargetType="Grid">
+                                        <Setter Property="Grid.Column" Value="1" />
+                                        <Setter Property="Grid.Row" Value="1" />
+                                        <Setter Property="Grid.RowSpan" Value="1" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding OpenMode, RelativeSource={RelativeSource TemplatedParent}}" Value="Standard">
+                                                <Setter Property="Grid.Column" Value="0" />
+                                                <Setter Property="Grid.Row" Value="2" />
+                                                <Setter Property="Grid.ColumnSpan" Value="3" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Grid.Style>
+                                <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(local:ShadowAssist.CacheMode)}">
+                                    <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
                                             Opacity="0"
                                             Background="{TemplateBinding BottomDrawerBackground}"
                                             x:Name="BottomDrawerShadow">
-                                        </Border>
-                                    </AdornerDecorator>
-                                    <ContentPresenter Content="{TemplateBinding BottomDrawerContent}" ContentTemplate="{TemplateBinding BottomDrawerContentTemplate}" ContentStringFormat="{TemplateBinding BottomDrawerContentStringFormat}"
-                                                      IsEnabled="{TemplateBinding IsBottomDrawerOpen}"/>
-                                </Grid>
+                                    </Border>
+                                </AdornerDecorator>
+                                <ContentPresenter Content="{TemplateBinding BottomDrawerContent}" ContentTemplate="{TemplateBinding BottomDrawerContentTemplate}" ContentStringFormat="{TemplateBinding BottomDrawerContentStringFormat}"
+                                                  IsEnabled="{TemplateBinding IsBottomDrawerOpen}"/>
                             </Grid>
                         </Grid>
                     </Border>


### PR DESCRIPTION
This is to match specification https://material.io/components/navigation-drawer

This supersedes #789  