### PR TITLE
Add Placement Property to DialogHost (with EmbeddedDialogHost)

### DIFF
--- a/MainDemo.Wpf/Dialogs.xaml
+++ b/MainDemo.Wpf/Dialogs.xaml
@@ -242,6 +242,7 @@
                 Grid.Column="3"
                 Grid.Row="1" >
                 <materialDesign:DialogHost
+                    Placement="Mouse"
                     VerticalAlignment="Center"
                     IsOpen="{Binding IsSample4DialogOpen}"
                     DialogContent="{Binding Sample4Content}"

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -365,6 +365,15 @@ namespace MaterialDesignThemes.Wpf
             set => SetValue(IsOpenProperty, value);
         }
 
+        public static readonly DependencyProperty PlacementProperty = DependencyProperty.Register(
+            nameof(Placement), typeof(PlacementMode), typeof(DialogHost), new PropertyMetadata(PlacementMode.Center));
+
+        public PlacementMode Placement
+        {
+            get => (PlacementMode)GetValue(PlacementProperty);
+            set => SetValue(PlacementProperty, value);
+        }
+
         public static readonly DependencyProperty DialogContentProperty = DependencyProperty.Register(
             nameof(DialogContent), typeof(object), typeof(DialogHost), new PropertyMetadata(default(object)));
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -139,6 +139,7 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                         <wpf:PopupEx PlacementTarget="{Binding ElementName=DialogHostRoot, Mode=OneWay}"
+                                     Placement="{TemplateBinding Placement}"
                                      x:Name="PART_Popup" 
                                      Style="{TemplateBinding PopupStyle}"
                                      wpf:ThemeAssist.Theme="{TemplateBinding DialogTheme}">
@@ -218,6 +219,7 @@
     <Style x:Key="MaterialDesignEmbeddedDialogHost" TargetType="{x:Type wpf:DialogHost}">
         <Setter Property="DialogMargin" Value="35" />
         <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth5" />
+        <Setter Property="Placement" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Template">
@@ -408,5 +410,35 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+        <Style.Triggers>
+            <Trigger Property="Placement" Value="Center">
+                <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                <Setter Property="VerticalContentAlignment" Value="Center"/>
+            </Trigger>
+            <Trigger Property="Placement" Value="Left">
+                <Setter Property="HorizontalContentAlignment" Value="Left"/>
+                <Setter Property="VerticalContentAlignment" Value="Center"/>
+            </Trigger>
+            <Trigger Property="Placement" Value="Top">
+                <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                <Setter Property="VerticalContentAlignment" Value="Top"/>
+            </Trigger>
+            <Trigger Property="Placement" Value="Right">
+                <Setter Property="HorizontalContentAlignment" Value="Right"/>
+                <Setter Property="VerticalContentAlignment" Value="Center"/>
+            </Trigger>
+            <Trigger Property="Placement" Value="Bottom">
+                <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                <Setter Property="VerticalContentAlignment" Value="Bottom"/>
+            </Trigger>
+            <Trigger Property="Placement" Value="Absolute">
+                <Setter Property="HorizontalContentAlignment" Value="Left"/>
+                <Setter Property="VerticalContentAlignment" Value="Top"/>
+            </Trigger>
+            <Trigger Property="Placement" Value="AbsolutePoint">
+                <Setter Property="HorizontalContentAlignment" Value="Left"/>
+                <Setter Property="VerticalContentAlignment" Value="Top"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 </ResourceDictionary>


### PR DESCRIPTION
Replaces https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/pull/2520 and should address https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2316

Placement property will now set `HorizontalContentAlignment` `VerticalContentAlignment` for `MaterialDesignEmbeddedDialogHost`