### PR TITLE
Menu improvements

### DIFF
--- a/MainDemo.Wpf/MenusAndToolBars.xaml
+++ b/MainDemo.Wpf/MenusAndToolBars.xaml
@@ -13,14 +13,14 @@
         <smtx:XamlDisplay
             UniqueKey="menus_1"
             DockPanel.Dock="Top"
-            Margin="5 5 0 5">
-            <Menu IsMainMenu="True">
+            Margin="5 5 0 15">
+            <Menu IsMainMenu="True" Height="48">
                 <MenuItem Header="_File">
                     <MenuItem
                         Header="Save"
                         Icon="{materialDesign:PackIcon Kind=ContentSave}">
                     </MenuItem>
-                    
+
                     <MenuItem Header="Save As.."/>
 
                     <MenuItem
@@ -29,16 +29,16 @@
                         Icon="{materialDesign:PackIcon Kind=ExitToApp}"/>
 
                     <Separator/>
-                    
+
                     <MenuItem
                         Header="Excellent"
                         IsCheckable="True"
                         IsChecked="True"/>
-                    
+
                     <MenuItem
                         Header="Rubbish"
                         IsCheckable="True"/>
-                    
+
                     <MenuItem
                         Header="Dig Deeper"
                         InputGestureText="Ctrl+D">
@@ -49,7 +49,7 @@
                             Header="Disappointment"
                             IsCheckable="True"/>
                     </MenuItem>
-                    
+
                     <MenuItem
                         Header="Look Deeper"
                         InputGestureText="Ctrl+D">
@@ -57,7 +57,7 @@
                         <MenuItem Header="Ice Cream"/>
                     </MenuItem>
                 </MenuItem>
-                
+
                 <MenuItem Header="_Edit">
                     <MenuItem
                         Header="_Cut"
@@ -75,6 +75,46 @@
                         Icon="{materialDesign:PackIcon Kind=ContentPaste}"/>
                 </MenuItem>
             </Menu>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay
+            UniqueKey="bigMenu"
+            DockPanel.Dock="Top"
+            Margin="5 5 0 5">
+            <materialDesign:Card Height="80">
+                <Menu>
+                    <MenuItem Header="Big">
+                        <MenuItem Header="Test 1"/>
+                        <MenuItem Header="Test 1"/>
+                        <MenuItem Header="Test 1"/>
+                    </MenuItem>
+                    <MenuItem Header="Menu">
+                        <MenuItem Header="Test 1"/>
+                        <MenuItem Header="Test 1"/>
+                        <MenuItem Header="Test 1"/>
+                    </MenuItem>
+                </Menu>
+            </materialDesign:Card>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay
+            UniqueKey="smallMenu"
+            DockPanel.Dock="Top"
+            Margin="5 5 0 20">
+            <materialDesign:Card Height="25">
+                <Menu>
+                    <MenuItem Header="Small">
+                        <MenuItem Header="Test 1"/>
+                        <MenuItem Header="Test 1"/>
+                        <MenuItem Header="Test 1"/>
+                    </MenuItem>
+                    <MenuItem Header="Menu">
+                        <MenuItem Header="Test 1"/>
+                        <MenuItem Header="Test 1"/>
+                        <MenuItem Header="Test 1"/>
+                    </MenuItem>
+                </Menu>
+            </materialDesign:Card>
         </smtx:XamlDisplay>
 
         <smtx:XamlDisplay

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
@@ -87,6 +87,9 @@
         x:Key="MaterialDesignMenuItem"
         BasedOn="{x:Null}">
         <Setter
+            Property="Background"
+            Value="{DynamicResource MaterialDesignPaper}" />
+        <Setter
             Property="Padding"
             Value="24 0 24 0"></Setter>
         <Setter
@@ -114,7 +117,7 @@
                             x:Name="templateRoot"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            Background="{TemplateBinding Background}"
+                            
                             SnapsToDevicePixels="True" />
                         <Border
                             x:Name="BackgroundRoot"
@@ -248,7 +251,7 @@
                             CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
                             <Border
                                 x:Name="SubMenuBorder"
-                                Background="{Binding Path=Background, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=MenuBase}}"
+                                Background="{DynamicResource MaterialDesignPaper}"
                                 Effect="{DynamicResource MaterialDesignShadowDepth1}"
                                 CornerRadius="2">
 
@@ -471,7 +474,7 @@
 
         <Setter
             Property="Background"
-            Value="{DynamicResource MaterialDesignPaper}" />
+            Value="Transparent" />
         <Setter
             Property="FontFamily"
             Value="{StaticResource MaterialDesignFont}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
@@ -337,7 +337,7 @@
                                 Value="16 0" />
                             <Setter
                                 Property="Height"
-                                Value="48" />
+                                Value="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType={x:Type Menu}}}" />
                             <Setter
                                 TargetName="templateRoot"
                                 Property="CornerRadius"


### PR DESCRIPTION
I made two improvements for menus :
- Menu headers are now transparent
- Menu headers now fill the available height

I also added some examples in the demo

![image](https://user-images.githubusercontent.com/54487782/156428302-0fb66128-7609-4a9d-acc4-c0197a611f1d.png)

![image](https://user-images.githubusercontent.com/54487782/156428210-c472e464-d2c9-4f6f-b814-390c317e1b1a.png)

Please note that since the menus no longer have a fixed height, this change could affect the layout of the controls on a page. So the people who use the menus will have to manually set a fixed height on the menus to get the same layout.