### PR TITLE
Update to NavigationRail

### DIFF
--- a/MainDemo.Wpf/NavigationRail.xaml
+++ b/MainDemo.Wpf/NavigationRail.xaml
@@ -49,11 +49,23 @@
                 <smtx:XamlDisplay
                     UniqueKey="navrail_1"
                     Margin="5,5,5,0">
-                    <TabControl Style="{StaticResource MaterialDesignNavigatilRailTabControl}">
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Head, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}">
-                            <TextBlock>
+                    <TabControl Style="{StaticResource MaterialDesignNavigatilRailTabControl}" BorderThickness="0"
+                                BorderBrush="Transparent" TabStripPlacement="Left"
+                                materialDesign:ShadowAssist.ShadowDepth="Depth0"
+                                materialDesign:ColorZoneAssist.Mode="Standard" SnapsToDevicePixels="True"
+                                materialDesign:NavigationRailAssist.ShowSelectionBackground="True">
+                        <materialDesign:NavigationRailAssist.FloatingContent>
+                            <Button Style="{StaticResource MaterialDesignFloatingActionAccentButton}"
+                                    Content="{materialDesign:PackIcon Kind=Plus}" Margin="8"/>
+                        </materialDesign:NavigationRailAssist.FloatingContent>
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Folder" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="All Files" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <TextBlock >
                                 <Run Text="tab 1 content. Default look and behaviors."/>
                                 <LineBreak/>
                                 <LineBreak/>
@@ -63,9 +75,13 @@
                             </TextBlock>
                         </TabItem>
 
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Spade, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}">
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="ClockOutline" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Recent" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
                             <TextBlock>
                                 <Run Text="tab 2 content. Default look and behaviors."/>
                                 <LineBreak/>
@@ -73,6 +89,34 @@
                                 <Run FontStyle="Italic">
                                     Praesent sed dui arcu. Vivamus porta auctor sagittis
                                 </Run>
+                            </TextBlock>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Images" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Photos" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <TextBlock>
+                                <Run Text="tab 3 content. Default look and behaviors."/>
+                                <LineBreak/>
+                                <LineBreak/>
+                            </TextBlock>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="MusicBoxMultiple" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Sounds" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <TextBlock>
+                                <Run Text="tab 4 content. Default look and behaviors."/>
+                                <LineBreak/>
+                                <LineBreak/>
                             </TextBlock>
                         </TabItem>
                     </TabControl>
@@ -81,25 +125,20 @@
                     UniqueKey="navrail_4"
                     Margin="5,5,5,0"
                     Grid.Column="1">
-                    <TabControl
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}"
-                        materialDesign:ColorZoneAssist.Mode="SecondaryMid">
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Heart, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}">
-                            <TextBlock>
-                                <Run Text="tab 1 content. Default look and behaviors."/>
-                                <LineBreak/>
-                                <LineBreak/>
-                                <Run FontStyle="Italic">
-                                    Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...
-                                </Run>
-                            </TextBlock>
-                        </TabItem>
+                    <TabControl TabStripPlacement="Bottom"
+                                Style="{StaticResource MaterialDesignNavigatilRailTabControl}"
+                                materialDesign:ColorZoneAssist.Mode="PrimaryLight"
+                                materialDesign:NavigationRailAssist.ShowSelectionBackground="True"
+                                materialDesign:NavigationRailAssist.SelectionCornerRadius="50"
+                                HorizontalContentAlignment="Center">
 
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Spade, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}">
+                        <TabItem Margin="4">
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="ClockOutline" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Recent" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
                             <TextBlock>
                                 <Run Text="tab 2 content. Default look and behaviors."/>
                                 <LineBreak/>
@@ -109,8 +148,43 @@
                                 </Run>
                             </TextBlock>
                         </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Images" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Photos" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <TextBlock>
+                                <Run Text="tab 3 content. Default look and behaviors."/>
+                                <LineBreak/>
+                                <LineBreak/>
+                                <Run FontStyle="Italic">
+                                    Praesevzddvvvvvvvvvv
+                                </Run>
+                            </TextBlock>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="MusicBoxMultiple" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Sounds" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <TextBlock>
+                                <Run Text="tab 4 content. Default look and behaviors."/>
+                                <LineBreak/>
+                                <LineBreak/>
+                                <Run FontStyle="Italic">
+                                    Prfadsssssssssssssssbvdcas
+                                </Run>
+                            </TextBlock>
+                        </TabItem>
                     </TabControl>
-                </smtx:XamlDisplay>      
+                </smtx:XamlDisplay>
+                
                 <smtx:XamlDisplay
                     UniqueKey="navrail_2"
                     Margin="5,5,5,0"
@@ -118,58 +192,14 @@
                     <TabControl
                         Style="{StaticResource MaterialDesignNavigatilRailTabControl}"
                         TabStripPlacement="Right">
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Heart, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}">
-                            <TextBlock>
-                                <Run Text="tab 1 content. Default look and right aligned. "/>
-                                <LineBreak/>
-                                <LineBreak/>
-                                <Run FontStyle="Italic">
-                                    Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...
-                                </Run>
-                            </TextBlock>
-                        </TabItem>
-
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Spade, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}">
-                            <TextBlock>
-                                <Run Text="tab 2 content. Default look and right aligned. "/>
-                                <LineBreak/>
-                                <LineBreak/>
-                                <Run FontStyle="Italic">
-                                    Praesent sed dui arcu. Vivamus porta auctor sagittis
-                                </Run>
-                            </TextBlock>
-                        </TabItem>
-
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Tree, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}">
-                            <TextBlock>
-                                <Run Text="tab 3 content. Default look and right aligned. "/>
-                                <LineBreak/>
-                                <LineBreak/>
-                                <Run FontStyle="Italic">
-                                    Praesent sed dui arcu. Vivamus porta auctor sagittis
-                                </Run>
-                            </TextBlock>
-                        </TabItem>
-                    </TabControl>
-                </smtx:XamlDisplay>     
-                <smtx:XamlDisplay
-                    UniqueKey="navrail_3"
-                    Margin="5,5,5,0"
-                    Grid.Row="1"
-                    Grid.Column="1">
-                    <TabControl
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}"
-                        materialDesign:ColorZoneAssist.Mode="PrimaryMid">
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Heart, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}">
-                            <TextBlock>
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Folder" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="All Files" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <TextBlock >
                                 <Run Text="tab 1 content. Default look and behaviors."/>
                                 <LineBreak/>
                                 <LineBreak/>
@@ -179,9 +209,13 @@
                             </TextBlock>
                         </TabItem>
 
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Spade, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}">
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="ClockOutline" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Recent" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
                             <TextBlock>
                                 <Run Text="tab 2 content. Default look and behaviors."/>
                                 <LineBreak/>
@@ -192,16 +226,105 @@
                             </TextBlock>
                         </TabItem>
 
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Tree, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}">
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Images" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Photos" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
                             <TextBlock>
-                                <Run Text="tab 3 content. Default look and right aligned. "/>
+                                <Run Text="tab 3 content. Default look and behaviors."/>
+                                <LineBreak/>
+                                <LineBreak/>
+                            </TextBlock>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="MusicBoxMultiple" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Sounds" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <TextBlock>
+                                <Run Text="tab 4 content. Default look and behaviors."/>
+                                <LineBreak/>
+                                <LineBreak/>
+                            </TextBlock>
+                        </TabItem>
+
+
+                    </TabControl>
+                </smtx:XamlDisplay>
+                
+                <smtx:XamlDisplay
+                    UniqueKey="navrail_3"
+                    Margin="5,5,5,0"
+                    Grid.Row="1"
+                    Grid.Column="1">
+                    <TabControl VerticalContentAlignment="Bottom"
+                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}"
+                        materialDesign:ColorZoneAssist.Mode="PrimaryMid">
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Folder" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="All Files" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <TextBlock >
+                                <Run Text="tab 1 content. Default look and behaviors."/>
+                                <LineBreak/>
+                                <LineBreak/>
+                                <Run FontStyle="Italic">
+                                    Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...
+                                </Run>
+                            </TextBlock>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="ClockOutline" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Recent" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <TextBlock>
+                                <Run Text="tab 2 content. Default look and behaviors."/>
                                 <LineBreak/>
                                 <LineBreak/>
                                 <Run FontStyle="Italic">
                                     Praesent sed dui arcu. Vivamus porta auctor sagittis
                                 </Run>
+                            </TextBlock>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Images" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Photos" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <TextBlock>
+                                <Run Text="tab 3 content. Default look and behaviors."/>
+                                <LineBreak/>
+                                <LineBreak/>
+                            </TextBlock>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="MusicBoxMultiple" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Sounds" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <TextBlock>
+                                <Run Text="tab 4 content. Default look and behaviors."/>
+                                <LineBreak/>
+                                <LineBreak/>
                             </TextBlock>
                         </TabItem>
                     </TabControl>
@@ -215,41 +338,82 @@
             materialDesign:ColorZoneAssist.Mode="Standard"
             Margin="5">
             <smtx:XamlDisplay UniqueKey="navrail_floating_1">
-                <TabControl
+                <TabControl 
                     Style="{StaticResource MaterialDesignNavigatilRailTabControl}" 
-                    materialDesign:ColorZoneAssist.Mode="PrimaryDark">
+                    materialDesign:ColorZoneAssist.Mode="PrimaryMid"
+                    TabStripPlacement="Top"
+                    materialDesign:NavigationRailAssist.SelectionCornerRadius="50 10 10 10"
+                    materialDesign:NavigationRailAssist.ShowSelectionBackground="True">
                     <materialDesign:NavigationRailAssist.FloatingContent>
                         <Button
                             Style="{StaticResource MaterialDesignFloatingActionAccentButton}"
-                            Margin="0,8"
-                            Content="{materialDesign:PackIcon Kind=Plus}"/>
+                            Margin="8">
+                            <materialDesign:PackIcon Kind="Plus" Width="24" Height="24"/>
+                        </Button>
                     </materialDesign:NavigationRailAssist.FloatingContent>
 
-                    <TabItem
-                        Header="{materialDesign:PackIcon Kind=Heart, Size=24}"
-                        Style="{StaticResource MaterialDesignNavigationRailTabItem}">
-                        <TextBlock>
-                            <Run Text="tab 1 content. Default look and behaviors."/>
-                            <LineBreak/>
-                            <LineBreak/>
-                            <Run FontStyle="Italic">
-                                Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...
-                            </Run>
+                    <TabItem >
+                        <TabItem.Header>
+                            <StackPanel Height="auto" Width="auto">
+                                <materialDesign:PackIcon Kind="Folder" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                <TextBlock Text="All Files" HorizontalAlignment="Center"/>
+                            </StackPanel>
+                        </TabItem.Header>
+                        <TextBlock >
+                                <Run Text="tab 1 content. Default look and behaviors."/>
+                                <LineBreak/>
+                                <LineBreak/>
+                                <Run FontStyle="Italic">
+                                    Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...
+                                </Run>
                         </TextBlock>
                     </TabItem>
 
-                    <TabItem
-                        Header="{materialDesign:PackIcon Kind=Spade, Size=24}"
-                        Style="{StaticResource MaterialDesignNavigationRailTabItem}">
+                    <TabItem >
+                        <TabItem.Header>
+                            <StackPanel Height="auto" Width="auto">
+                                <materialDesign:PackIcon Kind="ClockOutline" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Recent" HorizontalAlignment="Center"/>
+                            </StackPanel>
+                        </TabItem.Header>
                         <TextBlock>
-                            <Run Text="tab 2 content. Default look and behaviors."/>
-                            <LineBreak/>
-                            <LineBreak/>
-                            <Run FontStyle="Italic">
-                                Praesent sed dui arcu. Vivamus porta auctor sagittis
-                            </Run>
+                                <Run Text="tab 2 content. Default look and behaviors."/>
+                                <LineBreak/>
+                                <LineBreak/>
+                                <Run FontStyle="Italic">
+                                    Praesent sed dui arcu. Vivamus porta auctor sagittis
+                                </Run>
                         </TextBlock>
                     </TabItem>
+
+                    <TabItem >
+                        <TabItem.Header>
+                            <StackPanel Height="auto" Width="auto">
+                                <materialDesign:PackIcon Kind="Images" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Photos" HorizontalAlignment="Center"/>
+                            </StackPanel>
+                        </TabItem.Header>
+                        <TextBlock>
+                                <Run Text="tab 3 content. Default look and behaviors."/>
+                                <LineBreak/>
+                                <LineBreak/>
+                        </TextBlock>
+                    </TabItem>
+
+                    <TabItem >
+                        <TabItem.Header>
+                            <StackPanel Height="auto" Width="auto">
+                                <materialDesign:PackIcon Kind="MusicBoxMultiple" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Sounds" HorizontalAlignment="Center"/>
+                            </StackPanel>
+                        </TabItem.Header>
+                        <TextBlock>
+                                <Run Text="tab 4 content. Default look and behaviors."/>
+                                <LineBreak/>
+                                <LineBreak/>
+                        </TextBlock>
+                    </TabItem>
+                    
                 </TabControl>
             </smtx:XamlDisplay>
         </GroupBox>
@@ -267,13 +431,42 @@
                         Style="{StaticResource MaterialDesignNavigatilRailTabControl}" 
                         materialDesign:ColorZoneAssist.Mode="Standard"
                         materialDesign:ShadowAssist.ShadowDepth="Depth0">
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Heart, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}"/>
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Folder" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="All Files" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <Grid  Width="100"/>
+                        </TabItem>
 
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Spade, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}"/>
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="ClockOutline" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Recent" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Images" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Photos" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="MusicBoxMultiple" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Sounds" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                        </TabItem>
                     </TabControl>
                 </smtx:XamlDisplay>
                 
@@ -282,13 +475,42 @@
                         Style="{StaticResource MaterialDesignNavigatilRailTabControl}" 
                         materialDesign:ColorZoneAssist.Mode="Standard"
                         materialDesign:ShadowAssist.ShadowDepth="Depth1">
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Heart, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}"/>
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Folder" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="All Files" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <Grid  Width="100"/>
+                        </TabItem>
 
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Spade, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}"/>
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="ClockOutline" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Recent" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Images" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Photos" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="MusicBoxMultiple" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Sounds" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                        </TabItem>
                     </TabControl>
                 </smtx:XamlDisplay>
                 
@@ -297,13 +519,42 @@
                         Style="{StaticResource MaterialDesignNavigatilRailTabControl}" 
                         materialDesign:ColorZoneAssist.Mode="Standard"
                         materialDesign:ShadowAssist.ShadowDepth="Depth2">
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Heart, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}"/>
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Folder" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="All Files" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <Grid  Width="100"/>
+                        </TabItem>
 
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Spade, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}"/>
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="ClockOutline" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Recent" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Images" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Photos" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="MusicBoxMultiple" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Sounds" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                        </TabItem>
                     </TabControl>
                 </smtx:XamlDisplay>
                 
@@ -312,13 +563,42 @@
                         Style="{StaticResource MaterialDesignNavigatilRailTabControl}" 
                         materialDesign:ColorZoneAssist.Mode="Standard"
                         materialDesign:ShadowAssist.ShadowDepth="Depth3">
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Heart, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}"/>
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Folder" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="All Files" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                            <Grid  Width="100"/>
+                        </TabItem>
 
-                        <TabItem
-                            Header="{materialDesign:PackIcon Kind=Spade, Size=24}"
-                            Style="{StaticResource MaterialDesignNavigationRailTabItem}"/>
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="ClockOutline" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Recent" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="Images" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Photos" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                        </TabItem>
+
+                        <TabItem >
+                            <TabItem.Header>
+                                <StackPanel Height="auto" Width="auto">
+                                    <materialDesign:PackIcon Kind="MusicBoxMultiple" Width="24" Height="24" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Sounds" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </TabItem.Header>
+                        </TabItem>
                     </TabControl>
                 </smtx:XamlDisplay>
             </StackPanel>      

--- a/MaterialDesignThemes.Wpf/NavigationRailAssist.cs
+++ b/MaterialDesignThemes.Wpf/NavigationRailAssist.cs
@@ -30,11 +30,11 @@ namespace MaterialDesignThemes.Wpf
 
         #region Property SelectionCornerRadius
 
-        public static readonly DependencyProperty SelectionUniformCornerRadiusProperty = DependencyProperty.RegisterAttached(
-            "SelectionUniformCornerRadius", typeof(CornerRadius), typeof(NavigationRailAssist), new PropertyMetadata(default(CornerRadius)));
+        public static readonly DependencyProperty SelectionCornerRadiusProperty = DependencyProperty.RegisterAttached(
+            "SelectionCornerRadius", typeof(CornerRadius), typeof(NavigationRailAssist), new PropertyMetadata(default(CornerRadius)));
 
-        public static object GetSelectionUniformCornerRadius(DependencyObject element) => (CornerRadius)element.GetValue(SelectionUniformCornerRadiusProperty);
-        public static void SetSelectionUniformCornerRadius(DependencyObject element, CornerRadius value) => element.SetValue(SelectionUniformCornerRadiusProperty, value);
+        public static object GetSelectionCornerRadius(DependencyObject element) => (CornerRadius)element.GetValue(SelectionCornerRadiusProperty);
+        public static void SetSelectionCornerRadius(DependencyObject element, CornerRadius value) => element.SetValue(SelectionCornerRadiusProperty, value);
 
         #endregion
     }

--- a/MaterialDesignThemes.Wpf/NavigationRailAssist.cs
+++ b/MaterialDesignThemes.Wpf/NavigationRailAssist.cs
@@ -17,5 +17,15 @@ namespace MaterialDesignThemes.Wpf
         public static void SetFloatingContent(DependencyObject element, object value) => element.SetValue(FloatingContentProperty, value);
 
         #endregion
+
+        #region Property FloatingContent
+
+        public static readonly DependencyProperty ShowSelectionBackgroundProperty = DependencyProperty.RegisterAttached(
+            "ShowSelectionBackground", typeof(bool), typeof(NavigationRailAssist), new PropertyMetadata(false));
+
+        public static object GetShowSelectionBackground(DependencyObject element) => (bool)element.GetValue(ShowSelectionBackgroundProperty);
+        public static void SetShowSelectionBackground(DependencyObject element, bool value) => element.SetValue(ShowSelectionBackgroundProperty, value);
+
+        #endregion
     }
 }

--- a/MaterialDesignThemes.Wpf/NavigationRailAssist.cs
+++ b/MaterialDesignThemes.Wpf/NavigationRailAssist.cs
@@ -18,13 +18,23 @@ namespace MaterialDesignThemes.Wpf
 
         #endregion
 
-        #region Property FloatingContent
+        #region Property ShowSelectionBackground
 
         public static readonly DependencyProperty ShowSelectionBackgroundProperty = DependencyProperty.RegisterAttached(
             "ShowSelectionBackground", typeof(bool), typeof(NavigationRailAssist), new PropertyMetadata(false));
 
         public static object GetShowSelectionBackground(DependencyObject element) => (bool)element.GetValue(ShowSelectionBackgroundProperty);
         public static void SetShowSelectionBackground(DependencyObject element, bool value) => element.SetValue(ShowSelectionBackgroundProperty, value);
+
+        #endregion
+
+        #region Property SelectionCornerRadius
+
+        public static readonly DependencyProperty SelectionUniformCornerRadiusProperty = DependencyProperty.RegisterAttached(
+            "SelectionUniformCornerRadius", typeof(CornerRadius), typeof(NavigationRailAssist), new PropertyMetadata(default(CornerRadius)));
+
+        public static object GetSelectionUniformCornerRadius(DependencyObject element) => (CornerRadius)element.GetValue(SelectionUniformCornerRadiusProperty);
+        public static void SetSelectionUniformCornerRadius(DependencyObject element, CornerRadius value) => element.SetValue(SelectionUniformCornerRadiusProperty, value);
 
         #endregion
     }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -203,7 +203,6 @@
         <Setter Property="Padding" Value="0"/>
         <Setter Property="Height" Value="72" />
         <Setter Property="Width" Value="72" />
-        <Setter Property="Margin" Value="4"/>
         <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesignFlatButtonRipple}" />
         <Setter Property="Template">
             <Setter.Value>
@@ -211,7 +210,7 @@
                     <Grid x:Name="Root"
                           Cursor="Hand">
                         <Grid >
-                            <Ellipse Fill="{TemplateBinding Foreground}"
+                            <Rectangle Fill="{TemplateBinding Foreground}"
                                          x:Name="MouseOverBorder"
                                          Visibility="Hidden"
                                          Opacity=".08"/>
@@ -244,7 +243,7 @@
                                             TextOptions.TextRenderingMode="Auto"/>
 
                             </wpf:ColorZone>
-                            <Ellipse x:Name="GeometryEllipse" Fill="Transparent" IsHitTestVisible="False" Focusable="False" />
+                            <Rectangle x:Name="GeometryEllipse" Fill="Transparent" IsHitTestVisible="False" Focusable="False" />
                         </Grid>
                         <Border x:Name="SelectionHighlightBorder" 
                                 Visibility="Hidden" >

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -221,7 +221,7 @@
                                        x:Name="MouseOverBorder"
                                        Visibility="Hidden"
                                        Opacity=".08"
-                                       CornerRadius="{Binding Path=(wpf:NavigationRailAssist.SelectionUniformCornerRadius), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}"/>
+                                       CornerRadius="{Binding Path=(wpf:NavigationRailAssist.SelectionCornerRadius), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}"/>
                             <wpf:ColorZone x:Name="colorZone"
                                            HorizontalAlignment="Stretch"
                                            VerticalAlignment="Stretch"
@@ -264,7 +264,7 @@
                             <Border x:Name="PART_BackgroundSelection"
                                        Background="{TemplateBinding Background}"
                                        Opacity="0.12"
-                                       CornerRadius="{Binding Path=(wpf:NavigationRailAssist.SelectionUniformCornerRadius), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}"/>
+                                       CornerRadius="{Binding Path=(wpf:NavigationRailAssist.SelectionCornerRadius), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}"/>
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -6,6 +6,7 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+            <converters:BorderClipConverter x:Key="BorderClipConverter"/>
         </ResourceDictionary>
     </ResourceDictionary.MergedDictionaries>
 
@@ -216,10 +217,11 @@
                     <Grid x:Name="Root"
                           Cursor="Hand">
                         <Grid >
-                            <Rectangle Fill="{TemplateBinding Background}"
-                                         x:Name="MouseOverBorder"
-                                         Visibility="Hidden"
-                                         Opacity=".08"/>
+                            <Border Background="{TemplateBinding Background}"
+                                       x:Name="MouseOverBorder"
+                                       Visibility="Hidden"
+                                       Opacity=".08"
+                                       CornerRadius="{Binding Path=(wpf:NavigationRailAssist.SelectionUniformCornerRadius), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}"/>
                             <wpf:ColorZone x:Name="colorZone"
                                            HorizontalAlignment="Stretch"
                                            VerticalAlignment="Stretch"
@@ -231,7 +233,6 @@
                                            wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}">
                                 <wpf:Ripple Focusable="False"
                                             ClipToBounds="True"
-                                            Clip="{Binding ElementName=GeometryEllipse, Path=RenderedGeometry}"
                                             Content="{TemplateBinding Header}"
                                             ContentTemplate="{TemplateBinding HeaderTemplate}"
                                             ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
@@ -246,16 +247,24 @@
                                             TextBlock.FontWeight="Medium"
                                             TextBlock.FontSize="15"
                                             TextOptions.TextFormattingMode="Ideal" 
-                                            TextOptions.TextRenderingMode="Auto"/>
-
+                                            TextOptions.TextRenderingMode="Auto">
+                                    <wpf:Ripple.Clip>
+                                        <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                                            <Binding ElementName="MouseOverBorder" Path="ActualWidth" />
+                                            <Binding ElementName="MouseOverBorder" Path="ActualHeight" />
+                                            <Binding ElementName="MouseOverBorder" Path="CornerRadius" />
+                                            <Binding ElementName="MouseOverBorder" Path="BorderThickness" />
+                                        </MultiBinding>
+                                    </wpf:Ripple.Clip>
+                                </wpf:Ripple>
                             </wpf:ColorZone>
-                            <Rectangle x:Name="GeometryEllipse" Fill="Transparent" IsHitTestVisible="False" Focusable="False" />
                         </Grid>
                         <Border x:Name="SelectionHighlightBorder" 
                                 Visibility="Hidden" >
-                            <Rectangle x:Name="PART_BackgroundSelection"
-                                       Fill="{TemplateBinding Background}"
-                                       Opacity="0.12"/>
+                            <Border x:Name="PART_BackgroundSelection"
+                                       Background="{TemplateBinding Background}"
+                                       Opacity="0.12"
+                                       CornerRadius="{Binding Path=(wpf:NavigationRailAssist.SelectionUniformCornerRadius), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}"/>
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -336,7 +345,6 @@
         <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth0"/>
         <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Right"/>
         <Setter Property="ItemContainerStyle" Value="{StaticResource MaterialDesignNavigationRailTabItem}"/>
-        <Setter Property="wpf:NavigationRailAssist.ShowSelectionBackground" Value="False"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabControl}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -1,8 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
-                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
->
+                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
 
     <Style x:Key="FocusVisual">
         <Setter Property="Control.Template">
@@ -199,59 +198,73 @@
 
     <Style TargetType="{x:Type TabItem}" x:Key="MaterialDesignNavigationRailTabItem">
         <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}"/>
-        <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
+        <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}"/>
-        <Setter Property="Padding" Value="16"/>
+        <Setter Property="Padding" Value="0"/>
         <Setter Property="Height" Value="72" />
         <Setter Property="Width" Value="72" />
+        <Setter Property="Margin" Value="4"/>
         <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesignFlatButtonRipple}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabItem}">
-                    <Grid x:Name="Root" >
-                        <wpf:ColorZone x:Name="tabitemcz"
-                                       HorizontalAlignment="Stretch"
-                                       VerticalAlignment="Stretch"
-                                       Focusable="False"
-                                       Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}" 
-                                       Background="{x:Null}"
-                                       wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
-                                       wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}">
-                            <wpf:Ripple Focusable="False"
-                                        ClipToBounds="True"
-                                        Content="{TemplateBinding Header}" 
-                                        ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                        ContentStringFormat="{TemplateBinding HeaderStringFormat}"
-                                        HorizontalContentAlignment="Center"
-                                        VerticalContentAlignment="Center"
-                                        RecognizesAccessKey="True"
-                                        x:Name="contentPresenter"
-                                        Opacity=".82"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                                        Padding="{TemplateBinding Padding}"
-                                        TextBlock.FontWeight="Medium"
-                                        TextBlock.FontSize="15"
-                                        TextOptions.TextFormattingMode="Ideal" 
-                                        TextOptions.TextRenderingMode="Auto">
-                            </wpf:Ripple>
-                        </wpf:ColorZone>
+                    <Grid x:Name="Root"
+                          Cursor="Hand">
+                        <Grid >
+                            <Ellipse Fill="{TemplateBinding Foreground}"
+                                         x:Name="MouseOverBorder"
+                                         Visibility="Hidden"
+                                         Opacity=".08"/>
+                            <wpf:ColorZone x:Name="colorZone"
+                                           HorizontalAlignment="Stretch"
+                                           VerticalAlignment="Stretch"
+                                           Cursor="Hand"
+                                           Focusable="False"
+                                           Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}" 
+                                           Background="{x:Null}"
+                                           wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
+                                           wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}">
+                                <wpf:Ripple Focusable="False"
+                                            ClipToBounds="True"
+                                            Clip="{Binding ElementName=GeometryEllipse, Path=RenderedGeometry}"
+                                            Content="{TemplateBinding Header}"
+                                            ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                            ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                            ContentStringFormat="{TemplateBinding HeaderStringFormat}"
+                                            HorizontalContentAlignment="Center"
+                                            VerticalContentAlignment="Center"
+                                            RecognizesAccessKey="True"
+                                            x:Name="contentPresenter"
+                                            Opacity=".52"
+                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
+                                            Padding="{TemplateBinding Padding}"
+                                            TextBlock.FontWeight="Medium"
+                                            TextBlock.FontSize="15"
+                                            TextOptions.TextFormattingMode="Ideal" 
+                                            TextOptions.TextRenderingMode="Auto"/>
+
+                            </wpf:ColorZone>
+                            <Ellipse x:Name="GeometryEllipse" Fill="Transparent" IsHitTestVisible="False" Focusable="False" />
+                        </Grid>
                         <Border x:Name="SelectionHighlightBorder" 
-                                BorderBrush="{TemplateBinding BorderBrush}" 
-                                BorderThickness="0"
-                                Visibility="Hidden" RenderTransformOrigin="0.5,0.5">
-                            <Rectangle x:Name="PART_BackgroundSelection" Fill="{TemplateBinding Background}" Opacity="0.12"/>
+                                Visibility="Hidden" >
+                            <Rectangle x:Name="PART_BackgroundSelection"
+                                       Fill="{TemplateBinding Background}"
+                                       Opacity="0.12"/>
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.23"/>
                         </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True" SourceName="Root">
+                            <Setter TargetName="MouseOverBorder" Property="Visibility" Value="Visible"/>
+                        </Trigger>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter TargetName="contentPresenter" Property="Opacity" Value="1"/>
                             <Setter TargetName="SelectionHighlightBorder" Property="Visibility" Value="Visible" />
                         </Trigger>
+
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="IsSelected" Value="True"/>
@@ -261,57 +274,39 @@
                             <Setter TargetName="SelectionHighlightBorder" Property="Visibility" Value="Visible" />
                             <Setter TargetName="contentPresenter" Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}"/>
                         </MultiTrigger>
-                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid">
-                            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
-                            <Setter Property="Background" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
-                        </Trigger>
-                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="PrimaryLight">
-                            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueLightForegroundBrush}" />
-                            <Setter Property="Background" Value="{DynamicResource PrimaryHueLightForegroundBrush}" />
-                        </Trigger>
-                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="PrimaryDark">
-                            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueDarkForegroundBrush}" />
-                            <Setter Property="Background" Value="{DynamicResource PrimaryHueDarkForegroundBrush}" />
-                        </Trigger>
-                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="SecondaryMid">
-                            <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
-                            <Setter Property="Background" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
-                        </Trigger>
-                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="Custom">
-                            <Setter Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}" />
-                            <Setter Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}" />
-                        </Trigger>
                     </ControlTemplate.Triggers>
+                    
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
-
     <Style  TargetType="{x:Type TabControl}" x:Key="MaterialDesignNavigatilRailTabControl">
         <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
-        <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}"/>
+        <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
         <Setter Property="VerticalContentAlignment" Value="Top"/>
-        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesignFlatButtonRipple}" />
         <Setter Property="TabStripPlacement" Value="Left" />
         <Setter Property="BorderThickness" Value="0,0,1,0"/>
         <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth0"/>
         <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Right"/>
+        <Setter Property="ItemContainerStyle" Value="{StaticResource MaterialDesignNavigationRailTabItem}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabControl}">
                     <DockPanel Background="{TemplateBinding Background}" 
                                KeyboardNavigation.TabNavigation="Local">
-
-                        <Grid x:Name="TabGrid" DockPanel.Dock="Left">
-                            <!--tabs-->
+                        <!--tabs-->
+                        <Grid x:Name="TabGrid" DockPanel.Dock="Left" SnapsToDevicePixels="True">
                             <wpf:Card wpf:ShadowAssist.ShadowDepth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth)}"
                                       wpf:ShadowAssist.ShadowEdges="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowEdges)}"
                                       BorderBrush="{DynamicResource MaterialDesignDivider}"
                                       BorderThickness="{TemplateBinding BorderThickness}"
-                                      RenderTransformOrigin="0.5,0.5" />
+                                      UniformCornerRadius="0" x:Name="shadowCard"
+                                      Background="{TemplateBinding Background}" 
+                                      Visibility="Visible"/>
 
                             <wpf:ColorZone x:Name="PART_ColorZone" 
                                            VerticalAlignment="Stretch"
@@ -324,18 +319,33 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="1*"/>
                                     </Grid.RowDefinitions>
-                                    <ContentPresenter Focusable="False" 
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="1*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <ContentPresenter Focusable="False"
+                                                      x:Name="FloatingContentPanel"
+                                                      Grid.Row="0"
+                                                      Grid.Column="0"
+                                                      HorizontalAlignment="Center"
+                                                      VerticalAlignment="Center"
                                                       Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:NavigationRailAssist.FloatingContent)}" />
                                     <UniformGrid x:Name="HeaderPanel"
-                                         Columns="1"
-                                         Rows="0"
-                                         VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                         Grid.Row="1"
-                                         IsItemsHost="True"
-                                         Focusable="False"
-                                         HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                                                 Grid.Row="1"
+                                                 Grid.Column="0"
+                                                 Columns="1"
+                                                 Rows="0" 
+                                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                 IsItemsHost="True"
+                                                 Focusable="False"
+                                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"/>
 
-                                    <Rectangle x:Name="DividerRect" Fill="{DynamicResource MaterialDesignShadowBrush}" Opacity="0.1" Width="1" Height="Auto" Grid.RowSpan="2" HorizontalAlignment="Right" />
+                                    <Rectangle x:Name="DividerRect" Fill="{DynamicResource MaterialDesignDivider}"
+                                               Width="1"
+                                               Height="Auto"
+                                               Grid.RowSpan="2"
+                                               HorizontalAlignment="Right"
+                                               Visibility="Collapsed"/>
                                 </Grid>
                             </wpf:ColorZone>
 
@@ -348,11 +358,11 @@
                                        Mode="Standard" 
                                        Foreground="{DynamicResource MaterialDesignBody}"
                                        Background="{x:Null}">
+
                             <ContentPresenter x:Name="PART_SelectedContentHost"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
                                               Focusable="False"
                                               Margin="{TemplateBinding Padding}"
-                                              TextElement.Foreground="{Binding ElementName=PART_ColorZoneSelectedContent, Path=Foreground}"
                                               ContentSource="SelectedContent"
                                               ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                               ContentTemplate="{TemplateBinding ContentTemplate}"
@@ -361,6 +371,10 @@
                         </wpf:ColorZone>
                     </DockPanel>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="wpf:ShadowAssist.ShadowDepth" Value="Depth0">
+                            <Setter TargetName="shadowCard" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="DividerRect" Property="Visibility" Value="Visible" />
+                        </Trigger>
                         <Trigger Property="wpf:ColorZoneAssist.Mode" Value="Standard">
                             <Setter TargetName="PART_ColorZone" Property="Background" Value="Transparent"/>
                         </Trigger>
@@ -376,8 +390,8 @@
                             <Setter TargetName="DividerRect" Property="Grid.RowSpan" Value="1" />
                             <Setter TargetName="HeaderPanel" Property="Rows" Value="1"/>
                             <Setter TargetName="HeaderPanel" Property="Columns" Value="0"/>
-                            <Setter TargetName="HeaderPanel" Property="HorizontalAlignment" Value="Left"/>
-                            <Setter TargetName="HeaderPanel" Property="VerticalAlignment" Value="Stretch"/>
+                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1"/>
+                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0"/>
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
                             <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Top"/>
@@ -391,8 +405,8 @@
                             <Setter TargetName="DividerRect" Property="Grid.RowSpan" Value="1" />
                             <Setter TargetName="HeaderPanel" Property="Rows" Value="1"/>
                             <Setter TargetName="HeaderPanel" Property="Columns" Value="0"/>
-                            <Setter TargetName="HeaderPanel" Property="HorizontalAlignment" Value="Left"/>
-                            <Setter TargetName="HeaderPanel" Property="VerticalAlignment" Value="Stretch"/>
+                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1"/>
+                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0"/>
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
                             <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Left"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -3,6 +3,12 @@
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
 
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        </ResourceDictionary>
+    </ResourceDictionary.MergedDictionaries>
+
     <Style x:Key="FocusVisual">
         <Setter Property="Control.Template">
             <Setter.Value>
@@ -210,7 +216,7 @@
                     <Grid x:Name="Root"
                           Cursor="Hand">
                         <Grid >
-                            <Rectangle Fill="{TemplateBinding Foreground}"
+                            <Rectangle Fill="{TemplateBinding Background}"
                                          x:Name="MouseOverBorder"
                                          Visibility="Hidden"
                                          Opacity=".08"/>
@@ -261,7 +267,6 @@
                         </Trigger>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter TargetName="contentPresenter" Property="Opacity" Value="1"/>
-                            <Setter TargetName="SelectionHighlightBorder" Property="Visibility" Value="Visible" />
                         </Trigger>
 
                         <MultiTrigger>
@@ -269,12 +274,51 @@
                                 <Condition Property="IsSelected" Value="True"/>
                                 <Condition Property="wpf:ColorZoneAssist.Mode" Value="Standard"/>
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="contentPresenter" Property="Opacity" Value="1"/>
-                            <Setter TargetName="SelectionHighlightBorder" Property="Visibility" Value="Visible" />
                             <Setter TargetName="contentPresenter" Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}"/>
                         </MultiTrigger>
+
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
+                                <Condition Binding="{Binding Path=(wpf:NavigationRailAssist.ShowSelectionBackground), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="True"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="SelectionHighlightBorder" Property="Visibility" Value="Visible" />
+                        </MultiDataTrigger>
+
+                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="Standard">
+                            <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignBody}" />
+                            <Setter Property="Background" Value="{DynamicResource MaterialDesignBody}" />
+                        </Trigger>
+                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid">
+                            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
+                            <Setter Property="Background" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
+                        </Trigger>
+                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="PrimaryLight">
+                            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueLightForegroundBrush}" />
+                            <Setter Property="Background" Value="{DynamicResource PrimaryHueLightForegroundBrush}" />
+                        </Trigger>
+                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="PrimaryDark">
+                            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueDarkForegroundBrush}" />
+                            <Setter Property="Background" Value="{DynamicResource PrimaryHueDarkForegroundBrush}" />
+                        </Trigger>
+                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="SecondaryLight">
+                            <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueLightForegroundBrush}" />
+                            <Setter Property="Background" Value="{DynamicResource SecondaryHueLightForegroundBrush}" />
+                        </Trigger>
+                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="SecondaryMid">
+                            <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                            <Setter Property="Background" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                        </Trigger>
+                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="SecondaryDark">
+                            <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueDarkForegroundBrush}" />
+                            <Setter Property="Background" Value="{DynamicResource SecondaryHueDarkForegroundBrush}" />
+                        </Trigger>
+                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="Custom">
+                            <Setter Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}" />
+                            <Setter Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}" />
+                        </Trigger>
+                        
                     </ControlTemplate.Triggers>
-                    
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -292,6 +336,7 @@
         <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth0"/>
         <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Right"/>
         <Setter Property="ItemContainerStyle" Value="{StaticResource MaterialDesignNavigationRailTabItem}"/>
+        <Setter Property="wpf:NavigationRailAssist.ShowSelectionBackground" Value="False"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabControl}">


### PR DESCRIPTION
Update the NavigationRail Control to make it more like the specs:
![firefox_sUJGA60OMK](https://user-images.githubusercontent.com/58171461/121545608-f7c07100-ca0a-11eb-9d44-77e71aaf5b3b.png) ![MaterialDesignDemo_vYZ7Gk6j0d](https://user-images.githubusercontent.com/58171461/121545511-e4150a80-ca0a-11eb-8aef-0ff098211b93.png) ![MaterialDesignDemo_UX5lINWSSW](https://user-images.githubusercontent.com/58171461/121545519-e4ada100-ca0a-11eb-9cb5-a3cae56f24b8.png)

### **Changes:**

- Fixed FAB positioning
- Fixed the color of the tab strip when standard mode is set (should be the same as the content)
- Fixed the color of the selection (no background rectangle by default, can still be added by selecting a Background on the TabItem)
- Added a MouseOver Color to provide feedback
- Changed DividerRect color

### **Known bugs:**

- When changing theme, the header icons stop following the ColorZone Foreground color and instead follow the tabitem's MaterialDesignBody color, while the text stays right. It's already present in the current version. I tried fixing it, but to no avail...

![MaterialDesignDemo_ghfa73ATht](https://user-images.githubusercontent.com/58171461/121548098-0740b980-ca0d-11eb-90ed-a3ac1c227d8f.png)  ![MaterialDesignDemo_9HXFCemMAa](https://user-images.githubusercontent.com/58171461/121548199-1cb5e380-ca0d-11eb-9c23-3bec4699e9ea.png) ![MaterialDesignDemo_L9r9g8knNW](https://user-images.githubusercontent.com/58171461/121548101-0871e680-ca0d-11eb-87e0-4af3f7d22bb5.png)


