### PR TITLE
Allow for setting ListBoxItemAssist.ShowSelection on the root control

### DIFF
--- a/MainDemo.Wpf/Lists.xaml
+++ b/MainDemo.Wpf/Lists.xaml
@@ -69,12 +69,15 @@
                 UniqueKey="list_4"
                 Grid.Column="1">
                 <Grid>
-                    <ListBox>
+                    <ListBox materialDesign:ListBoxItemAssist.ShowSelection="False">
+                        <!--
+                        Alternatively you can specify ListBoxItemAssist.ShowSelection on individual items
                         <ListBox.ItemContainerStyle>
                             <Style TargetType="ListBoxItem" BasedOn="{StaticResource MaterialDesignListBoxItem}">
                                 <Setter Property="materialDesign:ListBoxItemAssist.ShowSelection" Value="False"/>
                             </Style>
                         </ListBox.ItemContainerStyle>
+                        -->
                         <TextBlock Text="Listbox"/>
                         <TextBlock Text="Without"/>
                         <TextBlock Text="Selection"/>

--- a/MaterialDesignThemes.UITests/WPF/ListBoxes/ListBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/ListBoxes/ListBoxTests.cs
@@ -130,5 +130,25 @@ ScrollViewer.VerticalScrollBarVisibility=""Visible"">
 
             recorder.Success();
         }
+
+        [Fact]
+        public async Task OnListBoxAssist_WithShowSelectDisabled_SelectionIsDisabled()
+        {
+            await using var recorder = new TestRecorder(App);
+            var listBox = await LoadXaml<ListBox>($@"
+<ListBox materialDesign:ListBoxItemAssist.ShowSelection=""False"">
+    <ListBoxItem>Mercury</ListBoxItem>
+    <ListBoxItem>Venus</ListBoxItem>
+    <ListBoxItem>Earth</ListBoxItem>
+    <ListBoxItem>Pluto</ListBoxItem>
+</ListBox>
+");
+            var earth = await listBox.GetElement<ListBoxItem>("/ListBoxItem[2]");
+            await earth.LeftClick();
+            var selectedBorder = await earth.GetElement<Border>("SelectedBorder");
+            await Wait.For(async () => Assert.False(await selectedBorder.GetIsVisible()));
+
+            recorder.Success();
+        }
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
@@ -223,7 +223,7 @@
         <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
         <Setter Property="Padding" Value="8"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
-        <Setter Property="wpf:ListBoxItemAssist.ShowSelection" Value="True"/>
+        <Setter Property="wpf:ListBoxItemAssist.ShowSelection" Value="{Binding Path=(wpf:ListBoxItemAssist.ShowSelection), RelativeSource={RelativeSource AncestorType=ListBox}}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListBoxItem}">


### PR DESCRIPTION
This allows for it to propagate down.

Fixes #2450 