### PR TITLE
Renamed MaterialDesignNavigatilRailTabControl to MaterialDesignNaviga…

### DIFF
--- a/MainDemo.Wpf/NavigationRail.xaml
+++ b/MainDemo.Wpf/NavigationRail.xaml
@@ -35,7 +35,7 @@
                     <TabControl
                         materialDesign:NavigationRailAssist.ShowSelectionBackground="True"
                         SnapsToDevicePixels="True"
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}"
+                        Style="{StaticResource MaterialDesignNavigationRailTabControl}"
                         TabStripPlacement="Left">
                         <materialDesign:NavigationRailAssist.FloatingContent>
                             <Button
@@ -168,7 +168,7 @@
                         materialDesign:ColorZoneAssist.Mode="PrimaryLight"
                         materialDesign:NavigationRailAssist.SelectionCornerRadius="50"
                         materialDesign:NavigationRailAssist.ShowSelectionBackground="True"
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}"
+                        Style="{StaticResource MaterialDesignNavigationRailTabControl}"
                         TabStripPlacement="Bottom">
 
                         <TabItem Margin="4">
@@ -241,7 +241,7 @@
                 Margin="0,8,8,0"
                 UniqueKey="navrail_2">
                 <materialDesign:Card>
-                    <TabControl Style="{StaticResource MaterialDesignNavigatilRailTabControl}" TabStripPlacement="Right">
+                    <TabControl Style="{StaticResource MaterialDesignNavigationRailTabControl}" TabStripPlacement="Right">
                         <TabItem>
                             <TabItem.Header>
                                 <StackPanel Width="auto" Height="auto">
@@ -331,7 +331,7 @@
                     <TabControl
                         VerticalContentAlignment="Bottom"
                         materialDesign:ColorZoneAssist.Mode="PrimaryMid"
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}">
+                        Style="{StaticResource MaterialDesignNavigationRailTabControl}">
                         <TabItem>
                             <TabItem.Header>
                                 <StackPanel Width="auto" Height="auto">
@@ -427,7 +427,7 @@
                     materialDesign:ColorZoneAssist.Mode="PrimaryMid"
                     materialDesign:NavigationRailAssist.SelectionCornerRadius="50 10 10 10"
                     materialDesign:NavigationRailAssist.ShowSelectionBackground="True"
-                    Style="{StaticResource MaterialDesignNavigatilRailTabControl}"
+                    Style="{StaticResource MaterialDesignNavigationRailTabControl}"
                     TabStripPlacement="Top">
                     <materialDesign:NavigationRailAssist.FloatingContent>
                         <Button Margin="8" Style="{StaticResource MaterialDesignFloatingActionAccentButton}">
@@ -532,7 +532,7 @@
                     <TabControl
                         materialDesign:ColorZoneAssist.Mode="Standard"
                         materialDesign:ShadowAssist.ShadowDepth="Depth0"
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}">
+                        Style="{StaticResource MaterialDesignNavigationRailTabControl}">
                         <TabItem>
                             <TabItem.Header>
                                 <StackPanel Width="auto" Height="auto">
@@ -594,7 +594,7 @@
                     <TabControl
                         materialDesign:ColorZoneAssist.Mode="Standard"
                         materialDesign:ShadowAssist.ShadowDepth="Depth1"
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}">
+                        Style="{StaticResource MaterialDesignNavigationRailTabControl}">
                         <TabItem>
                             <TabItem.Header>
                                 <StackPanel Width="auto" Height="auto">
@@ -656,7 +656,7 @@
                     <TabControl
                         materialDesign:ColorZoneAssist.Mode="Standard"
                         materialDesign:ShadowAssist.ShadowDepth="Depth2"
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}">
+                        Style="{StaticResource MaterialDesignNavigationRailTabControl}">
                         <TabItem>
                             <TabItem.Header>
                                 <StackPanel Width="auto" Height="auto">
@@ -718,7 +718,7 @@
                     <TabControl
                         materialDesign:ColorZoneAssist.Mode="Standard"
                         materialDesign:ShadowAssist.ShadowDepth="Depth3"
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}">
+                        Style="{StaticResource MaterialDesignNavigationRailTabControl}">
                         <TabItem>
                             <TabItem.Header>
                                 <StackPanel Width="auto" Height="auto">

--- a/MaterialDesign3.Demo.Wpf/NavigationRail.xaml
+++ b/MaterialDesign3.Demo.Wpf/NavigationRail.xaml
@@ -49,7 +49,7 @@
                 <smtx:XamlDisplay
                     UniqueKey="navrail_1"
                     Margin="5,5,5,0">
-                    <TabControl Style="{StaticResource MaterialDesignNavigatilRailTabControl}" BorderThickness="0"
+                    <TabControl Style="{StaticResource MaterialDesignNavigationRailTabControl}" BorderThickness="0"
                                 BorderBrush="Transparent" TabStripPlacement="Left"
                                 materialDesign:ShadowAssist.ShadowDepth="Depth0"
                                 materialDesign:ColorZoneAssist.Mode="Standard" SnapsToDevicePixels="True"
@@ -126,7 +126,7 @@
                     Margin="5,5,5,0"
                     Grid.Column="1">
                     <TabControl TabStripPlacement="Bottom"
-                                Style="{StaticResource MaterialDesignNavigatilRailTabControl}"
+                                Style="{StaticResource MaterialDesignNavigationRailTabControl}"
                                 materialDesign:ColorZoneAssist.Mode="PrimaryLight"
                                 materialDesign:NavigationRailAssist.ShowSelectionBackground="True"
                                 materialDesign:NavigationRailAssist.SelectionCornerRadius="50"
@@ -190,7 +190,7 @@
                     Margin="5,5,5,0"
                     Grid.Row="1">
                     <TabControl
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}"
+                        Style="{StaticResource MaterialDesignNavigationRailTabControl}"
                         TabStripPlacement="Right">
                         <TabItem >
                             <TabItem.Header>
@@ -264,7 +264,7 @@
                     Grid.Row="1"
                     Grid.Column="1">
                     <TabControl VerticalContentAlignment="Bottom"
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}"
+                        Style="{StaticResource MaterialDesignNavigationRailTabControl}"
                         materialDesign:ColorZoneAssist.Mode="PrimaryMid">
                         <TabItem >
                             <TabItem.Header>
@@ -339,7 +339,7 @@
             Margin="5">
             <smtx:XamlDisplay UniqueKey="navrail_floating_1">
                 <TabControl 
-                    Style="{StaticResource MaterialDesignNavigatilRailTabControl}" 
+                    Style="{StaticResource MaterialDesignNavigationRailTabControl}" 
                     materialDesign:ColorZoneAssist.Mode="PrimaryMid"
                     TabStripPlacement="Top"
                     materialDesign:NavigationRailAssist.SelectionCornerRadius="50 10 10 10"
@@ -428,7 +428,7 @@
             <StackPanel Orientation="Horizontal">
                 <smtx:XamlDisplay UniqueKey="navrail_noshadow_1">
                     <TabControl
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}" 
+                        Style="{StaticResource MaterialDesignNavigationRailTabControl}" 
                         materialDesign:ColorZoneAssist.Mode="Standard"
                         materialDesign:ShadowAssist.ShadowDepth="Depth0">
                         <TabItem >
@@ -472,7 +472,7 @@
                 
                 <smtx:XamlDisplay UniqueKey="navrail_wshadow_1">
                     <TabControl
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}" 
+                        Style="{StaticResource MaterialDesignNavigationRailTabControl}" 
                         materialDesign:ColorZoneAssist.Mode="Standard"
                         materialDesign:ShadowAssist.ShadowDepth="Depth1">
                         <TabItem >
@@ -516,7 +516,7 @@
                 
                 <smtx:XamlDisplay UniqueKey="navrail_wshadow_2">
                     <TabControl
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}" 
+                        Style="{StaticResource MaterialDesignNavigationRailTabControl}" 
                         materialDesign:ColorZoneAssist.Mode="Standard"
                         materialDesign:ShadowAssist.ShadowDepth="Depth2">
                         <TabItem >
@@ -560,7 +560,7 @@
                 
                 <smtx:XamlDisplay UniqueKey="navrail_wshadow_3">
                     <TabControl
-                        Style="{StaticResource MaterialDesignNavigatilRailTabControl}" 
+                        Style="{StaticResource MaterialDesignNavigationRailTabControl}" 
                         materialDesign:ColorZoneAssist.Mode="Standard"
                         materialDesign:ShadowAssist.ShadowDepth="Depth3">
                         <TabItem >

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -578,4 +578,8 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <!-- Obsolete: will be removed in 5.0.0 release -->
+    <Style x:Key="MaterialDesignNavigatilRailTabControl" TargetType="{x:Type TabControl}"> BasedOn="{StaticResource MaterialDesignNavigationRailTabControl}"/>
+
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -430,7 +430,7 @@
         </Setter>
     </Style>
 
-    <Style x:Key="MaterialDesignNavigatilRailTabControl" TargetType="{x:Type TabControl}">
+    <Style x:Key="MaterialDesignNavigationRailTabControl" TargetType="{x:Type TabControl}">
         <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
         <Setter Property="VerticalContentAlignment" Value="Top" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -580,6 +580,6 @@
     </Style>
 
     <!-- Obsolete: will be removed in 5.0.0 release -->
-    <Style x:Key="MaterialDesignNavigatilRailTabControl" TargetType="{x:Type TabControl}"> BasedOn="{StaticResource MaterialDesignNavigationRailTabControl}"/>
+    <Style x:Key="MaterialDesignNavigatilRailTabControl" TargetType="{x:Type TabControl}" BasedOn="{StaticResource MaterialDesignNavigationRailTabControl}" />
 
 </ResourceDictionary>


### PR DESCRIPTION
Breaking change:
Renamed misspelled MaterialDesignNavigatilRailTabControl to MaterialDesignNavigationRailTabControl

