### PR TITLE
Combo box template

### DIFF
--- a/MainDemo.Wpf/ComboBoxes.xaml
+++ b/MainDemo.Wpf/ComboBoxes.xaml
@@ -38,7 +38,7 @@
                     <Setter Property="Width" Value="96" />
                 </Style>
             </StackPanel.Resources>
-     
+
             <smtx:XamlDisplay UniqueKey="comboboxes_1" Margin="0">
 
                 <ComboBox materialDesign:HintAssist.Hint="OS">
@@ -47,7 +47,7 @@
                     <ComboBoxItem Content="Linux"/>
                     <ComboBoxItem Content="Windows"/>
                 </ComboBox>
-            </smtx:XamlDisplay>           
+            </smtx:XamlDisplay>
             <smtx:XamlDisplay UniqueKey="comboboxes_2">
                 <ComboBox
                     materialDesign:HintAssist.Hint="Search"
@@ -78,7 +78,7 @@
                     materialDesign:TextFieldAssist.HasClearButton="True"
                     materialDesign:TextFieldAssist.SuffixText="sw"
                     materialDesign:TextFieldAssist.UnderlineBrush="{DynamicResource SecondaryHueMidBrush}"
-                    materialDesign:ColorZoneAssist.Mode="Inverted"
+                    materialDesign:ColorZoneAssist.Mode="SecondaryLight"
                     materialDesign:HintAssist.Hint="OS"
                     materialDesign:HintAssist.HelperText="Select one OS"
                     MinWidth="128">

--- a/MainDemo.Wpf/FieldsLineUp.xaml
+++ b/MainDemo.Wpf/FieldsLineUp.xaml
@@ -199,10 +199,10 @@
                     Grid.Column="3"
                     Grid.Row="3"
                     Style="{StaticResource MaterialDesignFilledComboBox}" />
-                <TextBlock
+                <ComboBox
                     Grid.Column="3"
                     Grid.Row="4"
-                    Style="{StaticResource NotAvailable}" />
+                    Style="{StaticResource MaterialDesignOutlinedComboBox}" />
 
                 <DatePicker
                     Grid.Column="4"

--- a/MaterialDesignThemes.Wpf/ComboBoxAssist.cs
+++ b/MaterialDesignThemes.Wpf/ComboBoxAssist.cs
@@ -1,9 +1,11 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 
 namespace MaterialDesignThemes.Wpf
 {
     public static class ComboBoxAssist
     {
+        [Obsolete("ClassicMode is now obsolete and has no affect.")]
         /// <summary>
         /// By default ComboBox uses the wrapper popup. Popup can be switched to classic Windows desktop view by means of this attached property.
         /// </summary>
@@ -14,9 +16,11 @@ namespace MaterialDesignThemes.Wpf
             new FrameworkPropertyMetadata(false,
                 FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
 
+        [Obsolete("ClassicMode is now obsolete and has no affect.")]
         public static bool GetClassicMode(DependencyObject element)
             => (bool)element.GetValue(ClassicModeProperty);
 
+        [Obsolete("ClassicMode is now obsolete and has no affect.")]
         public static void SetClassicMode(DependencyObject element, bool value)
             => element.SetValue(ClassicModeProperty, value);
 

--- a/MaterialDesignThemes.Wpf/ComboBoxAssist.cs
+++ b/MaterialDesignThemes.Wpf/ComboBoxAssist.cs
@@ -5,10 +5,10 @@ namespace MaterialDesignThemes.Wpf
 {
     public static class ComboBoxAssist
     {
-        [Obsolete("ClassicMode is now obsolete and has no affect.")]
         /// <summary>
         /// By default ComboBox uses the wrapper popup. Popup can be switched to classic Windows desktop view by means of this attached property.
         /// </summary>
+        [Obsolete("ClassicMode is now obsolete and has no affect.")]
         public static readonly DependencyProperty ClassicModeProperty = DependencyProperty.RegisterAttached(
             "ClassicMode",
             typeof(bool),

--- a/MaterialDesignThemes.Wpf/ComboBoxPopup.cs
+++ b/MaterialDesignThemes.Wpf/ComboBoxPopup.cs
@@ -226,12 +226,10 @@ namespace MaterialDesignThemes.Wpf
         protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
         {
             base.OnPropertyChanged(e);
-            if (e.Property == ChildProperty)
+            if (e.Property == ChildProperty &&
+                PopupPlacement != ComboBoxPopupPlacement.Undefined)
             {
-                if (PopupPlacement != ComboBoxPopupPlacement.Undefined)
-                {
-                    UpdateChildTemplate(PopupPlacement);
-                }
+                UpdateChildTemplate(PopupPlacement);
             }
         }
 
@@ -270,11 +268,8 @@ namespace MaterialDesignThemes.Wpf
 
         private void SetChildTemplateIfNeed(ControlTemplate? template)
         {
-            var contentControl = Child as ContentControl;
-            if (contentControl is null) return;
-            //throw new InvalidOperationException($"The type of {nameof(Child)} must be {nameof(ContentControl)}");
-
-            if (!ReferenceEquals(contentControl.Template, template))
+            if (Child is ContentControl contentControl &&
+                !ReferenceEquals(contentControl.Template, template))
             {
                 contentControl.Template = template;
             }
@@ -293,7 +288,7 @@ namespace MaterialDesignThemes.Wpf
             var screen = Screen.FromPoint(locationFromScreen);
             var screenWidth = (int)screen.Bounds.Width;
             var screenHeight = (int)screen.Bounds.Height;
-            
+
             //Adjust the location to be in terms of the current screen
             var locationX = (int)(locationFromScreen.X - screen.Bounds.X) % screenWidth;
             var locationY = (int)(locationFromScreen.Y - screen.Bounds.Y) % screenHeight;
@@ -321,13 +316,9 @@ namespace MaterialDesignThemes.Wpf
         {
             return delegate (DependencyObject d, DependencyPropertyChangedEventArgs e)
             {
-                var popup = d as ComboBoxPopup;
-                if (popup is null) return;
-
-                var template = e.NewValue as ControlTemplate;
-                if (template is null) return;
-
-                if (popup.PopupPlacement == popupPlacement)
+                if (d is ComboBoxPopup popup &&
+                    e.NewValue is ControlTemplate template &&
+                    popup.PopupPlacement == popupPlacement)
                 {
                     popup.SetChildTemplateIfNeed(template);
                 }
@@ -354,12 +345,11 @@ namespace MaterialDesignThemes.Wpf
 
         private static void PopupPlacementPropertyChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            var popup = d as ComboBoxPopup;
-            if (popup is null) return;
-
-            if (!(e.NewValue is ComboBoxPopupPlacement)) return;
-            var placement = (ComboBoxPopupPlacement)e.NewValue;
-            popup.UpdateChildTemplate(placement);
+            if (d is ComboBoxPopup popup &&
+                e.NewValue is ComboBoxPopupPlacement placement)
+            {
+                popup.UpdateChildTemplate(placement);
+            }
         }
 
         private static CustomPopupPlacement GetClassicPopupPlacement(ComboBoxPopup popup, PositioningData data)
@@ -373,10 +363,10 @@ namespace MaterialDesignThemes.Wpf
         }
 
         private static CustomPopupPlacement GetDownPopupPlacement(PositioningData data)
-            => new CustomPopupPlacement(new Point(data.OffsetX, data.NewDownY), PopupPrimaryAxis.None);
+            => new(new Point(data.OffsetX, data.NewDownY), PopupPrimaryAxis.None);
 
         private static CustomPopupPlacement GetUpPopupPlacement(PositioningData data)
-            => new CustomPopupPlacement(new Point(data.OffsetX, data.NewUpY), PopupPrimaryAxis.None);
+            => new(new Point(data.OffsetX, data.NewUpY), PopupPrimaryAxis.None);
 
         private struct PositioningData
         {
@@ -398,9 +388,12 @@ namespace MaterialDesignThemes.Wpf
                 OffsetX = Round(offsetX);
                 NewUpY = Round(newUpY);
                 NewDownY = Round(newDownY);
-                PopupSize = popupSize; TargetSize = targetSize;
-                LocationX = locationX; LocationY = locationY;
-                ScreenWidth = screenWidth; ScreenHeight = screenHeight;
+                PopupSize = popupSize;
+                TargetSize = targetSize;
+                LocationX = locationX;
+                LocationY = locationY;
+                ScreenWidth = screenWidth;
+                ScreenHeight = screenHeight;
             }
         }
     }

--- a/MaterialDesignThemes.Wpf/ComboBoxPopupPlacement.cs
+++ b/MaterialDesignThemes.Wpf/ComboBoxPopupPlacement.cs
@@ -1,5 +1,8 @@
-﻿namespace MaterialDesignThemes.Wpf
+﻿using System;
+
+namespace MaterialDesignThemes.Wpf
 {
+    [Obsolete("ComboBoxPopupPlacement is now obsolete and no longer used.")]
     public enum ComboBoxPopupPlacement
     {
         Undefined,

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -529,12 +529,10 @@
                                AllowsTransparency="True"
                                ClassicMode="True"
                                ClassicContentTemplate="{StaticResource PopupContentClassicTemplate}"
-                               CornerRadius="0,0,4,4"
                                wpf:ColorZoneAssist.Mode="{Binding Path=(wpf:ColorZoneAssist.Mode), RelativeSource={RelativeSource TemplatedParent}}"
                                ContentMargin="6,0,6,6"
                                ContentMinWidth="{Binding Path=ActualWidth, ElementName=templateRoot}"
                                DefaultVerticalOffset="-1"
-                               DownContentTemplate="{StaticResource PopupContentDownTemplate}"
                                DownVerticalOffset="0"
                                Focusable="False"
                                HorizontalOffset="0"
@@ -547,7 +545,6 @@
                                Tag="{DynamicResource MaterialDesignPaper}"
                                UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
                                VerticalOffset="0"
-                               UpContentTemplate="{StaticResource PopupContentUpTemplate}"
                                UpVerticalOffset="15">
                     <wpf:ComboBoxPopup.Background>
                         <MultiBinding Converter="{StaticResource FallbackBrushConverter}">
@@ -555,6 +552,16 @@
                             <Binding Path="Tag" ElementName="PART_Popup" />
                         </MultiBinding>
                     </wpf:ComboBoxPopup.Background>
+                    <wpf:ComboBoxPopup.Style>
+                        <Style TargetType="wpf:ComboBoxPopup" BasedOn="{StaticResource {x:Type wpf:ComboBoxPopup}}">
+                            <Setter Property="CornerRadius" Value="0,0,4,4" />
+                            <Style.Triggers>
+                                <Trigger Property="OpenDirection" Value="Up">
+                                    <Setter Property="CornerRadius" Value="4,4,0,0" />
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </wpf:ComboBoxPopup.Style>
                     <ContentControl>
                         <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}"
                                   MinHeight="1"
@@ -941,7 +948,6 @@
 
     <Style x:Key="MaterialDesignComboBox" TargetType="{x:Type ComboBox}">
         <Setter Property="wpf:ComboBoxAssist.ShowSelectedItem" Value="False" />
-
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextBoxBorder}"/>
         <Setter Property="BorderThickness" Value="0 0 0 1"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -45,110 +45,6 @@
         </Setter>
     </Style>
 
-    <ControlTemplate x:Key="PopupContentUpTemplate" TargetType="ContentControl">
-        <Grid MinWidth="{Binding Path=ContentMinWidth, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}"
-              Margin="{Binding Path=ContentMargin, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
-            <Border Background="Transparent"
-                    BorderBrush="{DynamicResource MaterialDesignShadowBrush}"
-                    BorderThickness="1"
-                    CornerRadius="{Binding Path=CornerRadius, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}">
-                <Border.Effect>
-                    <BlurEffect Radius="6"/>
-                </Border.Effect>
-            </Border>
-            <Border Margin="1"
-                 CornerRadius="{Binding Path=CornerRadius, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}" >
-                <Grid SnapsToDevicePixels="True">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <Border Grid.Row="0" Height="{StaticResource PopupTopBottomMargin}" Background="{Binding ElementName=PART_Popup, Path=Background}"/>
-                    <ContentPresenter Grid.Row="1"/>
-                    <Border Grid.Row="2" Height="{StaticResource PopupContentPresenterExtend}" Background="{Binding ElementName=PART_Popup, Path=Background}"/>
-
-                    <Grid Grid.Row="3">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <Border Grid.Column="0" Width="{StaticResource PopupLeftRightMargin}" Background="{Binding ElementName=PART_Popup, Path=Background}"/>
-                        <Grid Grid.Column="1"
-                             Width="{Binding RelativeSource={RelativeSource AncestorType={x:Type wpf:ComboBoxPopup}}, Path=VisiblePlacementWidth}"
-                             Height="{Binding ElementName=templateRoot, Path=ActualHeight}"/>
-                        <Border Grid.Column="2" MinWidth="{StaticResource PopupLeftRightMargin}" Background="{Binding ElementName=PART_Popup, Path=Background}"/>
-                    </Grid>
-                    <Border Grid.Row="4" Height="{StaticResource PopupTopBottomMargin}" Background="{Binding ElementName=PART_Popup, Path=Background}"/>
-                </Grid>
-            </Border>
-        </Grid>
-    </ControlTemplate>
-
-    <ControlTemplate x:Key="PopupContentDownTemplate" TargetType="ContentControl">
-        <Grid MinWidth="{Binding Path=ContentMinWidth, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}"
-              Margin="{Binding Path=ContentMargin, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
-            <Border Background="Transparent"
-                    BorderBrush="{DynamicResource MaterialDesignShadowBrush}"
-                    BorderThickness="1"
-                    CornerRadius="{Binding Path=CornerRadius, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}">
-                <Border.Effect>
-                    <BlurEffect Radius="6"/>
-                </Border.Effect>
-            </Border>
-            <Border Margin="1"
-                    CornerRadius="{Binding Path=CornerRadius, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}">
-                <Grid SnapsToDevicePixels="True">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <Border Grid.Row="0"
-                        Height="{StaticResource PopupTopBottomMargin}"
-                        Background="{Binding ElementName=PART_Popup, Path=Background}"/>
-                    <Grid Grid.Row="1">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <Border Grid.Column="0"
-                            Background="{Binding ElementName=PART_Popup, Path=Background}"
-                            Width="{StaticResource PopupLeftRightMargin}"/>
-                        <Grid Grid.Column="1"
-                          Width="{Binding RelativeSource={RelativeSource AncestorType={x:Type wpf:ComboBoxPopup}}, Path=VisiblePlacementWidth}"
-                          Height="{Binding ElementName=templateRoot, Path=ActualHeight}"/>
-                        <Border Grid.Column="2"
-                            Background="{Binding ElementName=PART_Popup, Path=Background}"
-                            MinWidth="{StaticResource PopupLeftRightMargin}"/>
-                    </Grid>
-
-                    <Border Grid.Row="2"
-                        Background="{Binding ElementName=PART_Popup, Path=Background}"
-                        Height="{StaticResource PopupContentPresenterExtend}"/>
-
-                    <ContentPresenter Grid.Row="3"/>
-
-                    <Border Grid.Row="4"
-                        Background="{Binding ElementName=PART_Popup, Path=Background}"
-                        Height="{StaticResource PopupTopBottomMargin}" />
-                </Grid>
-            </Border>
-        </Grid>
-    </ControlTemplate>
-
     <ControlTemplate x:Key="PopupContentClassicTemplate" TargetType="ContentControl">
         <Grid MinWidth="{Binding Path=ContentMinWidth, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}"
               Margin="{Binding Path=ContentMargin, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}">
@@ -1010,5 +906,111 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
     </Style>
+
+    <!-- OBSOLETE -->
+    <ControlTemplate x:Key="PopupContentUpTemplate" TargetType="ContentControl">
+        <Grid MinWidth="{Binding Path=ContentMinWidth, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}"
+              Margin="{Binding Path=ContentMargin, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Border Background="Transparent"
+                    BorderBrush="{DynamicResource MaterialDesignShadowBrush}"
+                    BorderThickness="1"
+                    CornerRadius="{Binding Path=CornerRadius, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}">
+                <Border.Effect>
+                    <BlurEffect Radius="6"/>
+                </Border.Effect>
+            </Border>
+            <Border Margin="1"
+                 CornerRadius="{Binding Path=CornerRadius, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}" >
+                <Grid SnapsToDevicePixels="True">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Border Grid.Row="0" Height="{StaticResource PopupTopBottomMargin}" Background="{Binding ElementName=PART_Popup, Path=Background}"/>
+                    <ContentPresenter Grid.Row="1"/>
+                    <Border Grid.Row="2" Height="{StaticResource PopupContentPresenterExtend}" Background="{Binding ElementName=PART_Popup, Path=Background}"/>
+
+                    <Grid Grid.Row="3">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Border Grid.Column="0" Width="{StaticResource PopupLeftRightMargin}" Background="{Binding ElementName=PART_Popup, Path=Background}"/>
+                        <Grid Grid.Column="1"
+                             Width="{Binding RelativeSource={RelativeSource AncestorType={x:Type wpf:ComboBoxPopup}}, Path=VisiblePlacementWidth}"
+                             Height="{Binding ElementName=templateRoot, Path=ActualHeight}"/>
+                        <Border Grid.Column="2" MinWidth="{StaticResource PopupLeftRightMargin}" Background="{Binding ElementName=PART_Popup, Path=Background}"/>
+                    </Grid>
+                    <Border Grid.Row="4" Height="{StaticResource PopupTopBottomMargin}" Background="{Binding ElementName=PART_Popup, Path=Background}"/>
+                </Grid>
+            </Border>
+        </Grid>
+    </ControlTemplate>
+
+    <!-- OBSOLETE -->
+    <ControlTemplate x:Key="PopupContentDownTemplate" TargetType="ContentControl">
+        <Grid MinWidth="{Binding Path=ContentMinWidth, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}"
+              Margin="{Binding Path=ContentMargin, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Border Background="Transparent"
+                    BorderBrush="{DynamicResource MaterialDesignShadowBrush}"
+                    BorderThickness="1"
+                    CornerRadius="{Binding Path=CornerRadius, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}">
+                <Border.Effect>
+                    <BlurEffect Radius="6"/>
+                </Border.Effect>
+            </Border>
+            <Border Margin="1"
+                    CornerRadius="{Binding Path=CornerRadius, RelativeSource={RelativeSource AncestorType=wpf:ComboBoxPopup}}">
+                <Grid SnapsToDevicePixels="True">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Border Grid.Row="0"
+                        Height="{StaticResource PopupTopBottomMargin}"
+                        Background="{Binding ElementName=PART_Popup, Path=Background}"/>
+                    <Grid Grid.Row="1">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Border Grid.Column="0"
+                            Background="{Binding ElementName=PART_Popup, Path=Background}"
+                            Width="{StaticResource PopupLeftRightMargin}"/>
+                        <Grid Grid.Column="1"
+                          Width="{Binding RelativeSource={RelativeSource AncestorType={x:Type wpf:ComboBoxPopup}}, Path=VisiblePlacementWidth}"
+                          Height="{Binding ElementName=templateRoot, Path=ActualHeight}"/>
+                        <Border Grid.Column="2"
+                            Background="{Binding ElementName=PART_Popup, Path=Background}"
+                            MinWidth="{StaticResource PopupLeftRightMargin}"/>
+                    </Grid>
+
+                    <Border Grid.Row="2"
+                        Background="{Binding ElementName=PART_Popup, Path=Background}"
+                        Height="{StaticResource PopupContentPresenterExtend}"/>
+
+                    <ContentPresenter Grid.Row="3"/>
+
+                    <Border Grid.Row="4"
+                        Background="{Binding ElementName=PART_Popup, Path=Background}"
+                        Height="{StaticResource PopupTopBottomMargin}" />
+                </Grid>
+            </Border>
+        </Grid>
+    </ControlTemplate>
 
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -421,6 +421,7 @@
                     x:Name="templateRoot"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"
+                    CornerRadius="{Binding Path=(wpf:TextFieldAssist.TextFieldCornerRadius), RelativeSource={RelativeSource TemplatedParent}}"
                     SnapsToDevicePixels="True"
                     wpf:BottomDashedLineAdorner.IsAttached="False">
                     <Grid>
@@ -526,28 +527,28 @@
                 <wpf:ComboBoxPopup x:Name="PART_Popup"
                                Grid.Column="0"
                                AllowsTransparency="True"
+                               ClassicMode="True"
+                               ClassicContentTemplate="{StaticResource PopupContentClassicTemplate}"
+                               CornerRadius="0,0,4,4"
+                               wpf:ColorZoneAssist.Mode="{Binding Path=(wpf:ColorZoneAssist.Mode), RelativeSource={RelativeSource TemplatedParent}}"
+                               ContentMargin="6,0,6,6"
+                               ContentMinWidth="{Binding Path=ActualWidth, ElementName=templateRoot}"
+                               DefaultVerticalOffset="-1"
+                               DownContentTemplate="{StaticResource PopupContentDownTemplate}"
+                               DownVerticalOffset="0"
                                Focusable="False"
                                HorizontalOffset="0"
-                               RelativeHorizontalOffset="-23"
                                IsOpen="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                               PlacementTarget="{Binding ElementName=templateRoot}"
-                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                               UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
                                Placement="Custom"
+                               PlacementTarget="{Binding ElementName=templateRoot}"
                                PopupAnimation="Fade"
-                               VerticalOffset="0"
-                               DefaultVerticalOffset="5"
-                               DownVerticalOffset="-15"
-                               UpVerticalOffset="15"
-                               CornerRadius="2"
-                               ContentMargin="6"
-                               ContentMinWidth="{Binding ElementName=templateRoot, Path=ActualWidth, Converter={StaticResource MathAddConverter}, ConverterParameter=32}"
-                               wpf:ColorZoneAssist.Mode="{Binding Path=(wpf:ColorZoneAssist.Mode), RelativeSource={RelativeSource TemplatedParent}}"
+                               RelativeHorizontalOffset="-6"
+                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                Tag="{DynamicResource MaterialDesignPaper}"
-                               ClassicMode="{Binding Path=(wpf:ComboBoxAssist.ClassicMode), RelativeSource={RelativeSource TemplatedParent}}"
+                               UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
+                               VerticalOffset="0"
                                UpContentTemplate="{StaticResource PopupContentUpTemplate}"
-                               DownContentTemplate="{StaticResource PopupContentDownTemplate}"
-                               ClassicContentTemplate="{StaticResource PopupContentClassicTemplate}">
+                               UpVerticalOffset="15">
                     <wpf:ComboBoxPopup.Background>
                         <MultiBinding Converter="{StaticResource FallbackBrushConverter}">
                             <Binding Path="Background" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -587,17 +588,6 @@
             </Grid>
         </AdornerDecorator>
         <ControlTemplate.Triggers>
-            <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
-                <Setter TargetName="templateRoot" Property="CornerRadius" Value="{Binding Path=(wpf:TextFieldAssist.TextFieldCornerRadius), RelativeSource={RelativeSource TemplatedParent}}" />
-                <Setter TargetName="PART_Popup" Property="RelativeHorizontalOffset" Value="-6" />
-                <Setter TargetName="PART_Popup" Property="DefaultVerticalOffset" Value="-1" />
-                <Setter TargetName="PART_Popup" Property="DownVerticalOffset" Value="0" />
-                <Setter TargetName="PART_Popup" Property="UpVerticalOffset" Value="0" />
-                <Setter TargetName="PART_Popup" Property="CornerRadius" Value="0,0,4,4" />
-                <Setter TargetName="PART_Popup" Property="ContentMargin" Value="6,0,6,6" />
-                <Setter TargetName="PART_Popup" Property="ContentMinWidth" Value="{Binding Path=ActualWidth, ElementName=templateRoot}" />
-                <Setter TargetName="PART_Popup" Property="ClassicMode" Value="True" />
-            </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
                 <Setter TargetName="templateRoot" Property="CornerRadius" Value="{Binding Path=(wpf:TextFieldAssist.TextFieldCornerRadius), RelativeSource={RelativeSource TemplatedParent}}" />
                 <Setter TargetName="PART_Popup" Property="RelativeHorizontalOffset" Value="-6" />
@@ -607,7 +597,6 @@
                 <Setter TargetName="PART_Popup" Property="CornerRadius" Value="{Binding Path=(wpf:TextFieldAssist.TextFieldCornerRadius), RelativeSource={RelativeSource TemplatedParent}}" />
                 <Setter TargetName="PART_Popup" Property="ContentMargin" Value="6,0,6,6" />
                 <Setter TargetName="PART_Popup" Property="ContentMinWidth" Value="{Binding Path=ActualWidth, ElementName=templateRoot}" />
-                <Setter TargetName="PART_Popup" Property="ClassicMode" Value="True" />
                 <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
                 <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
                 <Setter TargetName="HintWrapper" Property="Opacity"
@@ -624,14 +613,6 @@
                     </Setter.Value>
                 </Setter>
             </Trigger>
-            <MultiTrigger>
-                <MultiTrigger.Conditions>
-                    <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
-                    <Condition SourceName="PART_Popup" Property="PopupPlacement" Value="Classic" />
-                </MultiTrigger.Conditions>
-                <Setter Property="ItemContainerStyle" Value="{StaticResource MaterialDesignComboBoxItemStyle}" />
-            </MultiTrigger>
             <Trigger Property="IsEditable" Value="True">
                 <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible" />
                 <Setter TargetName="Underline" Property="Visibility"
@@ -699,21 +680,10 @@
                 </MultiTrigger.Conditions>
                 <Setter TargetName="templateRoot" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
             </MultiTrigger>
+            <!-- TODO Single trigger -->
             <MultiTrigger>
                 <MultiTrigger.Conditions>
                     <Condition Property="IsEnabled" Value="False" />
-                    <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
-                </MultiTrigger.Conditions>
-                <Setter TargetName="templateRoot" Property="wpf:BottomDashedLineAdorner.Brush" Value="{Binding BorderBrush, RelativeSource={RelativeSource TemplatedParent}}" />
-                <Setter TargetName="templateRoot" Property="wpf:BottomDashedLineAdorner.Thickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}}" />
-                <Setter TargetName="templateRoot" Property="wpf:BottomDashedLineAdorner.IsAttached" Value="True" />
-                <Setter TargetName="templateRoot" Property="BorderBrush" Value="Transparent" />
-            </MultiTrigger>
-            <MultiTrigger>
-                <MultiTrigger.Conditions>
-                    <Condition Property="IsEnabled" Value="False" />
-                    <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
                 </MultiTrigger.Conditions>
                 <Setter TargetName="toggleButton" Property="BorderBrush" Value="Transparent" />
             </MultiTrigger>
@@ -790,10 +760,10 @@
             </MultiTrigger>
 
             <!-- IsDropDownOpen -->
+            <!-- TODO: Single trigger -->
             <MultiTrigger>
                 <MultiTrigger.Conditions>
                     <Condition Property="IsDropDownOpen" Value="True" />
-                    <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
                 </MultiTrigger.Conditions>
                 <Setter TargetName="Underline" Property="IsActive" Value="True" />
             </MultiTrigger>
@@ -821,17 +791,6 @@
                     <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
                 </MultiTrigger.Conditions>
                 <Setter TargetName="HintWrapper" Property="Opacity" Value="1" />
-            </MultiTrigger>
-            <MultiTrigger>
-                <MultiTrigger.Conditions>
-                    <Condition Property="IsDropDownOpen" Value="True" />
-                    <Condition Property="IsEditable" Value="False" />
-                    <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
-                </MultiTrigger.Conditions>
-                <Setter TargetName="Underline" Property="Visibility" Value="Hidden" />
-                <Setter TargetName="toggleButton" Property="BorderBrush" Value="Transparent" />
-                <Setter TargetName="templateRoot" Property="BorderBrush" Value="Transparent" />
             </MultiTrigger>
 
             <!-- IsMouseOver -->
@@ -877,14 +836,6 @@
             </MultiTrigger>
 
             <!-- PART_Popup.IsOpen -->
-            <MultiTrigger>
-                <MultiTrigger.Conditions>
-                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True" />
-                    <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
-                </MultiTrigger.Conditions>
-                <Setter Property="Background" TargetName="templateRoot" Value="{Binding Background, ElementName=PART_Popup}" />
-            </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
                     <Condition SourceName="PART_Popup" Property="IsOpen" Value="True" />
@@ -989,7 +940,6 @@
     </ControlTemplate>
 
     <Style x:Key="MaterialDesignComboBox" TargetType="{x:Type ComboBox}">
-        <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
         <Setter Property="wpf:ComboBoxAssist.ShowSelectedItem" Value="False" />
 
         <Setter Property="Background" Value="Transparent"/>
@@ -1034,7 +984,6 @@
     </Style>
 
     <Style x:Key="MaterialDesignFilledComboBox" TargetType="{x:Type ComboBox}" BasedOn="{StaticResource MaterialDesignFloatingHintComboBox}">
-        <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
         <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />
         <Setter Property="wpf:ComboBoxAssist.ShowSelectedItem" Value="False" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -440,7 +440,6 @@
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
@@ -475,7 +474,6 @@
                                 <wpf:SmartHint
                                     x:Name="Hint"
                                     Grid.Column="1"
-                                    Grid.ColumnSpan="2"
                                     HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                     FontSize="{TemplateBinding FontSize}"
                                     FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
@@ -500,7 +498,7 @@
 
                                 <TextBlock
                                     x:Name="SuffixTextBlock"
-                                    Grid.Column="3"
+                                    Grid.Column="2"
                                     FontSize="{TemplateBinding FontSize}"
                                     Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                     Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}"
@@ -940,12 +938,32 @@
             <MultiTrigger>
                 <MultiTrigger.Conditions>
                     <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
+                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="SecondaryLight"/>
+                </MultiTrigger.Conditions>
+                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource SecondaryHueLightBrush}" />
+                <Setter TargetName="PART_Popup" Property="Background"
+                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryHueLightForegroundBrush}" />
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
                     <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="SecondaryMid"/>
                 </MultiTrigger.Conditions>
                 <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource SecondaryHueMidBrush}" />
                 <Setter TargetName="PART_Popup" Property="Background"
                         Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
                 <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
+                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="SecondaryDark"/>
+                </MultiTrigger.Conditions>
+                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource SecondaryHueDarkBrush}" />
+                <Setter TargetName="PART_Popup" Property="Background"
+                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryHueDarkForegroundBrush}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
@@ -971,6 +989,9 @@
     </ControlTemplate>
 
     <Style x:Key="MaterialDesignComboBox" TargetType="{x:Type ComboBox}">
+        <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
+        <Setter Property="wpf:ComboBoxAssist.ShowSelectedItem" Value="False" />
+
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextBoxBorder}"/>
         <Setter Property="BorderThickness" Value="0 0 0 1"/>
@@ -980,10 +1001,10 @@
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
         <Setter Property="Padding" Value="{x:Static wpf:Constants.TextBoxDefaultPadding}" />
-        <Setter Property="VerticalContentAlignment" Value="Top" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         <Setter Property="HorizontalAlignment" Value="Stretch"/>
-        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalAlignment" Value="Stretch"/>
         <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
         <Setter Property="ScrollViewer.PanningMode" Value="Both" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />


### PR DESCRIPTION
Fixes #2340

This brings the ComboBox template inline with the latest material design specification. Rather than attempting to put the popup over the top of the ComboBox, it places it just below the underline. 
This also marks many ComboBox members as obsolete, these will be removed in a future version.