### PR TITLE
Added MaterialDesignTabRadioButton orientation styles

### DIFF
--- a/MainDemo.Wpf/Toggles.xaml
+++ b/MainDemo.Wpf/Toggles.xaml
@@ -21,6 +21,9 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         
         <Grid.ColumnDefinitions>
@@ -465,66 +468,6 @@
             </ListBox>
         </smtx:XamlDisplay>
         
-        <StackPanel
-            Grid.Column="1"
-            Grid.Row="5"
-            Margin="0 24 0 0">
-            <smtx:XamlDisplay
-                UniqueKey="buttons_60"
-                HorizontalAlignment="Left">
-                <StackPanel
-                    Orientation="Horizontal"
-                    Margin="4">
-                    <RadioButton
-                        Style="{StaticResource MaterialDesignTabRadioButton}"
-                        Margin="4"
-                        IsChecked="True"
-                        Content="FIRST"/>
-                    
-                    <RadioButton
-                        Style="{StaticResource MaterialDesignTabRadioButton}"
-                        Margin="4"
-                        IsChecked="False"
-                        Content="SECOND"/>
-                    
-                    <RadioButton
-                        Style="{StaticResource MaterialDesignTabRadioButton}"
-                        Margin="4"
-                        IsChecked="False"
-                        IsEnabled="False"
-                        Content="THIRD"/>
-                </StackPanel>
-            </smtx:XamlDisplay>
-            
-            <smtx:XamlDisplay
-                UniqueKey="buttons_61"
-                HorizontalAlignment="Left">
-                <materialDesign:ColorZone Mode="PrimaryMid">
-                    <StackPanel
-                        Orientation="Horizontal"
-                        Margin="2">
-                        <RadioButton
-                            Style="{StaticResource MaterialDesignTabRadioButton}"
-                            Margin="4"
-                            IsChecked="True"
-                            Content="FIRST"/>
-                        
-                        <RadioButton
-                            Style="{StaticResource MaterialDesignTabRadioButton}"
-                            Margin="4"
-                            IsChecked="False"
-                            Content="SECOND"/>
-                        
-                        <RadioButton
-                            Style="{StaticResource MaterialDesignTabRadioButton}"
-                            Margin="4"
-                            IsChecked="False"
-                            IsEnabled="False"
-                            Content="THIRD"/>
-                    </StackPanel>
-                </materialDesign:ColorZone>
-            </smtx:XamlDisplay>
-        </StackPanel>
         
         <Border
             Margin="0 24 0 0"
@@ -597,5 +540,259 @@
                     materialDesign:RippleAssist.IsDisabled="True"/>
             </StackPanel>
         </smtx:XamlDisplay>
+
+
+        <TextBlock
+            Grid.Row="10"
+            Grid.Column="0"
+            Style="{StaticResource MaterialDesignHeadline5TextBlock}"
+            Margin="0 24"
+            Text="Tabs"/>
+
+        <Border
+            Margin="0 24 0 0"
+            BorderThickness="0 1 0 0"
+            BorderBrush="{DynamicResource MaterialDesignDivider}"
+            Grid.Row="9"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"/>
+
+        <StackPanel Grid.Row="11">
+            <WrapPanel Orientation="Horizontal">
+                <StackPanel>
+                    <smtx:XamlDisplay
+                    UniqueKey="buttons_60"
+                    HorizontalAlignment="Left">
+                        <StackPanel
+                        Orientation="Horizontal"
+                        Margin="4">
+                            <RadioButton
+                            Style="{StaticResource MaterialDesignTabRadioButton}"
+                            Margin="4"
+                            IsChecked="True"
+                            Content="FIRST"/>
+
+                            <RadioButton
+                            Style="{StaticResource MaterialDesignTabRadioButton}"
+                            Margin="4"
+                            IsChecked="False"
+                            Content="SECOND"/>
+
+                            <RadioButton
+                            Style="{StaticResource MaterialDesignTabRadioButton}"
+                            Margin="4"
+                            IsChecked="False"
+                            IsEnabled="False"
+                            Content="THIRD"/>
+                        </StackPanel>
+                    </smtx:XamlDisplay>
+
+                    <smtx:XamlDisplay
+                    UniqueKey="buttons_61"
+                    HorizontalAlignment="Left">
+                        <materialDesign:ColorZone Mode="PrimaryMid">
+                            <StackPanel
+                            Orientation="Horizontal"
+                            Margin="2">
+                                <RadioButton
+                                Style="{StaticResource MaterialDesignTabRadioButton}"
+                                Margin="4"
+                                IsChecked="True"
+                                Content="FIRST"/>
+
+                                <RadioButton
+                                Style="{StaticResource MaterialDesignTabRadioButton}"
+                                Margin="4"
+                                IsChecked="False"
+                                Content="SECOND"/>
+
+                                <RadioButton
+                                Style="{StaticResource MaterialDesignTabRadioButton}"
+                                Margin="4"
+                                IsChecked="False"
+                                IsEnabled="False"
+                                Content="THIRD"/>
+                            </StackPanel>
+                        </materialDesign:ColorZone>
+                    </smtx:XamlDisplay>
+                </StackPanel>
+
+                <StackPanel>
+                    <smtx:XamlDisplay
+                    UniqueKey="buttons_71"
+                    HorizontalAlignment="Left">
+                        <StackPanel
+                        Orientation="Horizontal"
+                        Margin="4">
+                            <RadioButton
+                            Style="{StaticResource MaterialDesignTabRadioButtonTop}"
+                            Margin="4"
+                            IsChecked="True"
+                            Content="FIRST"/>
+
+                            <RadioButton
+                            Style="{StaticResource MaterialDesignTabRadioButtonTop}"
+                            Margin="4"
+                            IsChecked="False"
+                            Content="SECOND"/>
+
+                            <RadioButton
+                            Style="{StaticResource MaterialDesignTabRadioButtonTop}"
+                            Margin="4"
+                            IsChecked="False"
+                            IsEnabled="False"
+                            Content="THIRD"/>
+                        </StackPanel>
+                    </smtx:XamlDisplay>
+
+                    <smtx:XamlDisplay
+                    UniqueKey="buttons_72"
+                    HorizontalAlignment="Left">
+                        <materialDesign:ColorZone Mode="PrimaryMid">
+                            <StackPanel
+                            Orientation="Horizontal"
+                            Margin="2">
+                                <RadioButton
+                                Style="{StaticResource MaterialDesignTabRadioButtonTop}"
+                                Margin="4"
+                                IsChecked="True"
+                                Content="FIRST"/>
+
+                                <RadioButton
+                                Style="{StaticResource MaterialDesignTabRadioButtonTop}"
+                                Margin="4"
+                                IsChecked="False"
+                                Content="SECOND"/>
+
+                                <RadioButton
+                                Style="{StaticResource MaterialDesignTabRadioButtonTop}"
+                                Margin="4"
+                                IsChecked="False"
+                                IsEnabled="False"
+                                Content="THIRD"/>
+                            </StackPanel>
+                        </materialDesign:ColorZone>
+                    </smtx:XamlDisplay>
+                </StackPanel>
+
+            </WrapPanel>
+            <WrapPanel Orientation="Horizontal" Margin="0 24 0 0">
+                <StackPanel Orientation="Horizontal">
+                    <smtx:XamlDisplay
+                    UniqueKey="buttons_73"
+                    HorizontalAlignment="Left">
+                        <StackPanel
+                        Orientation="Vertical"
+                        Margin="4">
+                            <RadioButton
+                            Style="{StaticResource MaterialDesignTabRadioButtonRight}"
+                            Margin="4"
+                            IsChecked="True"
+                            Content="FIRST"/>
+
+                            <RadioButton
+                            Style="{StaticResource MaterialDesignTabRadioButtonRight}"
+                            Margin="4"
+                            IsChecked="False"
+                            Content="SECOND"/>
+
+                            <RadioButton
+                            Style="{StaticResource MaterialDesignTabRadioButtonRight}"
+                            Margin="4"
+                            IsChecked="False"
+                            IsEnabled="False"
+                            Content="THIRD"/>
+                        </StackPanel>
+                    </smtx:XamlDisplay>
+
+                    <smtx:XamlDisplay
+                    UniqueKey="buttons_74"
+                    HorizontalAlignment="Left">
+                        <materialDesign:ColorZone Mode="PrimaryMid">
+                            <StackPanel
+                            Orientation="Vertical"
+                            Margin="2">
+                                <RadioButton
+                                Style="{StaticResource MaterialDesignTabRadioButtonRight}"
+                                Margin="4"
+                                IsChecked="True"
+                                Content="FIRST"/>
+
+                                <RadioButton
+                                Style="{StaticResource MaterialDesignTabRadioButtonRight}"
+                                Margin="4"
+                                IsChecked="False"
+                                Content="SECOND"/>
+
+                                <RadioButton
+                                Style="{StaticResource MaterialDesignTabRadioButtonRight}"
+                                Margin="4"
+                                IsChecked="False"
+                                IsEnabled="False"
+                                Content="THIRD"/>
+                            </StackPanel>
+                        </materialDesign:ColorZone>
+                    </smtx:XamlDisplay>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal">
+                    <smtx:XamlDisplay
+                    UniqueKey="buttons_75"
+                    HorizontalAlignment="Left">
+                        <StackPanel
+                        Orientation="Vertical"
+                        Margin="4">
+                            <RadioButton
+                            Style="{StaticResource MaterialDesignTabRadioButtonLeft}"
+                            Margin="4"
+                            IsChecked="True"
+                            Content="FIRST"/>
+
+                            <RadioButton
+                            Style="{StaticResource MaterialDesignTabRadioButtonLeft}"
+                            Margin="4"
+                            IsChecked="False"
+                            Content="SECOND"/>
+
+                            <RadioButton
+                            Style="{StaticResource MaterialDesignTabRadioButtonLeft}"
+                            Margin="4"
+                            IsChecked="False"
+                            IsEnabled="False"
+                            Content="THIRD"/>
+                        </StackPanel>
+                    </smtx:XamlDisplay>
+
+                    <smtx:XamlDisplay
+                    UniqueKey="buttons_76"
+                    HorizontalAlignment="Left">
+                        <materialDesign:ColorZone Mode="PrimaryMid">
+                            <StackPanel
+                            Orientation="Vertical"
+                            Margin="2">
+                                <RadioButton
+                                Style="{StaticResource MaterialDesignTabRadioButtonLeft}"
+                                Margin="4"
+                                IsChecked="True"
+                                Content="FIRST"/>
+
+                                <RadioButton
+                                Style="{StaticResource MaterialDesignTabRadioButtonLeft}"
+                                Margin="4"
+                                IsChecked="False"
+                                Content="SECOND"/>
+
+                                <RadioButton
+                                Style="{StaticResource MaterialDesignTabRadioButtonLeft}"
+                                Margin="4"
+                                IsChecked="False"
+                                IsEnabled="False"
+                                Content="THIRD"/>
+                            </StackPanel>
+                        </materialDesign:ColorZone>
+                    </smtx:XamlDisplay>
+                </StackPanel>
+            </WrapPanel>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
@@ -242,10 +242,6 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RadioButton}">
                     <Grid SnapsToDevicePixels="true">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="*" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
                         <ProgressBar x:Name="ProgressBar"
                                        Style="{DynamicResource MaterialDesignLinearProgressBar}"
                                        Minimum="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Minimum)}"
@@ -260,10 +256,8 @@
                                        Opacity="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Opacity)}"
                                        HorizontalAlignment="Left"
                                        VerticalAlignment="Center"
-                                       BorderThickness="0"
-                                       Grid.Row="0"
-                                       Grid.RowSpan="2" />
-                        <Border Background="{TemplateBinding Background}" Grid.Row="0">
+                                       BorderThickness="0" />
+                        <Border Background="{TemplateBinding Background}" Margin="{TemplateBinding BorderThickness}">
                             <wpf:Ripple Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Focusable="False"
                                         HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                         VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -272,8 +266,7 @@
                                         Opacity=".82"
                                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
-                        <Border x:Name="SelectionHighlightBorder" Background="{TemplateBinding BorderBrush}" Height="2"
-                                Grid.Row="1"
+                        <Border x:Name="SelectionHighlightBorder" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}"
                                 Visibility="Hidden" />
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -289,7 +282,19 @@
             </Setter.Value>
         </Setter>
     </Style>
-
+    <Style x:Key="MaterialDesignTabRadioButtonLeft"  TargetType="{x:Type RadioButton}" BasedOn="{StaticResource MaterialDesignTabRadioButton}">
+        <Setter Property="BorderThickness" Value="2 0 0 0" />
+    </Style>
+    <Style x:Key="MaterialDesignTabRadioButtonTop"  TargetType="{x:Type RadioButton}" BasedOn="{StaticResource MaterialDesignTabRadioButton}">
+        <Setter Property="BorderThickness" Value="0 2 0 0" />
+    </Style>
+    <Style x:Key="MaterialDesignTabRadioButtonRight"  TargetType="{x:Type RadioButton}" BasedOn="{StaticResource MaterialDesignTabRadioButton}">
+        <Setter Property="BorderThickness" Value="0 0 2 0" />
+    </Style>
+    <Style x:Key="MaterialDesignTabRadioButtonBottom"  TargetType="{x:Type RadioButton}" BasedOn="{StaticResource MaterialDesignTabRadioButton}">
+        <Setter Property="BorderThickness" Value="0 0 0 2" />
+    </Style>
+    
     <Style x:Key="MaterialDesignToolRadioButton" TargetType="{x:Type RadioButton}">
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}"/>


### PR DESCRIPTION
Previously the selected line could only be depicted at the bottom of the MaterialDesignTabRadioButton. In some cases you also want it on other sides of the tab.
This feature makes it able to change the BorderThickness to manipulate the border.

I added convenience styles: MaterialDesignTabRadioButtonLeft, MaterialDesignTabRadioButtonTop, MaterialDesignTabRadioButtonRight, MaterialDesignTabRadioButtonBottom

The Toggles.xaml is updated to contain examples