### PR TITLE
Fix some functions with wrong parameters in SnackBarMessageQueue.cs

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/DialogHost/DialogHostTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DialogHost/DialogHostTests.cs
@@ -64,6 +64,7 @@ namespace MaterialDesignThemes.UITests.WPF.DialogHost
             await closeButton.Click();
 
             await Wait.For(async () => Assert.Equal("1", await resultTextBlock.GetText()));
+            recorder.Success();
         }
     }
 }

--- a/MaterialDesignThemes.UITests/WPF/Theme/ColorAdjustTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/Theme/ColorAdjustTests.cs
@@ -35,7 +35,6 @@ namespace MaterialDesignThemes.UITests.WPF.Theme
             await App.InitialzeWithMaterialDesign(BaseTheme.Light, primary, colorAdjustment:new ColorAdjustment());
 
             IWindow window = await App.CreateWindow<ColorAdjustWindow>();
-            await recorder.SaveScreenshot();
 
             Color windowBackground = await window.GetBackgroundColor();
 

--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
@@ -172,7 +172,7 @@ namespace MaterialDesignThemes.Wpf
             => Enqueue(content, actionContent, actionHandler, false);
 
         public void Enqueue(object content, object? actionContent, Action? actionHandler, bool promote)
-            => Enqueue(content, actionContent, _ => actionHandler?.Invoke(), promote, false, false);
+            => Enqueue(content, actionContent, _ => actionHandler?.Invoke(), false, promote, false);
 
         public void Enqueue<TArgument>(object content, object? actionContent, Action<TArgument?>? actionHandler,
             TArgument? actionArgument)
@@ -180,7 +180,7 @@ namespace MaterialDesignThemes.Wpf
 
         public void Enqueue<TArgument>(object content, object? actionContent, Action<TArgument?>? actionHandler,
             TArgument? actionArgument, bool promote) =>
-            Enqueue(content, actionContent, actionHandler, actionArgument, promote, promote);
+            Enqueue(content, actionContent, actionHandler, actionArgument, promote, false);
 
         public void Enqueue<TArgument>(object content, object? actionContent, Action<TArgument?>? actionHandler,
             TArgument? actionArgument, bool promote, bool neverConsiderToBeDuplicate, TimeSpan? durationOverride = null)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ steps:
 - task: PublishPipelineArtifact@1
   name: "PublishUITestsScreenshots"
   inputs:
-    artifact: 'Screenshots'
+    artifact: 'Screenshots-$(Build.BuildNumber)'
     targetPath: 'MaterialDesignThemes.UITests/bin/$(buildConfiguration)/net5.0-windows/Screenshots'
     publishLocation: 'pipeline'
   condition: always()


### PR DESCRIPTION
![微信图片_20210707171526](https://user-images.githubusercontent.com/34342879/124734009-437c1280-df04-11eb-9e17-067f1d64f73d.png)

- Try to call Enqueue method in SnackbarMessageQueue，you will find that the value of promote parameter  is always false
-  Wrong function
```
public void Enqueue(object content, object? actionContent, Action? actionHandler, bool promote)
            => Enqueue(content, actionContent, _ => actionHandler?.Invoke(), promote, false, false);
```