### PR TITLE
allow setting background of menu item

### DIFF
--- a/MainDemo.Wpf/MenusAndToolBars.xaml
+++ b/MainDemo.Wpf/MenusAndToolBars.xaml
@@ -93,6 +93,11 @@
                         <MenuItem Header="Test 1"/>
                         <MenuItem Header="Test 1"/>
                     </MenuItem>
+                    <MenuItem Header="In Color" Background="{DynamicResource PrimaryHueMidBrush}" Foreground="{DynamicResource PrimaryHueMidForegroundBrush}">
+                        <MenuItem Header="Test 1" Background="{DynamicResource SecondaryHueMidBrush}" Foreground="{DynamicResource SecondaryHueMidForegroundBrush}"/>
+                        <MenuItem Header="Test 1" Background="{DynamicResource SecondaryHueMidBrush}" Foreground="{DynamicResource SecondaryHueMidForegroundBrush}"/>
+                        <MenuItem Header="Test 1" Background="{DynamicResource SecondaryHueMidBrush}" Foreground="{DynamicResource SecondaryHueMidForegroundBrush}"/>
+                    </MenuItem>
                 </Menu>
             </materialDesign:Card>
         </smtx:XamlDisplay>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
@@ -117,7 +117,7 @@
                             x:Name="templateRoot"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            
+                            Background="{TemplateBinding Background}"
                             SnapsToDevicePixels="True" />
                         <Border
                             x:Name="BackgroundRoot"
@@ -251,7 +251,7 @@
                             CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
                             <Border
                                 x:Name="SubMenuBorder"
-                                Background="{DynamicResource MaterialDesignPaper}"
+                                Background="{TemplateBinding Background}"
                                 Effect="{DynamicResource MaterialDesignShadowDepth1}"
                                 CornerRadius="2">
 


### PR DESCRIPTION
With the current version I unfortunately could not easily change the background of a menu. Setting the background property on a MenuItem simply had no effect. Here the result of the included sample code where the foreground change is applied but not the background which results in white on white:
![image](https://user-images.githubusercontent.com/3511772/162261252-48790470-23ac-4292-8415-ee905c8f9d51.png)

With the changes in this pull request the result changes to this:
![image](https://user-images.githubusercontent.com/3511772/162261271-256110ee-c055-4761-92f5-199fccad641f.png)
_A common use case would use the same color for both the main and child menu items but I used different colors for illustration._