### PR TITLE
Embedded dialoghosts focus first focusable field

### DIFF
--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -646,7 +646,7 @@ namespace MaterialDesignThemes.Wpf
         /// <returns>The popup content.</returns>
         internal UIElement? FocusPopup()
         {
-            var child = _popup?.Child;
+            var child = _popup?.Child ?? _popupContentControl;
             if (child is null) return null;
 
             CommandManager.InvalidateRequerySuggested();


### PR DESCRIPTION
This PR will make the embedded dialoghost on par with the popup version's focus when opening the dialog

Sample 5 uses the embedded dialoghost for test:
![image](https://user-images.githubusercontent.com/1004198/108385457-faa11700-720b-11eb-9be7-7eb2a31056a9.png)
