### PR TITLE
Fixes build warnings

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/Buttons/OutlineButtonTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/Buttons/OutlineButtonTests.cs
@@ -53,11 +53,11 @@ namespace MaterialDesignThemes.UITests.WPF.Buttons
 
             //Act
             Thickness borderThickness = await internalBorder.GetBorderThickness();
-            SolidColorBrush? borderBrush = (await internalBorder.GetBorderBrush()) as SolidColorBrush;
+            Color? borderBrush = await internalBorder.GetBorderBrushColor();
 
             //Assert
             Assert.Equal(new Thickness(5), borderThickness);
-            Assert.Equal(Colors.Red, borderBrush?.Color);
+            Assert.Equal(Colors.Red, borderBrush);
 
             recorder.Success();
         }

--- a/MaterialDesignToolkit.Full.sln
+++ b/MaterialDesignToolkit.Full.sln
@@ -35,6 +35,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		MaterialDesignColors.nuspec = MaterialDesignColors.nuspec
 		MaterialDesignThemes.MahApps.nuspec = MaterialDesignThemes.MahApps.nuspec
 		MaterialDesignThemes.nuspec = MaterialDesignThemes.nuspec
+		nuget.config = nuget.config
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+        <clear />
+        <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+    <packageSourceMapping>
+        <!-- key value for <packageSource> should match key values from <packageSources> element -->
+        <packageSource key="nuget">
+            <package pattern="*" />
+        </packageSource>
+    </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
Fixes build warnings caused by updated centralized package management changes.
https://devblogs.microsoft.com/nuget/introducing-central-package-management/
Also fixes flaky test