### PR TITLE
DialogHost FocusVisualStyle inherited from ContentControl overriden

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -13,6 +13,7 @@
     </Style>
 
     <Style TargetType="{x:Type wpf:DialogHost}">
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="DialogMargin" Value="35" />
         <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth5" />
         <Setter Property="DialogTheme" Value="Inherit" />


### PR DESCRIPTION
I found an unexpected and unwanted checkered keyboard focus rectangle was appearing in my app after closing a dialog using return or escape. I discovered that overriding the global style for `DialogHost` and setting its `FocusVisualStyle` to `null` caused the problem to go away:

```xaml
<Style
    TargetType="md:DialogHost"
    BasedOn="{StaticResource MaterialDesignEmbeddedDialogHost}"
    >
    <Setter
        Property="FocusVisualStyle"
        Value="{x:Null}"
        />
</Style>
```

I also tried setting `Focusable` to `false`, but this caused problems with keyboard navigation, so I wouldn't recommend it.

I'm submitting this PR in case the Material Design in XAML crew agrees with me that `DialogHost` displaying an indication of it having keyboard focus is of questionable utility and might come across as just as an annoying glitch or artifact to some.