### PR TITLE
Feature/material desing tab radio button default bottom line fix

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
@@ -229,6 +229,7 @@
         <Setter Property="Padding" Value="16 4 16 4"/>
         <Setter Property="MinHeight" Value="32" />
         <Setter Property="MinWidth" Value="80" />
+        <Setter Property="BorderThickness" Value="0 0 0 2" />
         <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesignFlatButtonRipple}" />
         <Setter Property="TextBlock.FontWeight" Value="Medium"/>
         <Setter Property="TextBlock.FontSize" Value="14"/>


### PR DESCRIPTION
This commit fixes the MaterialDesignTabRadioButton style to have the bottom line (as it always did).
This line accidentily got lost in my previous pull request.