### PR TITLE
Fix #2556

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -33,7 +33,7 @@ runs:
 
     - name: Test
       shell: pwsh
-      run: dotnet test ${{ inputs.solution }} --configuration ${{ inputs.buildConfiguration }} --no-build --verbosity detailed --blame-crash
+      run: dotnet test ${{ inputs.solution }} --configuration ${{ inputs.buildConfiguration }} --no-build --verbosity normal --blame-crash
 
     - name: Upload Screenshots
       if: ${{ always() }}

--- a/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
@@ -391,7 +391,10 @@ namespace MaterialDesignThemes.UITests.WPF.TextBoxes
 ");
             
             var scrollViewer = await textBox.GetElement<ScrollViewer>("PART_ContentHost");
-            Assert.Equal(VerticalAlignment.Top, await scrollViewer.GetVerticalAlignment());
+            //The default for this changed with issue 2556.
+            //It should be stretch so that the horizontal scroll bar is at the bottom and not
+            //pushed to the bottom of the text.
+            Assert.Equal(VerticalAlignment.Stretch, await scrollViewer.GetVerticalAlignment());
 
             foreach (var alignment in Enum.GetValues<VerticalAlignment>())
             {

--- a/MaterialDesignThemes.Wpf.Tests/TextBoxTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/TextBoxTests.cs
@@ -18,13 +18,17 @@ namespace MaterialDesignThemes.Wpf.Tests
         }
 
         [StaFact]
-        [Description("Issue 1301")]
-        public void DefaultVerticalContentAlignment_ShouldBeTop()
+        [Description("Issue 2556")]
+        public void DefaultVerticalContentAlignment_ShouldBeStretch()
         {
+            //The default was initially set to Top from issue 1301
+            //However because TextBox contains a ScrollViewer this pushes
+            //the horizontal scroll bar up by default, which is different
+            //than the default WPF behavior.
             var textBox = new TextBox();
             textBox.ApplyDefaultStyle();
 
-            Assert.Equal(VerticalAlignment.Top, textBox.VerticalContentAlignment);
+            Assert.Equal(VerticalAlignment.Stretch, textBox.VerticalContentAlignment);
         }
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -54,7 +54,7 @@
         <Setter Property="CaretBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="SelectionBrush" Value="{DynamicResource PrimaryHueLightBrush}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="VerticalContentAlignment" Value="Top" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="AllowDrop" Value="true" />
         <Setter Property="Cursor" Value="Arrow" />
@@ -337,7 +337,6 @@
                             <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
                         </Trigger>
                         <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
-                            <Setter Property="VerticalContentAlignment" Value="Top" />
                             <Setter Property="BorderThickness" Value="1" />
                             <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
                             <Setter Property="Padding" Value="16,16,12,16" />


### PR DESCRIPTION
Fixes #2556  by altering the VerticalContentAlignment properties on MaterialDesignTextBoxBase and a trigger for the outlined style.