### PR TITLE
Implementing canceling of drawer host closing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Company>Mulholland Software/James Willock</Company>
 
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
 
     <SignAssembly>true</SignAssembly>

--- a/Directory.packages.props
+++ b/Directory.packages.props
@@ -20,7 +20,7 @@
         <PackageVersion Include="ShowMeTheXAML.AvalonEdit" Version="2.0.0" />
         <PackageVersion Include="ShowMeTheXAML.MSBuild" Version="2.0.0" />
         <PackageVersion Include="VirtualizingWrapPanel" Version="1.5.4" />
-        <PackageVersion Include="XAMLTest" Version="0.1.0" />
+        <PackageVersion Include="XAMLTest" Version="1.0.0-ci221" />
         <PackageVersion Include="xunit" Version="2.4.1" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
         <PackageVersion Include="Xunit.StaFact" Version="1.0.37" />

--- a/MaterialDesignThemes.UITests/Samples/DrawerHost/CancellingDrawerHost.xaml
+++ b/MaterialDesignThemes.UITests/Samples/DrawerHost/CancellingDrawerHost.xaml
@@ -1,0 +1,33 @@
+﻿<UserControl x:Class="MaterialDesignThemes.UITests.Samples.DrawHost.CancellingDrawerHost"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:MaterialDesignThemes.UITests.Samples.DrawHost"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ToggleButton.xaml" />
+    </UserControl.Resources>
+    <materialDesign:DrawerHost DrawerClosing="DrawerHost_DrawerClosing" x:Name="DrawerHost">
+        <materialDesign:DrawerHost.LeftDrawerContent>
+            <StackPanel Width="150" x:Name="DrawerContents">
+                <Button Content="Close w/ Routed Command"
+                        x:Name="CloseButton"
+                        Command="{x:Static materialDesign:DrawerHost.CloseDrawerCommand}"
+                        CommandParameter="{x:Static Dock.Left}" />
+                <Button Content="Close With DP Toggle"
+                        x:Name="CloseButtonDp"
+                        Click="CloseButtonAlt_Click"/>
+            </StackPanel>
+        </materialDesign:DrawerHost.LeftDrawerContent>
+        <Button Content="Open Left Drawer"
+                x:Name="ShowButton"
+                Margin="10"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Top"
+                Command="{x:Static materialDesign:DrawerHost.OpenDrawerCommand}"
+                CommandParameter="{x:Static Dock.Left}" />
+    </materialDesign:DrawerHost>
+</UserControl>

--- a/MaterialDesignThemes.UITests/Samples/DrawerHost/CancellingDrawerHost.xaml.cs
+++ b/MaterialDesignThemes.UITests/Samples/DrawerHost/CancellingDrawerHost.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System.Windows.Controls;
+
+namespace MaterialDesignThemes.UITests.Samples.DrawHost
+{
+    /// <summary>
+    /// Interaction logic for CancellingDrawerHost.xaml
+    /// </summary>
+    public partial class CancellingDrawerHost : UserControl
+    {
+        public CancellingDrawerHost()
+            => InitializeComponent();
+
+        private void DrawerHost_DrawerClosing(object sender, Wpf.DrawerClosingEventArgs e)
+        {
+            //Always cancel
+            e.Cancel();
+        }
+
+        private void CloseButtonAlt_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            DrawerHost.IsLeftDrawerOpen = false;
+        }
+    }
+}

--- a/MaterialDesignThemes.UITests/TestBase.cs
+++ b/MaterialDesignThemes.UITests/TestBase.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
 [assembly: GenerateHelpers(typeof(SmartHint))]
 [assembly: GenerateHelpers(typeof(TimePicker))]
+[assembly: GenerateHelpers(typeof(DrawerHost))]
 
 namespace MaterialDesignThemes.UITests
 {

--- a/MaterialDesignThemes.UITests/WPF/DrawerHosts/DrawerHostTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DrawerHosts/DrawerHostTests.cs
@@ -1,0 +1,128 @@
+﻿using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using MaterialDesignThemes.UITests.Samples.DrawHost;
+using MaterialDesignThemes.Wpf;
+using XamlTest;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MaterialDesignThemes.UITests.WPF.DrawerHosts;
+
+public class DialogHostTests : TestBase
+{
+    public DialogHostTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task DrawerHost_OpenAndClose_RaisesEvents()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        IVisualElement<DrawerHost> drawerHost = await LoadXaml<DrawerHost>(@"
+<materialDesign:DrawerHost>
+  <materialDesign:DrawerHost.LeftDrawerContent>
+    <StackPanel Width=""150"" x:Name=""DrawerContents"" />
+  </materialDesign:DrawerHost.LeftDrawerContent>
+
+  <StackPanel HorizontalAlignment=""Center"" VerticalAlignment=""Top"">
+    <ToggleButton Content=""L"" IsChecked=""{Binding IsLeftDrawerOpen, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type materialDesign:DrawerHost}}}""
+                  Style=""{StaticResource MaterialDesignActionLightToggleButton}"" ToolTip=""Open Left Drawer"" />
+    <Button Content=""Open Left Drawer"" Margin=""10"" Command=""{x:Static materialDesign:DrawerHost.OpenDrawerCommand}"" CommandParameter=""{x:Static Dock.Left}"" />
+  </StackPanel>
+</materialDesign:DrawerHost>");
+
+        var contentCover = await drawerHost.GetElement<FrameworkElement>("PART_ContentCover");
+        var toggleButton = await drawerHost.GetElement<ToggleButton>("/ToggleButton");
+        var showButton = await drawerHost.GetElement<Button>("/Button");
+        var contents = await drawerHost.GetElement<StackPanel>("DrawerContents");
+
+        var openedEvent = await drawerHost.RegisterForEvent(nameof(DrawerHost.DrawerOpened));
+        var closingEvent = await drawerHost.RegisterForEvent(nameof(DrawerHost.DrawerClosing));
+
+        await toggleButton.LeftClick();
+        //Allow for animations to start
+        await Task.Delay(10);
+
+        await Wait.For(async () =>
+        {
+            var invocations = await openedEvent.GetInvocations();
+            Assert.Equal(1, invocations.Count);
+        });
+
+        await drawerHost.LeftClick();
+
+        await Wait.For(async () => await contentCover.GetOpacity() <= 0.0);
+        await Wait.For(async () =>
+        {
+            var invocations = await closingEvent.GetInvocations();
+            Assert.Equal(1, invocations.Count);
+        });
+
+        await showButton.LeftClick();
+        //Allow for animations to start
+        await Task.Delay(10);
+
+        await Wait.For(async () =>
+        {
+            var invocations = await openedEvent.GetInvocations();
+            Assert.Equal(2, invocations.Count);
+        });
+        await Wait.For(async () => await contentCover.GetOpacity() > 0.0);
+
+        await drawerHost.LeftClick();
+
+        await Wait.For(async () => await contentCover.GetOpacity() <= 0.0);
+        await Wait.For(async () =>
+        {
+            var invocations = await closingEvent.GetInvocations();
+            Assert.Equal(2, invocations.Count);
+        });
+
+        recorder.Success();
+    }
+
+    [Fact]
+    public async Task DrawerHost_CancelingClosingEvent_DrawerStaysOpen()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        IVisualElement<DrawerHost> drawerHost = (await LoadUserControl<CancellingDrawerHost>()).As<DrawerHost>();
+        var showButton = await drawerHost.GetElement<Button>("ShowButton");
+        var closeButton = await drawerHost.GetElement<Button>("CloseButton");
+        var closeButtonDp = await drawerHost.GetElement<Button>("CloseButtonDp");
+
+        var openedEvent = await drawerHost.RegisterForEvent(nameof(DrawerHost.DrawerOpened));
+
+        await showButton.LeftClick();
+        //Allow open animation to finish
+        await Task.Delay(300);
+        await Wait.For(async () => (await openedEvent.GetInvocations()).Count == 1);
+
+        var closingEvent = await drawerHost.RegisterForEvent(nameof(DrawerHost.DrawerClosing));
+
+        //Attempt closing with routed command
+        await closeButton.LeftClick();
+        await Task.Delay(100);
+        await Wait.For(async () => (await closingEvent.GetInvocations()).Count == 1);
+        Assert.True(await drawerHost.GetIsLeftDrawerOpen());
+
+        //Attempt closing with click away
+        await drawerHost.LeftClick();
+        await Task.Delay(100);
+        await Wait.For(async () => (await closingEvent.GetInvocations()).Count == 2);
+        Assert.True(await drawerHost.GetIsLeftDrawerOpen());
+
+        //Attempt closing with DP property toggle
+        await closeButtonDp.LeftClick();
+        await Task.Delay(100);
+        await Wait.For(async () => (await closingEvent.GetInvocations()).Count == 3);
+        Assert.True(await drawerHost.GetIsLeftDrawerOpen());
+
+
+        recorder.Success();
+    }
+}
+

--- a/MaterialDesignThemes.Wpf/DrawerClosingEventArgs.cs
+++ b/MaterialDesignThemes.Wpf/DrawerClosingEventArgs.cs
@@ -5,7 +5,8 @@ namespace MaterialDesignThemes.Wpf
 {
     public class DrawerClosingEventArgs : RoutedEventArgs
     {
-        public DrawerClosingEventArgs(Dock dock, RoutedEvent routedEvent) : base(routedEvent)
+        public DrawerClosingEventArgs(Dock dock, RoutedEvent routedEvent)
+            : base(routedEvent)
         {
             Dock = dock;
         }

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -491,7 +491,8 @@ namespace MaterialDesignThemes.Wpf
             remove { RemoveHandler(DrawerClosingEvent, value); }
         }
 
-        protected void OnDrawerClosing(DrawerClosingEventArgs eventArgs) => RaiseEvent(eventArgs);
+        protected void OnDrawerClosing(DrawerClosingEventArgs eventArgs)
+            => RaiseEvent(eventArgs);
 
         #endregion
 
@@ -598,6 +599,17 @@ namespace MaterialDesignThemes.Wpf
         private static void IsDrawerOpenPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs, Dock dock)
         {
             var drawerHost = (DrawerHost)dependencyObject;
+            if (!(bool)dependencyPropertyChangedEventArgs.NewValue)
+            {
+                var args = new DrawerClosingEventArgs(dock, DrawerClosingEvent);
+                drawerHost.OnDrawerClosing(args);
+                if (args.IsCancelled)
+                {
+                    drawerHost.SetCurrentValue(dependencyPropertyChangedEventArgs.Property, dependencyPropertyChangedEventArgs.OldValue);
+                    return;
+                }
+            }
+
             if (!drawerHost._lockZIndexes && (bool)dependencyPropertyChangedEventArgs.NewValue)
                 drawerHost.PrepareZIndexes(drawerHost._zIndexPropertyLookup[dependencyPropertyChangedEventArgs.Property]);
             drawerHost.UpdateVisualStates();


### PR DESCRIPTION
Fixes #2506 

The expands the number of ways that the drawer host closing event is raised. It is now raised and cancel-able in all cases.

Bumped lang version of the library to 10.
Updated to latest XAMLTest