### PR TITLE
Don't disable primary content when dialog visible to workaround #2285

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -189,7 +189,6 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsOpen" Value="True">
-                            <Setter TargetName="ContentPresenter" Property="IsEnabled" Value="False" />
                             <Setter TargetName="PART_ContentCoverGrid" Property="IsHitTestVisible" Value="True" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -377,7 +376,6 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsOpen" Value="True">
-                            <Setter TargetName="ContentPresenter" Property="IsEnabled" Value="False" />
                             <Setter TargetName="PART_ContentCoverGrid" Property="IsHitTestVisible" Value="True" />
                         </Trigger>
                     </ControlTemplate.Triggers>


### PR DESCRIPTION
Resolves #2285 

I continue to believe that issue #2285 is not due to a bug in the code of Material Design in XAML.  Instead, I think it is a bug in the code of WPF.  See https://github.com/dotnet/wpf/issues/4319.

Nonetheless, it is reasonable to consider working around the deficiencies of dependencies.  This PR makes such a workaround, which was identified in https://github.com/dotnet/wpf/issues/4319 (see the third workaround).  Specifically, the change is to keep the primary content enabled (i.e. don't set `IsEnabled` to `false` for the element with name `ContentPresenter`).  This is a reasonable change because the `Grid` with name `PART_ContentCoverGrid` already obscures the view of the element with name `ContentPresenter` and intercepts all user interaction.

On the other hand, I also think it is reasonable to leave the code as is since this bug probably only affects a small number of users.  Instead, those affected can wait for a fix in WPF.  While this bug does affect me, I have already created custom NuGet packages of `MaterialDesignThemes` and `MaterialDesignColors` that includes this change, so I am not blocked in any way by this PR.

If the decision is made to merge this PR, it might also be a good idea to comment out that line instead of deleting it and add a comment nearby that links to #2285.