### PR TITLE
Increasing minimum framework to net462

### DIFF
--- a/MaterialDesignColors.Wpf/MaterialDesignColors.Wpf.csproj
+++ b/MaterialDesignColors.Wpf/MaterialDesignColors.Wpf.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>MaterialDesignColors</RootNamespace>
     <AssemblyName>MaterialDesignColors</AssemblyName>
-    <TargetFrameworks>net452;netcoreapp3.1;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <MDIXColorsVersion Condition="$(MDIXColorsVersion) == '' Or $(MDIXColorsVersion) == '*Undefined*'">1.0.1</MDIXColorsVersion>
     <AssemblyTitle>MaterialDesignColors.Wpf</AssemblyTitle>

--- a/MaterialDesignColors.nuspec
+++ b/MaterialDesignColors.nuspec
@@ -15,12 +15,14 @@
     <copyright>$copyright$</copyright>
     <tags>WPF XAML Material Design Colour Color UI UX</tags>
     <dependencies>
-      <group targetFramework="net452" />
+      <group targetFramework="net462" />
       <group targetFramework="netcoreapp3.1" />
+      <group targetFramework="net6.0-windows" />
     </dependencies>
   </metadata>
   <files>
-    <file src="MaterialDesignColors.Wpf\bin\$configuration$\net452\MaterialDesignColors.*" target="lib\net452" exclude="**\*.json" />
+    <file src="MaterialDesignColors.Wpf\bin\$configuration$\net452\MaterialDesignColors.*" target="lib\net462" exclude="**\*.json" />
     <file src="MaterialDesignColors.Wpf\bin\$configuration$\netcoreapp3.1\MaterialDesignColors.*" target="lib\netcoreapp3.1" exclude="**\*.json" />
+    <file src="MaterialDesignColors.Wpf\bin\$configuration$\net6.0-windows\MaterialDesignColors.*" target="lib\net6.0-windows" exclude="**\*.json" />
   </files>
 </package>

--- a/MaterialDesignThemes.MahApps.nuspec
+++ b/MaterialDesignThemes.MahApps.nuspec
@@ -15,7 +15,7 @@
     <copyright>$copyright$</copyright>
     <tags>WPF XAML MahApps Material Design Theme Colour Color UI UX</tags>
     <dependencies>
-      <group targetFramework="net452">
+      <group targetFramework="net462">
         <dependency id="MaterialDesignColors" version="[1.2.1, 2.0)" />
         <dependency id="MaterialDesignThemes" version="[3.0.0, 4.0)" />
         <dependency id="MahApps.Metro" version="[2.0.0-alpha0748, 3.0)" />
@@ -25,10 +25,16 @@
         <dependency id="MaterialDesignThemes" version="[3.0.0, 4.0)" />
         <dependency id="MahApps.Metro" version="[2.0.0, 3.0)" />
       </group>
+      <group targetFramework="net6.0-windows">
+        <dependency id="MaterialDesignColors" version="[1.2.1, 2.0)" />
+        <dependency id="MaterialDesignThemes" version="[3.0.0, 4.0)" />
+        <dependency id="MahApps.Metro" version="[2.0.0, 3.0)" />
+      </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="MaterialDesignThemes.MahApps\bin\$configuration$\net452\MaterialDesignThemes.MahApps.*" target="lib\net452" exclude="**\*.json" />
+    <file src="MaterialDesignThemes.MahApps\bin\$configuration$\net452\MaterialDesignThemes.MahApps.*" target="lib\net462" exclude="**\*.json" />
     <file src="MaterialDesignThemes.MahApps\bin\$configuration$\netcoreapp3.1\MaterialDesignThemes.MahApps.*" target="lib\netcoreapp3.1" exclude="**\*.json" />
+    <file src="MaterialDesignThemes.MahApps\bin\$configuration$\net6.0-windows\MaterialDesignThemes.MahApps.*" target="lib\net6.0-windows" exclude="**\*.json" />
   </files>
 </package>

--- a/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.csproj
+++ b/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net452;netcoreapp3.1;net6.0-windows</TargetFrameworks>
+        <TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
         <UseWPF>true</UseWPF>
         <MDIXMahAppsVersion Condition="$(MDIXMahAppsVersion) == '' Or $(MDIXMahAppsVersion) == '*Undefined*'">1.0.1</MDIXMahAppsVersion>
         <AssemblyTitle>MaterialDesignThemes.MahApps</AssemblyTitle>

--- a/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
@@ -47,7 +47,15 @@ namespace MaterialDesignThemes.UITests.WPF.DialogHosts
             await closeDialogButton.LeftClick();
 
             var retry = new Retry(5, TimeSpan.FromSeconds(5));
-            await Wait.For(async () => await overlay.GetVisibility() != Visibility.Visible, retry);
+            try
+            {
+                await Wait.For(async () => await overlay.GetVisibility() != Visibility.Visible, retry);
+            }
+            catch(TimeoutException)
+            {
+                await closeDialogButton.LeftClick();
+                await Wait.For(async () => await overlay.GetVisibility() != Visibility.Visible, retry);
+            }
             await testOverlayButton.LeftClick();
             await Wait.For(async () => Assert.Equal("Clicks: 2", await resultTextBlock.GetText()), retry);
 

--- a/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
+++ b/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp3.1;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <MDIXVersion Condition="$(MDIXVersion) == '' Or $(MDIXVersion) == '*Undefined*'">1.0.1</MDIXVersion>
     <AssemblyTitle>MaterialDesignThemes.Wpf</AssemblyTitle>

--- a/MaterialDesignThemes.nuspec
+++ b/MaterialDesignThemes.nuspec
@@ -15,17 +15,21 @@
     <copyright>$copyright$</copyright>
     <tags>WPF XAML Material Design Theme Colour Color UI UX</tags>
     <dependencies>
-      <group targetFramework="net452">
+      <group targetFramework="net462">
         <dependency id="MaterialDesignColors" version="[1.2.1, 2.0)" />
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="MaterialDesignColors" version="[1.2.1, 2.0)" />
       </group>
+      <group targetFramework="net6.0-windows">
+        <dependency id="MaterialDesignColors" version="[1.2.1, 2.0)" />
+      </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="MaterialDesignThemes.Wpf\bin\$configuration$\net452\MaterialDesignThemes.Wpf.*" target="lib\net452" exclude="**\*.json" />
+    <file src="MaterialDesignThemes.Wpf\bin\$configuration$\net462\MaterialDesignThemes.Wpf.*" target="lib\net462" exclude="**\*.json" />
     <file src="MaterialDesignThemes.Wpf\bin\$configuration$\netcoreapp3.1\MaterialDesignThemes.Wpf.*" target="lib\netcoreapp3.1" exclude="**\*.json" />
+    <file src="MaterialDesignThemes.Wpf\bin\$configuration$\net6.0-windows\MaterialDesignThemes.Wpf.*" target="lib\net6.0-windows" exclude="**\*.json" />
     <file src="MaterialDesignThemes.Wpf\Resources\Roboto\*.ttf" target="build\Resources\Roboto" />
     <file src="MaterialDesignThemes.Wpf\MaterialDesignThemes.targets" target="build" />
     <file src="MaterialDesignThemes.Wpf\VisualStudioToolsManifest.xml" target="tools"/>


### PR DESCRIPTION
As .NET Framework 4.5.2 is officially end of life, this moves the minimum framework to .NET Framework 4.6.2.

This also add a target for net6.0-windows to take advantages of performance in the latest framework.

Attempted fix for flaky test