### PR TITLE
Transparent menu headers

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
@@ -87,6 +87,9 @@
         x:Key="MaterialDesignMenuItem"
         BasedOn="{x:Null}">
         <Setter
+            Property="Background"
+            Value="{DynamicResource MaterialDesignPaper}" />
+        <Setter
             Property="Padding"
             Value="24 0 24 0"></Setter>
         <Setter
@@ -114,7 +117,7 @@
                             x:Name="templateRoot"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            Background="{TemplateBinding Background}"
+                            
                             SnapsToDevicePixels="True" />
                         <Border
                             x:Name="BackgroundRoot"
@@ -248,7 +251,7 @@
                             CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
                             <Border
                                 x:Name="SubMenuBorder"
-                                Background="{Binding Path=Background, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=MenuBase}}"
+                                Background="{DynamicResource MaterialDesignPaper}"
                                 Effect="{DynamicResource MaterialDesignShadowDepth1}"
                                 CornerRadius="2">
 
@@ -471,7 +474,7 @@
 
         <Setter
             Property="Background"
-            Value="{DynamicResource MaterialDesignPaper}" />
+            Value="Transparent" />
         <Setter
             Property="FontFamily"
             Value="{StaticResource MaterialDesignFont}" />


### PR DESCRIPTION
The menu headers had a defined background colour. I changed the background colour to transparent. The next step is to remove the height property so that the headers fill the available height.