### PR TITLE
Fix animation not clipping in Calendar

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
@@ -314,7 +314,7 @@
                         </DataTemplate>
                     </ControlTemplate.Resources>
 
-                    <Grid x:Name="PART_Root">
+                    <Grid x:Name="PART_Root" Cursor="">
                         <Grid.Resources>
                             <SolidColorBrush x:Key="DisabledColor" Color="#A5FFFFFF"/>
                         </Grid.Resources>
@@ -330,7 +330,8 @@
                         </VisualStateManager.VisualStateGroups>
 
                         <wpf:Card UniformCornerRadius="2" Background="{TemplateBinding Background}" Padding="0 -1 0 0"
-                                  wpf:ShadowAssist.ShadowDepth="{TemplateBinding wpf:ShadowAssist.ShadowDepth}">
+                                  wpf:ShadowAssist.ShadowDepth="{TemplateBinding wpf:ShadowAssist.ShadowDepth}"
+                                  ClipContent="True">
                   
                             <Grid RenderOptions.ClearTypeHint="Enabled">
                                 <Grid.Resources>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
@@ -314,7 +314,7 @@
                         </DataTemplate>
                     </ControlTemplate.Resources>
 
-                    <Grid x:Name="PART_Root" Cursor="">
+                    <Grid x:Name="PART_Root">
                         <Grid.Resources>
                             <SolidColorBrush x:Key="DisabledColor" Color="#A5FFFFFF"/>
                         </Grid.Resources>


### PR DESCRIPTION
Fixes a bug introduced by #2454 where card clipping has been disabled by default.

![BD1xmxAYhI](https://user-images.githubusercontent.com/58171461/159455730-e0e43ab0-2ba8-4f41-b57d-92383eee6f81.gif)

