### PR TITLE
Optimize Expander

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
@@ -189,6 +189,11 @@
                                                     <CubicEase EasingMode="EaseInOut"/>
                                                 </DoubleAnimation.EasingFunction>
                                             </DoubleAnimation>
+                                            <ObjectAnimationUsingKeyFrames Duration="0:0:0"
+                                                                           Storyboard.TargetName="PART_Content"
+                                                                           Storyboard.TargetProperty="Visibility">
+                                                <DiscreteObjectKeyFrame KeyTime="0%" Value="{x:Static Visibility.Visible}"/>
+                                            </ObjectAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
 
@@ -206,6 +211,11 @@
                                                     <CubicEase EasingMode="EaseInOut"/>
                                                 </DoubleAnimation.EasingFunction>
                                             </DoubleAnimation>
+                                            <ObjectAnimationUsingKeyFrames Duration="{DynamicResource CollapseDuration}" 
+                                                                           Storyboard.TargetName="PART_Content" 
+                                                                           Storyboard.TargetProperty="Visibility">
+                                                <DiscreteObjectKeyFrame KeyTime="100%" Value="{x:Static Visibility.Collapsed}"/>
+                                            </ObjectAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
                                 </VisualStateGroup.Transitions>
@@ -220,6 +230,11 @@
                                                          Storyboard.TargetProperty="(ScaleTransform.ScaleY)" 
                                                          To="1" 
                                                          Duration="0" />
+                                        <ObjectAnimationUsingKeyFrames Duration="0"
+                                                                       Storyboard.TargetName="PART_Content"
+                                                                       Storyboard.TargetProperty="Visibility">
+                                            <DiscreteObjectKeyFrame KeyTime="0%" Value="{x:Static Visibility.Visible}"/>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
 
@@ -233,6 +248,11 @@
                                                          Storyboard.TargetProperty="(ScaleTransform.ScaleY)"
                                                          To="0"
                                                          Duration="0" />
+                                        <ObjectAnimationUsingKeyFrames Duration="0" 
+                                                                       Storyboard.TargetName="PART_Content" 
+                                                                       Storyboard.TargetProperty="Visibility">
+                                            <DiscreteObjectKeyFrame KeyTime="100%" Value="{x:Static Visibility.Collapsed}"/>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
 
@@ -271,18 +291,19 @@
                                     <Grid.LayoutTransform>
                                         <RotateTransform Angle="{Binding Path=ExpandDirection, RelativeSource={RelativeSource AncestorType=Expander}, Converter={StaticResource ExpanderRotateAngleConverter}, ConverterParameter=-1}"/>
                                     </Grid.LayoutTransform>
-                                    
+
                                     <ContentPresenter Name="PART_Content" Focusable="False"
+                                                      Visibility="Collapsed"
                                                       ContentTemplate="{TemplateBinding ContentTemplate}"
                                                       ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                       ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"/>
 
                                 </Grid>
                             </Border>
-
                         </DockPanel>
                     </Border>
                     <ControlTemplate.Triggers>
+
                         <Trigger Property="ExpandDirection" Value="Right">
                             <Setter Property="DockPanel.Dock" TargetName="HeaderSite" Value="Left"/>
                             <Setter Property="Style" TargetName="HeaderSite" Value="{StaticResource MaterialDesignVerticalHeaderStyle}"/>


### PR DESCRIPTION
Right now the "Pickers" page has slow loading times since there are a lot of controls in the expanders. I checked why and I've seen that the MaterialDesignExpander style does not implement the [Visibility optimization present in the default theme](https://github.com/dotnet/wpf/blob/c271205b80c27df976acbd7236ec637090d127c1/src/Microsoft.DotNet.Wpf/src/Themes/XAML/Expander.xaml#L526-L530).

I've added this optimization while retaining the animation, so instead of using a Setter with a Trigger, I've added the animations for the Visibility. 

With this optimization the page loads much faster and the controls inside the Expander are only loaded when the expander is opened.