### PR TITLE
Fix for DatePicker Background color which can't changed

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -456,6 +456,7 @@
                             x:Name="PART_TextBox"
                             Grid.Column="0"
                             Grid.Row="0"
+                            Background="{TemplateBinding Background}"
                             Focusable="{TemplateBinding Focusable}"
                             Style="{DynamicResource MaterialDesignDatePickerTextBox}"
                             VerticalContentAlignment="Center"


### PR DESCRIPTION
a fix for https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2504 where we couldn't change the background color because it always set to Transparent or `MaterialDesignFilledDatePicker` style background color