### PR TITLE
Fixed long-running operations on SnackBarMessage callback (#2627)

### DIFF
--- a/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
+++ b/MaterialDesignThemes.Wpf/SnackbarMessageQueue.cs
@@ -384,6 +384,11 @@ namespace MaterialDesignThemes.Wpf
             {
                 if (++clickCount == 1)
                     DoActionCallback(messageQueueItem);
+
+                // Don't operate with eventWaitHandle if disposed/invalid
+                if (actionClickWaitHandle.SafeWaitHandle.IsInvalid || actionClickWaitHandle.SafeWaitHandle.IsClosed)
+                    return;
+
                 actionClickWaitHandle.Set();
             };
             snackbar.SetCurrentValue(Snackbar.MessageProperty, snackbarMessage);


### PR DESCRIPTION
actionClickWaitHandle will be disposed after message auto-closed. We need to avoid call any methods on disposed EventWaitHandle, need to check is it closed (disposed) or invalid

Fixes #2627 