### PR TITLE
Change animation duration

### DIFF
--- a/MaterialDesignThemes.Wpf/Ripple.cs
+++ b/MaterialDesignThemes.Wpf/Ripple.cs
@@ -15,6 +15,8 @@ namespace MaterialDesignThemes.Wpf
     [TemplateVisualState(GroupName = "CommonStates", Name = TemplateStateMouseOut)]
     public class Ripple : ContentControl
     {
+        private const double RippleAnimationDuration = 225; //in milliseconds
+
         public const string TemplateStateNormal = "Normal";
         public const string TemplateStateMousePressed = "MousePressed";
         public const string TemplateStateMouseOut = "MouseOut";
@@ -45,7 +47,7 @@ namespace MaterialDesignThemes.Wpf
                 if (scaleTrans != null)
                 {
                     double currentScale = scaleTrans.ScaleX;
-                    var newTime = TimeSpan.FromMilliseconds(300 * (1.0 - currentScale));
+                    var newTime = TimeSpan.FromMilliseconds(RippleAnimationDuration * (1.0 - currentScale));
 
                     // change the scale animation according to the current scale
                     var scaleXKeyFrame = ripple.Template.FindName("MousePressedToNormalScaleXKeyFrame", ripple) as EasingDoubleKeyFrame;

--- a/MaterialDesignThemes.Wpf/ShadowAssist.cs
+++ b/MaterialDesignThemes.Wpf/ShadowAssist.cs
@@ -6,6 +6,7 @@ using System.Windows.Media.Effects;
 
 namespace MaterialDesignThemes.Wpf
 {
+
     public enum ShadowDepth
     {
         Depth0,
@@ -39,6 +40,8 @@ namespace MaterialDesignThemes.Wpf
 
     public static class ShadowAssist
     {
+        private const double ShadowAnimationDuration = 100; //in milliseconds
+
         public static readonly DependencyProperty ShadowDepthProperty = DependencyProperty.RegisterAttached(
             "ShadowDepth", typeof(ShadowDepth), typeof(ShadowAssist), new FrameworkPropertyMetadata(default(ShadowDepth), FrameworkPropertyMetadataOptions.AffectsRender));
 
@@ -75,7 +78,7 @@ namespace MaterialDesignThemes.Wpf
             {
                 SetLocalInfo(dependencyObject, new ShadowLocalInfo(dropShadowEffect.Opacity));
 
-                var doubleAnimation = new DoubleAnimation(1, new Duration(TimeSpan.FromMilliseconds(350)))
+                var doubleAnimation = new DoubleAnimation(1, new Duration(TimeSpan.FromMilliseconds(ShadowAnimationDuration)))
                 {
                     FillBehavior = FillBehavior.HoldEnd
                 };
@@ -86,7 +89,7 @@ namespace MaterialDesignThemes.Wpf
                 var shadowLocalInfo = GetLocalInfo(dependencyObject);
                 if (shadowLocalInfo == null) return;
 
-                var doubleAnimation = new DoubleAnimation(shadowLocalInfo.StandardOpacity, new Duration(TimeSpan.FromMilliseconds(350)))
+                var doubleAnimation = new DoubleAnimation(shadowLocalInfo.StandardOpacity, new Duration(TimeSpan.FromMilliseconds(ShadowAnimationDuration)))
                 {
                     FillBehavior = FillBehavior.HoldEnd
                 };


### PR DESCRIPTION
Google uses some [Easing ](https://material.io/design/motion/speed.html#easing) for their animations.
I don't know how to do it in WPF so I just reduced the duration of the animations
I changed the animation duration of the Ripple and ShadowAssist to try to match the guidelines as closely as possible.
This PR is related to this issue https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2339
