### PR TITLE
Uncomment Tab Control default Styles

### DIFF
--- a/MainDemo.Wpf/Domain/MainWindowViewModel.cs
+++ b/MainDemo.Wpf/Domain/MainWindowViewModel.cs
@@ -287,6 +287,14 @@ namespace MaterialDesignDemo.Domain
                 });
 
             yield return new DemoItem(
+                "Tabs",
+                typeof(Tabs),
+                new[]
+                {
+                    DocumentationLink.DemoPageLink<Tabs>()
+                });
+
+            yield return new DemoItem(
                 "Trees",
                 typeof(Trees),
                 new[]

--- a/MainDemo.Wpf/Tabs.xaml
+++ b/MainDemo.Wpf/Tabs.xaml
@@ -1,0 +1,212 @@
+﻿<UserControl
+    x:Class="MaterialDesignDemo.Tabs"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    mc:Ignorable="d">
+    <WrapPanel Margin="0,0,8,8">
+        <smtx:XamlDisplay
+            Margin="16,4,0,16"
+            VerticalContentAlignment="Top"
+            UniqueKey="tabs_1">
+            <TabControl Style="{StaticResource MaterialDesignTabControl}">
+                <TabItem Header="Tab 1" Style="{StaticResource MaterialDesignTabItem}">
+                    <TextBlock
+                        Width="200"
+                        Height="200"
+                        Margin="5"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                        Text="Standard Tab 1" />
+                </TabItem>
+                <TabItem Header="Tab 2" Style="{StaticResource MaterialDesignTabItem}">
+                    <TextBlock
+                        Width="200"
+                        Height="200"
+                        Margin="5"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                        Text="Standard Tab 2" />
+                </TabItem>
+            </TabControl>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay
+            Margin="16,4,0,16"
+            VerticalContentAlignment="Top"
+            UniqueKey="tabs_2">
+            <TabControl Style="{StaticResource MaterialDesignTabControl}">
+                <TabItem Header="Tab 1" Style="{StaticResource MaterialDesignTabItemCompact}">
+                    <TextBlock
+                        Width="200"
+                        Height="200"
+                        Margin="5"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                        Text="Compact Tab 1" />
+                </TabItem>
+                <TabItem Header="Tab 2" Style="{StaticResource MaterialDesignTabItemCompact}">
+                    <TextBlock
+                        Width="200"
+                        Height="200"
+                        Margin="5"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                        Text="Compact Tab 2" />
+                </TabItem>
+            </TabControl>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay
+            Margin="16,4,0,16"
+            VerticalContentAlignment="Top"
+            UniqueKey="tabs_3">
+            <TabControl Style="{StaticResource MaterialDesignTabControl}" TabStripPlacement="Left">
+                <TabItem Header="Tab 1" Style="{StaticResource MaterialDesignTabItem}">
+                    <TextBlock
+                        Width="200"
+                        Height="200"
+                        Margin="5"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                        Text="Standard Left Tab 1" />
+                </TabItem>
+                <TabItem Header="Tab 2" Style="{StaticResource MaterialDesignTabItem}">
+                    <TextBlock
+                        Width="200"
+                        Height="200"
+                        Margin="5"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                        Text="Standard Left Tab 2" />
+                </TabItem>
+            </TabControl>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay
+            Margin="16,4,0,16"
+            VerticalContentAlignment="Top"
+            UniqueKey="tabs_4">
+            <TabControl materialDesign:ColorZoneAssist.Mode="Inverted" Style="{StaticResource MaterialDesignTabControl}">
+                <TabItem Header="Tab 1" Style="{StaticResource MaterialDesignTabItem}">
+                    <TextBlock
+                        Width="200"
+                        Height="200"
+                        Margin="5"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                        Text="Standard Tab 1 with Inverted ColorZone Mode"
+                        TextWrapping="WrapWithOverflow" />
+                </TabItem>
+                <TabItem Header="Tab 2" Style="{StaticResource MaterialDesignTabItem}">
+                    <TextBlock
+                        Width="200"
+                        Height="200"
+                        Margin="5"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                        Text="Standard Tab 2 with Inverted ColorZone Mode"
+                        TextWrapping="WrapWithOverflow" />
+                </TabItem>
+            </TabControl>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay
+            Margin="16,4,0,16"
+            VerticalContentAlignment="Top"
+            UniqueKey="tabs_5">
+            <TabControl materialDesign:ColorZoneAssist.Mode="PrimaryDark" Style="{StaticResource MaterialDesignTabControl}">
+                <TabItem Header="Tab 1" Style="{StaticResource MaterialDesignTabItemCompact}">
+                    <TextBlock
+                        Width="200"
+                        Height="200"
+                        Margin="5"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                        Text="Compact Tab 1 with PrimaryDark ColorZone Mode"
+                        TextWrapping="WrapWithOverflow" />
+                </TabItem>
+                <TabItem Header="Tab 2" Style="{StaticResource MaterialDesignTabItemCompact}">
+                    <TextBlock
+                        Width="200"
+                        Height="200"
+                        Margin="5"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                        Text="Compact Tab 2 with PrimaryDark ColorZone Mode"
+                        TextWrapping="WrapWithOverflow" />
+                </TabItem>
+            </TabControl>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay
+            Margin="16,4,0,16"
+            VerticalContentAlignment="Top"
+            UniqueKey="tabs_6">
+            <TabControl materialDesign:ColorZoneAssist.Mode="SecondaryMid" Style="{StaticResource MaterialDesignTabControl}">
+                <TabItem Header="Tab 1" Style="{StaticResource MaterialDesignTabItemCompact}">
+                    <TextBlock
+                        Width="200"
+                        Height="200"
+                        Margin="5"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                        Text="Compact Tab 1 with SecondaryMid ColorZone Mode"
+                        TextWrapping="WrapWithOverflow" />
+                </TabItem>
+                <TabItem Header="Tab 2" Style="{StaticResource MaterialDesignTabItemCompact}">
+                    <TextBlock
+                        Width="200"
+                        Height="200"
+                        Margin="5"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                        Text="Compact Tab 2 with SecondaryMid ColorZone Mode"
+                        TextWrapping="WrapWithOverflow" />
+                </TabItem>
+            </TabControl>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay
+            Margin="16,4,0,16"
+            VerticalContentAlignment="Top"
+            UniqueKey="tabs_7">
+            <TabControl
+                materialDesign:ColorZoneAssist.Mode="Inverted"
+                Style="{StaticResource MaterialDesignTabControl}"
+                TabStripPlacement="Right">
+                <TabItem
+                    Header="Tab 1"
+                    Style="{StaticResource MaterialDesignTabItemCompact}"
+                    Typography.Capitals="Normal">
+                    <TextBlock
+                        Width="200"
+                        Height="200"
+                        Margin="5"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                        Text="Compact Right Tab 1 with Inverted ColorZone Mode and Normal Header Typography"
+                        TextWrapping="WrapWithOverflow" />
+                </TabItem>
+                <TabItem
+                    Header="Tab 2"
+                    Style="{StaticResource MaterialDesignTabItemCompact}"
+                    Typography.Capitals="Normal">
+                    <TextBlock
+                        Width="200"
+                        Height="200"
+                        Margin="5"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                        Text="Compact Right Tab 2 with Inverted ColorZone Mode and Normal Header Typography"
+                        TextWrapping="WrapWithOverflow" />
+                </TabItem>
+            </TabControl>
+        </smtx:XamlDisplay>
+    </WrapPanel>
+</UserControl>

--- a/MainDemo.Wpf/Tabs.xaml.cs
+++ b/MainDemo.Wpf/Tabs.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace MaterialDesignDemo
+{
+    /// <summary>
+    /// Interaction logic for Tabs.xaml
+    /// </summary>
+    public partial class Tabs : UserControl
+    {
+        public Tabs()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesign2.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesign2.Defaults.xaml
@@ -81,6 +81,8 @@
     <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource MaterialDesignScrollBar}" />
     <Style TargetType="{x:Type ScrollViewer}" BasedOn="{StaticResource MaterialDesignScrollViewer}" />
     <Style TargetType="{x:Type Slider}" BasedOn="{StaticResource MaterialDesignSlider}" />
+    <Style TargetType="{x:Type TabControl}" BasedOn="{StaticResource MaterialDesignTabControl}" />
+    <Style TargetType="{x:Type TabItem}" BasedOn="{StaticResource MaterialDesignTabItem}" />
     <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignTextBox}" />
     <Style TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource MaterialDesignSwitchToggleButton}" />
     <Style TargetType="{x:Type ToolBar}" BasedOn="{StaticResource MaterialDesignToolBar}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Defaults.xaml
@@ -83,6 +83,8 @@
     <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource MaterialDesignScrollBar}" />
     <Style TargetType="{x:Type ScrollViewer}" BasedOn="{StaticResource MaterialDesignScrollViewer}" />
     <Style TargetType="{x:Type Slider}" BasedOn="{StaticResource MaterialDesignSlider}" />
+    <Style TargetType="{x:Type TabControl}" BasedOn="{StaticResource MaterialDesignTabControl}" />
+    <Style TargetType="{x:Type TabItem}" BasedOn="{StaticResource MaterialDesignTabItem}" />
     <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignTextBox}" />
     <Style TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource MaterialDesignSwitchToggleButton}" />
     <Style TargetType="{x:Type ToolBar}" BasedOn="{StaticResource MaterialDesignToolBar}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -1,12 +1,13 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
-                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
+    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary>
-            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
-            <converters:BorderClipConverter x:Key="BorderClipConverter"/>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+            <converters:BorderClipConverter x:Key="BorderClipConverter" />
         </ResourceDictionary>
     </ResourceDictionary.MergedDictionaries>
 
@@ -14,16 +15,21 @@
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Rectangle Margin="2" SnapsToDevicePixels="true" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" StrokeThickness="1" StrokeDashArray="1 2"/>
+                    <Rectangle
+                        Margin="2"
+                        SnapsToDevicePixels="true"
+                        Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                        StrokeDashArray="1 2"
+                        StrokeThickness="1" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
 
-    <!--<Style  TargetType="{x:Type TabControl}" x:Key="MaterialDesignTabControl">
-        <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
-        <Setter Property="VerticalContentAlignment" Value="Stretch"/>
+    <Style x:Key="MaterialDesignTabControl" TargetType="{x:Type TabControl}">
+        <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesignFlatButtonRipple}" />
@@ -31,139 +37,165 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabControl}">
                     <DockPanel KeyboardNavigation.TabNavigation="Local">
-                        <wpf:ColorZone x:Name="PART_ColorZone" 
-                                       DockPanel.Dock="Top"
-                                       Focusable="False"
-                                       Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}" 
-                                       wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
-                                       wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}" >
-                            <UniformGrid x:Name="HeaderPanel"
-                                         Rows="1"
-                                         IsItemsHost="True"
-                                         Focusable="False"
-                                         KeyboardNavigation.TabIndex="1"
-                                         HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                        <wpf:ColorZone
+                            x:Name="PART_ColorZone"
+                            wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
+                            wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}"
+                            DockPanel.Dock="Top"
+                            Focusable="False"
+                            Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}">
+                            <UniformGrid
+                                x:Name="HeaderPanel"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                Focusable="False"
+                                IsItemsHost="True"
+                                KeyboardNavigation.TabIndex="1"
+                                Rows="1" />
                         </wpf:ColorZone>
-                        <wpf:ColorZone x:Name="PART_ColorZoneSelectedContent" 
-                                       Padding="{TemplateBinding Padding}" 
-                                       VerticalAlignment="Stretch"
-                                       HorizontalAlignment="Stretch"
-                                       Mode="Standard" 
-                                       Focusable="False"
-                                       Foreground="{DynamicResource MaterialDesignBody}"
-                                       Background="{x:Null}">
-                            <ContentPresenter x:Name="PART_SelectedContentHost"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                                              Focusable="False"
-                                              Margin="{TemplateBinding Padding}"
-                                              TextElement.Foreground="{Binding ElementName=PART_ColorZone, Path=Foreground}"
-                                              TextBlock.Foreground="{Binding ElementName=PART_ColorZone, Path=Foreground}"
-                                              ContentSource="SelectedContent"
-                                              ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                              ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}">
-                            </ContentPresenter>
+                        <wpf:ColorZone
+                            x:Name="PART_ColorZoneSelectedContent"
+                            Padding="{TemplateBinding Padding}"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            Background="{x:Null}"
+                            Focusable="False"
+                            Foreground="{DynamicResource MaterialDesignBody}"
+                            Mode="Standard">
+                            <ContentPresenter
+                                x:Name="PART_SelectedContentHost"
+                                Margin="{TemplateBinding Padding}"
+                                ContentSource="SelectedContent"
+                                ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                Focusable="False"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                TextBlock.Foreground="{Binding ElementName=PART_ColorZone, Path=Foreground}"
+                                TextElement.Foreground="{Binding ElementName=PART_ColorZone, Path=Foreground}" />
                         </wpf:ColorZone>
                     </DockPanel>
 
                     <ControlTemplate.Triggers>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
-                            <Setter TargetName="PART_ColorZone" Property="DockPanel.Dock" Value="Bottom"/>
+                            <Setter TargetName="PART_ColorZone" Property="DockPanel.Dock" Value="Bottom" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Left">
-                            <Setter TargetName="PART_ColorZone" Property="DockPanel.Dock" Value="Left"/>
-                            <Setter TargetName="HeaderPanel" Property="Rows" Value="0"/>
-                            <Setter TargetName="HeaderPanel" Property="Columns" Value="1"/>
+                            <Setter TargetName="PART_ColorZone" Property="DockPanel.Dock" Value="Left" />
+                            <Setter TargetName="HeaderPanel" Property="Rows" Value="0" />
+                            <Setter TargetName="HeaderPanel" Property="Columns" Value="1" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
-                            <Setter TargetName="PART_ColorZone" Property="DockPanel.Dock" Value="Right"/>
-                            <Setter TargetName="HeaderPanel" Property="Rows" Value="0"/>
-                            <Setter TargetName="HeaderPanel" Property="Columns" Value="1"/>
+                            <Setter TargetName="PART_ColorZone" Property="DockPanel.Dock" Value="Right" />
+                            <Setter TargetName="HeaderPanel" Property="Rows" Value="0" />
+                            <Setter TargetName="HeaderPanel" Property="Columns" Value="1" />
                         </Trigger>
-
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
-    <Style TargetType="{x:Type TabItem}" x:Key="MaterialDesignTabItem">
-        <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
-        <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}"/>
-        <Setter Property="Padding" Value="16 12 16 12"/>
+    <Style x:Key="MaterialDesignTabItem" TargetType="{x:Type TabItem}">
+        <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}" />
+        <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+        <Setter Property="Typography.Capitals" Value="AllSmallCaps" />
+        <Setter Property="Padding" Value="16,12,16,12" />
         <Setter Property="Height" Value="72" />
         <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesignFlatButtonRipple}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabItem}">
-                    <Grid x:Name="Root" >
+                    <Grid x:Name="Root">
+                        <wpf:ColorZone
+                            x:Name="tabitemcz"
+                            Grid.RowSpan="2"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
+                            wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}"
+                            Background="{x:Null}"
+                            Focusable="False"
+                            Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}">
+                            <wpf:Ripple
+                                x:Name="contentPresenter"
+                                Padding="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="Center"
+                                VerticalContentAlignment="Center"
+                                Content="{TemplateBinding Header}"
+                                ContentStringFormat="{TemplateBinding HeaderStringFormat}"
+                                ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                Focusable="False"
+                                Opacity=".82"
+                                RecognizesAccessKey="True"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                TextBlock.FontSize="15"
+                                TextBlock.FontWeight="Medium"
+                                TextOptions.TextFormattingMode="Ideal"
+                                TextOptions.TextRenderingMode="Auto"
+                                Typography.Capitals="{TemplateBinding Typography.Capitals}" />
+                        </wpf:ColorZone>
+                        <Border
+                            x:Name="SelectionHighlightBorder"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="0,0,0,2"
+                            RenderTransformOrigin="0.5,0.5"
+                            Visibility="Hidden">
+                            <Border.RenderTransform>
+                                <ScaleTransform x:Name="ScaleTransform" ScaleX="0" ScaleY="1" />
+                            </Border.RenderTransform>
+                            <Rectangle
+                                x:Name="PART_BackgroundSelection"
+                                Fill="{TemplateBinding Background}"
+                                Opacity="0.12" />
+                        </Border>
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="SelectionStates">
                                 <VisualState x:Name="Selected">
                                     <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="ScaleTransform" From="0" To="1" Duration="0:0:0.3">
+                                        <DoubleAnimation
+                                            Storyboard.TargetName="ScaleTransform"
+                                            Storyboard.TargetProperty="ScaleX"
+                                            From="0"
+                                            To="1"
+                                            Duration="0:0:0.3">
                                             <DoubleAnimation.EasingFunction>
                                                 <SineEase EasingMode="EaseOut" />
                                             </DoubleAnimation.EasingFunction>
                                         </DoubleAnimation>
-                                        <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="PART_BackgroundSelection" To="0.12" BeginTime="0:0:0.3" Duration="0" />
+                                        <DoubleAnimation
+                                            BeginTime="0:0:0.3"
+                                            Storyboard.TargetName="PART_BackgroundSelection"
+                                            Storyboard.TargetProperty="Opacity"
+                                            To="0.12"
+                                            Duration="0" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Unselected">
                                     <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="ScaleTransform" To="0" Duration="0" />
-                                        <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="PART_BackgroundSelection" To="0" Duration="0" />
+                                        <DoubleAnimation
+                                            Storyboard.TargetName="ScaleTransform"
+                                            Storyboard.TargetProperty="ScaleX"
+                                            To="0"
+                                            Duration="0" />
+                                        <DoubleAnimation
+                                            Storyboard.TargetName="PART_BackgroundSelection"
+                                            Storyboard.TargetProperty="Opacity"
+                                            To="0"
+                                            Duration="0" />
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-
-
-                        <wpf:ColorZone Grid.RowSpan="2" x:Name="tabitemcz"
-                                       HorizontalAlignment="Stretch"
-                                       VerticalAlignment="Stretch"
-                                       Focusable="False"
-                                       Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}" 
-                                       Background="{x:Null}"
-                                       wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
-                                       wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}">
-                            <wpf:Ripple Focusable="False"
-                                        Typography.Capitals="AllSmallCaps"
-                                        Content="{TemplateBinding Header}" 
-                                        ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                        ContentStringFormat="{TemplateBinding HeaderStringFormat}"
-                                        HorizontalContentAlignment="Center"
-                                        VerticalContentAlignment="Center"
-                                        RecognizesAccessKey="True"
-                                        x:Name="contentPresenter"
-                                        Opacity=".82"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                                        Padding="{TemplateBinding Padding}"
-                                        TextBlock.FontWeight="Medium"
-                                        TextBlock.FontSize="15"
-                                        TextOptions.TextFormattingMode="Ideal" 
-                                        TextOptions.TextRenderingMode="Auto">
-                            </wpf:Ripple>
-                        </wpf:ColorZone>
-                        <Border x:Name="SelectionHighlightBorder" 
-                                BorderBrush="{TemplateBinding BorderBrush}" 
-                                BorderThickness="0,0,0,2"
-                                Visibility="Hidden" RenderTransformOrigin="0.5,0.5">
-                            <Border.RenderTransform>
-                                <ScaleTransform x:Name="ScaleTransform" ScaleX="0" ScaleY="1" />
-                            </Border.RenderTransform>
-                            <Rectangle x:Name="PART_BackgroundSelection" Fill="{TemplateBinding Background}" Opacity="0.12"/>
-                        </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.38"/>
+                            <Setter Property="Opacity" Value="0.38" />
                         </Trigger>
                         <Trigger Property="IsSelected" Value="True">
-                            <Setter TargetName="contentPresenter" Property="Opacity" Value="1"/>
+                            <Setter TargetName="contentPresenter" Property="Opacity" Value="1" />
                             <Setter TargetName="SelectionHighlightBorder" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <DataTrigger Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom">
@@ -175,21 +207,37 @@
                         <DataTrigger Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right">
                             <Setter TargetName="SelectionHighlightBorder" Property="BorderThickness" Value="2,0,0,0" />
                         </DataTrigger>
-                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="PrimaryLight">
-                            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueLightForegroundBrush}" />
-                            <Setter Property="Background" Value="{DynamicResource PrimaryHueLightForegroundBrush}" />
+                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="Standard">
+                            <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignBody}" />
+                            <Setter Property="Background" Value="{DynamicResource MaterialDesignBody}" />
                         </Trigger>
                         <Trigger Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid">
                             <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
                             <Setter Property="Background" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
                         </Trigger>
+                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="PrimaryLight">
+                            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueLightForegroundBrush}" />
+                            <Setter Property="Background" Value="{DynamicResource PrimaryHueLightForegroundBrush}" />
+                        </Trigger>
                         <Trigger Property="wpf:ColorZoneAssist.Mode" Value="PrimaryDark">
                             <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueDarkForegroundBrush}" />
                             <Setter Property="Background" Value="{DynamicResource PrimaryHueDarkForegroundBrush}" />
                         </Trigger>
+                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="SecondaryLight">
+                            <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueLightForegroundBrush}" />
+                            <Setter Property="Background" Value="{DynamicResource SecondaryHueLightForegroundBrush}" />
+                        </Trigger>
                         <Trigger Property="wpf:ColorZoneAssist.Mode" Value="SecondaryMid">
                             <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
                             <Setter Property="Background" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                        </Trigger>
+                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="SecondaryDark">
+                            <Setter Property="BorderBrush" Value="{DynamicResource SecondaryHueDarkForegroundBrush}" />
+                            <Setter Property="Background" Value="{DynamicResource SecondaryHueDarkForegroundBrush}" />
+                        </Trigger>
+                        <Trigger Property="wpf:ColorZoneAssist.Mode" Value="Custom">
+                            <Setter Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}" />
+                            <Setter Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -197,57 +245,62 @@
         </Setter>
     </Style>
 
-    <Style TargetType="{x:Type TabItem}" x:Key="MaterialDesignTabItemCompact" BasedOn="{StaticResource MaterialDesignTabItem}">
+    <Style
+        x:Key="MaterialDesignTabItemCompact"
+        BasedOn="{StaticResource MaterialDesignTabItem}"
+        TargetType="{x:Type TabItem}">
         <Setter Property="Height" Value="48" />
-    </Style>-->
+    </Style>
 
-    <!--NAVIGATION RAIL-->
+    <!--  NAVIGATION RAIL  -->
 
-    <Style TargetType="{x:Type TabItem}" x:Key="MaterialDesignNavigationRailTabItem">
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
-        <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}"/>
-        <Setter Property="Padding" Value="0"/>
+    <Style x:Key="MaterialDesignNavigationRailTabItem" TargetType="{x:Type TabItem}">
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
+        <Setter Property="Padding" Value="0" />
         <Setter Property="Height" Value="72" />
         <Setter Property="Width" Value="72" />
         <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesignFlatButtonRipple}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabItem}">
-                    <Grid x:Name="Root"
-                          Cursor="Hand">
-                        <Grid >
-                            <Border Background="{TemplateBinding Background}"
-                                       x:Name="MouseOverBorder"
-                                       Visibility="Hidden"
-                                       Opacity=".08"
-                                       CornerRadius="{Binding Path=(wpf:NavigationRailAssist.SelectionCornerRadius), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}"/>
-                            <wpf:ColorZone x:Name="colorZone"
-                                           HorizontalAlignment="Stretch"
-                                           VerticalAlignment="Stretch"
-                                           Cursor="Hand"
-                                           Focusable="False"
-                                           Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}" 
-                                           Background="{x:Null}"
-                                           wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
-                                           wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}">
-                                <wpf:Ripple Focusable="False"
-                                            ClipToBounds="True"
-                                            Content="{TemplateBinding Header}"
-                                            ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                            ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                            ContentStringFormat="{TemplateBinding HeaderStringFormat}"
-                                            HorizontalContentAlignment="Center"
-                                            VerticalContentAlignment="Center"
-                                            RecognizesAccessKey="True"
-                                            x:Name="contentPresenter"
-                                            Opacity=".52"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                                            Padding="{TemplateBinding Padding}"
-                                            TextBlock.FontWeight="Medium"
-                                            TextBlock.FontSize="15"
-                                            TextOptions.TextFormattingMode="Ideal" 
-                                            TextOptions.TextRenderingMode="Auto">
+                    <Grid x:Name="Root" Cursor="Hand">
+                        <Grid>
+                            <Border
+                                x:Name="MouseOverBorder"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="{Binding Path=(wpf:NavigationRailAssist.SelectionCornerRadius), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}"
+                                Opacity=".08"
+                                Visibility="Hidden" />
+                            <wpf:ColorZone
+                                x:Name="colorZone"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
+                                wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}"
+                                Background="{x:Null}"
+                                Cursor="Hand"
+                                Focusable="False"
+                                Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}">
+                                <wpf:Ripple
+                                    x:Name="contentPresenter"
+                                    Padding="{TemplateBinding Padding}"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalContentAlignment="Center"
+                                    ClipToBounds="True"
+                                    Content="{TemplateBinding Header}"
+                                    ContentStringFormat="{TemplateBinding HeaderStringFormat}"
+                                    ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                    ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                    Focusable="False"
+                                    Opacity=".52"
+                                    RecognizesAccessKey="True"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                    TextBlock.FontSize="15"
+                                    TextBlock.FontWeight="Medium"
+                                    TextOptions.TextFormattingMode="Ideal"
+                                    TextOptions.TextRenderingMode="Auto">
                                     <wpf:Ripple.Clip>
                                         <MultiBinding Converter="{StaticResource BorderClipConverter}">
                                             <Binding ElementName="MouseOverBorder" Path="ActualWidth" />
@@ -259,37 +312,37 @@
                                 </wpf:Ripple>
                             </wpf:ColorZone>
                         </Grid>
-                        <Border x:Name="SelectionHighlightBorder" 
-                                Visibility="Hidden" >
-                            <Border x:Name="PART_BackgroundSelection"
-                                       Background="{TemplateBinding Background}"
-                                       Opacity="0.12"
-                                       CornerRadius="{Binding Path=(wpf:NavigationRailAssist.SelectionCornerRadius), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}"/>
+                        <Border x:Name="SelectionHighlightBorder" Visibility="Hidden">
+                            <Border
+                                x:Name="PART_BackgroundSelection"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="{Binding Path=(wpf:NavigationRailAssist.SelectionCornerRadius), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}"
+                                Opacity="0.12" />
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.38"/>
+                            <Setter Property="Opacity" Value="0.38" />
                         </Trigger>
-                        <Trigger Property="IsMouseOver" Value="True" SourceName="Root">
-                            <Setter TargetName="MouseOverBorder" Property="Visibility" Value="Visible"/>
+                        <Trigger SourceName="Root" Property="IsMouseOver" Value="True">
+                            <Setter TargetName="MouseOverBorder" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="IsSelected" Value="True">
-                            <Setter TargetName="contentPresenter" Property="Opacity" Value="1"/>
+                            <Setter TargetName="contentPresenter" Property="Opacity" Value="1" />
                         </Trigger>
 
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsSelected" Value="True"/>
-                                <Condition Property="wpf:ColorZoneAssist.Mode" Value="Standard"/>
+                                <Condition Property="IsSelected" Value="True" />
+                                <Condition Property="wpf:ColorZoneAssist.Mode" Value="Standard" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="contentPresenter" Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}"/>
+                            <Setter TargetName="contentPresenter" Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
                         </MultiTrigger>
 
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(wpf:NavigationRailAssist.ShowSelectionBackground), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="True"/>
+                                <Condition Binding="{Binding Path=(wpf:NavigationRailAssist.ShowSelectionBackground), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="True" />
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="SelectionHighlightBorder" Property="Visibility" Value="Visible" />
                         </MultiDataTrigger>
@@ -326,100 +379,110 @@
                             <Setter Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}" />
                             <Setter Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}" />
                         </Trigger>
-                        
+
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
-    <Style  TargetType="{x:Type TabControl}" x:Key="MaterialDesignNavigatilRailTabControl">
+    <Style x:Key="MaterialDesignNavigatilRailTabControl" TargetType="{x:Type TabControl}">
         <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
-        <Setter Property="VerticalContentAlignment" Value="Top"/>
+        <Setter Property="VerticalContentAlignment" Value="Top" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesignFlatButtonRipple}" />
         <Setter Property="TabStripPlacement" Value="Left" />
-        <Setter Property="BorderThickness" Value="0,0,1,0"/>
-        <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth0"/>
-        <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Right"/>
-        <Setter Property="ItemContainerStyle" Value="{StaticResource MaterialDesignNavigationRailTabItem}"/>
+        <Setter Property="BorderThickness" Value="0,0,1,0" />
+        <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth0" />
+        <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Right" />
+        <Setter Property="ItemContainerStyle" Value="{StaticResource MaterialDesignNavigationRailTabItem}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabControl}">
-                    <DockPanel Background="{TemplateBinding Background}" 
-                               KeyboardNavigation.TabNavigation="Local">
-                        <!--tabs-->
-                        <Grid x:Name="TabGrid" DockPanel.Dock="Left" SnapsToDevicePixels="True">
-                            <wpf:Card wpf:ShadowAssist.ShadowDepth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth)}"
-                                      wpf:ShadowAssist.ShadowEdges="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowEdges)}"
-                                      BorderBrush="{DynamicResource MaterialDesignDivider}"
-                                      BorderThickness="{TemplateBinding BorderThickness}"
-                                      UniformCornerRadius="0" x:Name="shadowCard"
-                                      Background="{TemplateBinding Background}" 
-                                      Visibility="Visible"/>
+                    <DockPanel Background="{TemplateBinding Background}" KeyboardNavigation.TabNavigation="Local">
+                        <!--  tabs  -->
+                        <Grid
+                            x:Name="TabGrid"
+                            DockPanel.Dock="Left"
+                            SnapsToDevicePixels="True">
+                            <wpf:Card
+                                x:Name="shadowCard"
+                                wpf:ShadowAssist.ShadowDepth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth)}"
+                                wpf:ShadowAssist.ShadowEdges="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowEdges)}"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{DynamicResource MaterialDesignDivider}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                UniformCornerRadius="0"
+                                Visibility="Visible" />
 
-                            <wpf:ColorZone x:Name="PART_ColorZone" 
-                                           VerticalAlignment="Stretch"
-                                           Focusable="False"
-                                           Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}" 
-                                           wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
-                                           wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}">
+                            <wpf:ColorZone
+                                x:Name="PART_ColorZone"
+                                VerticalAlignment="Stretch"
+                                wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
+                                wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}"
+                                Focusable="False"
+                                Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}">
                                 <Grid Background="{Binding ElementName=PART_ColorZone, Path=Background}">
                                     <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="1*"/>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="1*" />
                                     </Grid.RowDefinitions>
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="1*"/>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="1*" />
                                     </Grid.ColumnDefinitions>
-                                    <ContentPresenter Focusable="False"
-                                                      x:Name="FloatingContentPanel"
-                                                      Grid.Row="0"
-                                                      Grid.Column="0"
-                                                      HorizontalAlignment="Center"
-                                                      VerticalAlignment="Center"
-                                                      Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:NavigationRailAssist.FloatingContent)}" />
-                                    <UniformGrid x:Name="HeaderPanel"
-                                                 Grid.Row="1"
-                                                 Grid.Column="0"
-                                                 Columns="1"
-                                                 Rows="0" 
-                                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                 IsItemsHost="True"
-                                                 Focusable="False"
-                                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                                    <ContentPresenter
+                                        x:Name="FloatingContentPanel"
+                                        Grid.Row="0"
+                                        Grid.Column="0"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:NavigationRailAssist.FloatingContent)}"
+                                        Focusable="False" />
+                                    <UniformGrid
+                                        x:Name="HeaderPanel"
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                        Columns="1"
+                                        Focusable="False"
+                                        IsItemsHost="True"
+                                        Rows="0" />
 
-                                    <Rectangle x:Name="DividerRect" Fill="{DynamicResource MaterialDesignDivider}"
-                                               Width="1"
-                                               Height="Auto"
-                                               Grid.RowSpan="2"
-                                               HorizontalAlignment="Right"
-                                               Visibility="Collapsed"/>
+                                    <Rectangle
+                                        x:Name="DividerRect"
+                                        Grid.RowSpan="2"
+                                        Width="1"
+                                        Height="Auto"
+                                        HorizontalAlignment="Right"
+                                        Fill="{DynamicResource MaterialDesignDivider}"
+                                        Visibility="Collapsed" />
                                 </Grid>
                             </wpf:ColorZone>
 
                         </Grid>
-                        <!--selected content-->
-                        <wpf:ColorZone x:Name="PART_ColorZoneSelectedContent" 
-                                       Padding="{TemplateBinding Padding}" 
-                                       VerticalAlignment="Stretch"
-                                       HorizontalAlignment="Stretch"
-                                       Mode="Standard" 
-                                       Foreground="{DynamicResource MaterialDesignBody}"
-                                       Background="{x:Null}">
+                        <!--  selected content  -->
+                        <wpf:ColorZone
+                            x:Name="PART_ColorZoneSelectedContent"
+                            Padding="{TemplateBinding Padding}"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            Background="{x:Null}"
+                            Foreground="{DynamicResource MaterialDesignBody}"
+                            Mode="Standard">
 
-                            <ContentPresenter x:Name="PART_SelectedContentHost"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                                              Focusable="False"
-                                              Margin="{TemplateBinding Padding}"
-                                              ContentSource="SelectedContent"
-                                              ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                              ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}">
-                            </ContentPresenter>
+                            <ContentPresenter
+                                x:Name="PART_SelectedContentHost"
+                                Margin="{TemplateBinding Padding}"
+                                ContentSource="SelectedContent"
+                                ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                Focusable="False"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </wpf:ColorZone>
                     </DockPanel>
                     <ControlTemplate.Triggers>
@@ -428,42 +491,42 @@
                             <Setter TargetName="DividerRect" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="wpf:ColorZoneAssist.Mode" Value="Standard">
-                            <Setter TargetName="PART_ColorZone" Property="Background" Value="Transparent"/>
+                            <Setter TargetName="PART_ColorZone" Property="Background" Value="Transparent" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Top">
-                            <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Bottom"/>
+                            <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Bottom" />
                             <Setter Property="BorderThickness" Value="0,0,0,1" />
-                            <Setter TargetName="TabGrid" Property="DockPanel.Dock" Value="Top"/>
+                            <Setter TargetName="TabGrid" Property="DockPanel.Dock" Value="Top" />
                             <Setter TargetName="DividerRect" Property="Width" Value="Auto" />
                             <Setter TargetName="DividerRect" Property="Height" Value="1" />
                             <Setter TargetName="DividerRect" Property="VerticalAlignment" Value="Bottom" />
                             <Setter TargetName="DividerRect" Property="HorizontalAlignment" Value="Stretch" />
                             <Setter TargetName="DividerRect" Property="Grid.ColumnSpan" Value="2" />
                             <Setter TargetName="DividerRect" Property="Grid.RowSpan" Value="1" />
-                            <Setter TargetName="HeaderPanel" Property="Rows" Value="1"/>
-                            <Setter TargetName="HeaderPanel" Property="Columns" Value="0"/>
-                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1"/>
-                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0"/>
+                            <Setter TargetName="HeaderPanel" Property="Rows" Value="1" />
+                            <Setter TargetName="HeaderPanel" Property="Columns" Value="0" />
+                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
-                            <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Top"/>
+                            <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Top" />
                             <Setter Property="BorderThickness" Value="0,1,0,0" />
-                            <Setter TargetName="TabGrid" Property="DockPanel.Dock" Value="Bottom"/>
+                            <Setter TargetName="TabGrid" Property="DockPanel.Dock" Value="Bottom" />
                             <Setter TargetName="DividerRect" Property="Width" Value="Auto" />
                             <Setter TargetName="DividerRect" Property="Height" Value="1" />
                             <Setter TargetName="DividerRect" Property="VerticalAlignment" Value="Top" />
                             <Setter TargetName="DividerRect" Property="HorizontalAlignment" Value="Stretch" />
                             <Setter TargetName="DividerRect" Property="Grid.ColumnSpan" Value="2" />
                             <Setter TargetName="DividerRect" Property="Grid.RowSpan" Value="1" />
-                            <Setter TargetName="HeaderPanel" Property="Rows" Value="1"/>
-                            <Setter TargetName="HeaderPanel" Property="Columns" Value="0"/>
-                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1"/>
-                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0"/>
+                            <Setter TargetName="HeaderPanel" Property="Rows" Value="1" />
+                            <Setter TargetName="HeaderPanel" Property="Columns" Value="0" />
+                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
-                            <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Left"/>
-                            <Setter Property="BorderThickness" Value="1,0,0,0"/>
-                            <Setter TargetName="TabGrid" Property="DockPanel.Dock" Value="Right"/>
+                            <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Left" />
+                            <Setter Property="BorderThickness" Value="1,0,0,0" />
+                            <Setter TargetName="TabGrid" Property="DockPanel.Dock" Value="Right" />
                             <Setter TargetName="DividerRect" Property="HorizontalAlignment" Value="Left" />
                         </Trigger>
                     </ControlTemplate.Triggers>


### PR DESCRIPTION
Now there are default styles for `TabControl` and `TabItem` that support `ColorZone` to address https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/1616
and a page in the demo app to show them 
Light
![image](https://user-images.githubusercontent.com/7858946/147374090-e8298cde-d7f6-4154-baa0-b19374ac4429.png)
Dark
![image](https://user-images.githubusercontent.com/7858946/147374077-5117f828-9efa-427b-93e7-ad096350cb4b.png)
