### PR TITLE
Update disabled state opacity

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
@@ -113,7 +113,7 @@
                             <Setter TargetName="border" Property="wpf:ShadowAssist.Darken" Value="True" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Opacity" Value="0.23"/>
+                            <Setter Property="Opacity" Value="0.38"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -200,7 +200,7 @@
                                                                                         ConverterParameter=0.16}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Opacity" Value="0.23"/>
+                            <Setter Property="Opacity" Value="0.38"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -306,7 +306,7 @@
 
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Opacity" Value="0.23"/>
+                            <Setter Property="Opacity" Value="0.38"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -360,7 +360,7 @@
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Opacity" Value="0.23"/>
+                            <Setter Property="Opacity" Value="0.38"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -436,7 +436,7 @@
                             <Setter Property="Stroke" TargetName="border" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Opacity" Value="0.23"/>
+                            <Setter Property="Opacity" Value="0.38"/>
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="border" Property="wpf:ShadowAssist.Darken" Value="True" />
@@ -588,7 +588,7 @@
                             <Setter Property="Visibility" TargetName="overlay" Value="Visible"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Opacity" Value="0.23"/>
+                            <Setter Property="Opacity" Value="0.38"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -656,7 +656,7 @@
                                                                                         ConverterParameter=0.16}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Opacity" Value="0.23"/>
+                            <Setter Property="Opacity" Value="0.38"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -123,7 +123,7 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Opacity" Value="0.23"/>
+                            <Setter Property="Opacity" Value="0.38"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -244,7 +244,7 @@
                                         </Grid>
                                         <ControlTemplate.Triggers>
                                             <Trigger Property="IsEnabled" Value="false">
-                                                <Setter Property="Opacity" Value="0.23"/>
+                                                <Setter Property="Opacity" Value="0.38"/>
                                             </Trigger>
                                             <Trigger Property="IsMouseOver" Value="True">
                                                 <Setter TargetName="border" Property="wpf:ShadowAssist.Darken" Value="True" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
@@ -276,7 +276,7 @@
                             <Setter TargetName="SelectionHighlightBorder" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.23"/>
+                            <Setter Property="Opacity" Value="0.38"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Snackbar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Snackbar.xaml
@@ -44,7 +44,7 @@
                             <Setter Property="Background" Value="{DynamicResource MaterialDesignSnackbarMouseOver}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Opacity" Value="0.23" />
+                            <Setter Property="Opacity" Value="0.38" />
                         </Trigger>
                         <Trigger Property="DockPanel.Dock" Value="Bottom">
                             <Setter Property="Margin" Value="0 18 -8 -8" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -160,7 +160,7 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.23"/>
+                            <Setter Property="Opacity" Value="0.38"/>
                         </Trigger>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter TargetName="contentPresenter" Property="Opacity" Value="1"/>
@@ -269,7 +269,7 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.23"/>
+                            <Setter Property="Opacity" Value="0.38"/>
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True" SourceName="Root">
                             <Setter TargetName="MouseOverBorder" Property="Visibility" Value="Visible"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
@@ -51,7 +51,7 @@
                                 <VisualState x:Name="Normal"/>
                                 <VisualState x:Name="Disabled">
                                     <Storyboard>
-                                        <DoubleAnimation Duration="0" To="0.23" Storyboard.TargetProperty="(UIElement.Opacity)" />
+                                        <DoubleAnimation Duration="0" To="0.38" Storyboard.TargetProperty="(UIElement.Opacity)" />
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
@@ -186,7 +186,7 @@
                                 <VisualState x:Name="Normal"/>
                                 <VisualState x:Name="Disabled">
                                     <Storyboard>
-                                        <DoubleAnimation Duration="0" To="0.23" Storyboard.TargetProperty="(UIElement.Opacity)" />
+                                        <DoubleAnimation Duration="0" To="0.38" Storyboard.TargetProperty="(UIElement.Opacity)" />
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
@@ -452,7 +452,7 @@
                                 <VisualState Name="Normal"/>
                                 <VisualState Name="Disabled">
                                     <Storyboard>
-                                        <DoubleAnimation Duration="0" To="0.23" Storyboard.TargetProperty="(UIElement.Opacity)" />
+                                        <DoubleAnimation Duration="0" To="0.38" Storyboard.TargetProperty="(UIElement.Opacity)" />
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>


### PR DESCRIPTION
Resolves #2268.

In addition to Button, multiple controls were using 0.23 opacity for their disabled state, so I went ahead and changed them to 0.38 as well (as stated in https://material.io/design/interaction/states.html#disabled). There are a few other 0.23 opacity values still remaining, such as in "**Clock.xaml**" or for "**AttentionToActionBrush**", but they are not used for a disabled state and I do not know where their value originates from, so I left them alone.