### PR TITLE
ExpandDuration and CollapseDuration bind dynamic

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
@@ -180,11 +180,11 @@
                                             <DoubleAnimation Storyboard.TargetProperty="Opacity" 
                                                              Storyboard.TargetName="ContentPanel" 
                                                              From="0" To="1"
-                                                             Duration="{StaticResource ExpandDuration}"/>
+                                                             Duration="{DynamicResource ExpandDuration}"/>
                                             <DoubleAnimation Storyboard.TargetName="ContentSiteScaleTransform" 
                                                              Storyboard.TargetProperty="(ScaleTransform.ScaleY)" 
                                                              From="0" To="1"
-                                                             Duration="{StaticResource ExpandDuration}">
+                                                             Duration="{DynamicResource ExpandDuration}">
                                                 <DoubleAnimation.EasingFunction>
                                                     <CubicEase EasingMode="EaseInOut"/>
                                                 </DoubleAnimation.EasingFunction>
@@ -197,11 +197,11 @@
                                             <DoubleAnimation Storyboard.TargetProperty="Opacity" 
                                                              Storyboard.TargetName="ContentPanel" 
                                                              From="1" To="0" 
-                                                             Duration="{StaticResource CollapseDuration}"/>
+                                                             Duration="{DynamicResource CollapseDuration}"/>
                                             <DoubleAnimation Storyboard.TargetName="ContentSiteScaleTransform" 
                                                              Storyboard.TargetProperty="(ScaleTransform.ScaleY)" 
                                                              From="1" To="0"
-                                                             Duration="{StaticResource CollapseDuration}">
+                                                             Duration="{DynamicResource CollapseDuration}">
                                                 <DoubleAnimation.EasingFunction>
                                                     <CubicEase EasingMode="EaseInOut"/>
                                                 </DoubleAnimation.EasingFunction>


### PR DESCRIPTION
To allow the duration of the animation to be overridden by the user, the binding has been changed from StaticResource to DynamicResource.

Background:
By animating the content of the expander, the complete content is rendered. If the content contains a list, all list elements are rendered, even if the list is virtualized. This leads to performance problems. 
By setting the animation duration to 0, the problem can be circumvented. 