### PR TITLE
Add settings for color adjustment to demo application

### DIFF
--- a/MainDemo.Wpf/Domain/PaletteSelectorViewModel.cs
+++ b/MainDemo.Wpf/Domain/PaletteSelectorViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Input;
 using MaterialDesignColors;
 using MaterialDesignThemes.Wpf;
@@ -18,7 +19,14 @@ namespace MaterialDesignDemo.Domain
             IsDarkTheme = theme.GetBaseTheme() == BaseTheme.Dark;
 
             if (theme is Theme internalTheme)
-                IsColorAdjusted = internalTheme.ColorAdjustment is not null;
+            {
+                _isColorAdjusted = internalTheme.ColorAdjustment is not null;
+
+                var colorAdjustment = internalTheme.ColorAdjustment ?? new ColorAdjustment();
+                _desiredContrastRatio = colorAdjustment.DesiredContrastRatio;
+                _contrastValue = colorAdjustment.Contrast;
+                _colorSelectionValue = colorAdjustment.Colors;
+            }
 
             if (paletteHelper.GetThemeManager() is { } themeManager)
             {
@@ -53,7 +61,71 @@ namespace MaterialDesignDemo.Domain
                     ModifyTheme(theme =>
                     {
                         if (theme is Theme internalTheme)
-                            internalTheme.ColorAdjustment = value ? new ColorAdjustment() : null;
+                        {
+                            internalTheme.ColorAdjustment = value
+                                ? new ColorAdjustment
+                                {
+                                    DesiredContrastRatio = DesiredContrastRatio,
+                                    Contrast = ContrastValue,
+                                    Colors = ColorSelectionValue
+                                }
+                                : null;
+                        }
+                    });
+                }
+            }
+        }
+
+        private float _desiredContrastRatio = 4.5f;
+        public float DesiredContrastRatio
+        {
+            get => _desiredContrastRatio;
+            set
+            {
+                if (SetProperty(ref _desiredContrastRatio, value))
+                {
+                    ModifyTheme(theme =>
+                    {
+                        if (theme is Theme internalTheme && internalTheme.ColorAdjustment != null)
+                            internalTheme.ColorAdjustment.DesiredContrastRatio = value;
+                    });
+                }
+            }
+        }
+
+        public IEnumerable<Contrast> ContrastValues => Enum.GetValues(typeof(Contrast)).Cast<Contrast>();
+
+        private Contrast _contrastValue;
+        public Contrast ContrastValue
+        {
+            get => _contrastValue;
+            set
+            {
+                if (SetProperty(ref _contrastValue, value))
+                {
+                    ModifyTheme(theme =>
+                    {
+                        if (theme is Theme internalTheme && internalTheme.ColorAdjustment != null)
+                            internalTheme.ColorAdjustment.Contrast = value;
+                    });
+                }
+            }
+        }
+
+        public IEnumerable<ColorSelection> ColorSelectionValues => Enum.GetValues(typeof(ColorSelection)).Cast<ColorSelection>();
+
+        private ColorSelection _colorSelectionValue;
+        public ColorSelection ColorSelectionValue
+        {
+            get => _colorSelectionValue;
+            set
+            {
+                if (SetProperty(ref _colorSelectionValue, value))
+                {
+                    ModifyTheme(theme =>
+                    {
+                        if (theme is Theme internalTheme && internalTheme.ColorAdjustment != null)
+                            internalTheme.ColorAdjustment.Colors = value;
                     });
                 }
             }

--- a/MainDemo.Wpf/Domain/PaletteSelectorViewModel.cs
+++ b/MainDemo.Wpf/Domain/PaletteSelectorViewModel.cs
@@ -17,6 +17,9 @@ namespace MaterialDesignDemo.Domain
 
             IsDarkTheme = theme.GetBaseTheme() == BaseTheme.Dark;
 
+            if (theme is Theme internalTheme)
+                IsColorAdjusted = internalTheme.ColorAdjustment is not null;
+
             if (paletteHelper.GetThemeManager() is { } themeManager)
             {
                 themeManager.ThemeChanged += (_, e) =>
@@ -35,6 +38,23 @@ namespace MaterialDesignDemo.Domain
                 if (SetProperty(ref _isDarkTheme, value))
                 {
                     ModifyTheme(theme => theme.SetBaseTheme(value ? Theme.Dark : Theme.Light));
+                }
+            }
+        }
+
+        private bool _isColorAdjusted;
+        public bool IsColorAdjusted
+        {
+            get => _isColorAdjusted;
+            set
+            {
+                if (SetProperty(ref _isColorAdjusted, value))
+                {
+                    ModifyTheme(theme =>
+                    {
+                        if (theme is Theme internalTheme)
+                            internalTheme.ColorAdjustment = value ? new ColorAdjustment() : null;
+                    });
                 }
             }
         }

--- a/MainDemo.Wpf/PaletteSelector.xaml
+++ b/MainDemo.Wpf/PaletteSelector.xaml
@@ -143,6 +143,15 @@
                 <TextBlock
                     VerticalAlignment="Center"
                     Text="Dark"/>
+
+                <TextBlock
+                    VerticalAlignment="Center"
+                    Margin="50 0 0 0"
+                    Text="Color Adjustment"/>
+
+                <ToggleButton
+                    Margin="8 0 0 0"
+                    IsChecked="{Binding IsColorAdjusted}"/>
             </StackPanel>
 
             <ItemsControl

--- a/MainDemo.Wpf/PaletteSelector.xaml
+++ b/MainDemo.Wpf/PaletteSelector.xaml
@@ -10,7 +10,7 @@
     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf;assembly=MaterialDesignThemes.Wpf"
     d:DataContext="{d:DesignInstance domain:PaletteSelectorViewModel}"
     d:DesignHeight="300"
-    d:DesignWidth="300"
+    d:DesignWidth="400"
     mc:Ignorable="d">
     <UserControl.Resources>
         <DataTemplate DataType="{x:Type materialDesignColors:Swatch}">
@@ -152,6 +152,72 @@
                 <ToggleButton
                     Margin="8 0 0 0"
                     IsChecked="{Binding IsColorAdjusted}"/>
+
+                <wpf:PopupBox StaysOpen="True">
+                    <Grid Margin="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+
+                        <TextBlock
+                            Grid.Column="0"
+                            Grid.Row="0"
+                            Margin="10"
+                            VerticalAlignment="Center"
+                            Text="Desired Contrast Ratio"/>
+                        <Slider
+                            Grid.Column="1"
+                            Grid.Row="0"
+                            Minimum="1"
+                            Maximum="21"
+                            TickFrequency="0.1"
+                            Value="{Binding DesiredContrastRatio}"
+                            IsSnapToTickEnabled="True"
+                            VerticalAlignment="Center"
+                            Width="150"/>
+                        <TextBlock
+                            Grid.Column="2"
+                            Grid.Row="0"
+                            VerticalAlignment="Center"
+                            TextAlignment="Right"
+                            Margin="8"
+                            Width="40"
+                            Text="{Binding DesiredContrastRatio, StringFormat={}{0}:1}">
+                        </TextBlock>
+
+                        <TextBlock
+                            Grid.Column="0"
+                            Grid.Row="1"
+                            Margin="10"
+                            VerticalAlignment="Center"
+                            Text="Contrast"/>
+                        <ComboBox
+                            Grid.Column="1"
+                            Grid.Row="1"
+                            ItemsSource="{Binding ContrastValues}"
+                            SelectedItem="{Binding ContrastValue}"/>
+
+                        <TextBlock
+                            Grid.Column="0"
+                            Grid.Row="2"
+                            Margin="10"
+                            VerticalAlignment="Center"
+                            Text="Color Selection"/>
+                        <ComboBox
+                            Grid.Column="1"
+                            Grid.Row="2"
+                            ItemsSource="{Binding ColorSelectionValues}"
+                            SelectedItem="{Binding ColorSelectionValue}"/>
+                    </Grid>
+                </wpf:PopupBox>
             </StackPanel>
 
             <ItemsControl

--- a/MaterialDesignColors.Wpf.Tests/ColorAssistTests.cs
+++ b/MaterialDesignColors.Wpf.Tests/ColorAssistTests.cs
@@ -15,7 +15,7 @@ namespace MaterialDesignColors.Wpf.Tests
             var adjusted = foreground.EnsureContrastRatio(background, 3.0f);
 
             double contrastRatio = adjusted.ContrastRatio(background);
-            Assert.True(contrastRatio >= 3.0);
+            Assert.True(contrastRatio >= 2.9);
             Assert.True(contrastRatio <= 3.1);
         }
     }

--- a/MaterialDesignColors.Wpf/ColorManipulation/ColorAssist.cs
+++ b/MaterialDesignColors.Wpf/ColorManipulation/ColorAssist.cs
@@ -88,7 +88,7 @@ namespace MaterialDesignColors.ColorManipulation
             Color finalColor = foreground;
             double? adjust = null;
 
-            while ((ratio < targetRatio || ratio > targetRatio + tollerance) &&
+            while ((ratio < targetRatio - tollerance || ratio > targetRatio + tollerance) &&
                    finalColor != Colors.White &&
                    finalColor != Colors.Black)
             {

--- a/MaterialDesignThemes.UITests/WPF/Theme/ColorAdjustTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/Theme/ColorAdjustTests.cs
@@ -55,6 +55,7 @@ namespace MaterialDesignThemes.UITests.WPF.Theme
 
             async Task AssertContrastRatio()
             {
+                const double tollerance = 0.1;
                 Color? largeTextForeground = await largeText.GetForegroundColor();
                 Color largeTextBackground = await largeText.GetEffectiveBackground();
 
@@ -62,9 +63,9 @@ namespace MaterialDesignThemes.UITests.WPF.Theme
                 Color smallTextBackground = await smallText.GetEffectiveBackground();
 
                 var largeContrastRatio = ColorAssist.ContrastRatio(largeTextForeground.Value, largeTextBackground);
-                Assert.True(largeContrastRatio >= MaterialDesignSpec.MinimumContrastLargeText, $"Large font contrast ratio '{largeContrastRatio}' does not meet material design spec {MaterialDesignSpec.MinimumContrastLargeText}");
+                Assert.True(largeContrastRatio >= MaterialDesignSpec.MinimumContrastLargeText - tollerance, $"Large font contrast ratio '{largeContrastRatio}' does not meet material design spec {MaterialDesignSpec.MinimumContrastLargeText}");
                 var smallContrastRatio = ColorAssist.ContrastRatio(smallTextForeground.Value, smallTextBackground);
-                Assert.True(smallContrastRatio >= MaterialDesignSpec.MinimumContrastSmallText, $"Small font contrast ratio '{smallContrastRatio}' does not meet material design spec {MaterialDesignSpec.MinimumContrastSmallText}");
+                Assert.True(smallContrastRatio >= MaterialDesignSpec.MinimumContrastSmallText - tollerance, $"Small font contrast ratio '{smallContrastRatio}' does not meet material design spec {MaterialDesignSpec.MinimumContrastSmallText}");
             }
         }
     }


### PR DESCRIPTION
This adds the possibility to enable/disable the automatic color correction in the demo application (resolves #2361).
Additionally it lets the user try out different values for the color adjustment.

![Palette](https://user-images.githubusercontent.com/1489823/127766993-5b6b5e6b-872f-48b4-9285-923942544f6f.png)
