### PR TITLE
Fix Tabs Width and Overflowing issues

### DIFF
--- a/MainDemo.Wpf/Tabs.xaml
+++ b/MainDemo.Wpf/Tabs.xaml
@@ -278,6 +278,15 @@
                         <TabItem Header="TAB 2">
                             <TextBlock Margin="8" Text="Left placement" />
                         </TabItem>
+                        <TabItem Header="TAB 3 Diff Width">
+                            <TextBlock Margin="8" Text="Tab 3 with different width" />
+                        </TabItem>
+                        <TabItem Header="TAB 4 Looong">
+                            <TextBlock Margin="8" Text="Tab 4 with long width" />
+                        </TabItem>
+                        <TabItem Header="TABB 5">
+                            <TextBlock Margin="8" Text="Left placement tabb 5" />
+                        </TabItem>
                     </TabControl>
                 </materialDesign:Card>
             </smtx:XamlDisplay>
@@ -357,6 +366,30 @@
                         </TabItem>
                         <TabItem Header="TAB 2">
                             <TextBlock Margin="8" Text="Full-width secondary example tab 2" />
+                        </TabItem>
+                        <TabItem Header="TAB 3333">
+                            <TextBlock Margin="8" Text="Full-width secondary example tab 3333" />
+                        </TabItem>
+                        <TabItem Header="TAB4 Wide">
+                            <TextBlock Margin="8" Text="Full-width secondary example tab 4 wide" />
+                        </TabItem>
+                        <TabItem Header="TABbbbbbbbbbbxxxxx 5">
+                            <TextBlock Margin="8" Text="Full-width secondary example tab 5" />
+                        </TabItem>
+                        <TabItem Header="TAB 6 Different Width">
+                            <TextBlock Margin="8" Text="Full-width secondary example tab 6 different width" />
+                        </TabItem>
+                        <TabItem Header="TAB 7 Looooong">
+                            <TextBlock Margin="8" Text="Full-width secondary example tab 7 looooong" />
+                        </TabItem>
+                        <TabItem Header="TAB 8 Width">
+                            <TextBlock Margin="8" Text="Full-width secondary example tab 8 width" />
+                        </TabItem>
+                        <TabItem Header="TAAX999">
+                            <TextBlock Margin="8" Text="Full-width secondary example tab 9" />
+                        </TabItem>
+                        <TabItem Header="Tab10">
+                            <TextBlock Margin="8" Text="Full-width secondary example tab 10" />
                         </TabItem>
                     </TabControl>
                 </materialDesign:Card>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -50,15 +50,28 @@
                                 VerticalAlignment="Stretch"
                                 Background="{TemplateBinding wpf:ColorZoneAssist.Background}"
                                 Focusable="False">
-
-                                <UniformGrid
-                                    x:Name="HeaderPanel"
-                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                    VerticalAlignment="Top"
-                                    Focusable="False"
-                                    IsItemsHost="True"
-                                    KeyboardNavigation.TabIndex="1"
-                                    Rows="1" />
+                                <ScrollViewer
+                                    HorizontalScrollBarVisibility="Hidden"
+                                    VerticalScrollBarVisibility="Hidden">
+                                    <StackPanel>
+                                        <UniformGrid
+                                            x:Name="CenteredHeaderPanel"
+                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                            Focusable="False"
+                                            IsItemsHost="True"
+                                            KeyboardNavigation.TabIndex="1"
+                                            Rows="1" />
+                                        <VirtualizingStackPanel
+                                            x:Name="HeaderPanel"
+                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                            Focusable="False"
+                                            IsItemsHost="True"
+                                            KeyboardNavigation.TabIndex="1"
+                                            Orientation="Horizontal" />
+                                    </StackPanel>
+                                </ScrollViewer>
                             </wpf:ColorZone>
                         </wpf:Card>
                         <Border
@@ -83,21 +96,37 @@
                     </DockPanel>
 
                     <ControlTemplate.Triggers>
+                        <Trigger Property="HorizontalContentAlignment" Value="Stretch">
+                            <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <Trigger Property="HorizontalContentAlignment" Value="Center">
+                            <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <Trigger Property="HorizontalContentAlignment" Value="Left">
+                            <Setter TargetName="HeaderPanel" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="HorizontalContentAlignment" Value="Right">
+                            <Setter TargetName="HeaderPanel" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
                             <Setter TargetName="PART_HeaderCard" Property="DockPanel.Dock" Value="Bottom" />
                             <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Top" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Left">
                             <Setter TargetName="PART_HeaderCard" Property="DockPanel.Dock" Value="Left" />
-                            <Setter TargetName="HeaderPanel" Property="Rows" Value="0" />
+                            <Setter TargetName="CenteredHeaderPanel" Property="Rows" Value="0" />
                             <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Right" />
-                            <Setter TargetName="HeaderPanel" Property="Columns" Value="1" />
+                            <Setter TargetName="CenteredHeaderPanel" Property="Columns" Value="1" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
                             <Setter TargetName="PART_HeaderCard" Property="DockPanel.Dock" Value="Right" />
                             <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Left" />
-                            <Setter TargetName="HeaderPanel" Property="Rows" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Columns" Value="1" />
+                            <Setter TargetName="CenteredHeaderPanel" Property="Rows" Value="0" />
+                            <Setter TargetName="CenteredHeaderPanel" Property="Columns" Value="1" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -579,7 +608,10 @@
         </Setter>
     </Style>
 
-    <!-- Obsolete: will be removed in 5.0.0 release -->
-    <Style x:Key="MaterialDesignNavigatilRailTabControl" TargetType="{x:Type TabControl}" BasedOn="{StaticResource MaterialDesignNavigationRailTabControl}" />
+    <!--  Obsolete: will be removed in 5.0.0 release  -->
+    <Style
+        x:Key="MaterialDesignNavigatilRailTabControl"
+        BasedOn="{StaticResource MaterialDesignNavigationRailTabControl}"
+        TargetType="{x:Type TabControl}" />
 
 </ResourceDictionary>


### PR DESCRIPTION
Fix for https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2603 https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2616

it might be a better way to do this 
also you can't scroll horizontal tabs with the mouse wheel -i think it's a wpf limitation (there are workarounds)- when your horizontal tabs are overflowing you can still navigate them with the keyboard arrow keys

![MaterialGif](https://user-images.githubusercontent.com/7858946/161371561-5ca85722-17d4-4588-9985-22ecc48c4085.gif)

