### PR TITLE
Fix RangeSlider style to match Slider

### DIFF
--- a/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.RangeSlider.xaml
+++ b/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.RangeSlider.xaml
@@ -124,25 +124,25 @@
                         Background="Transparent"
                         Orientation="Horizontal">
                 <RepeatButton x:Name="PART_LeftEdge"
-                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
+                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillBrush)}"
                               Style="{DynamicResource MaterialDesign.RangeSlider.HorizontalTrack}" />
 
                 <controls:MetroThumb x:Name="PART_LeftThumb"
-                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
+                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillBrush)}"
                                      Cursor="Arrow"
                                      Style="{DynamicResource MaterialDesign.RangeSlider.Thumb}" />
                 <controls:MetroThumb x:Name="PART_MiddleThumb"
                                      MinWidth="{TemplateBinding MinRangeWidth}"
                                      Cursor="Hand"
-                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
+                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackValueFillBrush)}"
                                      Style="{DynamicResource MaterialDesign.RangeSlider.HorizontalMiddleThumb}" />
                 <controls:MetroThumb x:Name="PART_RightThumb"
-                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
+                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillBrush)}"
                                      Cursor="Arrow"
                                      Style="{DynamicResource MaterialDesign.RangeSlider.Thumb}" />
 
                 <RepeatButton x:Name="PART_RightEdge"
-                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
+                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillBrush)}"
                               Style="{DynamicResource MaterialDesign.RangeSlider.HorizontalTrack}" />
             </StackPanel>
         </Grid>
@@ -241,25 +241,25 @@
                         Background="Transparent"
                         Orientation="Vertical">
                 <RepeatButton x:Name="PART_RightEdge"
-                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
+                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillBrush)}"
                               Style="{DynamicResource MaterialDesign.RangeSlider.VerticalTrack}" />
 
                 <controls:MetroThumb x:Name="PART_RightThumb"
-                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
+                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillBrush)}"
                                      Cursor="Arrow"
                                      Style="{DynamicResource MaterialDesign.RangeSlider.Thumb}" />
                 <controls:MetroThumb x:Name="PART_MiddleThumb"
                                      MinHeight="{TemplateBinding MinRangeWidth}"
                                      Cursor="Hand"
-                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
+                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackValueFillBrush)}"
                                      Style="{StaticResource MaterialDesign.RangeSlider.VerticalMiddleThumb}" />
                 <controls:MetroThumb x:Name="PART_LeftThumb"
-                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
+                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillBrush)}"
                                      Cursor="Arrow"
                                      Style="{DynamicResource MaterialDesign.RangeSlider.Thumb}" />
 
                 <RepeatButton x:Name="PART_LeftEdge"
-                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
+                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillBrush)}"
                               Style="{DynamicResource MaterialDesign.RangeSlider.VerticalTrack}" />
             </StackPanel>
         </Grid>

--- a/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.RangeSlider.xaml
+++ b/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.RangeSlider.xaml
@@ -1,5 +1,6 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf;assembly=MaterialDesignThemes.Wpf"
                     xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls">
 
     <ResourceDictionary.MergedDictionaries>
@@ -25,7 +26,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:MetroThumb}">
                     <Grid Background="{TemplateBinding Background}">
-                        <Rectangle Height="2" Fill="{TemplateBinding Foreground}" />
+                        <Rectangle Height="6" Margin="-2 0" Fill="{TemplateBinding Foreground}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
@@ -39,7 +40,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:MetroThumb}">
                     <Grid Background="{TemplateBinding Background}">
-                        <Rectangle Width="2" Fill="{TemplateBinding Foreground}" />
+                        <Rectangle Width="6" Margin="0 -2" Fill="{TemplateBinding Foreground}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
@@ -57,7 +58,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RepeatButton}">
                     <Grid Background="{TemplateBinding Background}">
-                        <Rectangle Height="2" Fill="{TemplateBinding Foreground}" />
+                        <Rectangle Height="4" Opacity="0.38" RadiusX="2" RadiusY="2" Fill="{TemplateBinding Foreground}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
@@ -71,7 +72,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RepeatButton}">
                     <Grid Background="{TemplateBinding Background}">
-                        <Rectangle Width="2" Fill="{TemplateBinding Foreground}" />
+                        <Rectangle Width="4" Opacity="0.38" RadiusX="2" RadiusY="2" Fill="{TemplateBinding Foreground}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
@@ -91,6 +92,7 @@
             <TickBar x:Name="PART_TopTick"
                      Grid.Row="0"
                      Height="4"
+                     Margin="4,0,4,2"
                      Fill="{TemplateBinding Foreground}"
                      IsSelectionRangeEnabled="{TemplateBinding IsSelectionRangeEnabled}"
                      Maximum="{TemplateBinding Maximum}"
@@ -105,6 +107,7 @@
             <TickBar x:Name="PART_BottomTick"
                      Grid.Row="2"
                      Height="4"
+                     Margin="4,2,4,0"
                      Fill="{TemplateBinding Foreground}"
                      IsSelectionRangeEnabled="{TemplateBinding IsSelectionRangeEnabled}"
                      Maximum="{TemplateBinding Maximum}"
@@ -121,25 +124,25 @@
                         Background="Transparent"
                         Orientation="Horizontal">
                 <RepeatButton x:Name="PART_LeftEdge"
-                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillBrush)}"
+                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
                               Style="{DynamicResource MaterialDesign.RangeSlider.HorizontalTrack}" />
 
                 <controls:MetroThumb x:Name="PART_LeftThumb"
-                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillBrush)}"
+                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
                                      Cursor="Arrow"
                                      Style="{DynamicResource MaterialDesign.RangeSlider.Thumb}" />
                 <controls:MetroThumb x:Name="PART_MiddleThumb"
                                      MinWidth="{TemplateBinding MinRangeWidth}"
                                      Cursor="Hand"
-                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackValueFillBrush)}"
+                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
                                      Style="{DynamicResource MaterialDesign.RangeSlider.HorizontalMiddleThumb}" />
                 <controls:MetroThumb x:Name="PART_RightThumb"
-                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillBrush)}"
+                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
                                      Cursor="Arrow"
                                      Style="{DynamicResource MaterialDesign.RangeSlider.Thumb}" />
 
                 <RepeatButton x:Name="PART_RightEdge"
-                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillBrush)}"
+                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
                               Style="{DynamicResource MaterialDesign.RangeSlider.HorizontalTrack}" />
             </StackPanel>
         </Grid>
@@ -206,6 +209,7 @@
             <TickBar x:Name="PART_TopTick"
                      Grid.Column="0"
                      Width="4"
+                     Margin="0,4,2,4"
                      Fill="{TemplateBinding Foreground}"
                      IsSelectionRangeEnabled="{TemplateBinding IsSelectionRangeEnabled}"
                      Maximum="{TemplateBinding Maximum}"
@@ -220,6 +224,7 @@
             <TickBar x:Name="PART_BottomTick"
                      Grid.Column="2"
                      Width="4"
+                     Margin="2,4,0,4"
                      Fill="{TemplateBinding Foreground}"
                      IsSelectionRangeEnabled="{TemplateBinding IsSelectionRangeEnabled}"
                      Maximum="{TemplateBinding Maximum}"
@@ -236,25 +241,25 @@
                         Background="Transparent"
                         Orientation="Vertical">
                 <RepeatButton x:Name="PART_RightEdge"
-                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillBrush)}"
+                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
                               Style="{DynamicResource MaterialDesign.RangeSlider.VerticalTrack}" />
 
                 <controls:MetroThumb x:Name="PART_RightThumb"
-                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillBrush)}"
+                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
                                      Cursor="Arrow"
                                      Style="{DynamicResource MaterialDesign.RangeSlider.Thumb}" />
                 <controls:MetroThumb x:Name="PART_MiddleThumb"
                                      MinHeight="{TemplateBinding MinRangeWidth}"
                                      Cursor="Hand"
-                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackValueFillBrush)}"
+                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
                                      Style="{StaticResource MaterialDesign.RangeSlider.VerticalMiddleThumb}" />
                 <controls:MetroThumb x:Name="PART_LeftThumb"
-                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillBrush)}"
+                                     Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
                                      Cursor="Arrow"
                                      Style="{DynamicResource MaterialDesign.RangeSlider.Thumb}" />
 
                 <RepeatButton x:Name="PART_LeftEdge"
-                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillBrush)}"
+                              Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}"
                               Style="{DynamicResource MaterialDesign.RangeSlider.VerticalTrack}" />
             </StackPanel>
         </Grid>
@@ -309,20 +314,24 @@
     </ControlTemplate>
 
     <Style TargetType="{x:Type controls:RangeSlider}" x:Key="MaterialDesignRangeSlider">
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Margin" Value="6 0" />
         <Setter Property="controls:SliderHelper.ThumbFillBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
-        <Setter Property="controls:SliderHelper.ThumbFillDisabledBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <Setter Property="controls:SliderHelper.ThumbFillDisabledBrush" Value="{DynamicResource MaterialDesignCheckBoxDisabled}" />
         <Setter Property="controls:SliderHelper.ThumbFillHoverBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="controls:SliderHelper.ThumbFillPressedBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
-        <Setter Property="controls:SliderHelper.TrackFillBrush" Value="{DynamicResource MaterialDesignCheckBoxOff}" />
+        <Setter Property="controls:SliderHelper.TrackFillBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="controls:SliderHelper.TrackFillDisabledBrush" Value="{DynamicResource MaterialDesignCheckBoxDisabled}" />
-        <Setter Property="controls:SliderHelper.TrackFillHoverBrush" Value="{DynamicResource MaterialDesignCheckBoxOff}" />
-        <Setter Property="controls:SliderHelper.TrackFillPressedBrush" Value="{DynamicResource MaterialDesignCheckBoxOff}" />
+        <Setter Property="controls:SliderHelper.TrackFillHoverBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <Setter Property="controls:SliderHelper.TrackFillPressedBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="controls:SliderHelper.TrackValueFillBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
-        <Setter Property="controls:SliderHelper.TrackValueFillDisabledBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <Setter Property="controls:SliderHelper.TrackValueFillDisabledBrush" Value="{DynamicResource MaterialDesignCheckBoxDisabled}" />
         <Setter Property="controls:SliderHelper.TrackValueFillHoverBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="controls:SliderHelper.TrackValueFillPressedBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <Setter Property="IsMoveToPointEnabled" Value="True" />
+        <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth1" />
+        <Setter Property="wpf:SliderAssist.OnlyShowFocusVisualWhileDragging" Value="True" />
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="Template" Value="{StaticResource MaterialDesignMahAppsRangeSliderHorizontal}" />
@@ -330,6 +339,9 @@
         <Style.Triggers>
             <Trigger Property="Orientation" Value="Vertical">
                 <Setter Property="Template" Value="{StaticResource MaterialDesignRangeSliderVertical}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource MaterialDesignCheckBoxDisabled}" />
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.RangeSlider.xaml
+++ b/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.RangeSlider.xaml
@@ -160,38 +160,38 @@
 
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter TargetName="PART_LeftEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillHoverBrush)}" />
-                <Setter TargetName="PART_LeftThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillHoverBrush)}" />
+                <Setter TargetName="PART_LeftThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillHoverBrush)}" />
                 <Setter TargetName="PART_MiddleThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackValueFillHoverBrush)}" />
                 <Setter TargetName="PART_RightEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillHoverBrush)}" />
-                <Setter TargetName="PART_RightThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillHoverBrush)}" />
+                <Setter TargetName="PART_RightThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillHoverBrush)}" />
             </Trigger>
             <Trigger SourceName="PART_LeftEdge" Property="IsPressed" Value="True">
                 <Setter TargetName="PART_LeftEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillPressedBrush)}" />
-                <Setter TargetName="PART_LeftThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
+                <Setter TargetName="PART_LeftThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
                 <Setter TargetName="PART_MiddleThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackValueFillPressedBrush)}" />
                 <Setter TargetName="PART_RightEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillPressedBrush)}" />
-                <Setter TargetName="PART_RightThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
+                <Setter TargetName="PART_RightThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
             </Trigger>
             <Trigger SourceName="PART_RightEdge" Property="IsPressed" Value="True">
                 <Setter TargetName="PART_LeftEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillPressedBrush)}" />
-                <Setter TargetName="PART_LeftThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
+                <Setter TargetName="PART_LeftThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
                 <Setter TargetName="PART_MiddleThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackValueFillPressedBrush)}" />
                 <Setter TargetName="PART_RightEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillPressedBrush)}" />
-                <Setter TargetName="PART_RightThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
+                <Setter TargetName="PART_RightThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
             </Trigger>
             <Trigger SourceName="PART_MiddleThumb" Property="IsDragging" Value="True">
                 <Setter TargetName="PART_LeftEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillPressedBrush)}" />
-                <Setter TargetName="PART_LeftThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
+                <Setter TargetName="PART_LeftThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
                 <Setter TargetName="PART_MiddleThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackValueFillPressedBrush)}" />
                 <Setter TargetName="PART_RightEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillPressedBrush)}" />
-                <Setter TargetName="PART_RightThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
+                <Setter TargetName="PART_RightThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="False">
                 <Setter TargetName="PART_LeftEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillDisabledBrush)}" />
-                <Setter TargetName="PART_LeftThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillDisabledBrush)}" />
+                <Setter TargetName="PART_LeftThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillDisabledBrush)}" />
                 <Setter TargetName="PART_MiddleThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackValueFillDisabledBrush)}" />
                 <Setter TargetName="PART_RightEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillDisabledBrush)}" />
-                <Setter TargetName="PART_RightThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillDisabledBrush)}" />
+                <Setter TargetName="PART_RightThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillDisabledBrush)}" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
@@ -277,38 +277,38 @@
 
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter TargetName="PART_LeftEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillHoverBrush)}" />
-                <Setter TargetName="PART_LeftThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillHoverBrush)}" />
+                <Setter TargetName="PART_LeftThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillHoverBrush)}" />
                 <Setter TargetName="PART_MiddleThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackValueFillHoverBrush)}" />
                 <Setter TargetName="PART_RightEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillHoverBrush)}" />
-                <Setter TargetName="PART_RightThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillHoverBrush)}" />
+                <Setter TargetName="PART_RightThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillHoverBrush)}" />
             </Trigger>
             <Trigger SourceName="PART_LeftEdge" Property="IsPressed" Value="True">
                 <Setter TargetName="PART_LeftEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillPressedBrush)}" />
-                <Setter TargetName="PART_LeftThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
+                <Setter TargetName="PART_LeftThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
                 <Setter TargetName="PART_MiddleThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackValueFillPressedBrush)}" />
                 <Setter TargetName="PART_RightEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillPressedBrush)}" />
-                <Setter TargetName="PART_RightThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
+                <Setter TargetName="PART_RightThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
             </Trigger>
             <Trigger SourceName="PART_RightEdge" Property="IsPressed" Value="True">
                 <Setter TargetName="PART_LeftEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillPressedBrush)}" />
-                <Setter TargetName="PART_LeftThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
+                <Setter TargetName="PART_LeftThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
                 <Setter TargetName="PART_MiddleThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackValueFillPressedBrush)}" />
                 <Setter TargetName="PART_RightEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillPressedBrush)}" />
-                <Setter TargetName="PART_RightThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
+                <Setter TargetName="PART_RightThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
             </Trigger>
             <Trigger SourceName="PART_MiddleThumb" Property="IsDragging" Value="True">
                 <Setter TargetName="PART_LeftEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillPressedBrush)}" />
-                <Setter TargetName="PART_LeftThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
+                <Setter TargetName="PART_LeftThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
                 <Setter TargetName="PART_MiddleThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackValueFillPressedBrush)}" />
                 <Setter TargetName="PART_RightEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillPressedBrush)}" />
-                <Setter TargetName="PART_RightThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
+                <Setter TargetName="PART_RightThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillPressedBrush)}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="False">
                 <Setter TargetName="PART_LeftEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillDisabledBrush)}" />
-                <Setter TargetName="PART_LeftThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillDisabledBrush)}" />
+                <Setter TargetName="PART_LeftThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillDisabledBrush)}" />
                 <Setter TargetName="PART_MiddleThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackValueFillDisabledBrush)}" />
                 <Setter TargetName="PART_RightEdge" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.TrackFillDisabledBrush)}" />
-                <Setter TargetName="PART_RightThumb" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillDisabledBrush)}" />
+                <Setter TargetName="PART_RightThumb" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:SliderHelper.ThumbFillDisabledBrush)}" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>

--- a/MaterialDesignThemes.Wpf/SliderAssist.cs
+++ b/MaterialDesignThemes.Wpf/SliderAssist.cs
@@ -1,5 +1,5 @@
 ﻿using System.Windows;
-using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 
 namespace MaterialDesignThemes.Wpf
 {
@@ -12,10 +12,10 @@ namespace MaterialDesignThemes.Wpf
                 typeof(SliderAssist),
                 new PropertyMetadata(false));
 
-        public static void SetOnlyShowFocusVisualWhileDragging(Slider slider, bool value)
-            => slider.SetValue(OnlyShowFocusVisualWhileDraggingProperty, value);
+        public static void SetOnlyShowFocusVisualWhileDragging(RangeBase element, bool value)
+            => element.SetValue(OnlyShowFocusVisualWhileDraggingProperty, value);
 
-        public static bool GetOnlyShowFocusVisualWhileDragging(Slider element)
+        public static bool GetOnlyShowFocusVisualWhileDragging(RangeBase element)
             => (bool)element.GetValue(OnlyShowFocusVisualWhileDraggingProperty);
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
@@ -90,12 +90,12 @@
                 <Ellipse
                     x:Name="grip"
                     Fill="{TemplateBinding Foreground}"
-                    Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Slider}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
+                    Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
                     Margin="-1,0" />
             </AdornerDecorator>
         </Grid>
         <ControlTemplate.Triggers>
-            <DataTrigger Binding="{Binding Orientation, RelativeSource={RelativeSource FindAncestor, AncestorType=Track}}" Value="{x:Static Orientation.Vertical}">
+            <DataTrigger Binding="{Binding Orientation, RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}}" Value="{x:Static Orientation.Vertical}">
                 <Setter TargetName="thumbGrid" Property="Height" Value="18" />
                 <Setter TargetName="thumbGrid" Property="Width" Value="20" />
                 <Setter TargetName="grip" Property="Margin" Value="0,-1" />
@@ -119,8 +119,8 @@
             <DataTrigger Value="True">
                 <DataTrigger.Binding>
                     <MultiBinding Converter="{StaticResource BooleanAllConverter}">
-                        <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=Slider}" />
-                        <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=Slider}" Converter="{StaticResource InvertBooleanConverter}"  />
+                        <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
+                        <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" Converter="{StaticResource InvertBooleanConverter}"  />
                     </MultiBinding>
                 </DataTrigger.Binding>
                 <DataTrigger.EnterActions>
@@ -134,7 +134,7 @@
                 <DataTrigger.Binding>
                     <MultiBinding Converter="{StaticResource BooleanAllConverter}">
                         <Binding Path="IsDragging" RelativeSource="{RelativeSource Self}" />
-                        <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=Slider}" />
+                        <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
                     </MultiBinding>
                 </DataTrigger.Binding>
                 <DataTrigger.EnterActions>
@@ -255,7 +255,7 @@
                         <AdornerDecorator.CacheMode>
                             <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </AdornerDecorator.CacheMode>
-                        <Grid Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Slider}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}">
+                        <Grid Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}">
                             <Rectangle
                                 Fill="{DynamicResource MaterialDesignToolTipBackground}"
                                 Margin="0,0,0,5"
@@ -267,7 +267,7 @@
                     <TextBlock
                         Foreground="{DynamicResource MaterialDesignPaper}"
                         Margin="12,0,12,5"
-                        Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Slider}, Path=Value}"
+                        Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=Value}"
                         TextAlignment="Center"
                         VerticalAlignment="Center" />
                 </Grid>
@@ -279,7 +279,7 @@
                 <Ellipse
                     x:Name="grip"
                     Fill="{TemplateBinding Foreground}"
-                    Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Slider}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
+                    Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
                     Margin="-1,0" />
             </AdornerDecorator>
         </Grid>
@@ -303,8 +303,8 @@
             <DataTrigger Value="True">
                 <DataTrigger.Binding>
                     <MultiBinding Converter="{StaticResource BooleanAllConverter}">
-                        <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=Slider}" />
-                        <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=Slider}" Converter="{StaticResource InvertBooleanConverter}" />
+                        <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
+                        <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" Converter="{StaticResource InvertBooleanConverter}" />
                     </MultiBinding>
                 </DataTrigger.Binding>
                 <DataTrigger.EnterActions>
@@ -318,7 +318,7 @@
                 <DataTrigger.Binding>
                     <MultiBinding Converter="{StaticResource BooleanAllConverter}">
                         <Binding Path="IsDragging" RelativeSource="{RelativeSource Self}" />
-                        <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=Slider}" />
+                        <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
                     </MultiBinding>
                 </DataTrigger.Binding>
                 <DataTrigger.EnterActions>
@@ -439,7 +439,7 @@
                         <AdornerDecorator.CacheMode>
                             <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </AdornerDecorator.CacheMode>
-                        <Grid Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Slider}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}">
+                        <Grid Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}">
                             <Rectangle
                                 Fill="{DynamicResource MaterialDesignToolTipBackground}"
                                 Margin="0,0,5,0"
@@ -451,7 +451,7 @@
                     <TextBlock
                         Foreground="{DynamicResource MaterialDesignPaper}"
                         Margin="12,0,17,0"
-                        Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Slider}, Path=Value}"
+                        Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=Value}"
                         TextAlignment="Center"
                         VerticalAlignment="Center" />
                 </Grid>
@@ -462,7 +462,7 @@
                 </AdornerDecorator.CacheMode>
                 <Ellipse
                      x:Name="grip"
-                     Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Slider}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
+                     Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
                      Fill="{TemplateBinding Foreground}"
                      Margin="0,-1" />
             </AdornerDecorator>
@@ -487,8 +487,8 @@
             <DataTrigger Value="True">
                 <DataTrigger.Binding>
                     <MultiBinding Converter="{StaticResource BooleanAllConverter}">
-                        <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=Slider}" />
-                        <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=Slider}" Converter="{StaticResource InvertBooleanConverter}"  />
+                        <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
+                        <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" Converter="{StaticResource InvertBooleanConverter}"  />
                     </MultiBinding>
                 </DataTrigger.Binding>
                 <DataTrigger.EnterActions>
@@ -502,7 +502,7 @@
                 <DataTrigger.Binding>
                     <MultiBinding Converter="{StaticResource BooleanAllConverter}">
                         <Binding Path="IsDragging" RelativeSource="{RelativeSource Self}" />
-                        <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=Slider}" />
+                        <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
                     </MultiBinding>
                 </DataTrigger.Binding>
                 <DataTrigger.EnterActions>


### PR DESCRIPTION
Fix for #2350

There is no RangeSlider demo in the demo app. Adding RangeSlider demo would require referencing `MahApps.Metro` and `MaterialDesignThemes.MahApps.csproj` so I didnt include it in this PR.

It probably still doesnt match 100% in style/behavior, but this is how it looks now:
![2021-09-30_22-25-12](https://user-images.githubusercontent.com/63662834/135525939-3fa6f19e-e400-42c7-8cf0-d0c8ec3f9e38.png)

