### PR TITLE
Disable CharacterCounter for RichTextBox, fixes #2462

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RichTextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RichTextBox.xaml
@@ -7,5 +7,6 @@
 
     <Style x:Key="MaterialDesignRichTextBox" TargetType="RichTextBox" BasedOn="{StaticResource MaterialDesignTextBoxBase}">
         <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="-4 0 1 0" />
+        <Setter Property="wpf:TextFieldAssist.CharacterCounterStyle" Value="{x:Null}" />
     </Style>
 </ResourceDictionary>


### PR DESCRIPTION
After investigating and trying to fix [this](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2462) issue I concluded that the best solution here is to disable the _CharacterCounter_ for `RichTextBox`, and in this way removing the binding errors that is reported in the issue.

`RichTextBox` supports neither `Text` or `MaxLength` in the original WPF control, both are needed properties in the current _CharacterCounter_ implementation. 

There are ways to get programmatically access to the content and do a count, but it will not count exactly what the end user will see as you can have line breaks and other formatting characters in the text.  I think this will lead to more bug reports about the counter reporting the wrong number. 

`MaxLength` can be implemented as well but its more logical to do it in a custom control. As per the contribution guidelines this is a theme library, not a control library.

If you agree @Keboo you can merge this PR :)

