### PR TITLE
Proposal: add CornerRadius properties to the DrawerHost

### DIFF
--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -172,6 +172,15 @@ namespace MaterialDesignThemes.Wpf
             get => (bool)GetValue(TopDrawerCloseOnClickAwayProperty);
             set => SetValue(TopDrawerCloseOnClickAwayProperty, value);
         }
+        
+        public static readonly DependencyProperty TopDrawerCornerRadiusProperty = DependencyProperty.Register(
+            nameof(TopDrawerCornerRadius), typeof(CornerRadius), typeof(DrawerHost), new PropertyMetadata(default(CornerRadius)));
+
+        public CornerRadius? TopDrawerCornerRadius
+        {
+            get => (CornerRadius?)GetValue(TopDrawerCornerRadiusProperty);
+            set => SetValue(TopDrawerCornerRadiusProperty, value);
+        }
 
         #endregion
 
@@ -251,6 +260,15 @@ namespace MaterialDesignThemes.Wpf
         {
             get => (bool)GetValue(LeftDrawerCloseOnClickAwayProperty);
             set => SetValue(LeftDrawerCloseOnClickAwayProperty, value);
+        }
+        
+        public static readonly DependencyProperty LeftDrawerCornerRadiusProperty = DependencyProperty.Register(
+            nameof(LeftDrawerCornerRadius), typeof(CornerRadius), typeof(DrawerHost), new PropertyMetadata(default(CornerRadius)));
+
+        public CornerRadius? LeftDrawerCornerRadius
+        {
+            get => (CornerRadius?)GetValue(LeftDrawerCornerRadiusProperty);
+            set => SetValue(LeftDrawerCornerRadiusProperty, value);
         }
 
         #endregion
@@ -332,6 +350,15 @@ namespace MaterialDesignThemes.Wpf
             get => (bool)GetValue(RightDrawerCloseOnClickAwayProperty);
             set => SetValue(RightDrawerCloseOnClickAwayProperty, value);
         }
+        
+        public static readonly DependencyProperty RightDrawerCornerRadiusProperty = DependencyProperty.Register(
+            nameof(RightDrawerCornerRadius), typeof(CornerRadius), typeof(DrawerHost), new PropertyMetadata(default(CornerRadius)));
+
+        public CornerRadius? RightDrawerCornerRadius
+        {
+            get => (CornerRadius?)GetValue(RightDrawerCornerRadiusProperty);
+            set => SetValue(RightDrawerCornerRadiusProperty, value);
+        }
 
         #endregion
 
@@ -412,6 +439,15 @@ namespace MaterialDesignThemes.Wpf
             get => (bool)GetValue(BottomDrawerCloseOnClickAwayProperty);
             set => SetValue(BottomDrawerCloseOnClickAwayProperty, value);
         }
+        
+        public static readonly DependencyProperty BottomDrawerCornerRadiusProperty = DependencyProperty.Register(
+            nameof(BottomDrawerCornerRadius), typeof(CornerRadius), typeof(DrawerHost), new PropertyMetadata(default(CornerRadius)));
+
+        public CornerRadius? BottomDrawerCornerRadius
+        {
+            get => (CornerRadius?)GetValue(BottomDrawerCornerRadiusProperty);
+            set => SetValue(BottomDrawerCornerRadiusProperty, value);
+        }        
 
         #endregion
 

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -823,7 +823,7 @@
                                 
                                 <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(local:ShadowAssist.CacheMode)}">
                                     <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
-                                            Opacity="0"
+                                            Opacity="0" CornerRadius="{TemplateBinding LeftDrawerCornerRadius}"
                                             Background="{TemplateBinding LeftDrawerBackground}"
                                             x:Name="LeftDrawerShadow">
                                     </Border>
@@ -852,7 +852,7 @@
                                 </Grid.Style>
                                 <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(local:ShadowAssist.CacheMode)}">
                                     <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
-                                            Opacity="0"
+                                            Opacity="0" CornerRadius="{TemplateBinding RightDrawerCornerRadius}"
                                             Background="{TemplateBinding RightDrawerBackground}"
                                             x:Name="RightDrawerShadow">
                                     </Border>
@@ -880,7 +880,7 @@
                                 </Grid.Style>
                                 <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(local:ShadowAssist.CacheMode)}">
                                     <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
-                                            Opacity="0"
+                                            Opacity="0" CornerRadius="{TemplateBinding TopDrawerCornerRadius}"
                                             Background="{TemplateBinding TopDrawerBackground}"
                                             x:Name="TopDrawerShadow">
                                     </Border>
@@ -908,7 +908,7 @@
                                 </Grid.Style>
                                 <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(local:ShadowAssist.CacheMode)}">
                                     <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
-                                            Opacity="0"
+                                            Opacity="0" CornerRadius="{TemplateBinding BottomDrawerCornerRadius}"
                                             Background="{TemplateBinding BottomDrawerBackground}"
                                             x:Name="BottomDrawerShadow">
                                     </Border>


### PR DESCRIPTION
fixes #2332 

Result:

![o2o1NHPer4](https://user-images.githubusercontent.com/58171461/119524165-b038b480-bd7d-11eb-9804-aaca19af05ca.png)
![0NnD4N5Mzh](https://user-images.githubusercontent.com/58171461/119524167-b169e180-bd7d-11eb-8b38-0bc5dfd97a07.png)
![YOaLU7IclC](https://user-images.githubusercontent.com/58171461/119524177-b29b0e80-bd7d-11eb-862e-298b0e99e2c4.png)

It just adds four properties for the CornerRadius of each Drawer. To make it appear like in the Spec and pictures you'll need to specify each corner radius in the property, like this:

`        <materialDesign:DrawerHost  LeftDrawerCornerRadius="0 20 20 0" BottomDrawerCornerRadius="25 25 0 0">`

Maybe it could be improved to accept only one number and automatically figure out which two corners to smooth, although that would remove some customization. Not sure what's the right way