### PR TITLE
Changes for Shadow assist animation 

### DIFF
--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -44,10 +44,6 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <TextBlock
             Style="{StaticResource MaterialDesignHeadline5TextBlock}"
@@ -1096,19 +1092,38 @@
             </smtx:XamlDisplay>
         </StackPanel>
 
+        <Rectangle
+            Margin="0 24 0 0"
+            Height="1"
+            Fill="{DynamicResource MaterialDesignDivider}"
+            Grid.Row="11" />
+
         <TextBlock
             Style="{StaticResource MaterialDesignHeadline5TextBlock}"
-            Grid.Row="11"
+            Grid.Row="12"
             Margin="0 24"
-            Text="Buttons - With Custom ShadowAssist Animation Duration"/>
+            Text="Buttons - With Custom Animation Duration"/>
 
         <StackPanel
-            Grid.Row="12"
+            Grid.Row="13"
             Orientation="Horizontal">
-            <Button materialDesign:ShadowAssist.ShadowAnimationDuration="0:0:0" Margin="0,0,20,0">Instant</Button>
-            <Button Margin="0,0,20,0">Default</Button>
-            <Button materialDesign:ShadowAssist.ShadowAnimationDuration="0:0:2">Long</Button>
+            <smtx:XamlDisplay UniqueKey="button_duration_1" Margin="0,0,20,0">
+                <Button Style="{StaticResource MaterialDesignRaisedAccentButton}"
+                    materialDesign:ShadowAssist.ShadowAnimationDuration="0:0:0">
+                    Instant Duration
+                </Button>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay UniqueKey="button_duration_2" Margin="0,0,20,0">
+                <Button>
+                    Default Duration
+                </Button>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay UniqueKey="button_duration_3" Margin="0,0,20,0">
+                <Button Style="{StaticResource MaterialDesignRaisedDarkButton}"
+                    materialDesign:ShadowAssist.ShadowAnimationDuration="0:0:0.5">
+                    Long Duration
+                </Button>
+            </smtx:XamlDisplay>
         </StackPanel>
-
     </Grid>
 </UserControl>

--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -44,6 +44,10 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <TextBlock
             Style="{StaticResource MaterialDesignHeadline5TextBlock}"
@@ -1091,5 +1095,20 @@
                 </materialDesign:PopupBox>
             </smtx:XamlDisplay>
         </StackPanel>
+
+        <TextBlock
+            Style="{StaticResource MaterialDesignHeadline5TextBlock}"
+            Grid.Row="11"
+            Margin="0 24"
+            Text="Buttons - With Custom ShadowAssist Animation Duration"/>
+
+        <StackPanel
+            Grid.Row="12"
+            Orientation="Horizontal">
+            <Button materialDesign:ShadowAssist.ShadowAnimationDuration="0:0:0" Margin="0,0,20,0">Instant</Button>
+            <Button Margin="0,0,20,0">Default</Button>
+            <Button materialDesign:ShadowAssist.ShadowAnimationDuration="0:0:2">Long</Button>
+        </StackPanel>
+
     </Grid>
 </UserControl>

--- a/MaterialDesignThemes.Wpf/ShadowAssist.cs
+++ b/MaterialDesignThemes.Wpf/ShadowAssist.cs
@@ -161,7 +161,7 @@ namespace MaterialDesignThemes.Wpf
                propertyType: typeof(TimeSpan),
                ownerType: typeof(ShadowAssist),
                defaultMetadata: new FrameworkPropertyMetadata(
-                   defaultValue: new TimeSpan(0, 0, 0, 0, 180),
+                   defaultValue: new TimeSpan(0, 0, 0, 0, 150),
                    flags: FrameworkPropertyMetadataOptions.Inherits)
                );
         

--- a/MaterialDesignThemes.Wpf/ShadowAssist.cs
+++ b/MaterialDesignThemes.Wpf/ShadowAssist.cs
@@ -105,9 +105,15 @@ namespace MaterialDesignThemes.Wpf
                 if (shadowLocalInfo == null) return;
 
                 TimeSpan time = GetShadowAnimationDuration(dependencyObject);
-                var doubleAnimation = new DoubleAnimation(shadowLocalInfo.StandardOpacity, new Duration(time))
+
+                var doubleAnimation = new DoubleAnimation()
                 {
-                    FillBehavior = FillBehavior.HoldEnd
+                    To = shadowLocalInfo.StandardOpacity,
+                    Duration = new Duration(time),
+                    FillBehavior = FillBehavior.HoldEnd,
+                    EasingFunction = new CubicEase(),
+                    AccelerationRatio = 0.4,
+                    DecelerationRatio = 0.2
                 };
                 dropShadowEffect.BeginAnimation(DropShadowEffect.OpacityProperty, doubleAnimation);
             }
@@ -161,7 +167,7 @@ namespace MaterialDesignThemes.Wpf
                propertyType: typeof(TimeSpan),
                ownerType: typeof(ShadowAssist),
                defaultMetadata: new FrameworkPropertyMetadata(
-                   defaultValue: new TimeSpan(0, 0, 0, 0, 150),
+                   defaultValue: new TimeSpan(0, 0, 0, 0, 180),
                    flags: FrameworkPropertyMetadataOptions.Inherits)
                );
         

--- a/MaterialDesignThemes.Wpf/ShadowAssist.cs
+++ b/MaterialDesignThemes.Wpf/ShadowAssist.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Effects;
 
 namespace MaterialDesignThemes.Wpf
 {
+
     public enum ShadowDepth
     {
         Depth0,
@@ -37,8 +40,10 @@ namespace MaterialDesignThemes.Wpf
         public double StandardOpacity { get; }
     }
 
-    public static class ShadowAssist
+    public class ShadowAssist
     {
+
+        #region AttachedProperty : ShadowDepthProperty
         public static readonly DependencyProperty ShadowDepthProperty = DependencyProperty.RegisterAttached(
             "ShadowDepth", typeof(ShadowDepth), typeof(ShadowAssist), new FrameworkPropertyMetadata(default(ShadowDepth), FrameworkPropertyMetadataOptions.AffectsRender));
 
@@ -51,7 +56,9 @@ namespace MaterialDesignThemes.Wpf
         {
             return (ShadowDepth)element.GetValue(ShadowDepthProperty);
         }
+        #endregion
 
+        #region AttachedProperty : LocalInfoPropertyKey
         private static readonly DependencyPropertyKey LocalInfoPropertyKey = DependencyProperty.RegisterAttachedReadOnly(
             "LocalInfo", typeof(ShadowLocalInfo), typeof(ShadowAssist), new PropertyMetadata(default(ShadowLocalInfo)));
 
@@ -60,14 +67,18 @@ namespace MaterialDesignThemes.Wpf
 
         private static ShadowLocalInfo? GetLocalInfo(DependencyObject element)
             => (ShadowLocalInfo?)element.GetValue(LocalInfoPropertyKey.DependencyProperty);
+        #endregion
 
+        #region AttachedProperty : DarkenProperty
         public static readonly DependencyProperty DarkenProperty = DependencyProperty.RegisterAttached(
             "Darken", typeof(bool), typeof(ShadowAssist), new FrameworkPropertyMetadata(default(bool), FrameworkPropertyMetadataOptions.AffectsRender, DarkenPropertyChangedCallback));
 
         private static void DarkenPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+
             var uiElement = dependencyObject as UIElement;
             var dropShadowEffect = uiElement?.Effect as DropShadowEffect;
+
 
             if (dropShadowEffect == null) return;
 
@@ -75,9 +86,16 @@ namespace MaterialDesignThemes.Wpf
             {
                 SetLocalInfo(dependencyObject, new ShadowLocalInfo(dropShadowEffect.Opacity));
 
-                var doubleAnimation = new DoubleAnimation(1, new Duration(TimeSpan.FromMilliseconds(350)))
+                TimeSpan time = GetShadowAnimationDuration(dependencyObject);
+
+                var doubleAnimation = new DoubleAnimation()
                 {
-                    FillBehavior = FillBehavior.HoldEnd
+                    To = 1,
+                    Duration = new Duration(time),
+                    FillBehavior = FillBehavior.HoldEnd,
+                    EasingFunction = new CubicEase(),
+                    AccelerationRatio = 0.4,
+                    DecelerationRatio = 0.2
                 };
                 dropShadowEffect.BeginAnimation(DropShadowEffect.OpacityProperty, doubleAnimation);
             }
@@ -86,7 +104,8 @@ namespace MaterialDesignThemes.Wpf
                 var shadowLocalInfo = GetLocalInfo(dependencyObject);
                 if (shadowLocalInfo == null) return;
 
-                var doubleAnimation = new DoubleAnimation(shadowLocalInfo.StandardOpacity, new Duration(TimeSpan.FromMilliseconds(350)))
+                TimeSpan time = GetShadowAnimationDuration(dependencyObject);
+                var doubleAnimation = new DoubleAnimation(shadowLocalInfo.StandardOpacity, new Duration(time))
                 {
                     FillBehavior = FillBehavior.HoldEnd
                 };
@@ -103,7 +122,9 @@ namespace MaterialDesignThemes.Wpf
         {
             return (bool)element.GetValue(DarkenProperty);
         }
+        #endregion
 
+        #region AttachedProperty : CacheModeProperty
         public static readonly DependencyProperty CacheModeProperty = DependencyProperty.RegisterAttached(
             "CacheMode", typeof(CacheMode), typeof(ShadowAssist), new FrameworkPropertyMetadata(new BitmapCache { EnableClearType = true, SnapsToDevicePixels = true }, FrameworkPropertyMetadataOptions.Inherits));
 
@@ -116,7 +137,9 @@ namespace MaterialDesignThemes.Wpf
         {
             return (CacheMode)element.GetValue(CacheModeProperty);
         }
+        #endregion
 
+        #region AttachedProperty : ShadowEdgesProperty
         public static readonly DependencyProperty ShadowEdgesProperty = DependencyProperty.RegisterAttached(
             "ShadowEdges", typeof(ShadowEdges), typeof(ShadowAssist), new PropertyMetadata(ShadowEdges.All));
 
@@ -129,5 +152,21 @@ namespace MaterialDesignThemes.Wpf
         {
             return (ShadowEdges)element.GetValue(ShadowEdgesProperty);
         }
+        #endregion
+
+        #region AttachedProperty : ShadowAnimationDurationProperty
+        public static readonly DependencyProperty ShadowAnimationDurationProperty =
+           DependencyProperty.RegisterAttached(
+               name: "ShadowAnimationDuration",
+               propertyType: typeof(TimeSpan),
+               ownerType: typeof(ShadowAssist),
+               defaultMetadata: new FrameworkPropertyMetadata(
+                   defaultValue: new TimeSpan(0, 0, 0, 0, 180),
+                   flags: FrameworkPropertyMetadataOptions.Inherits)
+               );
+        
+        public static TimeSpan GetShadowAnimationDuration(DependencyObject element) => (TimeSpan)element.GetValue(ShadowAnimationDurationProperty);
+        public static void SetShadowAnimationDuration(DependencyObject element, TimeSpan value) => element.SetValue(ShadowAnimationDurationProperty, value);
+        #endregion
     }
 }


### PR DESCRIPTION
Some changes for the shadow assist animation : 

-  Reduction of the default animation duration
-  Add easing on animations
-  Add an attached property to customize the duration of the animations
-  Add an example in the demo

These issues can be closed :

- https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2650
- https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2355
- https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2339