### PR TITLE
Fix ScrollViewer for Chip lists

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
@@ -417,7 +417,9 @@
                             BorderThickness="{TemplateBinding BorderThickness}" 
                             SnapsToDevicePixels="true"
                             Padding="{TemplateBinding Padding}">
-                        <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                        <ScrollViewer Focusable="false" Padding="{TemplateBinding Padding}">
+                            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                        </ScrollViewer>
                     </Border>
                     <ControlTemplate.Triggers>
                         <MultiTrigger>


### PR DESCRIPTION
MaterialDesignFilterChipListBox and MaterialDesignChoiceChipListBox don't have a working Scrollbar. I just copied the solution that works in MaterialDesignListBox (line 344) and that fixed the issue. 