### PR TITLE
Update to Clock styles to follow spec

### DIFF
--- a/MaterialDesignThemes.Wpf/Clock.cs
+++ b/MaterialDesignThemes.Wpf/Clock.cs
@@ -30,8 +30,8 @@ namespace MaterialDesignThemes.Wpf
     [TemplatePart(Name = HoursCanvasPartName, Type = typeof(Canvas))]
     [TemplatePart(Name = MinutesCanvasPartName, Type = typeof(Canvas))]
     [TemplatePart(Name = SecondsCanvasPartName, Type = typeof(Canvas))]
-    [TemplatePart(Name = MinuteReadOutPartName, Type = typeof(TextBlock))]
-    [TemplatePart(Name = HourReadOutPartName, Type = typeof(TextBlock))]
+    [TemplatePart(Name = MinuteReadOutPartName, Type = typeof(Grid))]
+    [TemplatePart(Name = HourReadOutPartName, Type = typeof(Grid))]
     [TemplateVisualState(GroupName = "DisplayModeStates", Name = HoursVisualStateName)]
     [TemplateVisualState(GroupName = "DisplayModeStates", Name = MinutesVisualStateName)]
     public class Clock : Control
@@ -49,9 +49,9 @@ namespace MaterialDesignThemes.Wpf
 
         private Point _centreCanvas = new(0, 0);
         private Point _currentStartPosition = new(0, 0);
-        private TextBlock? _hourReadOutPartName;
-        private TextBlock? _minuteReadOutPartName;
-        private TextBlock? _secondReadOutPartName;
+        private Grid? _hourReadOutPartName;
+        private Grid? _minuteReadOutPartName;
+        private Grid? _secondReadOutPartName;
 
         static Clock()
         {
@@ -211,6 +211,24 @@ namespace MaterialDesignThemes.Wpf
             private set => SetValue(HourLineAnglePropertyKey, value);
         }
 
+        public static readonly DependencyProperty IsHeaderVisibleProperty = DependencyProperty.Register(
+            nameof(IsHeaderVisible), typeof(bool), typeof(Clock), new PropertyMetadata(default(bool)));
+
+        public bool IsHeaderVisible
+        {
+            get => (bool)GetValue(IsHeaderVisibleProperty);
+            set => SetValue(IsHeaderVisibleProperty, value);
+        }
+
+        public static readonly DependencyProperty CornerRadiusProperty = DependencyProperty.Register(
+            nameof(CornerRadius), typeof(CornerRadius), typeof(Clock), new PropertyMetadata(default(CornerRadius)));
+
+        public CornerRadius CornerRadius
+        {
+            get => (CornerRadius)GetValue(CornerRadiusProperty);
+            set => SetValue(CornerRadiusProperty, value);
+        }
+
         public static readonly RoutedEvent ClockChoiceMadeEvent =
             EventManager.RegisterRoutedEvent(
                 "ClockChoiceMade",
@@ -241,9 +259,9 @@ namespace MaterialDesignThemes.Wpf
                 _minuteReadOutPartName.PreviewMouseLeftButtonDown -= MinuteReadOutPartNameOnPreviewMouseLeftButtonDown;
             if (_secondReadOutPartName != null)
                 _secondReadOutPartName.PreviewMouseLeftButtonDown -= SecondReadOutPartNameOnPreviewMouseLeftButtonDown;
-            _hourReadOutPartName = GetTemplateChild(HourReadOutPartName) as TextBlock;
-            _minuteReadOutPartName = GetTemplateChild(MinuteReadOutPartName) as TextBlock;
-            _secondReadOutPartName = GetTemplateChild(SecondReadOutPartName) as TextBlock;
+            _hourReadOutPartName = GetTemplateChild(HourReadOutPartName) as Grid;
+            _minuteReadOutPartName = GetTemplateChild(MinuteReadOutPartName) as Grid;
+            _secondReadOutPartName = GetTemplateChild(SecondReadOutPartName) as Grid;
             if (_hourReadOutPartName != null)
                 _hourReadOutPartName.PreviewMouseLeftButtonDown += HourReadOutPartNameOnPreviewMouseLeftButtonDown;
             if (_minuteReadOutPartName != null)

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
@@ -3,10 +3,17 @@
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
 
-    <converters:ClockLineConverter x:Key="ClockHourLineConverter" DisplayMode="Hours" />
-    <converters:ClockLineConverter x:Key="ClockMinuteLineConverter" DisplayMode="Minutes" />
-    <converters:ClockLineConverter x:Key="ClockSecondLineConverter" DisplayMode="Seconds" />
-    <converters:NotConverter x:Key="NotConverter" />
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+            <converters:ClockLineConverter x:Key="ClockHourLineConverter" DisplayMode="Hours" />
+            <converters:ClockLineConverter x:Key="ClockMinuteLineConverter" DisplayMode="Minutes" />
+            <converters:ClockLineConverter x:Key="ClockSecondLineConverter" DisplayMode="Seconds" />
+            <converters:NotConverter x:Key="NotConverter" />
+            <converters:BorderClipConverter x:Key="BorderClipConverter" />
+        </ResourceDictionary>
+    </ResourceDictionary.MergedDictionaries>
+
 
     <Style x:Key="MaterialDesignClockItemThumb" TargetType="{x:Type Thumb}">
         <Setter Property="Template">
@@ -22,12 +29,15 @@
         <Setter Property="FontSize" Value="14" />
         <Setter Property="FontWeight" Value="Medium" />
         <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RadioButton}">
                     <Grid>
                         <Ellipse Fill="{TemplateBinding Background}" />
-                        <ContentPresenter Content="{TemplateBinding Content}" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
@@ -40,6 +50,57 @@
         </Style.Triggers>
     </Style>
 
+    <Style x:Key="MaterialDesignCalendarMeridiemRadioButtonDefault" TargetType="{x:Type RadioButton}">
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontWeight" Value="Medium" />
+        <Setter Property="Background" Value="{DynamicResource MaterialDesignBodyLight}" />
+        <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBodyLight}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type RadioButton}">
+                    <Grid>
+                        <Border Background="{TemplateBinding Background}"
+                                Opacity=".12"/>
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="MaterialDesignCalendarMeridiemRadioButtonThemed" TargetType="{x:Type RadioButton}">
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontWeight" Value="Medium" />
+        <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type RadioButton}">
+                    <Grid>
+                        <Border Background="{TemplateBinding Background}"/>
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
     <Style x:Key="MaterialDesignClock" TargetType="{x:Type wpf:Clock}">
         <Setter Property="Width" Value="280" />
         <Setter Property="Height" Value="470" />
@@ -48,6 +109,7 @@
         <Setter Property="ButtonRadiusInnerRatio" Value=".6" />
         <Setter Property="FlowDirection" Value="LeftToRight" />
         <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
+        <Setter Property="IsHeaderVisible" Value="True"/>
         <Setter Property="ButtonStyle">
             <Setter.Value>
                 <Style TargetType="{x:Type wpf:ClockItemButton}">
@@ -386,11 +448,15 @@
                         </VisualStateManager.VisualStateGroups>
                         <Grid>
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="auto" />
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
-                            <Border Background="{DynamicResource PrimaryHueMidBrush}" Height="120"  CornerRadius="2 2 0 0">
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0 6 38 0"
+                            <Border Background="{DynamicResource PrimaryHueMidBrush}"
+                                    Height="120"  CornerRadius="2 2 0 0"
+                                    Visibility="{TemplateBinding IsHeaderVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <StackPanel Orientation="Horizontal"
+                                            VerticalAlignment="Center"
+                                            HorizontalAlignment="Right"
                                             x:Name="TimeReadoutStackPanel">
                                     <StackPanel.Resources>
                                         <Style x:Key="TimeTextBlock" TargetType="{x:Type TextBlock}">
@@ -446,47 +512,62 @@
                                                VerticalAlignment="Bottom" Margin="2 0 0 16" Foreground="{DynamicResource PrimaryHueMidForegroundBrush}" />
                                 </StackPanel>
                             </Border>
-                            <Ellipse x:Name="BackgroundEllipse" Grid.Row="1" Margin="0,24.5,0,94" Width="230" Height="230" Fill="{DynamicResource PrimaryHueLightBrush}" Opacity=".23" />
-                            <Canvas x:Name="PART_HoursCanvas" Grid.Row="1" Margin="0,24.5,0,159.5" Width="230" Height="230"
-											RenderTransformOrigin=".5,.5">
-                                <Path x:Name="HourLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Width="2.75" RenderTransformOrigin="0.5,0.985"
-                                      Height="96.959" Canvas.Top="19.047">
-                                    <Path.RenderTransform>
-                                        <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
-                                    </Path.RenderTransform>
-                                </Path>
-                                <Canvas.RenderTransform>
-                                    <ScaleTransform x:Name="HoursScaleTransform" ScaleX="1" ScaleY="1" />
-                                </Canvas.RenderTransform>
-                            </Canvas>
-                            <Canvas x:Name="PART_MinutesCanvas" Grid.Row="1" Margin="0,24.5,0,159.5" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
-											RenderTransformOrigin=".5,.5">
-                                <Path x:Name="MinuteLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047" Width="2.75" RenderTransformOrigin="0.5,0.985">
-                                    <Path.RenderTransform>
-                                        <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
-                                    </Path.RenderTransform>
-                                </Path>
-                                <Canvas.RenderTransform>
-                                    <ScaleTransform x:Name="MinutesScaleTransform" ScaleX="1" ScaleY="1" />
-                                </Canvas.RenderTransform>
-                            </Canvas>
-                            <Canvas x:Name="PART_SecondsCanvas" Grid.Row="1" Margin="0,24.5,0,159.5" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
-											RenderTransformOrigin=".5,.5">
-                                <Path x:Name="SecondLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047" Width="2.75" RenderTransformOrigin="0.5,0.985">
-                                    <Path.RenderTransform>
-                                        <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
-                                    </Path.RenderTransform>
-                                </Path>
-                                <Canvas.RenderTransform>
-                                    <ScaleTransform x:Name="SecondsScaleTransform" ScaleX="1" ScaleY="1" />
-                                </Canvas.RenderTransform>
-                            </Canvas>
-                            <RadioButton Content="AM" HorizontalAlignment="Left" Height="47.333" Margin="31.666,0,0,37.667" Grid.Row="1" VerticalAlignment="Bottom" Width="47.333" Style="{StaticResource MaterialDesignCalendarMeridiemRadioButton}"
+                            <Grid Grid.Row="1" VerticalAlignment="Center">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="auto"/>
+                                </Grid.RowDefinitions>
+                                <Ellipse x:Name="BackgroundEllipse" Width="230" Height="230" Fill="{DynamicResource PrimaryHueLightBrush}" Opacity=".23" />
+                                <Canvas x:Name="PART_HoursCanvas" Width="230" Height="230"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="HourLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Width="2.75" RenderTransformOrigin="0.5,0.985"
+                                          Height="96.959" Canvas.Top="19.047">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="HoursScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+                                <Canvas x:Name="PART_MinutesCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="MinuteLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047" Width="2.75" RenderTransformOrigin="0.5,0.985">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="MinutesScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+                                <Canvas x:Name="PART_SecondsCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="SecondLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047" Width="2.75" RenderTransformOrigin="0.5,0.985">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="SecondsScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+
+                                <RadioButton Content="AM" HorizontalAlignment="Left" Height="47.333" Margin="32,0,0,0"
+                                         Grid.Row="1" VerticalAlignment="Bottom" Width="47.333"
+                                         Style="{StaticResource MaterialDesignCalendarMeridiemRadioButton}"
                                          x:Name="AMRadioButton"
                                          IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}}" />
-                            <RadioButton Content="PM" HorizontalAlignment="Right" Height="47.333" Margin="0,0,31.667,37.667" Grid.Row="1" VerticalAlignment="Bottom" Width="47.333" Style="{StaticResource MaterialDesignCalendarMeridiemRadioButton}"
+                                <RadioButton Content="PM" HorizontalAlignment="Right" Height="47.333" Margin="0,0,32,0"
+                                         Grid.Row="1" VerticalAlignment="Bottom" Width="47.333"
+                                         Style="{StaticResource MaterialDesignCalendarMeridiemRadioButton}"
                                          x:Name="PMRadioButton"
                                          IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem}" />
+
+                            </Grid>
+
+
+
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
@@ -497,7 +578,7 @@
                             <Setter TargetName="AmPmReadout" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="AMRadioButton" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="PMRadioButton" Property="Visibility" Value="Collapsed" />
-                            <Setter TargetName="BackgroundEllipse" Property="Margin" Value="0,24.5,0,26" />
+                            <!--<Setter TargetName="BackgroundEllipse" Property="Margin" Value="0,24.5,0,26" />-->
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -545,6 +626,2411 @@
                 <Setter Property="Height" Value="402" />
             </Trigger>
         </Style.Triggers>
+    </Style>
+
+
+    <Style x:Key="MaterialDesignClockVertical" TargetType="{x:Type wpf:Clock}">
+        <Setter Property="Height" Value="auto"/>
+        <Setter Property="Width" Value="auto"/>
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="ButtonRadiusRatio" Value=".835" />
+        <Setter Property="ButtonRadiusInnerRatio" Value=".6" />
+        <Setter Property="FlowDirection" Value="LeftToRight" />
+        <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
+        <Setter Property="IsHeaderVisible" Value="True"/>
+        <Setter Property="CornerRadius" Value="8"/>
+        <Setter Property="ButtonStyle">
+            <Setter.Value>
+                <Style TargetType="{x:Type wpf:ClockItemButton}">
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="Width" Value="32" />
+                    <Setter Property="Height" Value="32" />
+                    <Setter Property="HorizontalContentAlignment" Value="Center" />
+                    <Setter Property="VerticalContentAlignment" Value="Center" />
+                    <Setter Property="Canvas.ZIndex" Value="0" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type wpf:ClockItemButton}">
+                                <Grid>
+                                    <Thumb Style="{StaticResource MaterialDesignClockItemThumb}" Background="{TemplateBinding Background}" Opacity="23"
+												   x:Name="PART_Thumb"/>
+                                    <ContentPresenter Content="{TemplateBinding Content}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+															  IsHitTestVisible="False"/>
+                                </Grid>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource PrimaryHueLightBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="LesserButtonStyle">
+            <Setter.Value>
+                <Style TargetType="{x:Type wpf:ClockItemButton}">
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="Width" Value="12" />
+                    <Setter Property="Height" Value="12" />
+                    <Setter Property="HorizontalContentAlignment" Value="Center" />
+                    <Setter Property="VerticalContentAlignment" Value="Center" />
+                    <Setter Property="Canvas.ZIndex" Value="1" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type wpf:ClockItemButton}">
+                                <Grid>
+                                    <Thumb Style="{StaticResource MaterialDesignClockItemThumb}" Background="{TemplateBinding Background}" Opacity=".52"
+												   x:Name="PART_Thumb"
+												   ToolTip="{TemplateBinding Content}"/>
+                                    <Ellipse Fill="{TemplateBinding Background}" HorizontalAlignment="Center" VerticalAlignment="Center" Height="6" Width="6"
+													 IsHitTestVisible="False"/>
+                                </Grid>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource PrimaryHueLightBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type wpf:Clock}">
+                    <Border Background="{TemplateBinding Background}"
+							BorderBrush="{TemplateBinding BorderBrush}" 
+        					BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="2">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="DisplayModeStates">
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition From="*" To="Hours">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.4">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    <VisualTransition From="Hours" To="Minutes">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    <VisualTransition From="Minutes" To="Seconds">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                </VisualStateGroup.Transitions>
+                                <VisualState x:Name="Hours">
+                                    <Storyboard>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1" Duration="0" />
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To=".85" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To=".85" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To=".85" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To=".85" Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Minutes">
+                                    <Storyboard>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1.2" Duration="0" />
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="1" Duration="0"/>
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1" Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Seconds">
+                                    <Storyboard>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1.2" Duration="0" />
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="1" Duration="0"/>
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1" Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <Grid Margin="24" >
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+
+                            <!--#region Time Display-->
+
+                            <Border HorizontalAlignment="Center" Margin="0 0 0 36"
+                                    Visibility="{TemplateBinding IsHeaderVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <StackPanel Orientation="Horizontal">
+                                    <StackPanel Orientation="Horizontal"
+                                            VerticalAlignment="Center"
+                                            HorizontalAlignment="Right"
+                                            x:Name="TimeReadoutStackPanel">
+                                        <StackPanel.Resources>
+                                            <Style x:Key="TimeTextBlock" TargetType="{x:Type TextBlock}">
+                                                <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
+                                                <Setter Property="FontSize" Value="48" />
+                                                <Setter Property="FontWeight" Value="Normal" />
+                                            </Style>
+                                        </StackPanel.Resources>
+
+                                        <Grid Width="96" Height="80" x:Name="PART_HourReadOut">
+                                            <Border x:Name="PART_HourReadOutBorder"
+                                                    Opacity=".12"
+                                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background" Value="{DynamicResource MaterialDesignBodyLight}"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Hours}">
+                                                                <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                            </Border>
+                                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:%h}}" 
+													   x:Name="PART_HourReadOutText"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Hours}">
+                                                                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
+
+                                        <TextBlock Text=":" Style="{StaticResource TimeTextBlock}"
+                                                   Foreground="{DynamicResource MaterialDesignBody}"
+                                                   VerticalAlignment="Center"
+                                                   Width="24" TextAlignment="Center"/>
+
+                                        <Grid Width="96" Height="80" x:Name="PART_MinuteReadOut">
+                                            <Border x:Name="PART_MinuteReadOutBorder"
+                                                    Opacity=".12"
+                                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background" Value="{DynamicResource MaterialDesignBodyLight}"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Minutes}">
+                                                                <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                            </Border>
+                                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:mm}}"  
+													   x:Name="PART_MinuteReadOutText"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Minutes}">
+                                                                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
+
+                                        <TextBlock x:Name="PART_SecondColonPrefix" Text=":"
+                                                   Style="{StaticResource TimeTextBlock}"
+                                                   Foreground="{DynamicResource MaterialDesignBody}"
+                                                   VerticalAlignment="Center"
+                                                   Width="24" TextAlignment="Center"/>
+
+                                        <Grid Width="96" Height="80" x:Name="PART_SecondReadOut">
+                                            <Border x:Name="PART_SecondReadOutBorder"
+                                                    Opacity=".12"
+                                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background" Value="{DynamicResource MaterialDesignBodyLight}"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Seconds}">
+                                                                <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                            </Border>
+                                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:ss}}"  
+													   x:Name="PART_SecondReadOutText"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Seconds}">
+                                                                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
+                                    </StackPanel>
+                                    <Border x:Name="AmPmBorder" CornerRadius="{TemplateBinding CornerRadius}"
+                                            VerticalAlignment="Center" Margin="12 0 0 0" Height="80">
+                                        <StackPanel>
+                                            <StackPanel.Clip>
+                                                <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                                                    <Binding ElementName="AmPmBorder" Path="ActualWidth" />
+                                                    <Binding ElementName="AmPmBorder" Path="ActualHeight" />
+                                                    <Binding ElementName="AmPmBorder" Path="CornerRadius" />
+                                                    <Binding ElementName="AmPmBorder" Path="BorderThickness" />
+                                                </MultiBinding>
+                                            </StackPanel.Clip>
+                                            <RadioButton Content="AM" Height="40" Width="52"
+                                             Style="{StaticResource MaterialDesignCalendarMeridiemRadioButtonDefault}"
+                                             x:Name="AMRadioButton"
+                                             IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}}" />
+                                            <RadioButton Content="PM" Height="40" Width="52"
+                                             Style="{StaticResource MaterialDesignCalendarMeridiemRadioButtonDefault}"
+                                             x:Name="PMRadioButton"
+                                             IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem}" />
+                                        </StackPanel>
+                                    </Border>
+
+                                </StackPanel>
+
+                            </Border>
+
+                            <!--#endregion-->
+
+                            <!--#region Clock circle-->
+
+                            <Grid Grid.Row="1" VerticalAlignment="Top" >
+                                <Ellipse x:Name="BackgroundEllipse" Width="230" Height="230" Fill="{DynamicResource MaterialDesignBodyLight}" Opacity=".12" />
+                                <Canvas x:Name="PART_HoursCanvas" Width="230" Height="230"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="HourLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Width="2.75" RenderTransformOrigin="0.5,0.985"
+                                          Height="96.959" Canvas.Top="19.047">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="HoursScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+                                <Canvas x:Name="PART_MinutesCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="MinuteLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047" Width="2.75" RenderTransformOrigin="0.5,0.985">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="MinutesScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+                                <Canvas x:Name="PART_SecondsCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="SecondLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047" Width="2.75" RenderTransformOrigin="0.5,0.985">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="SecondsScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+                            </Grid>
+
+                            <!--#endregion-->
+
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Is24Hours" Value="True">
+                            <Setter TargetName="PART_HourReadOutText" Property="Text" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:HH}}" />
+                            <Setter TargetName="AmPmBorder" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="Is24Hours" Value="True" />
+                                <Condition Property="IsPostMeridiem" Value="False" />
+                                <Condition Property="IsMidnightHour" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="HourLine" Property="Height" Value="76" />
+                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="Is24Hours" Value="True" />
+                                <Condition Property="IsMiddayHour" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="HourLine" Property="Height" Value="76" />
+                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
+                        </MultiTrigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.None}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.Cycle}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.ToMinutesOnly}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.ToSeconds}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="MaterialDesignClockVerticalThemed" TargetType="{x:Type wpf:Clock}">
+        <Setter Property="Height" Value="auto"/>
+        <Setter Property="Width" Value="auto"/>
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="ButtonRadiusRatio" Value=".835" />
+        <Setter Property="ButtonRadiusInnerRatio" Value=".6" />
+        <Setter Property="FlowDirection" Value="LeftToRight" />
+        <Setter Property="Background" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Setter Property="IsHeaderVisible" Value="True"/>
+        <Setter Property="CornerRadius" Value="8"/>
+        <Setter Property="ButtonStyle">
+            <Setter.Value>
+                <Style TargetType="{x:Type wpf:ClockItemButton}">
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="Width" Value="32" />
+                    <Setter Property="Height" Value="32" />
+                    <Setter Property="HorizontalContentAlignment" Value="Center" />
+                    <Setter Property="VerticalContentAlignment" Value="Center" />
+                    <Setter Property="Canvas.ZIndex" Value="0" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type wpf:ClockItemButton}">
+                                <Grid>
+                                    <Thumb Style="{StaticResource MaterialDesignClockItemThumb}" Background="{TemplateBinding Background}" Opacity="23"
+												   x:Name="PART_Thumb"/>
+                                    <ContentPresenter Content="{TemplateBinding Content}"
+                                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+													  IsHitTestVisible="False"/>
+                                </Grid>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource SecondaryHueLightBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="LesserButtonStyle">
+            <Setter.Value>
+                <Style TargetType="{x:Type wpf:ClockItemButton}">
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="Width" Value="12" />
+                    <Setter Property="Height" Value="12" />
+                    <Setter Property="HorizontalContentAlignment" Value="Center" />
+                    <Setter Property="VerticalContentAlignment" Value="Center" />
+                    <Setter Property="Canvas.ZIndex" Value="1" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type wpf:ClockItemButton}">
+                                <Grid>
+                                    <Thumb Style="{StaticResource MaterialDesignClockItemThumb}" Background="{TemplateBinding Background}" Opacity=".52"
+												   x:Name="PART_Thumb"
+												   ToolTip="{TemplateBinding Content}"/>
+                                    <Ellipse Fill="{TemplateBinding Background}" HorizontalAlignment="Center" VerticalAlignment="Center" Height="6" Width="6"
+													 IsHitTestVisible="False"/>
+                                </Grid>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource SecondaryHueLightBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type wpf:Clock}">
+                    <Border Background="{TemplateBinding Background}"
+							BorderBrush="{TemplateBinding BorderBrush}" 
+        					BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="2">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="DisplayModeStates">
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition From="*" To="Hours">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.4">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    <VisualTransition From="Hours" To="Minutes">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    <VisualTransition From="Minutes" To="Seconds">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                </VisualStateGroup.Transitions>
+                                <VisualState x:Name="Hours">
+                                    <Storyboard>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1" Duration="0" />
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To=".85" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To=".85" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To=".85" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To=".85" Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Minutes">
+                                    <Storyboard>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1.2" Duration="0" />
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="1" Duration="0"/>
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1" Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Seconds">
+                                    <Storyboard>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1.2" Duration="0" />
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="1" Duration="0"/>
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1" Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <Grid Margin="24" >
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+
+                            <!--#region Time Display-->
+
+                            <Border HorizontalAlignment="Center" Margin="0 0 0 36"
+                                    Visibility="{TemplateBinding IsHeaderVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <StackPanel Orientation="Horizontal">
+                                    <StackPanel Orientation="Horizontal"
+                                            VerticalAlignment="Center"
+                                            HorizontalAlignment="Right"
+                                            x:Name="TimeReadoutStackPanel">
+                                        <StackPanel.Resources>
+                                            <Style x:Key="TimeTextBlock" TargetType="{x:Type TextBlock}">
+                                                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
+                                                <Setter Property="FontSize" Value="48" />
+                                                <Setter Property="FontWeight" Value="Normal" />
+                                            </Style>
+                                        </StackPanel.Resources>
+
+                                        <Grid Width="96" Height="80" x:Name="PART_HourReadOut">
+                                            <Border x:Name="PART_HourReadOutBorder"
+                                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Hours}">
+                                                                <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                            </Border>
+                                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:%h}}" 
+													   x:Name="PART_HourReadOutText"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Hours}">
+                                                                <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
+
+                                        <TextBlock Text=":" Style="{StaticResource TimeTextBlock}"
+                                                   Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}"
+                                                   VerticalAlignment="Center"
+                                                   Width="24" TextAlignment="Center"/>
+
+                                        <Grid Width="96" Height="80" x:Name="PART_MinuteReadOut">
+                                            <Border x:Name="PART_MinuteReadOutBorder"
+                                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Minutes}">
+                                                                <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                            </Border>
+                                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:mm}}"  
+													   x:Name="PART_MinuteReadOutText"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Minutes}">
+                                                                <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
+
+                                        <TextBlock x:Name="PART_SecondColonPrefix" Text=":"
+                                                   Style="{StaticResource TimeTextBlock}"
+                                                   Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}"
+                                                   VerticalAlignment="Center"
+                                                   Width="24" TextAlignment="Center"/>
+
+                                        <Grid Width="96" Height="80" x:Name="PART_SecondReadOut">
+                                            <Border x:Name="PART_SecondReadOutBorder"
+                                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Seconds}">
+                                                                <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                            </Border>
+                                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:ss}}"  
+													   x:Name="PART_SecondReadOutText"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Seconds}">
+                                                                <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
+                                    </StackPanel>
+                                    <Border x:Name="AmPmBorder" CornerRadius="{TemplateBinding CornerRadius}"
+                                            VerticalAlignment="Center" Margin="12 0 0 0" Height="80">
+                                        <StackPanel>
+                                            <StackPanel.Clip>
+                                                <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                                                    <Binding ElementName="AmPmBorder" Path="ActualWidth" />
+                                                    <Binding ElementName="AmPmBorder" Path="ActualHeight" />
+                                                    <Binding ElementName="AmPmBorder" Path="CornerRadius" />
+                                                    <Binding ElementName="AmPmBorder" Path="BorderThickness" />
+                                                </MultiBinding>
+                                            </StackPanel.Clip>
+                                            <RadioButton Content="AM" Height="40" Width="52"
+                                             Style="{StaticResource MaterialDesignCalendarMeridiemRadioButtonThemed}"
+                                             x:Name="AMRadioButton"
+                                             IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}}" />
+                                            <RadioButton Content="PM" Height="40" Width="52"
+                                             Style="{StaticResource MaterialDesignCalendarMeridiemRadioButtonThemed}"
+                                             x:Name="PMRadioButton"
+                                             IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem}" />
+                                        </StackPanel>
+                                    </Border>
+
+                                </StackPanel>
+
+                            </Border>
+
+                            <!--#endregion-->
+
+                            <!--#region Clock circle-->
+
+                            <Grid Grid.Row="1" VerticalAlignment="Top" >
+                                <Ellipse x:Name="BackgroundEllipse" Width="230" Height="230" Fill="{DynamicResource PrimaryHueMidBrush}" />
+                                <Canvas x:Name="PART_HoursCanvas" Width="230" Height="230"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="HourLine"
+                                          Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001"
+                                          Fill="{DynamicResource SecondaryHueMidBrush}"
+                                          Canvas.Left="113.625"
+                                          Stretch="Fill"
+                                          Stroke="{DynamicResource SecondaryHueMidBrush}"
+                                          Width="2.75"
+                                          RenderTransformOrigin="0.5,0.985"
+                                          Height="96.959"
+                                          Canvas.Top="19.047">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="HoursScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+                                <Canvas x:Name="PART_MinutesCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="MinuteLine"
+                                          Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001"
+                                          Fill="{DynamicResource SecondaryHueMidBrush}"
+                                          Height="96.959"
+                                          Canvas.Left="113.625"
+                                          Stretch="Fill"
+                                          Stroke="{DynamicResource SecondaryHueMidBrush}"
+                                          Canvas.Top="19.047"
+                                          Width="2.75"
+                                          RenderTransformOrigin="0.5,0.985">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="MinutesScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+                                <Canvas x:Name="PART_SecondsCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="SecondLine"
+                                          Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001"
+                                          Fill="{DynamicResource SecondaryHueMidBrush}"
+                                          Height="96.959"
+                                          Canvas.Left="113.625"
+                                          Stretch="Fill"
+                                          Stroke="{DynamicResource SecondaryHueMidBrush}"
+                                          Canvas.Top="19.047"
+                                          Width="2.75"
+                                          RenderTransformOrigin="0.5,0.985">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="SecondsScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+                            </Grid>
+
+                            <!--#endregion-->
+
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Is24Hours" Value="True">
+                            <Setter TargetName="PART_HourReadOutText" Property="Text" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:HH}}" />
+                            <Setter TargetName="AmPmBorder" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="Is24Hours" Value="True" />
+                                <Condition Property="IsPostMeridiem" Value="False" />
+                                <Condition Property="IsMidnightHour" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="HourLine" Property="Height" Value="76" />
+                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="Is24Hours" Value="True" />
+                                <Condition Property="IsMiddayHour" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="HourLine" Property="Height" Value="76" />
+                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
+                        </MultiTrigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.None}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.Cycle}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.ToMinutesOnly}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.ToSeconds}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="MaterialDesignClockHorizontal" TargetType="{x:Type wpf:Clock}">
+        <Setter Property="Height" Value="auto"/>
+        <Setter Property="Width" Value="auto"/>
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="ButtonRadiusRatio" Value=".835" />
+        <Setter Property="ButtonRadiusInnerRatio" Value=".6" />
+        <Setter Property="FlowDirection" Value="LeftToRight" />
+        <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
+        <Setter Property="IsHeaderVisible" Value="True"/>
+        <Setter Property="CornerRadius" Value="8"/>
+        <Setter Property="ButtonStyle">
+            <Setter.Value>
+                <Style TargetType="{x:Type wpf:ClockItemButton}">
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="Width" Value="32" />
+                    <Setter Property="Height" Value="32" />
+                    <Setter Property="HorizontalContentAlignment" Value="Center" />
+                    <Setter Property="VerticalContentAlignment" Value="Center" />
+                    <Setter Property="Canvas.ZIndex" Value="0" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type wpf:ClockItemButton}">
+                                <Grid>
+                                    <Thumb Style="{StaticResource MaterialDesignClockItemThumb}" Background="{TemplateBinding Background}" Opacity="23"
+												   x:Name="PART_Thumb"/>
+                                    <ContentPresenter Content="{TemplateBinding Content}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+															  IsHitTestVisible="False"/>
+                                </Grid>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource PrimaryHueLightBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="LesserButtonStyle">
+            <Setter.Value>
+                <Style TargetType="{x:Type wpf:ClockItemButton}">
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="Width" Value="12" />
+                    <Setter Property="Height" Value="12" />
+                    <Setter Property="HorizontalContentAlignment" Value="Center" />
+                    <Setter Property="VerticalContentAlignment" Value="Center" />
+                    <Setter Property="Canvas.ZIndex" Value="1" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type wpf:ClockItemButton}">
+                                <Grid>
+                                    <Thumb Style="{StaticResource MaterialDesignClockItemThumb}" Background="{TemplateBinding Background}" Opacity=".52"
+												   x:Name="PART_Thumb"
+												   ToolTip="{TemplateBinding Content}"/>
+                                    <Ellipse Fill="{TemplateBinding Background}" HorizontalAlignment="Center" VerticalAlignment="Center" Height="6" Width="6"
+													 IsHitTestVisible="False"/>
+                                </Grid>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource PrimaryHueLightBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type wpf:Clock}">
+                    <Border Background="{TemplateBinding Background}"
+							BorderBrush="{TemplateBinding BorderBrush}" 
+        					BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="2">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="DisplayModeStates">
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition From="*" To="Hours">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.4">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    <VisualTransition From="Hours" To="Minutes">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    <VisualTransition From="Minutes" To="Seconds">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                </VisualStateGroup.Transitions>
+                                <VisualState x:Name="Hours">
+                                    <Storyboard>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1" Duration="0" />
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To=".85" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To=".85" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To=".85" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To=".85" Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Minutes">
+                                    <Storyboard>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1.2" Duration="0" />
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="1" Duration="0"/>
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1" Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Seconds">
+                                    <Storyboard>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1.2" Duration="0" />
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="1" Duration="0"/>
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1" Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <Grid Margin="24" VerticalAlignment="Center">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+
+                            <!--#region Time Display-->
+
+                            <Border VerticalAlignment="Center" Margin=" 0 0 52 0"
+                                    Visibility="{TemplateBinding IsHeaderVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <StackPanel >
+                                    <StackPanel Orientation="Horizontal"
+                                            VerticalAlignment="Center"
+                                            HorizontalAlignment="Right"
+                                            x:Name="TimeReadoutStackPanel">
+                                        <StackPanel.Resources>
+                                            <Style x:Key="TimeTextBlock" TargetType="{x:Type TextBlock}">
+                                                <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
+                                                <Setter Property="FontSize" Value="48" />
+                                                <Setter Property="FontWeight" Value="Normal" />
+                                            </Style>
+                                        </StackPanel.Resources>
+
+                                        <Grid Width="96" Height="80" x:Name="PART_HourReadOut">
+                                            <Border x:Name="PART_HourReadOutBorder"
+                                                    Opacity=".12"
+                                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background" Value="{DynamicResource MaterialDesignBodyLight}"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Hours}">
+                                                                <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                            </Border>
+                                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:%h}}" 
+													   x:Name="PART_HourReadOutText"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Hours}">
+                                                                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
+
+                                        <TextBlock Text=":" Style="{StaticResource TimeTextBlock}"
+                                                   Foreground="{DynamicResource MaterialDesignBody}"
+                                                   VerticalAlignment="Center"
+                                                   Width="24" TextAlignment="Center"/>
+
+                                        <Grid Width="96" Height="80" x:Name="PART_MinuteReadOut">
+                                            <Border x:Name="PART_MinuteReadOutBorder"
+                                                    Opacity=".12"
+                                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background" Value="{DynamicResource MaterialDesignBodyLight}"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Minutes}">
+                                                                <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                            </Border>
+                                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:mm}}"  
+													   x:Name="PART_MinuteReadOutText"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Minutes}">
+                                                                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
+
+                                        <TextBlock x:Name="PART_SecondColonPrefix" Text=":"
+                                                   Style="{StaticResource TimeTextBlock}"
+                                                   Foreground="{DynamicResource MaterialDesignBody}"
+                                                   VerticalAlignment="Center"
+                                                   Width="24" TextAlignment="Center"/>
+
+                                        <Grid Width="96" Height="80" x:Name="PART_SecondReadOut">
+                                            <Border x:Name="PART_SecondReadOutBorder"
+                                                    Opacity=".12"
+                                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background" Value="{DynamicResource MaterialDesignBodyLight}"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Seconds}">
+                                                                <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                            </Border>
+                                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:ss}}"  
+													   x:Name="PART_SecondReadOutText"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Seconds}">
+                                                                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
+                                    </StackPanel>
+                                    <Border x:Name="AmPmBorder" CornerRadius="{TemplateBinding CornerRadius}" Margin="0 12 0 0"
+                                            HorizontalAlignment="Stretch" >
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <Grid.Clip>
+                                                <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                                                    <Binding ElementName="AmPmBorder" Path="ActualWidth" />
+                                                    <Binding ElementName="AmPmBorder" Path="ActualHeight" />
+                                                    <Binding ElementName="AmPmBorder" Path="CornerRadius" />
+                                                    <Binding ElementName="AmPmBorder" Path="BorderThickness" />
+                                                </MultiBinding>
+                                            </Grid.Clip>
+                                            <RadioButton Content="AM" Height="40"
+                                             Style="{StaticResource MaterialDesignCalendarMeridiemRadioButtonDefault}"
+                                             x:Name="AMRadioButton"
+                                             IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}}" />
+                                            <RadioButton Content="PM" Height="40" Grid.Column="1"
+                                             Style="{StaticResource MaterialDesignCalendarMeridiemRadioButtonDefault}"
+                                             x:Name="PMRadioButton"
+                                             IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem}" />
+                                        </Grid>
+                                    </Border>
+
+                                </StackPanel>
+
+                            </Border>
+
+                            <!--#endregion-->
+
+                            <!--#region Clock circle-->
+
+                            <Grid Grid.Column="1" VerticalAlignment="Top">
+                                <Ellipse x:Name="BackgroundEllipse" Width="230" Height="230" Fill="{DynamicResource MaterialDesignBodyLight}" Opacity=".12" />
+                                <Canvas x:Name="PART_HoursCanvas" Width="230" Height="230"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="HourLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Width="2.75" RenderTransformOrigin="0.5,0.985"
+                                          Height="96.959" Canvas.Top="19.047">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="HoursScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+                                <Canvas x:Name="PART_MinutesCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="MinuteLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047" Width="2.75" RenderTransformOrigin="0.5,0.985">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="MinutesScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+                                <Canvas x:Name="PART_SecondsCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="SecondLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047" Width="2.75" RenderTransformOrigin="0.5,0.985">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="SecondsScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+                            </Grid>
+
+                            <!--#endregion-->
+
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Is24Hours" Value="True">
+                            <Setter TargetName="PART_HourReadOutText" Property="Text" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:HH}}" />
+                            <Setter TargetName="AmPmBorder" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="Is24Hours" Value="True" />
+                                <Condition Property="IsPostMeridiem" Value="False" />
+                                <Condition Property="IsMidnightHour" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="HourLine" Property="Height" Value="76" />
+                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="Is24Hours" Value="True" />
+                                <Condition Property="IsMiddayHour" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="HourLine" Property="Height" Value="76" />
+                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
+                        </MultiTrigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.None}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.Cycle}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.ToMinutesOnly}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.ToSeconds}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="MaterialDesignClockHorizontalThemed" TargetType="{x:Type wpf:Clock}">
+        <Setter Property="Height" Value="auto"/>
+        <Setter Property="Width" Value="auto"/>
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="ButtonRadiusRatio" Value=".835" />
+        <Setter Property="ButtonRadiusInnerRatio" Value=".6" />
+        <Setter Property="FlowDirection" Value="LeftToRight" />
+        <Setter Property="Background" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Setter Property="IsHeaderVisible" Value="True"/>
+        <Setter Property="CornerRadius" Value="8"/>
+        <Setter Property="ButtonStyle">
+            <Setter.Value>
+                <Style TargetType="{x:Type wpf:ClockItemButton}">
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="Width" Value="32" />
+                    <Setter Property="Height" Value="32" />
+                    <Setter Property="HorizontalContentAlignment" Value="Center" />
+                    <Setter Property="VerticalContentAlignment" Value="Center" />
+                    <Setter Property="Canvas.ZIndex" Value="0" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type wpf:ClockItemButton}">
+                                <Grid>
+                                    <Thumb Style="{StaticResource MaterialDesignClockItemThumb}"
+                                           Background="{TemplateBinding Background}"
+                                           Opacity="23"
+										   x:Name="PART_Thumb"/>
+                                    <ContentPresenter Content="{TemplateBinding Content}"
+                                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+													  IsHitTestVisible="False"/>
+                                </Grid>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource SecondaryHueLightBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="LesserButtonStyle">
+            <Setter.Value>
+                <Style TargetType="{x:Type wpf:ClockItemButton}">
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="Width" Value="12" />
+                    <Setter Property="Height" Value="12" />
+                    <Setter Property="HorizontalContentAlignment" Value="Center" />
+                    <Setter Property="VerticalContentAlignment" Value="Center" />
+                    <Setter Property="Canvas.ZIndex" Value="1" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type wpf:ClockItemButton}">
+                                <Grid>
+                                    <Thumb Style="{StaticResource MaterialDesignClockItemThumb}" Background="{TemplateBinding Background}" Opacity=".52"
+												   x:Name="PART_Thumb"
+												   ToolTip="{TemplateBinding Content}"/>
+                                    <Ellipse Fill="{TemplateBinding Background}" HorizontalAlignment="Center" VerticalAlignment="Center" Height="6" Width="6"
+													 IsHitTestVisible="False"/>
+                                </Grid>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource SecondaryHueLightBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type wpf:Clock}">
+                    <Border Background="{TemplateBinding Background}"
+							BorderBrush="{TemplateBinding BorderBrush}" 
+        					BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="2">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="DisplayModeStates">
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition From="*" To="Hours">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.4">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    <VisualTransition From="Hours" To="Minutes">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    <VisualTransition From="Minutes" To="Seconds">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                </VisualStateGroup.Transitions>
+                                <VisualState x:Name="Hours">
+                                    <Storyboard>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1" Duration="0" />
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To=".85" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To=".85" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To=".85" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To=".85" Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Minutes">
+                                    <Storyboard>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1.2" Duration="0" />
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="1" Duration="0"/>
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1" Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Seconds">
+                                    <Storyboard>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="0" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1.2" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1.2" Duration="0" />
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                            <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                        </BooleanAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity"
+                                                         To="1" Duration="0"/>
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX"
+                                                         To="1" Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY"
+                                                         To="1" Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <Grid Margin="24" VerticalAlignment="Center">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+
+                            <!--#region Time Display-->
+
+                            <Border VerticalAlignment="Center" Margin=" 0 0 52 0"
+                                    Visibility="{TemplateBinding IsHeaderVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <StackPanel >
+                                    <StackPanel Orientation="Horizontal"
+                                            VerticalAlignment="Center"
+                                            HorizontalAlignment="Right"
+                                            x:Name="TimeReadoutStackPanel">
+                                        <StackPanel.Resources>
+                                            <Style x:Key="TimeTextBlock" TargetType="{x:Type TextBlock}">
+                                                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
+                                                <Setter Property="FontSize" Value="48" />
+                                                <Setter Property="FontWeight" Value="Normal" />
+                                            </Style>
+                                        </StackPanel.Resources>
+
+                                        <Grid Width="96" Height="80" x:Name="PART_HourReadOut">
+                                            <Border x:Name="PART_HourReadOutBorder"
+                                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background" Value="{DynamicResource MaterialDesignBodyLight}"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Hours}">
+                                                                <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                            </Border>
+                                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:%h}}" 
+													   x:Name="PART_HourReadOutText"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Hours}">
+                                                                <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
+
+                                        <TextBlock Text=":" Style="{StaticResource TimeTextBlock}"
+                                                   Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}"
+                                                   VerticalAlignment="Center"
+                                                   Width="24" TextAlignment="Center"/>
+
+                                        <Grid Width="96" Height="80" x:Name="PART_MinuteReadOut">
+                                            <Border x:Name="PART_MinuteReadOutBorder"
+                                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Minutes}">
+                                                                <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                            </Border>
+                                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:mm}}"  
+													   x:Name="PART_MinuteReadOutText"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Minutes}">
+                                                                <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
+
+                                        <TextBlock x:Name="PART_SecondColonPrefix" Text=":"
+                                                   Style="{StaticResource TimeTextBlock}"
+                                                   Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}"
+                                                   VerticalAlignment="Center"
+                                                   Width="24" TextAlignment="Center"/>
+
+                                        <Grid Width="96" Height="80" x:Name="PART_SecondReadOut">
+                                            <Border x:Name="PART_SecondReadOutBorder"
+                                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Seconds}">
+                                                                <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                            </Border>
+                                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:ss}}"  
+													   x:Name="PART_SecondReadOutText"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Seconds}">
+                                                                <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
+                                    </StackPanel>
+                                    <Border x:Name="AmPmBorder" CornerRadius="{TemplateBinding CornerRadius}" Margin="0 12 0 0"
+                                            HorizontalAlignment="Stretch" >
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <Grid.Clip>
+                                                <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                                                    <Binding ElementName="AmPmBorder" Path="ActualWidth" />
+                                                    <Binding ElementName="AmPmBorder" Path="ActualHeight" />
+                                                    <Binding ElementName="AmPmBorder" Path="CornerRadius" />
+                                                    <Binding ElementName="AmPmBorder" Path="BorderThickness" />
+                                                </MultiBinding>
+                                            </Grid.Clip>
+                                            <RadioButton Content="AM" Height="40"
+                                             Style="{StaticResource MaterialDesignCalendarMeridiemRadioButtonThemed}"
+                                             x:Name="AMRadioButton"
+                                             IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}}" />
+                                            <RadioButton Content="PM" Height="40" Grid.Column="1"
+                                             Style="{StaticResource MaterialDesignCalendarMeridiemRadioButtonThemed}"
+                                             x:Name="PMRadioButton"
+                                             IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem}" />
+                                        </Grid>
+                                    </Border>
+
+                                </StackPanel>
+
+                            </Border>
+
+                            <!--#endregion-->
+
+                            <!--#region Clock circle-->
+
+                            <Grid Grid.Column="1" VerticalAlignment="Top" >
+                                <Ellipse x:Name="BackgroundEllipse" Width="230" Height="230" Fill="{DynamicResource PrimaryHueMidBrush}" />
+                                <Canvas x:Name="PART_HoursCanvas" Width="230" Height="230"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="HourLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001"
+                                          Fill="{DynamicResource SecondaryHueMidBrush}"
+                                          Canvas.Left="113.625" Stretch="Fill"
+                                          Stroke="{DynamicResource SecondaryHueMidBrush}"
+                                          Width="2.75" RenderTransformOrigin="0.5,0.985"
+                                          Height="96.959" Canvas.Top="19.047">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="HoursScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+                                <Canvas x:Name="PART_MinutesCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="MinuteLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001"
+                                          Fill="{DynamicResource SecondaryHueMidBrush}"
+                                          Height="96.959" Canvas.Left="113.625" Stretch="Fill"
+                                          Stroke="{DynamicResource SecondaryHueMidBrush}"
+                                          Canvas.Top="19.047" Width="2.75"
+                                          RenderTransformOrigin="0.5,0.985">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="MinutesScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+                                <Canvas x:Name="PART_SecondsCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
+											    RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="SecondLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001"
+                                          Fill="{DynamicResource SecondaryHueMidBrush}" Height="96.959"
+                                          Canvas.Left="113.625" Stretch="Fill"
+                                          Stroke="{DynamicResource SecondaryHueMidBrush}"
+                                          Canvas.Top="19.047" Width="2.75"
+                                          RenderTransformOrigin="0.5,0.985">
+                                        <Path.RenderTransform>
+                                            <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <Canvas.RenderTransform>
+                                        <ScaleTransform x:Name="SecondsScaleTransform" ScaleX="1" ScaleY="1" />
+                                    </Canvas.RenderTransform>
+                                </Canvas>
+                            </Grid>
+
+                            <!--#endregion-->
+
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Is24Hours" Value="True">
+                            <Setter TargetName="PART_HourReadOutText" Property="Text" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:HH}}" />
+                            <Setter TargetName="AmPmBorder" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="Is24Hours" Value="True" />
+                                <Condition Property="IsPostMeridiem" Value="False" />
+                                <Condition Property="IsMidnightHour" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="HourLine" Property="Height" Value="76" />
+                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="Is24Hours" Value="True" />
+                                <Condition Property="IsMiddayHour" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="HourLine" Property="Height" Value="76" />
+                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
+                        </MultiTrigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.None}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.Cycle}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.ToMinutesOnly}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.ToSeconds}">
+                            <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
@@ -301,6 +301,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
+
                                     <VisualTransition From="Minutes" To="Seconds">
                                         <Storyboard>
                                             <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
@@ -359,6 +360,125 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
+
+                                    <VisualTransition From="Hours" To="Seconds">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+
+                                    <VisualTransition From="Seconds" To="Minutes">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+
                                 </VisualStateGroup.Transitions>
                                 <VisualState x:Name="Hours">
                                     <Storyboard>
@@ -465,47 +585,58 @@
                                             <Setter Property="FontWeight" Value="Normal" />
                                         </Style>
                                     </StackPanel.Resources>
-                                    <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:%h}}" 
-													   x:Name="PART_HourReadOut">
-                                        <TextBlock.Style>
-                                            <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
-                                                <Setter Property="Opacity" Value=".56"></Setter>
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Hours}">
-                                                        <Setter Property="Opacity" Value="1" />
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
+                                    <Grid x:Name="PART_HourReadOut">
+                                        <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:%h}}" 
+												   x:Name="PART_HourReadOutText" >
+                                            <TextBlock.Style>
+                                                <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                    <Setter Property="Opacity" Value=".56"></Setter>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Hours}">
+                                                            <Setter Property="Opacity" Value="1" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>                                        
+                                    </Grid>
+
                                     <TextBlock Text=":" Style="{StaticResource TimeTextBlock}" />
-                                    <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:mm}}" 
-													   x:Name="PART_MinuteReadOut">
-                                        <TextBlock.Style>
-                                            <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
-                                                <Setter Property="Opacity" Value=".56"></Setter>
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static  wpf:ClockDisplayMode.Minutes}">
-                                                        <Setter Property="Opacity" Value="1" />
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
+                                    
+                                    <Grid x:Name="PART_MinuteReadOut">
+                                        <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:mm}}" 
+													x:Name="PART_MinuteReadOutText">
+                                            <TextBlock.Style>
+                                                <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                    <Setter Property="Opacity" Value=".56"></Setter>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static  wpf:ClockDisplayMode.Minutes}">
+                                                            <Setter Property="Opacity" Value="1" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>                                        
+                                    </Grid>
+
                                     <TextBlock x:Name="PART_SecondColonPrefix" Text=":" Style="{StaticResource TimeTextBlock}" />
-                                    <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:ss}}"
-													   x:Name="PART_SecondReadOut">
-                                        <TextBlock.Style>
-                                            <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
-                                                <Setter Property="Opacity" Value=".56"></Setter>
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static  wpf:ClockDisplayMode.Seconds}">
-                                                        <Setter Property="Opacity" Value="1" />
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
+
+                                    <Grid x:Name="PART_SecondReadOut">
+                                        <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:ss}}"
+												    x:Name="PART_SecondReadOutText">
+                                            <TextBlock.Style>
+                                                <Style BasedOn="{StaticResource TimeTextBlock}" TargetType="{x:Type TextBlock}">
+                                                    <Setter Property="Opacity" Value=".56"></Setter>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static  wpf:ClockDisplayMode.Seconds}">
+                                                            <Setter Property="Opacity" Value="1" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>                                        
+                                    </Grid>
+
                                     <TextBlock FontSize="16" 
                                                x:Name="AmPmReadout"
                                                Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:tt}}" 
@@ -572,7 +703,7 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="Is24Hours" Value="True">
-                            <Setter TargetName="PART_HourReadOut" Property="Text" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:HH}}" />
+                            <Setter TargetName="PART_HourReadOutText" Property="Text" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:HH}}" />
                             <Setter TargetName="TimeReadoutStackPanel" Property="HorizontalAlignment" Value="Center" />
                             <Setter TargetName="TimeReadoutStackPanel" Property="Margin" Value="0 6 0 0" />
                             <Setter TargetName="AmPmReadout" Property="Visibility" Value="Collapsed" />
@@ -830,6 +961,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
+
                                     <VisualTransition From="Minutes" To="Seconds">
                                         <Storyboard>
                                             <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
@@ -888,6 +1020,125 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
+
+                                    <VisualTransition From="Hours" To="Seconds">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+
+                                    <VisualTransition From="Seconds" To="Minutes">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+
                                 </VisualStateGroup.Transitions>
                                 <VisualState x:Name="Hours">
                                     <Storyboard>
@@ -1434,6 +1685,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
+
                                     <VisualTransition From="Minutes" To="Seconds">
                                         <Storyboard>
                                             <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
@@ -1492,6 +1744,125 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
+
+                                    <VisualTransition From="Hours" To="Seconds">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+
+                                    <VisualTransition From="Seconds" To="Minutes">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+
                                 </VisualStateGroup.Transitions>
                                 <VisualState x:Name="Hours">
                                     <Storyboard>
@@ -2046,6 +2417,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
+
                                     <VisualTransition From="Minutes" To="Seconds">
                                         <Storyboard>
                                             <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
@@ -2104,6 +2476,125 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
+
+                                    <VisualTransition From="Hours" To="Seconds">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+
+                                    <VisualTransition From="Seconds" To="Minutes">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+
                                 </VisualStateGroup.Transitions>
                                 <VisualState x:Name="Hours">
                                     <Storyboard>
@@ -2660,6 +3151,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
+
                                     <VisualTransition From="Minutes" To="Seconds">
                                         <Storyboard>
                                             <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
@@ -2718,6 +3210,125 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
+
+                                    <VisualTransition From="Hours" To="Seconds">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="HoursScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1.2" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="0.85" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+
+                                    <VisualTransition From="Seconds" To="Minutes">
+                                        <Storyboard>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseIn" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="SecondsScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value=".85" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
+                                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
+                                            </BooleanAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="Opacity">
+                                                <DiscreteDoubleKeyFrame Value="0" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleX">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MinutesScaleTransform" Storyboard.TargetProperty="ScaleY">
+                                                <DiscreteDoubleKeyFrame Value="1.2" KeyTime="0" />
+                                                <EasingDoubleKeyFrame Value="1" KeyTime="0:0:0.5">
+                                                    <EasingDoubleKeyFrame.EasingFunction>
+                                                        <SineEase EasingMode="EaseOut" />
+                                                    </EasingDoubleKeyFrame.EasingFunction>
+                                                </EasingDoubleKeyFrame>
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    
                                 </VisualStateGroup.Transitions>
                                 <VisualState x:Name="Hours">
                                     <Storyboard>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
@@ -102,8 +102,6 @@
     </Style>
 
     <Style x:Key="MaterialDesignClock" TargetType="{x:Type wpf:Clock}">
-        <Setter Property="Width" Value="280" />
-        <Setter Property="Height" Value="470" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="ButtonRadiusRatio" Value=".835" />
         <Setter Property="ButtonRadiusInnerRatio" Value=".6" />
@@ -572,9 +570,9 @@
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
                             <Border Background="{DynamicResource PrimaryHueMidBrush}"
-                                    Height="120"  CornerRadius="2 2 0 0"
+                                    Height="120"  CornerRadius="2 2 0 0" Margin="0 0 0 12"
                                     Visibility="{TemplateBinding IsHeaderVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                <StackPanel Orientation="Horizontal"
+                                <StackPanel Orientation="Horizontal" Margin="24"
                                             VerticalAlignment="Center"
                                             HorizontalAlignment="Right"
                                             x:Name="TimeReadoutStackPanel">
@@ -598,11 +596,13 @@
                                                     </Style.Triggers>
                                                 </Style>
                                             </TextBlock.Style>
-                                        </TextBlock>                                        
+                                        </TextBlock>
                                     </Grid>
 
-                                    <TextBlock Text=":" Style="{StaticResource TimeTextBlock}" />
-                                    
+                                    <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0: : }}"
+                                               Margin="-16 0 -16 0" 
+                                               Style="{StaticResource TimeTextBlock}" />
+
                                     <Grid x:Name="PART_MinuteReadOut">
                                         <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:mm}}" 
 													x:Name="PART_MinuteReadOutText">
@@ -616,10 +616,13 @@
                                                     </Style.Triggers>
                                                 </Style>
                                             </TextBlock.Style>
-                                        </TextBlock>                                        
+                                        </TextBlock>
                                     </Grid>
 
-                                    <TextBlock x:Name="PART_SecondColonPrefix" Text=":" Style="{StaticResource TimeTextBlock}" />
+                                    <TextBlock x:Name="PART_SecondColonPrefix"
+                                               Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0: : }}"
+                                               Style="{StaticResource TimeTextBlock}"
+                                               Margin="-16 0 -16 0" />
 
                                     <Grid x:Name="PART_SecondReadOut">
                                         <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:ss}}"
@@ -634,16 +637,16 @@
                                                     </Style.Triggers>
                                                 </Style>
                                             </TextBlock.Style>
-                                        </TextBlock>                                        
+                                        </TextBlock>
                                     </Grid>
 
-                                    <TextBlock FontSize="16" 
+                                    <TextBlock FontSize="20" 
                                                x:Name="AmPmReadout"
                                                Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:tt}}" 
-                                               VerticalAlignment="Bottom" Margin="2 0 0 16" Foreground="{DynamicResource PrimaryHueMidForegroundBrush}" />
+                                               VerticalAlignment="Bottom" Margin="2 0 0 8" Foreground="{DynamicResource PrimaryHueMidForegroundBrush}" />
                                 </StackPanel>
                             </Border>
-                            <Grid Grid.Row="1" VerticalAlignment="Center">
+                            <Grid Grid.Row="1" VerticalAlignment="Center" Margin="24">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="*"/>
                                     <RowDefinition Height="auto"/>
@@ -651,7 +654,11 @@
                                 <Ellipse x:Name="BackgroundEllipse" Width="230" Height="230" Fill="{DynamicResource PrimaryHueLightBrush}" Opacity=".23" />
                                 <Canvas x:Name="PART_HoursCanvas" Width="230" Height="230"
 											    RenderTransformOrigin=".5,.5">
-                                    <Path x:Name="HourLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Width="2.75" RenderTransformOrigin="0.5,0.985"
+                                    <Path x:Name="HourLine"
+                                          Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001"
+                                          Fill="{DynamicResource PrimaryHueMidBrush}" Canvas.Left="113.625" Stretch="Fill"
+                                          Stroke="{DynamicResource PrimaryHueMidBrush}" Width="3"
+                                          RenderTransformOrigin="0.5,0.985"
                                           Height="96.959" Canvas.Top="19.047">
                                         <Path.RenderTransform>
                                             <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
@@ -663,7 +670,10 @@
                                 </Canvas>
                                 <Canvas x:Name="PART_MinutesCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
 											    RenderTransformOrigin=".5,.5">
-                                    <Path x:Name="MinuteLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047" Width="2.75" RenderTransformOrigin="0.5,0.985">
+                                    <Path x:Name="MinuteLine"
+                                          Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}"
+                                          Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}"
+                                          Canvas.Top="19.047" Width="3" RenderTransformOrigin="0.5,0.985">
                                         <Path.RenderTransform>
                                             <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
                                         </Path.RenderTransform>
@@ -674,7 +684,12 @@
                                 </Canvas>
                                 <Canvas x:Name="PART_SecondsCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
 											    RenderTransformOrigin=".5,.5">
-                                    <Path x:Name="SecondLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047" Width="2.75" RenderTransformOrigin="0.5,0.985">
+                                    <Path x:Name="SecondLine"
+                                          Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}"
+                                          Height="96.959" Canvas.Left="113.625" Stretch="Fill"
+                                          Stroke="{DynamicResource PrimaryHueMidBrush}"
+                                          Canvas.Top="19.047" Width="3"
+                                          RenderTransformOrigin="0.5,0.985">
                                         <Path.RenderTransform>
                                             <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
                                         </Path.RenderTransform>
@@ -684,85 +699,52 @@
                                     </Canvas.RenderTransform>
                                 </Canvas>
 
-                                <RadioButton Content="AM" HorizontalAlignment="Left" Height="47.333" Margin="32,0,0,0"
-                                         Grid.Row="1" VerticalAlignment="Bottom" Width="47.333"
-                                         Style="{StaticResource MaterialDesignCalendarMeridiemRadioButton}"
-                                         x:Name="AMRadioButton"
-                                         IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}}" />
-                                <RadioButton Content="PM" HorizontalAlignment="Right" Height="47.333" Margin="0,0,32,0"
-                                         Grid.Row="1" VerticalAlignment="Bottom" Width="47.333"
-                                         Style="{StaticResource MaterialDesignCalendarMeridiemRadioButton}"
-                                         x:Name="PMRadioButton"
-                                         IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem}" />
-
+                                <UniformGrid Rows="1" Grid.Row="1">
+                                    <RadioButton x:Name="AMRadioButton" Content="AM"
+                                                 HorizontalAlignment="Center" Margin="0,0,30,0"
+                                                 VerticalAlignment="Bottom" Width="47.333" Height="47.333" 
+                                                 Style="{StaticResource MaterialDesignCalendarMeridiemRadioButton}"
+                                                 IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}}" />
+                                    <RadioButton x:Name="PMRadioButton" Content="PM"
+                                                 HorizontalAlignment="Center" Margin="30,0,0,0"
+                                                 VerticalAlignment="Bottom" Width="47.333" Height="47.333"
+                                                 Style="{StaticResource MaterialDesignCalendarMeridiemRadioButton}"
+                                                 IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem}" />
+                                </UniformGrid>
                             </Grid>
-
-
-
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="Is24Hours" Value="True">
                             <Setter TargetName="PART_HourReadOutText" Property="Text" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:HH}}" />
-                            <Setter TargetName="TimeReadoutStackPanel" Property="HorizontalAlignment" Value="Center" />
-                            <Setter TargetName="TimeReadoutStackPanel" Property="Margin" Value="0 6 0 0" />
                             <Setter TargetName="AmPmReadout" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="AMRadioButton" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="PMRadioButton" Property="Visibility" Value="Collapsed" />
-                            <!--<Setter TargetName="BackgroundEllipse" Property="Margin" Value="0,24.5,0,26" />-->
                         </Trigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="Is24Hours" Value="True" />
-                                <Condition Property="IsPostMeridiem" Value="False" />
-                                <Condition Property="IsMidnightHour" Value="False" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="HourLine" Property="Height" Value="76" />
-                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="Is24Hours" Value="True" />
-                                <Condition Property="IsMiddayHour" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="HourLine" Property="Height" Value="76" />
-                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
-                        </MultiTrigger>
                         <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.None}">
                             <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
-                            <Setter TargetName="TimeReadoutStackPanel" Property="Margin" Value="0 6 38 0" />
                         </Trigger>
                         <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.Cycle}">
                             <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
-                            <Setter TargetName="TimeReadoutStackPanel" Property="Margin" Value="0 6 38 0" />
                         </Trigger>
                         <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.ToMinutesOnly}">
                             <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
-                            <Setter TargetName="TimeReadoutStackPanel" Property="Margin" Value="0 6 38 0" />
                         </Trigger>
                         <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.ToSeconds}">
                             <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Visible" />
                             <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Visible" />
-                            <Setter TargetName="TimeReadoutStackPanel" Property="Margin" Value="0 6 0 0" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-        <Style.Triggers>
-            <Trigger Property="Is24Hours" Value="True">
-                <Setter Property="Height" Value="402" />
-            </Trigger>
-        </Style.Triggers>
     </Style>
 
 
     <Style x:Key="MaterialDesignClockVertical" TargetType="{x:Type wpf:Clock}">
-        <Setter Property="Height" Value="auto"/>
-        <Setter Property="Width" Value="auto"/>
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="ButtonRadiusRatio" Value=".835" />
         <Setter Property="ButtonRadiusInnerRatio" Value=".6" />
@@ -1280,10 +1262,11 @@
                                             </TextBlock>
                                         </Grid>
 
-                                        <TextBlock Text=":" Style="{StaticResource TimeTextBlock}"
+                                        <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0: : }}"
+                                                   Style="{StaticResource TimeTextBlock}"
                                                    Foreground="{DynamicResource MaterialDesignBody}"
-                                                   VerticalAlignment="Center"
-                                                   Width="24" TextAlignment="Center"/>
+                                                   Margin="-6 0 -6 0"
+                                                   VerticalAlignment="Center" />
 
                                         <Grid Width="96" Height="80" x:Name="PART_MinuteReadOut">
                                             <Border x:Name="PART_MinuteReadOutBorder"
@@ -1316,11 +1299,12 @@
                                             </TextBlock>
                                         </Grid>
 
-                                        <TextBlock x:Name="PART_SecondColonPrefix" Text=":"
+                                        <TextBlock x:Name="PART_SecondColonPrefix"
+                                                   Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0: : }}"
                                                    Style="{StaticResource TimeTextBlock}"
                                                    Foreground="{DynamicResource MaterialDesignBody}"
-                                                   VerticalAlignment="Center"
-                                                   Width="24" TextAlignment="Center"/>
+                                                   VerticalAlignment="Center" 
+                                                   Margin="-6 0 -6 0"/>
 
                                         <Grid Width="96" Height="80" x:Name="PART_SecondReadOut">
                                             <Border x:Name="PART_SecondReadOutBorder"
@@ -1443,23 +1427,6 @@
                             <Setter TargetName="PART_HourReadOutText" Property="Text" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:HH}}" />
                             <Setter TargetName="AmPmBorder" Property="Visibility" Value="Collapsed" />
                         </Trigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="Is24Hours" Value="True" />
-                                <Condition Property="IsPostMeridiem" Value="False" />
-                                <Condition Property="IsMidnightHour" Value="False" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="HourLine" Property="Height" Value="76" />
-                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="Is24Hours" Value="True" />
-                                <Condition Property="IsMiddayHour" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="HourLine" Property="Height" Value="76" />
-                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
-                        </MultiTrigger>
                         <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.None}">
                             <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
@@ -1483,8 +1450,6 @@
     </Style>
 
     <Style x:Key="MaterialDesignClockVerticalThemed" TargetType="{x:Type wpf:Clock}">
-        <Setter Property="Height" Value="auto"/>
-        <Setter Property="Width" Value="auto"/>
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="ButtonRadiusRatio" Value=".835" />
         <Setter Property="ButtonRadiusInnerRatio" Value=".6" />
@@ -2003,10 +1968,11 @@
                                             </TextBlock>
                                         </Grid>
 
-                                        <TextBlock Text=":" Style="{StaticResource TimeTextBlock}"
+                                        <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0: : }}"
+                                                   Style="{StaticResource TimeTextBlock}"
                                                    Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}"
                                                    VerticalAlignment="Center"
-                                                   Width="24" TextAlignment="Center"/>
+                                                   Margin="-6 0 -6 0"/>
 
                                         <Grid Width="96" Height="80" x:Name="PART_MinuteReadOut">
                                             <Border x:Name="PART_MinuteReadOutBorder"
@@ -2038,11 +2004,12 @@
                                             </TextBlock>
                                         </Grid>
 
-                                        <TextBlock x:Name="PART_SecondColonPrefix" Text=":"
+                                        <TextBlock x:Name="PART_SecondColonPrefix"
+                                                   Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0: : }}"
                                                    Style="{StaticResource TimeTextBlock}"
                                                    Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}"
                                                    VerticalAlignment="Center"
-                                                   Width="24" TextAlignment="Center"/>
+                                                   Margin="-6 0 -6 0"/>
 
                                         <Grid Width="96" Height="80" x:Name="PART_SecondReadOut">
                                             <Border x:Name="PART_SecondReadOutBorder"
@@ -2177,23 +2144,6 @@
                             <Setter TargetName="PART_HourReadOutText" Property="Text" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:HH}}" />
                             <Setter TargetName="AmPmBorder" Property="Visibility" Value="Collapsed" />
                         </Trigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="Is24Hours" Value="True" />
-                                <Condition Property="IsPostMeridiem" Value="False" />
-                                <Condition Property="IsMidnightHour" Value="False" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="HourLine" Property="Height" Value="76" />
-                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="Is24Hours" Value="True" />
-                                <Condition Property="IsMiddayHour" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="HourLine" Property="Height" Value="76" />
-                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
-                        </MultiTrigger>
                         <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.None}">
                             <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
@@ -2217,8 +2167,6 @@
     </Style>
 
     <Style x:Key="MaterialDesignClockHorizontal" TargetType="{x:Type wpf:Clock}">
-        <Setter Property="Height" Value="auto"/>
-        <Setter Property="Width" Value="auto"/>
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="ButtonRadiusRatio" Value=".835" />
         <Setter Property="ButtonRadiusInnerRatio" Value=".6" />
@@ -2417,7 +2365,6 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-
                                     <VisualTransition From="Minutes" To="Seconds">
                                         <Storyboard>
                                             <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MinutesCanvas" Storyboard.TargetProperty="IsHitTestVisible">
@@ -2476,7 +2423,6 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-
                                     <VisualTransition From="Hours" To="Seconds">
                                         <Storyboard>
                                             <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_HoursCanvas" Storyboard.TargetProperty="IsHitTestVisible">
@@ -2535,7 +2481,6 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-
                                     <VisualTransition From="Seconds" To="Minutes">
                                         <Storyboard>
                                             <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_SecondsCanvas" Storyboard.TargetProperty="IsHitTestVisible">
@@ -2736,10 +2681,11 @@
                                             </TextBlock>
                                         </Grid>
 
-                                        <TextBlock Text=":" Style="{StaticResource TimeTextBlock}"
+                                        <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0: : }}"
+                                                   Style="{StaticResource TimeTextBlock}"
                                                    Foreground="{DynamicResource MaterialDesignBody}"
                                                    VerticalAlignment="Center"
-                                                   Width="24" TextAlignment="Center"/>
+                                                   Margin="-6 0 -6 0"/>
 
                                         <Grid Width="96" Height="80" x:Name="PART_MinuteReadOut">
                                             <Border x:Name="PART_MinuteReadOutBorder"
@@ -2772,11 +2718,12 @@
                                             </TextBlock>
                                         </Grid>
 
-                                        <TextBlock x:Name="PART_SecondColonPrefix" Text=":"
+                                        <TextBlock x:Name="PART_SecondColonPrefix"
+                                                   Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0: : }}"
                                                    Style="{StaticResource TimeTextBlock}"
                                                    Foreground="{DynamicResource MaterialDesignBody}"
                                                    VerticalAlignment="Center"
-                                                   Width="24" TextAlignment="Center"/>
+                                                   Margin="-6 0 -6 0"/>
 
                                         <Grid Width="96" Height="80" x:Name="PART_SecondReadOut">
                                             <Border x:Name="PART_SecondReadOutBorder"
@@ -2907,23 +2854,6 @@
                             <Setter TargetName="PART_HourReadOutText" Property="Text" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:HH}}" />
                             <Setter TargetName="AmPmBorder" Property="Visibility" Value="Collapsed" />
                         </Trigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="Is24Hours" Value="True" />
-                                <Condition Property="IsPostMeridiem" Value="False" />
-                                <Condition Property="IsMidnightHour" Value="False" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="HourLine" Property="Height" Value="76" />
-                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="Is24Hours" Value="True" />
-                                <Condition Property="IsMiddayHour" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="HourLine" Property="Height" Value="76" />
-                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
-                        </MultiTrigger>
                         <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.None}">
                             <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />
@@ -2947,8 +2877,6 @@
     </Style>
 
     <Style x:Key="MaterialDesignClockHorizontalThemed" TargetType="{x:Type wpf:Clock}">
-        <Setter Property="Height" Value="auto"/>
-        <Setter Property="Width" Value="auto"/>
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="ButtonRadiusRatio" Value=".835" />
         <Setter Property="ButtonRadiusInnerRatio" Value=".6" />
@@ -3469,10 +3397,11 @@
                                             </TextBlock>
                                         </Grid>
 
-                                        <TextBlock Text=":" Style="{StaticResource TimeTextBlock}"
+                                        <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0: : }}"
+                                                   Style="{StaticResource TimeTextBlock}"
                                                    Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}"
                                                    VerticalAlignment="Center"
-                                                   Width="24" TextAlignment="Center"/>
+                                                   Margin="-6 0 -6 0"/>
 
                                         <Grid Width="96" Height="80" x:Name="PART_MinuteReadOut">
                                             <Border x:Name="PART_MinuteReadOutBorder"
@@ -3504,11 +3433,12 @@
                                             </TextBlock>
                                         </Grid>
 
-                                        <TextBlock x:Name="PART_SecondColonPrefix" Text=":"
+                                        <TextBlock x:Name="PART_SecondColonPrefix"
+                                                   Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0: : }}"
                                                    Style="{StaticResource TimeTextBlock}"
                                                    Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}"
                                                    VerticalAlignment="Center"
-                                                   Width="24" TextAlignment="Center"/>
+                                                   Margin="-6 0 -6 0"/>
 
                                         <Grid Width="96" Height="80" x:Name="PART_SecondReadOut">
                                             <Border x:Name="PART_SecondReadOutBorder"
@@ -3635,23 +3565,6 @@
                             <Setter TargetName="PART_HourReadOutText" Property="Text" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Mode=OneWay, StringFormat={}{0:HH}}" />
                             <Setter TargetName="AmPmBorder" Property="Visibility" Value="Collapsed" />
                         </Trigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="Is24Hours" Value="True" />
-                                <Condition Property="IsPostMeridiem" Value="False" />
-                                <Condition Property="IsMidnightHour" Value="False" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="HourLine" Property="Height" Value="76" />
-                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="Is24Hours" Value="True" />
-                                <Condition Property="IsMiddayHour" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="HourLine" Property="Height" Value="76" />
-                            <Setter TargetName="HourLine" Property="Canvas.Top" Value="40" />
-                        </MultiTrigger>
                         <Trigger Property="DisplayAutomation" Value="{x:Static  wpf:ClockDisplayAutomation.None}">
                             <Setter TargetName="PART_SecondReadOut" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="PART_SecondColonPrefix" Property="Visibility" Value="Collapsed" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
@@ -1136,7 +1136,10 @@
                                 <Ellipse x:Name="BackgroundEllipse" Width="230" Height="230" Fill="{DynamicResource MaterialDesignBodyLight}" Opacity=".12" />
                                 <Canvas x:Name="PART_HoursCanvas" Width="230" Height="230"
 											    RenderTransformOrigin=".5,.5">
-                                    <Path x:Name="HourLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Width="2.75" RenderTransformOrigin="0.5,0.985"
+                                    <Path x:Name="HourLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001"
+                                          Fill="{DynamicResource PrimaryHueMidBrush}" Canvas.Left="113.625"
+                                          Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}"
+                                          Width="3" RenderTransformOrigin="0.5,0.985"
                                           Height="96.959" Canvas.Top="19.047">
                                         <Path.RenderTransform>
                                             <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
@@ -1148,7 +1151,12 @@
                                 </Canvas>
                                 <Canvas x:Name="PART_MinutesCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
 											    RenderTransformOrigin=".5,.5">
-                                    <Path x:Name="MinuteLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047" Width="2.75" RenderTransformOrigin="0.5,0.985">
+                                    <Path x:Name="MinuteLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001"
+                                          Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959"
+                                          Canvas.Left="113.625" Stretch="Fill"
+                                          Stroke="{DynamicResource PrimaryHueMidBrush}"
+                                          Canvas.Top="19.047" Width="3"
+                                          RenderTransformOrigin="0.5,0.985">
                                         <Path.RenderTransform>
                                             <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
                                         </Path.RenderTransform>
@@ -1159,7 +1167,12 @@
                                 </Canvas>
                                 <Canvas x:Name="PART_SecondsCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
 											    RenderTransformOrigin=".5,.5">
-                                    <Path x:Name="SecondLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047" Width="2.75" RenderTransformOrigin="0.5,0.985">
+                                    <Path x:Name="SecondLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001"
+                                          Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959"
+                                          Canvas.Left="113.625" Stretch="Fill"
+                                          Stroke="{DynamicResource PrimaryHueMidBrush}"
+                                          Canvas.Top="19.047" Width="3"
+                                          RenderTransformOrigin="0.5,0.985">
                                         <Path.RenderTransform>
                                             <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
                                         </Path.RenderTransform>
@@ -1730,7 +1743,7 @@
                                           Canvas.Left="113.625"
                                           Stretch="Fill"
                                           Stroke="{DynamicResource SecondaryHueMidBrush}"
-                                          Width="2.75"
+                                          Width="3"
                                           RenderTransformOrigin="0.5,0.985"
                                           Height="96.959"
                                           Canvas.Top="19.047">
@@ -1752,7 +1765,7 @@
                                           Stretch="Fill"
                                           Stroke="{DynamicResource SecondaryHueMidBrush}"
                                           Canvas.Top="19.047"
-                                          Width="2.75"
+                                          Width="3"
                                           RenderTransformOrigin="0.5,0.985">
                                         <Path.RenderTransform>
                                             <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
@@ -1772,7 +1785,7 @@
                                           Stretch="Fill"
                                           Stroke="{DynamicResource SecondaryHueMidBrush}"
                                           Canvas.Top="19.047"
-                                          Width="2.75"
+                                          Width="3"
                                           RenderTransformOrigin="0.5,0.985">
                                         <Path.RenderTransform>
                                             <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
@@ -2343,7 +2356,11 @@
                                 <Ellipse x:Name="BackgroundEllipse" Width="230" Height="230" Fill="{DynamicResource MaterialDesignBodyLight}" Opacity=".12" />
                                 <Canvas x:Name="PART_HoursCanvas" Width="230" Height="230"
 											    RenderTransformOrigin=".5,.5">
-                                    <Path x:Name="HourLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Width="2.75" RenderTransformOrigin="0.5,0.985"
+                                    <Path x:Name="HourLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001"
+                                          Fill="{DynamicResource PrimaryHueMidBrush}"
+                                          Canvas.Left="113.625" Stretch="Fill"
+                                          Stroke="{DynamicResource PrimaryHueMidBrush}"
+                                          Width="3" RenderTransformOrigin="0.5,0.985"
                                           Height="96.959" Canvas.Top="19.047">
                                         <Path.RenderTransform>
                                             <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
@@ -2353,9 +2370,17 @@
                                         <ScaleTransform x:Name="HoursScaleTransform" ScaleX="1" ScaleY="1" />
                                     </Canvas.RenderTransform>
                                 </Canvas>
-                                <Canvas x:Name="PART_MinutesCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
-											    RenderTransformOrigin=".5,.5">
-                                    <Path x:Name="MinuteLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047" Width="2.75" RenderTransformOrigin="0.5,0.985">
+                                <Canvas x:Name="PART_MinutesCanvas"
+                                        Width="230" Height="230"
+                                        Opacity="0"
+                                        IsHitTestVisible="False"
+										RenderTransformOrigin=".5,.5">
+                                    <Path x:Name="MinuteLine"
+                                          Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001"
+                                          Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959"
+                                          Canvas.Left="113.625" Stretch="Fill"
+                                          Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047"
+                                          Width="3" RenderTransformOrigin="0.5,0.985">
                                         <Path.RenderTransform>
                                             <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
                                         </Path.RenderTransform>
@@ -2366,7 +2391,12 @@
                                 </Canvas>
                                 <Canvas x:Name="PART_SecondsCanvas" Width="230" Height="230" Opacity="0" IsHitTestVisible="False"
 											    RenderTransformOrigin=".5,.5">
-                                    <Path x:Name="SecondLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001" Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959" Canvas.Left="113.625" Stretch="Fill" Stroke="{DynamicResource PrimaryHueMidBrush}" Canvas.Top="19.047" Width="2.75" RenderTransformOrigin="0.5,0.985">
+                                    <Path x:Name="SecondLine" Data="M2.25,95.515 C2.25,96.036356 1.8582492,96.459 1.375,96.459 C0.89175084,96.459 0.5,96.036356 0.5,95.515 C0.5,94.993643 0.89175084,94.571 1.375,94.571 C1.8582492,94.571 2.25,94.993643 2.25,95.515 z M1.375,95.469003 L1.375,0.50000001"
+                                          Fill="{DynamicResource PrimaryHueMidBrush}" Height="96.959"
+                                          Canvas.Left="113.625" Stretch="Fill"
+                                          Stroke="{DynamicResource PrimaryHueMidBrush}"
+                                          Canvas.Top="19.047" Width="3"
+                                          RenderTransformOrigin="0.5,0.985">
                                         <Path.RenderTransform>
                                             <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
                                         </Path.RenderTransform>
@@ -2803,7 +2833,7 @@
                                                     CornerRadius="{TemplateBinding CornerRadius}">
                                                 <Border.Style>
                                                     <Style TargetType="Border">
-                                                        <Setter Property="Background" Value="{DynamicResource MaterialDesignBodyLight}"/>
+                                                        <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=DisplayMode}" Value="{x:Static wpf:ClockDisplayMode.Hours}">
                                                                 <Setter Property="Background" Value="{DynamicResource SecondaryHueMidBrush}" />
@@ -2941,7 +2971,7 @@
                                           Fill="{DynamicResource SecondaryHueMidBrush}"
                                           Canvas.Left="113.625" Stretch="Fill"
                                           Stroke="{DynamicResource SecondaryHueMidBrush}"
-                                          Width="2.75" RenderTransformOrigin="0.5,0.985"
+                                          Width="3" RenderTransformOrigin="0.5,0.985"
                                           Height="96.959" Canvas.Top="19.047">
                                         <Path.RenderTransform>
                                             <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
@@ -2957,7 +2987,7 @@
                                           Fill="{DynamicResource SecondaryHueMidBrush}"
                                           Height="96.959" Canvas.Left="113.625" Stretch="Fill"
                                           Stroke="{DynamicResource SecondaryHueMidBrush}"
-                                          Canvas.Top="19.047" Width="2.75"
+                                          Canvas.Top="19.047" Width="3"
                                           RenderTransformOrigin="0.5,0.985">
                                         <Path.RenderTransform>
                                             <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
@@ -2973,7 +3003,7 @@
                                           Fill="{DynamicResource SecondaryHueMidBrush}" Height="96.959"
                                           Canvas.Left="113.625" Stretch="Fill"
                                           Stroke="{DynamicResource SecondaryHueMidBrush}"
-                                          Canvas.Top="19.047" Width="2.75"
+                                          Canvas.Top="19.047" Width="3"
                                           RenderTransformOrigin="0.5,0.985">
                                         <Path.RenderTransform>
                                             <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
@@ -40,6 +40,8 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Thumb.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Window.xaml" />
+
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Clock.xaml" />
     </ResourceDictionary.MergedDictionaries>
     
     <SolidColorBrush x:Key="MaterialDesignLightBackground" Color="#FFFAFAFA"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -427,6 +427,7 @@
         <Setter Property="Validation.ErrorTemplate" Value="{StaticResource MaterialDesignValidationErrorTemplate}"/>
         <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <Setter Property="IsHeaderVisible" Value="True"/>
         <Setter Property="ClockStyle" Value="{DynamicResource MaterialDesignClock}" />
         <Setter Property="ClockHostContentControlStyle">
             <Setter.Value>

--- a/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -173,6 +173,16 @@ namespace MaterialDesignThemes.Wpf
             set => SetValue(Is24HoursProperty, value);
         }
 
+        public static readonly DependencyProperty IsHeaderVisibleProperty = DependencyProperty.Register(
+            nameof(IsHeaderVisible), typeof(bool), typeof(TimePicker), new PropertyMetadata(default(bool)));
+
+        public bool IsHeaderVisible
+        {
+            get => (bool)GetValue(IsHeaderVisibleProperty);
+            set => SetValue(IsHeaderVisibleProperty, value);
+        }
+
+
         private static object OnCoerceIsDropDownOpen(DependencyObject d, object baseValue)
         {
             var timePicker = (TimePicker)d;


### PR DESCRIPTION
Fixes #2336 
Fixes #2317 

### Summary

- Adds four new styles to reflect the updated MaterialDesign specs: https://material.io/components/time-pickers
- Adds a  Property to disable the header in all styles
- Fixes the animations for selecting from seconds to minutes and from hours to seconds

### Notes

The new styles work both with standlalone Clock and with TimePicker (using ClockStyle). Same for the header visibility.
Could use some help with the naming of the styles tbh. Also I'm not sure if this is the right way of doing it, ie making multiple styles vs making properties. I felt properties would have been quite convoluted in this case. 
I'm also quite new to the whole git thing, so if I'm doing anything wrong, please let me know.

### Screenshots

![FSV2XKDuAr](https://user-images.githubusercontent.com/58171461/119951135-e8b5d980-bf9b-11eb-8b2b-40e3b97f82eb.png)
![J0yevVE8mA](https://user-images.githubusercontent.com/58171461/119951142-ea7f9d00-bf9b-11eb-9b3e-ba6d6dd9988a.png)
![2VtNv1KFmX](https://user-images.githubusercontent.com/58171461/119951164-ed7a8d80-bf9b-11eb-9b5e-00d5f38adc69.png)
![yOrDuK2LYK](https://user-images.githubusercontent.com/58171461/119951157-ec496080-bf9b-11eb-8b33-59b5ee91de20.png)
