### PR TITLE
Showcase outlined textbox with character counter

### DIFF
--- a/MainDemo.Wpf/Fields.xaml
+++ b/MainDemo.Wpf/Fields.xaml
@@ -304,6 +304,7 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
             <Grid.Resources>
@@ -393,6 +394,26 @@
                 Grid.Row="1"
                 Grid.Column="3"
                 UniqueKey="fields_29">
+                <StackPanel>
+                    <CheckBox
+                        x:Name="MaterialDesignOutlinedPasswordFieldTextCountComboBox"
+                        Content="View Text Input Count"/>
+
+                    <TextBox
+                        Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                        VerticalAlignment="Top"
+                        Height="100"
+                        TextWrapping="Wrap"
+                        MaxLength="40"
+                        materialDesign:TextFieldAssist.CharacterCounterVisibility="{Binding Path=IsChecked, ElementName=MaterialDesignOutlinedPasswordFieldTextCountComboBox, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        VerticalScrollBarVisibility="Auto"
+                        materialDesign:HintAssist.Hint="This is a limited text area"/>
+                </StackPanel>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay
+                Grid.Row="1"
+                Grid.Column="4"
+                UniqueKey="fields_30">
                 <StackPanel>
                     <CheckBox
                         x:Name="MaterialDesignOutlinedPasswordFieldPasswordBoxEnabledComboBox"


### PR DESCRIPTION
Fixes #2278

There seems to be an issue with the hint being cut off. Could that be the same as #2384?

Also I am experiencing that the character counter is hidden depending on window width. Seems a bit odd?