### PR TITLE
Fixed the MaterialDesignFilledComboBox style

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -304,19 +304,14 @@
         </Setter>
     </Style>
 
-    <ControlTemplate x:Key="MaterialDesignFloatingHintComboBoxTemplate" TargetType="{x:Type ComboBox}">
+    <ControlTemplate
+        x:Key="MaterialDesignFloatingHintComboBoxTemplate"
+        TargetType="{x:Type ComboBox}">
         <AdornerDecorator>
             <Grid>
-                <ToggleButton
-                    x:Name="toggleButton"
-                    IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                    Style="{StaticResource MaterialDesignComboBoxToggleButton}"
-                    BorderBrush="{TemplateBinding BorderBrush}"
-                    Background="{TemplateBinding Background}"
-                    Padding="{TemplateBinding Padding}"
-                    Margin="{Binding ElementName=InnerRoot, Path=Margin}"/>
                 <Border
                     x:Name="templateRoot"
+                    Background="{TemplateBinding Background}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"
                     CornerRadius="{Binding Path=(wpf:TextFieldAssist.TextFieldCornerRadius), RelativeSource={RelativeSource TemplatedParent}}"
@@ -324,8 +319,11 @@
                     wpf:BottomDashedLineAdorner.IsAttached="False">
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="0" MinWidth="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}" />
+                            <ColumnDefinition
+                                Width="*" />
+                            <ColumnDefinition
+                                Width="0"
+                                MinWidth="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}" />
                         </Grid.ColumnDefinitions>
                         <Border
                             Grid.Column="0"
@@ -338,9 +336,12 @@
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition
+                                        Width="Auto" />
+                                    <ColumnDefinition
+                                        Width="*" />
+                                    <ColumnDefinition
+                                        Width="Auto" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock
                                     x:Name="PrefixTextBlock"
@@ -414,198 +415,385 @@
                     Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}"
                     CornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
                     Background="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}" />
-                <Canvas VerticalAlignment="Bottom">
+                <Canvas
+                    VerticalAlignment="Bottom">
                     <TextBlock
-                    Canvas.Top="2"
-                    FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
-                    MaxWidth="{Binding ActualWidth, ElementName=toggleButton}"
-                    Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                    Text="{TemplateBinding wpf:HintAssist.HelperText}" />
+                        Canvas.Top="2"
+                        FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
+                        MaxWidth="{Binding ActualWidth, ElementName=toggleButton}"
+                        Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                        Text="{TemplateBinding wpf:HintAssist.HelperText}" />
                 </Canvas>
-                <wpf:ComboBoxPopup x:Name="PART_Popup"
-                               Grid.Column="0"
-                               AllowsTransparency="True"
-                               ClassicMode="True"
-                               ClassicContentTemplate="{StaticResource PopupContentClassicTemplate}"
-                               wpf:ColorZoneAssist.Mode="{Binding Path=(wpf:ColorZoneAssist.Mode), RelativeSource={RelativeSource TemplatedParent}}"
-                               ContentMargin="6,0,6,6"
-                               ContentMinWidth="{Binding Path=ActualWidth, ElementName=templateRoot}"
-                               DefaultVerticalOffset="-1"
-                               DownVerticalOffset="0"
-                               Focusable="False"
-                               HorizontalOffset="0"
-                               IsOpen="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                               Placement="Custom"
-                               PlacementTarget="{Binding ElementName=templateRoot}"
-                               PopupAnimation="Fade"
-                               RelativeHorizontalOffset="-6"
-                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                               Tag="{DynamicResource MaterialDesignPaper}"
-                               UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
-                               VerticalOffset="0"
-                               UpVerticalOffset="15">
+                <wpf:ComboBoxPopup
+                    x:Name="PART_Popup"
+                    Grid.Column="0"
+                    AllowsTransparency="True"
+                    ClassicMode="True"
+                    ClassicContentTemplate="{StaticResource PopupContentClassicTemplate}"
+                    wpf:ColorZoneAssist.Mode="{Binding Path=(wpf:ColorZoneAssist.Mode), RelativeSource={RelativeSource TemplatedParent}}"
+                    ContentMargin="6,0,6,6"
+                    ContentMinWidth="{Binding Path=ActualWidth, ElementName=templateRoot}"
+                    DefaultVerticalOffset="-1"
+                    DownVerticalOffset="0"
+                    Focusable="False"
+                    HorizontalOffset="0"
+                    IsOpen="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                    Placement="Custom"
+                    PlacementTarget="{Binding ElementName=templateRoot}"
+                    PopupAnimation="Fade"
+                    RelativeHorizontalOffset="-6"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                    Tag="{DynamicResource MaterialDesignPaper}"
+                    UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
+                    VerticalOffset="0"
+                    UpVerticalOffset="15">
                     <wpf:ComboBoxPopup.Background>
-                        <MultiBinding Converter="{StaticResource FallbackBrushConverter}">
-                            <Binding Path="Background" RelativeSource="{RelativeSource TemplatedParent}" />
-                            <Binding Path="Tag" ElementName="PART_Popup" />
+                        <MultiBinding
+                            Converter="{StaticResource FallbackBrushConverter}">
+                            <Binding
+                                Path="Background"
+                                RelativeSource="{RelativeSource TemplatedParent}" />
+                            <Binding
+                                Path="Tag"
+                                ElementName="PART_Popup" />
                         </MultiBinding>
                     </wpf:ComboBoxPopup.Background>
                     <wpf:ComboBoxPopup.Style>
-                        <Style TargetType="wpf:ComboBoxPopup" BasedOn="{StaticResource {x:Type wpf:ComboBoxPopup}}">
-                            <Setter Property="CornerRadius" Value="0,0,4,4" />
+                        <Style
+                            TargetType="wpf:ComboBoxPopup"
+                            BasedOn="{StaticResource {x:Type wpf:ComboBoxPopup}}">
+                            <Setter
+                                Property="CornerRadius"
+                                Value="0,0,4,4" />
                             <Style.Triggers>
-                                <Trigger Property="OpenDirection" Value="Up">
-                                    <Setter Property="CornerRadius" Value="4,4,0,0" />
+                                <Trigger
+                                    Property="OpenDirection"
+                                    Value="Up">
+                                    <Setter
+                                        Property="CornerRadius"
+                                        Value="4,4,0,0" />
                                 </Trigger>
                             </Style.Triggers>
                         </Style>
                     </wpf:ComboBoxPopup.Style>
                     <ContentControl>
-                        <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}"
-                                  MinHeight="1"
-                                  Background="{Binding Background, ElementName=PART_Popup}">
-                            <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained" />
+                        <ScrollViewer
+                            MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                            MinHeight="1"
+                            Background="{Binding Background, ElementName=PART_Popup}">
+                            <ItemsPresenter
+                                x:Name="ItemsPresenter"
+                                KeyboardNavigation.DirectionalNavigation="Contained" />
                         </ScrollViewer>
                     </ContentControl>
                 </wpf:ComboBoxPopup>
+                <ToggleButton
+                    x:Name="toggleButton"
+                    IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                    Style="{StaticResource MaterialDesignComboBoxToggleButton}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    Padding="{TemplateBinding Padding}"
+                    Margin="{Binding ElementName=InnerRoot, Path=Margin}" />
                 <Button
-                    x:Name="PART_ClearButton" 
+                    x:Name="PART_ClearButton"
                     Style="{DynamicResource MaterialDesignToolButton}"
                     Height="Auto"
-                    VerticalAlignment="Center"
+                    VerticalAlignment="Stretch"
                     HorizontalAlignment="Right"
                     Padding="0"
                     Focusable="False"
                     Command="{x:Static internal:ClearText.ClearCommand}">
                     <Button.Margin>
-                        <MultiBinding Converter="{StaticResource ComboBoxClearButtonMarginConverter}">
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Padding" />
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="BorderThickness" />
-                            <Binding ElementName="InnerRoot" Path="Margin" />
+                        <MultiBinding
+                            Converter="{StaticResource ComboBoxClearButtonMarginConverter}">
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="Padding" />
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="BorderThickness" />
+                            <Binding
+                                ElementName="InnerRoot"
+                                Path="Margin" />
                         </MultiBinding>
                     </Button.Margin>
                     <Button.Visibility>
-                        <MultiBinding Converter="{StaticResource ClearButtonVisibilityConverter}">
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.HasClearButton)" />
-                            <Binding ElementName="Hint" Path="IsContentNullOrEmpty" />
+                        <MultiBinding
+                            Converter="{StaticResource ClearButtonVisibilityConverter}">
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="(wpf:TextFieldAssist.HasClearButton)" />
+                            <Binding
+                                ElementName="Hint"
+                                Path="IsContentNullOrEmpty" />
                         </MultiBinding>
                     </Button.Visibility>
-                    <wpf:PackIcon Margin="0" Kind="CloseCircle" />
+                    <wpf:PackIcon
+                        Margin="0"
+                        Kind="CloseCircle" />
                 </Button>
             </Grid>
         </AdornerDecorator>
         <ControlTemplate.Triggers>
-            <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
-                <Setter TargetName="templateRoot" Property="CornerRadius" Value="{Binding Path=(wpf:TextFieldAssist.TextFieldCornerRadius), RelativeSource={RelativeSource TemplatedParent}}" />
-                <Setter TargetName="PART_Popup" Property="RelativeHorizontalOffset" Value="-6" />
-                <Setter TargetName="PART_Popup" Property="DefaultVerticalOffset" Value="0" />
-                <Setter TargetName="PART_Popup" Property="DownVerticalOffset" Value="0" />
-                <Setter TargetName="PART_Popup" Property="UpVerticalOffset" Value="0" />
-                <Setter TargetName="PART_Popup" Property="CornerRadius" Value="{Binding Path=(wpf:TextFieldAssist.TextFieldCornerRadius), RelativeSource={RelativeSource TemplatedParent}}" />
-                <Setter TargetName="PART_Popup" Property="ContentMargin" Value="6,0,6,6" />
-                <Setter TargetName="PART_Popup" Property="ContentMinWidth" Value="{Binding Path=ActualWidth, ElementName=templateRoot}" />
-                <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
-                <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
-                <Setter TargetName="HintWrapper" Property="Opacity"
-                        Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
-                <Setter TargetName="Hint" Property="FloatingOffset">
+            <Trigger
+                Property="wpf:TextFieldAssist.HasOutlinedTextField"
+                Value="True">
+                <Setter
+                    TargetName="templateRoot"
+                    Property="CornerRadius"
+                    Value="{Binding Path=(wpf:TextFieldAssist.TextFieldCornerRadius), RelativeSource={RelativeSource TemplatedParent}}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="RelativeHorizontalOffset"
+                    Value="-6" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="DefaultVerticalOffset"
+                    Value="0" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="DownVerticalOffset"
+                    Value="0" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="UpVerticalOffset"
+                    Value="0" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="CornerRadius"
+                    Value="{Binding Path=(wpf:TextFieldAssist.TextFieldCornerRadius), RelativeSource={RelativeSource TemplatedParent}}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="ContentMargin"
+                    Value="6,0,6,6" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="ContentMinWidth"
+                    Value="{Binding Path=ActualWidth, ElementName=templateRoot}" />
+                <Setter
+                    TargetName="Underline"
+                    Property="Visibility"
+                    Value="Collapsed" />
+                <Setter
+                    TargetName="Hint"
+                    Property="HintOpacity"
+                    Value="1" />
+                <Setter
+                    TargetName="HintWrapper"
+                    Property="Opacity"
+                    Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
+                <Setter
+                    TargetName="Hint"
+                    Property="FloatingOffset">
                     <Setter.Value>
-                        <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="FontFamily" />
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="FontSize" />
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.FloatingScale)" />
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.FloatingOffset)" />
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualHeight" />
+                        <MultiBinding
+                            Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="FontFamily" />
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="FontSize" />
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="(wpf:HintAssist.FloatingScale)" />
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="(wpf:HintAssist.FloatingOffset)" />
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="ActualHeight" />
                         </MultiBinding>
                     </Setter.Value>
                 </Setter>
             </Trigger>
-            <Trigger Property="IsEditable" Value="True">
-                <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible" />
-                <Setter TargetName="Underline" Property="Visibility"
-                        Value="{Binding Path=(wpf:TextFieldAssist.DecorationVisibility), RelativeSource={RelativeSource TemplatedParent}}" />
-                <Setter TargetName="contentPresenter" Property="Visibility" Value="Collapsed" />
+            <Trigger
+                Property="IsEditable"
+                Value="True">
+                <Setter
+                    TargetName="PART_EditableTextBox"
+                    Property="Visibility"
+                    Value="Visible" />
+                <Setter
+                    TargetName="Underline"
+                    Property="Visibility"
+                    Value="{Binding Path=(wpf:TextFieldAssist.DecorationVisibility), RelativeSource={RelativeSource TemplatedParent}}" />
+                <Setter
+                    TargetName="contentPresenter"
+                    Property="Visibility"
+                    Value="Collapsed" />
             </Trigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsGrouping" Value="True" />
-                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="False" />
+                    <Condition
+                        Property="IsGrouping"
+                        Value="True" />
+                    <Condition
+                        Property="VirtualizingPanel.IsVirtualizingWhenGrouping"
+                        Value="False" />
                 </MultiTrigger.Conditions>
-                <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+                <Setter
+                    Property="ScrollViewer.CanContentScroll"
+                    Value="False" />
             </MultiTrigger>
 
             <!-- Hint -->
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                    <Condition
+                        Property="wpf:HintAssist.IsFloating"
+                        Value="True" />
+                    <Condition
+                        Property="wpf:TextFieldAssist.HasOutlinedTextField"
+                        Value="False" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="Hint" Property="FloatingOffset">
+                <Setter
+                    TargetName="Hint"
+                    Property="FloatingOffset">
                     <Setter.Value>
-                        <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="FontFamily" />
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="FontSize" />
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.FloatingScale)" />
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.FloatingOffset)" />
+                        <MultiBinding
+                            Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="FontFamily" />
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="FontSize" />
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="(wpf:HintAssist.FloatingScale)" />
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="(wpf:HintAssist.FloatingOffset)" />
                         </MultiBinding>
                     </Setter.Value>
                 </Setter>
-                <Setter TargetName="InnerRoot" Property="Margin">
+                <Setter
+                    TargetName="InnerRoot"
+                    Property="Margin">
                     <Setter.Value>
-                        <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="FontFamily" />
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="FontSize" />
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.FloatingScale)" />
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.FloatingOffset)" />
+                        <MultiBinding
+                            Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="FontFamily" />
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="FontSize" />
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="(wpf:HintAssist.FloatingScale)" />
+                            <Binding
+                                RelativeSource="{RelativeSource TemplatedParent}"
+                                Path="(wpf:HintAssist.FloatingOffset)" />
                         </MultiBinding>
                     </Setter.Value>
                 </Setter>
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-                    <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-                    <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+                    <Condition
+                        Property="wpf:TextFieldAssist.HasOutlinedTextField"
+                        Value="True" />
+                    <Condition
+                        Property="wpf:HintAssist.IsFloating"
+                        Value="True" />
+                    <Condition
+                        SourceName="Hint"
+                        Property="IsHintInFloatingPosition"
+                        Value="True" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="HintBackgroundBorder" Property="Padding" Value="4, 0" />
-                <Setter Property="wpf:HintAssist.Background" Value="{DynamicResource MaterialDesignPaper}" />
+                <Setter
+                    TargetName="HintBackgroundBorder"
+                    Property="Padding"
+                    Value="4, 0" />
+                <Setter
+                    Property="wpf:HintAssist.Background"
+                    Value="{DynamicResource MaterialDesignPaper}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition SourceName="Hint" Property="IsContentNullOrEmpty" Value="False" />
-                    <Condition SourceName="PART_EditableTextBox" Property="IsKeyboardFocused" Value="True" />
+                    <Condition
+                        SourceName="Hint"
+                        Property="IsContentNullOrEmpty"
+                        Value="False" />
+                    <Condition
+                        SourceName="PART_EditableTextBox"
+                        Property="IsKeyboardFocused"
+                        Value="True" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="Hint" Property="Foreground" Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
-                <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
+                <Setter
+                    TargetName="Hint"
+                    Property="Foreground"
+                    Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
+                <Setter
+                    TargetName="Hint"
+                    Property="HintOpacity"
+                    Value="1" />
             </MultiTrigger>
 
             <!-- IsEnabled -->
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsEnabled" Value="False" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                    <Condition
+                        Property="IsEnabled"
+                        Value="False" />
+                    <Condition
+                        Property="wpf:TextFieldAssist.HasOutlinedTextField"
+                        Value="False" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="templateRoot" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+                <Setter
+                    TargetName="templateRoot"
+                    Property="Opacity"
+                    Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
             </MultiTrigger>
             <!-- TODO Single trigger -->
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsEnabled" Value="False" />
+                    <Condition
+                        Property="IsEnabled"
+                        Value="False" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="toggleButton" Property="BorderBrush" Value="Transparent" />
+                <Setter
+                    TargetName="toggleButton"
+                    Property="BorderBrush"
+                    Value="Transparent" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsEnabled" Value="False" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                    <Condition
+                        Property="IsEnabled"
+                        Value="False" />
+                    <Condition
+                        Property="wpf:TextFieldAssist.HasOutlinedTextField"
+                        Value="True" />
                 </MultiTrigger.Conditions>
-                <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaInactiveBorder}" />
-                <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-                <Setter TargetName="contentPresenter" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-                <Setter TargetName="PART_EditableTextBox" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-                <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-                <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-                <Setter TargetName="HintWrapper" Property="Opacity">
+                <Setter
+                    Property="BorderBrush"
+                    Value="{DynamicResource MaterialDesignTextAreaInactiveBorder}" />
+                <Setter
+                    TargetName="PrefixTextBlock"
+                    Property="Opacity"
+                    Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+                <Setter
+                    TargetName="contentPresenter"
+                    Property="Opacity"
+                    Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+                <Setter
+                    TargetName="PART_EditableTextBox"
+                    Property="Opacity"
+                    Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+                <Setter
+                    TargetName="SuffixTextBlock"
+                    Property="Opacity"
+                    Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+                <Setter
+                    TargetName="PART_ClearButton"
+                    Property="Opacity"
+                    Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+                <Setter
+                    TargetName="HintWrapper"
+                    Property="Opacity">
                     <Setter.Value>
                         <Binding
                             Path="(wpf:HintAssist.HintOpacity)"
@@ -617,231 +805,512 @@
             </MultiTrigger>
 
             <!-- IsKeyboardFocused -->
-            <Trigger Property="IsKeyboardFocused" Value="True">
-                <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
+            <Trigger
+                Property="IsKeyboardFocused"
+                Value="True">
+                <Setter
+                    Property="BorderBrush"
+                    Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
             </Trigger>
-            <Trigger Property="IsKeyboardFocusWithin" Value="True">
-                <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
+            <Trigger
+                Property="IsKeyboardFocusWithin"
+                Value="True">
+                <Setter
+                    Property="BorderBrush"
+                    Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
             </Trigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsKeyboardFocused" Value="True" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                    <Condition
+                        Property="IsKeyboardFocused"
+                        Value="True" />
+                    <Condition
+                        Property="wpf:TextFieldAssist.HasOutlinedTextField"
+                        Value="False" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="Underline" Property="IsActive" Value="True" />
+                <Setter
+                    TargetName="Underline"
+                    Property="IsActive"
+                    Value="True" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsKeyboardFocusWithin" Value="True" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-                    <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-                    <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+                    <Condition
+                        Property="IsKeyboardFocusWithin"
+                        Value="True" />
+                    <Condition
+                        Property="wpf:TextFieldAssist.HasOutlinedTextField"
+                        Value="True" />
+                    <Condition
+                        Property="wpf:HintAssist.IsFloating"
+                        Value="True" />
+                    <Condition
+                        SourceName="Hint"
+                        Property="IsHintInFloatingPosition"
+                        Value="True" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="HintWrapper" Property="Opacity" Value="1" />
+                <Setter
+                    TargetName="HintWrapper"
+                    Property="Opacity"
+                    Value="1" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsKeyboardFocusWithin" Value="True" />
-                    <Condition SourceName="Hint" Property="IsContentNullOrEmpty" Value="False" />
-                    <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                    <Condition
+                        Property="IsKeyboardFocusWithin"
+                        Value="True" />
+                    <Condition
+                        SourceName="Hint"
+                        Property="IsContentNullOrEmpty"
+                        Value="False" />
+                    <Condition
+                        Property="wpf:HintAssist.IsFloating"
+                        Value="True" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="Hint" Property="Foreground" Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
-                <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
+                <Setter
+                    TargetName="Hint"
+                    Property="Foreground"
+                    Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
+                <Setter
+                    TargetName="Hint"
+                    Property="HintOpacity"
+                    Value="1" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsKeyboardFocusWithin" Value="True" />
-                    <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-                    <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+                    <Condition
+                        Property="IsKeyboardFocusWithin"
+                        Value="True" />
+                    <Condition
+                        Property="wpf:HintAssist.IsFloating"
+                        Value="True" />
+                    <Condition
+                        SourceName="Hint"
+                        Property="IsHintInFloatingPosition"
+                        Value="True" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="Hint" Property="Foreground" Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
-                <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
+                <Setter
+                    TargetName="Hint"
+                    Property="Foreground"
+                    Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
+                <Setter
+                    TargetName="Hint"
+                    Property="HintOpacity"
+                    Value="1" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsKeyboardFocused" Value="True" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                    <Condition
+                        Property="IsKeyboardFocused"
+                        Value="True" />
+                    <Condition
+                        Property="wpf:TextFieldAssist.HasOutlinedTextField"
+                        Value="True" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="templateRoot" Property="Margin" Value="-1" />
-                <Setter TargetName="templateRoot" Property="BorderThickness" Value="2" />
+                <Setter
+                    TargetName="templateRoot"
+                    Property="Margin"
+                    Value="-1" />
+                <Setter
+                    TargetName="templateRoot"
+                    Property="BorderThickness"
+                    Value="2" />
             </MultiTrigger>
 
             <!-- IsDropDownOpen -->
             <!-- TODO: Single trigger -->
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsDropDownOpen" Value="True" />
+                    <Condition
+                        Property="IsDropDownOpen"
+                        Value="True" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="Underline" Property="IsActive" Value="True" />
+                <Setter
+                    TargetName="Underline"
+                    Property="IsActive"
+                    Value="True" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsDropDownOpen" Value="True" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                    <Condition
+                        Property="IsDropDownOpen"
+                        Value="True" />
+                    <Condition
+                        Property="wpf:TextFieldAssist.HasOutlinedTextField"
+                        Value="True" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="templateRoot" Property="Margin" Value="-1" />
-                <Setter TargetName="templateRoot" Property="BorderThickness" Value="2" />
-                <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
+                <Setter
+                    TargetName="templateRoot"
+                    Property="Margin"
+                    Value="-1" />
+                <Setter
+                    TargetName="templateRoot"
+                    Property="BorderThickness"
+                    Value="2" />
+                <Setter
+                    Property="BorderBrush"
+                    Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsDropDownOpen" Value="True" />
-                    <Condition SourceName="Hint" Property="IsContentNullOrEmpty" Value="False" />
+                    <Condition
+                        Property="IsDropDownOpen"
+                        Value="True" />
+                    <Condition
+                        SourceName="Hint"
+                        Property="IsContentNullOrEmpty"
+                        Value="False" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="Hint" Property="Foreground" Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
-                <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
+                <Setter
+                    TargetName="Hint"
+                    Property="Foreground"
+                    Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
+                <Setter
+                    TargetName="Hint"
+                    Property="HintOpacity"
+                    Value="1" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsDropDownOpen" Value="True" />
-                    <Condition SourceName="Hint" Property="IsContentNullOrEmpty" Value="False" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                    <Condition
+                        Property="IsDropDownOpen"
+                        Value="True" />
+                    <Condition
+                        SourceName="Hint"
+                        Property="IsContentNullOrEmpty"
+                        Value="False" />
+                    <Condition
+                        Property="wpf:TextFieldAssist.HasOutlinedTextField"
+                        Value="True" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="HintWrapper" Property="Opacity" Value="1" />
+                <Setter
+                    TargetName="HintWrapper"
+                    Property="Opacity"
+                    Value="1" />
             </MultiTrigger>
 
             <!-- IsMouseOver -->
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsMouseOver" Value="True" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                    <Condition
+                        Property="IsMouseOver"
+                        Value="True" />
+                    <Condition
+                        Property="wpf:TextFieldAssist.HasOutlinedTextField"
+                        Value="False" />
                 </MultiTrigger.Conditions>
-                <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
-                <Setter TargetName="Underline" Property="Background" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
+                <Setter
+                    Property="BorderBrush"
+                    Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
+                <Setter
+                    TargetName="Underline"
+                    Property="Background"
+                    Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsMouseOver" Value="True" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                    <Condition
+                        Property="IsMouseOver"
+                        Value="True" />
+                    <Condition
+                        Property="wpf:TextFieldAssist.HasOutlinedTextField"
+                        Value="True" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="templateRoot" Property="Margin" Value="-1" />
-                <Setter TargetName="templateRoot" Property="BorderThickness" Value="2" />
+                <Setter
+                    TargetName="templateRoot"
+                    Property="Margin"
+                    Value="-1" />
+                <Setter
+                    TargetName="templateRoot"
+                    Property="BorderThickness"
+                    Value="2" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsMouseOver" Value="True" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-                    <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-                    <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+                    <Condition
+                        Property="IsMouseOver"
+                        Value="True" />
+                    <Condition
+                        Property="wpf:TextFieldAssist.HasOutlinedTextField"
+                        Value="True" />
+                    <Condition
+                        Property="wpf:HintAssist.IsFloating"
+                        Value="True" />
+                    <Condition
+                        SourceName="Hint"
+                        Property="IsHintInFloatingPosition"
+                        Value="True" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="HintWrapper" Property="Opacity" Value="1" />
+                <Setter
+                    TargetName="HintWrapper"
+                    Property="Opacity"
+                    Value="1" />
             </MultiTrigger>
 
             <!-- Validation.HasError -->
-            <Trigger Property="Validation.HasError" Value="True">
-                <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignValidationErrorBrush}"/>
-                <Setter TargetName="Underline" Property="Background" Value="{DynamicResource MaterialDesignValidationErrorBrush}"/>
+            <Trigger
+                Property="Validation.HasError"
+                Value="True">
+                <Setter
+                    Property="BorderBrush"
+                    Value="{DynamicResource MaterialDesignValidationErrorBrush}" />
+                <Setter
+                    TargetName="Underline"
+                    Property="Background"
+                    Value="{DynamicResource MaterialDesignValidationErrorBrush}" />
             </Trigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="Validation.HasError" Value="True" />
-                    <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                    <Condition
+                        Property="Validation.HasError"
+                        Value="True" />
+                    <Condition
+                        Property="wpf:TextFieldAssist.HasOutlinedTextField"
+                        Value="True" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="templateRoot" Property="Margin" Value="-1" />
-                <Setter TargetName="templateRoot" Property="BorderThickness" Value="2" />
-                <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignValidationErrorBrush}" />
+                <Setter
+                    TargetName="templateRoot"
+                    Property="Margin"
+                    Value="-1" />
+                <Setter
+                    TargetName="templateRoot"
+                    Property="BorderThickness"
+                    Value="2" />
+                <Setter
+                    Property="BorderBrush"
+                    Value="{DynamicResource MaterialDesignValidationErrorBrush}" />
             </MultiTrigger>
 
             <!-- PART_Popup.IsOpen -->
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True" />
-                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Standard" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="IsOpen"
+                        Value="True" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="wpf:ColorZoneAssist.Mode"
+                        Value="Standard" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesignPaper}" />
-                <Setter TargetName="PART_Popup" Property="Background"
-                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
-                <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesignBody}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Tag"
+                    Value="{DynamicResource MaterialDesignPaper}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Background"
+                    Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+                <Setter
+                    Property="TextElement.Foreground"
+                    Value="{DynamicResource MaterialDesignBody}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True" />
-                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Inverted" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="IsOpen"
+                        Value="True" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="wpf:ColorZoneAssist.Mode"
+                        Value="Inverted" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesignBody}" />
-                <Setter TargetName="PART_Popup" Property="Background"
-                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
-                <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesignPaper}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Tag"
+                    Value="{DynamicResource MaterialDesignBody}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Background"
+                    Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+                <Setter
+                    Property="TextElement.Foreground"
+                    Value="{DynamicResource MaterialDesignPaper}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True" />
-                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="PrimaryLight" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="IsOpen"
+                        Value="True" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="wpf:ColorZoneAssist.Mode"
+                        Value="PrimaryLight" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource PrimaryHueLightBrush}" />
-                <Setter TargetName="PART_Popup" Property="Background"
-                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
-                <Setter Property="TextElement.Foreground" Value="{DynamicResource PrimaryHueLightForegroundBrush}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Tag"
+                    Value="{DynamicResource PrimaryHueLightBrush}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Background"
+                    Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+                <Setter
+                    Property="TextElement.Foreground"
+                    Value="{DynamicResource PrimaryHueLightForegroundBrush}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True" />
-                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="IsOpen"
+                        Value="True" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="wpf:ColorZoneAssist.Mode"
+                        Value="PrimaryMid" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource PrimaryHueMidBrush}" />
-                <Setter TargetName="PART_Popup" Property="Background"
-                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
-                <Setter Property="TextElement.Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Tag"
+                    Value="{DynamicResource PrimaryHueMidBrush}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Background"
+                    Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+                <Setter
+                    Property="TextElement.Foreground"
+                    Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True" />
-                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="PrimaryDark" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="IsOpen"
+                        Value="True" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="wpf:ColorZoneAssist.Mode"
+                        Value="PrimaryDark" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource PrimaryHueDarkBrush}" />
-                <Setter TargetName="PART_Popup" Property="Background"
-                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
-                <Setter Property="TextElement.Foreground" Value="{DynamicResource PrimaryHueDarkForegroundBrush}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Tag"
+                    Value="{DynamicResource PrimaryHueDarkBrush}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Background"
+                    Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+                <Setter
+                    Property="TextElement.Foreground"
+                    Value="{DynamicResource PrimaryHueDarkForegroundBrush}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
-                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="SecondaryLight"/>
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="IsOpen"
+                        Value="True" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="wpf:ColorZoneAssist.Mode"
+                        Value="SecondaryLight" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource SecondaryHueLightBrush}" />
-                <Setter TargetName="PART_Popup" Property="Background"
-                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
-                <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryHueLightForegroundBrush}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Tag"
+                    Value="{DynamicResource SecondaryHueLightBrush}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Background"
+                    Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+                <Setter
+                    Property="TextElement.Foreground"
+                    Value="{DynamicResource SecondaryHueLightForegroundBrush}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
-                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="SecondaryMid"/>
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="IsOpen"
+                        Value="True" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="wpf:ColorZoneAssist.Mode"
+                        Value="SecondaryMid" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource SecondaryHueMidBrush}" />
-                <Setter TargetName="PART_Popup" Property="Background"
-                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
-                <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Tag"
+                    Value="{DynamicResource SecondaryHueMidBrush}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Background"
+                    Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+                <Setter
+                    Property="TextElement.Foreground"
+                    Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True"/>
-                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="SecondaryDark"/>
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="IsOpen"
+                        Value="True" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="wpf:ColorZoneAssist.Mode"
+                        Value="SecondaryDark" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource SecondaryHueDarkBrush}" />
-                <Setter TargetName="PART_Popup" Property="Background"
-                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
-                <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryHueDarkForegroundBrush}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Tag"
+                    Value="{DynamicResource SecondaryHueDarkBrush}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Background"
+                    Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+                <Setter
+                    Property="TextElement.Foreground"
+                    Value="{DynamicResource SecondaryHueDarkForegroundBrush}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True" />
-                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Light" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="IsOpen"
+                        Value="True" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="wpf:ColorZoneAssist.Mode"
+                        Value="Light" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesignLightBackground}" />
-                <Setter TargetName="PART_Popup" Property="Background"
-                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
-                <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesignLightForeground}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Tag"
+                    Value="{DynamicResource MaterialDesignLightBackground}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Background"
+                    Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+                <Setter
+                    Property="TextElement.Foreground"
+                    Value="{DynamicResource MaterialDesignLightForeground}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition SourceName="PART_Popup" Property="IsOpen" Value="True" />
-                    <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Dark" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="IsOpen"
+                        Value="True" />
+                    <Condition
+                        SourceName="PART_Popup"
+                        Property="wpf:ColorZoneAssist.Mode"
+                        Value="Dark" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesignDarkBackground}" />
-                <Setter TargetName="PART_Popup" Property="Background"
-                        Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
-                <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesignDarkForeground}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Tag"
+                    Value="{DynamicResource MaterialDesignDarkBackground}" />
+                <Setter
+                    TargetName="PART_Popup"
+                    Property="Background"
+                    Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+                <Setter
+                    Property="TextElement.Foreground"
+                    Value="{DynamicResource MaterialDesignDarkForeground}" />
             </MultiTrigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>


### PR DESCRIPTION
The Filled ComboBox style was broken by previous code.

Broken style: 
![image](https://user-images.githubusercontent.com/6505319/145843416-6fe32307-5385-4d76-bc38-6485894667e0.png)

Fixed style: 
![image](https://user-images.githubusercontent.com/6505319/145843620-f7578b9a-2c34-4dba-a1e7-21b053b4a453.png)

I changed the order of the controls inside the "MaterialDesignFloatingHintComboBoxTemplate" ControlTemplate. In the AdornerDecorator there's a Grid in which the first item was the ToggleButton (the little triangle) that opens or closes the ComboBox. The TemplateBinding Background was applied to this item, but this control doesn't apply the CornerRadius property. So I changed the order of the controls and applied the Background TemplateBinding to the Border.

Current order inside Grid:
1. Border
2. wpf:Underline
3. Canvas
4. wpf:ComboBoxPopup
5. ToggleButton
6. Button (the clear button)

Previous order inside Grid: 
1. ToggleButton
2. Border
3. wpf:Underline
4. Canvas
5. wpf:ComboBoxPopup
6. Button (the clear button)

