### PR TITLE
Fix ComboBox dropdown icon doesn't align to inner textbox when have a floating hint

### DIFF
--- a/MaterialDesignThemes.Wpf/Converters/ComboBoxClearButtonMarginConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/ComboBoxClearButtonMarginConverter.cs
@@ -11,9 +11,10 @@ namespace MaterialDesignThemes.Wpf.Converters
         {
             var padding = (Thickness)values[0];
             var borderThickness = (Thickness)values[1];
+            var floatingHintTopOffset = ((Thickness)values[2]).Top;
             return new Thickness(
                 borderThickness.Left,
-                borderThickness.Top + padding.Top,
+                borderThickness.Top + padding.Top + floatingHintTopOffset,
                 borderThickness.Right + padding.Right + Constants.ComboBoxArrowSize + Constants.TextBoxInnerButtonSpacing,
                 borderThickness.Bottom + padding.Bottom);
         }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -312,7 +312,8 @@
                     Style="{StaticResource MaterialDesignComboBoxToggleButton}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     Background="{TemplateBinding Background}"
-                    Padding="{TemplateBinding Padding}" />
+                    Padding="{TemplateBinding Padding}"
+                    Margin="{Binding ElementName=InnerRoot, Path=Margin}"/>
                 <Border
                     x:Name="templateRoot"
                     BorderBrush="{TemplateBinding BorderBrush}"
@@ -478,6 +479,7 @@
                         <MultiBinding Converter="{StaticResource ComboBoxClearButtonMarginConverter}">
                             <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Padding" />
                             <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="BorderThickness" />
+                            <Binding ElementName="InnerRoot" Path="Margin" />
                         </MultiBinding>
                     </Button.Margin>
                     <Button.Visibility>


### PR DESCRIPTION
Updates logic to account for margin on ComboBox `toggleButton` and ComboBox `PART_ClearButton` based on margin on ComboBox `InnerRoot`. The Top Margin (indicating the floatingHintOffset) is set on the `InnerRoot` when having a floating hint. The margins of the `toggleButton` and `PART_ClearButton` are updated based on it for proper alignment.

![image](https://user-images.githubusercontent.com/18148655/136704898-454438b5-b10a-469d-ac12-c0dc21b879c9.png)


Fixes #2258 