### PR TITLE
Fix submenus of top-level MenuItems pushed up by 16 pixels

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
@@ -207,8 +207,7 @@
                                IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}"
                                PopupAnimation="Slide"
                                Placement="Bottom"
-                               VerticalOffset="-16"
-                                CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
+                               CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
                             <Border x:Name="SubMenuBorder"
                                     Background="{Binding Path=Background, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=MenuBase}}"
                                     Effect="{DynamicResource MaterialDesignShadowDepth1}"
@@ -239,6 +238,7 @@
                         <Trigger Property="Role" Value="SubmenuHeader">
                             <Setter TargetName="SubBlock" Property="Visibility" Value="Visible" />
                             <Setter TargetName="PART_Popup" Property="Placement" Value="Right" />
+                            <Setter TargetName="PART_Popup" Property="VerticalOffset" Value="-16" />
                             <Setter Property="Height" Value="32"/>
                             <Setter TargetName="BoldHeaderPresenter" Property="Visibility" Value="Collapsed"/>
                         </Trigger>


### PR DESCRIPTION
[Pull request 2201](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/pull/2201) has the side-effect of pushing up submenus of a menu bar:

![image](https://user-images.githubusercontent.com/739972/114570972-47213580-9c44-11eb-8aa3-22a1bc5b5898.png)

That pull request was intended only to fix submenu alignment when a submenu opened to the right of another submenu by raising the popup 16 pixels, but by applying the `VerticalOffset` directly to the popup it changed it everywhere.

This pull request applies the `VerticalOffset` via a control trigger only to submenu headers (menu items that are not part of a `Menu`.