### PR TITLE
Add ShowSelection Property to ListBoxItem

### DIFF
--- a/MainDemo.Wpf/Lists.xaml
+++ b/MainDemo.Wpf/Lists.xaml
@@ -128,7 +128,7 @@
 
             <smtx:XamlDisplay
                 UniqueKey="list_3"
-                Grid.Column="4"
+                Grid.Column="3"
                 Grid.Row="0">
                 <!-- and here's another -->
                 <ItemsControl
@@ -217,4 +217,3 @@
         </smtx:XamlDisplay>
     </Grid>
 </UserControl>
-

--- a/MainDemo.Wpf/Lists.xaml
+++ b/MainDemo.Wpf/Lists.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
     xmlns:domain="clr-namespace:MaterialDesignDemo.Domain"
     xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
     mc:Ignorable="d" 
     d:DesignHeight="300"
     d:DesignWidth="300"
@@ -44,6 +45,7 @@
                 <ColumnDefinition Width="1*"/>
                 <ColumnDefinition Width="1*"/>
                 <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="1*"/>
             </Grid.ColumnDefinitions>      
             <smtx:XamlDisplay
                 UniqueKey="list_1"
@@ -64,8 +66,27 @@
                 Content="Enabled"/>
 
             <smtx:XamlDisplay
+                UniqueKey="list_4"
+                Grid.Column="1">
+                <Grid>
+                    <ListBox>
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="ListBoxItem" BasedOn="{StaticResource MaterialDesignListBoxItem}">
+                                <Setter Property="materialDesign:ListBoxItemAssist.ShowSelection" Value="False"/>
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                        <TextBlock Text="Listbox"/>
+                        <TextBlock Text="Without"/>
+                        <TextBlock Text="Selection"/>
+                        <TextBlock Text="Highlights"/>
+                    </ListBox>                    
+                </Grid>
+
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
                 UniqueKey="list_2"
-                Grid.Column="1"
+                Grid.Column="2"
                 Grid.Row="0">
                 <!-- piece together your own items control to create some nice stuff that will make everyone think you are cool. and rightly so, because you are cool.  you might even be a hipster for all I know -->
                 <ItemsControl
@@ -107,7 +128,7 @@
 
             <smtx:XamlDisplay
                 UniqueKey="list_3"
-                Grid.Column="2"
+                Grid.Column="4"
                 Grid.Row="0">
                 <!-- and here's another -->
                 <ItemsControl

--- a/MaterialDesignThemes.Wpf/ListBoxItemAssist.cs
+++ b/MaterialDesignThemes.Wpf/ListBoxItemAssist.cs
@@ -18,5 +18,14 @@ namespace MaterialDesignThemes.Wpf
         public static void SetCornerRadius(DependencyObject element, CornerRadius value) => element.SetValue(CornerRadiusProperty, value);
         #endregion
 
+        #region ShowSelection
+        public static bool GetShowSelection(DependencyObject element)
+            => (bool)element.GetValue(ShowSelectionProperty);
+        public static void SetShowSelection(DependencyObject element, bool value)
+            => element.SetValue(ShowSelectionProperty, value);
+
+        public static readonly DependencyProperty ShowSelectionProperty =
+            DependencyProperty.RegisterAttached("ShowSelection", typeof(bool), typeof(ListBoxItemAssist), new PropertyMetadata(true));
+        #endregion
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
@@ -223,6 +223,7 @@
         <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
         <Setter Property="Padding" Value="8"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="wpf:ListBoxItemAssist.ShowSelection" Value="True"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListBoxItem}">
@@ -278,7 +279,8 @@
                             <Border x:Name="SelectedBorder" Opacity="0"
                                     Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}">
                             </Border>
-                            <wpf:Ripple Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                            <wpf:Ripple x:Name="Ripple"
+                                        Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
                                         Focusable="False"
                                         Content="{TemplateBinding Content}"
                                         ContentTemplate="{TemplateBinding ContentTemplate}"
@@ -294,6 +296,11 @@
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value=".56" />
                         </Trigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ListBoxItemAssist.ShowSelection)}" Value="False">
+                            <Setter TargetName="MouseOverBorder" Property="Visibility" Value="Collapsed"/>
+                            <Setter TargetName="SelectedBorder" Property="Visibility" Value="Collapsed"/>
+                            <Setter TargetName="Ripple" Property="Feedback" Value="Transparent"/>
+                        </DataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>

--- a/MaterialDesignThemes.Wpf/TreeViewAssist.cs
+++ b/MaterialDesignThemes.Wpf/TreeViewAssist.cs
@@ -126,9 +126,9 @@ namespace MaterialDesignThemes.Wpf
         #region ShowSelection
 
         public static bool GetShowSelection(DependencyObject element)
-            => (bool)element.GetValue(ExpanderSizeProperty);
+            => (bool)element.GetValue(ShowSelectionProperty);
         public static void SetShowSelection(DependencyObject element, bool value)
-            => element.SetValue(ExpanderSizeProperty, value);
+            => element.SetValue(ShowSelectionProperty, value);
 
         public static readonly DependencyProperty ShowSelectionProperty =
             DependencyProperty.RegisterAttached("ShowSelection", typeof(bool), typeof(TreeViewAssist), new PropertyMetadata(true));


### PR DESCRIPTION
Simple addition of a property to control the selection, click and hover highlights of ListBoxItem, similarly to the one added for TreeViewItem. Speaking of which, I've noticed an error in my last commit for TreeViewAssist, added the fix.

