### PR TITLE
Continuation of #2662

### DIFF
--- a/MainDemo.Wpf/ComboBoxes.xaml
+++ b/MainDemo.Wpf/ComboBoxes.xaml
@@ -52,6 +52,7 @@
                 <ComboBox
                     materialDesign:HintAssist.Hint="Search"
                     materialDesign:HintAssist.HintOpacity=".26"
+                    materialDesign:ComboBoxAssist.MaxLength="2"
                     IsEditable="True">
                     <ComboBoxItem Content="Apple"/>
                     <ComboBoxItem Content="Banana"/>

--- a/MaterialDesignThemes.UITests/WPF/TimePickers/MaterialDesignTimePicker.cs
+++ b/MaterialDesignThemes.UITests/WPF/TimePickers/MaterialDesignTimePicker.cs
@@ -5,40 +5,39 @@ using System.Windows.Controls.Primitives;
 using MaterialDesignThemes.Wpf;
 using XamlTest;
 
-namespace MaterialDesignThemes.UITests.WPF.TimePickers
+namespace MaterialDesignThemes.UITests.WPF.TimePickers;
+
+public static class MaterialDesignTimePicker
 {
-    public static class MaterialDesignTimePicker
+    public static async Task PickClock(this IVisualElement timePicker, int hour, int minute)
     {
-        public static async Task PickClock(this IVisualElement timePicker, int hour, int minute)
+        var button = await timePicker.GetElement<Button>("PART_Button");
+        await button.LeftClick();
+
+        var popup = await timePicker.GetElement<Popup>("PART_Popup");
+        await popup.ClickHour(hour);
+        await popup.ClickMinute(minute);
+    }
+
+    private static async Task ClickHour(this IVisualElement<Popup> popup, int hour)
+        => await popup.ClickButton(Clock.HoursCanvasPartName, (hour + 11) % 12);
+
+    private static async Task ClickMinute(this IVisualElement<Popup> popup, int minute)
+        => await popup.ClickButton(Clock.MinutesCanvasPartName, (minute % 5 == 0 ? (minute / 5 + 11) % 12 : minute - minute / 5 + 11));
+
+    private static async Task ClickButton(this IVisualElement<Popup> popup, string partName, int index)
+    {
+        const int delay = 250;
+
+        await Task.Delay(delay);
+        var canvas = await Wait.For(async () => await popup.GetElement(partName));
+        var button = await canvas.GetElement<ClockItemButton>($"/ClockItemButton[{index}]");
+        await Task.Delay(delay);
+        await Wait.For(async () =>
         {
-            var button = await timePicker.GetElement<Button>("PART_Button");
             await button.LeftClick();
-
-            var popup = await timePicker.GetElement<Popup>("PART_Popup");
-            await popup.ClickHour(hour);
-            await popup.ClickMinute(minute);
-        }
-
-        private static async Task ClickHour(this IVisualElement<Popup> popup, int hour)
-            => await popup.ClickButton(Clock.HoursCanvasPartName, (hour + 11) % 12);
-
-        private static async Task ClickMinute(this IVisualElement<Popup> popup, int minute)
-            => await popup.ClickButton(Clock.MinutesCanvasPartName, (minute % 5 == 0 ? (minute / 5 + 11) % 12 : minute - minute / 5 + 11));
-
-        private static async Task ClickButton(this IVisualElement<Popup> popup, string partName, int index)
-        {
-            const int delay = 200;
-
             await Task.Delay(delay);
-            var canvas = await Wait.For(async () => await popup.GetElement(partName));
-            var button = await canvas.GetElement<ClockItemButton>($"/ClockItemButton[{index}]");
-            await Task.Delay(delay);
-            await Wait.For(async () =>
-            {
-                await button.LeftClick();
-                await Task.Delay(delay);
-                return await button.GetIsChecked() == true;
-            });
-        }
+            return await button.GetIsChecked() == true;
+        });
     }
 }

--- a/MaterialDesignThemes.Wpf/ComboBoxAssist.cs
+++ b/MaterialDesignThemes.Wpf/ComboBoxAssist.cs
@@ -2,85 +2,65 @@
 using System.Windows;
 using System.Windows.Controls;
 
-namespace MaterialDesignThemes.Wpf
+namespace MaterialDesignThemes.Wpf;
+
+public static class ComboBoxAssist
 {
-    public static class ComboBoxAssist
-    {
-        #region AttachedProperty : ClassicMode
-        /// <summary>
-        /// By default ComboBox uses the wrapper popup. Popup can be switched to classic Windows desktop view by means of this attached property.
-        /// </summary>
-        [Obsolete("ClassicMode is now obsolete and has no affect.")]
-        public static readonly DependencyProperty ClassicModeProperty = DependencyProperty.RegisterAttached(
-            "ClassicMode",
-            typeof(bool),
-            typeof(ComboBoxAssist),
-            new FrameworkPropertyMetadata(false,
-                FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
+    #region AttachedProperty : ClassicMode
+    /// <summary>
+    /// By default ComboBox uses the wrapper popup. Popup can be switched to classic Windows desktop view by means of this attached property.
+    /// </summary>
+    [Obsolete("ClassicMode is now obsolete and has no affect.")]
+    public static readonly DependencyProperty ClassicModeProperty = DependencyProperty.RegisterAttached(
+        "ClassicMode",
+        typeof(bool),
+        typeof(ComboBoxAssist),
+        new FrameworkPropertyMetadata(false,
+            FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
 
-        [Obsolete("ClassicMode is now obsolete and has no affect.")]
-        public static bool GetClassicMode(DependencyObject element)
-            => (bool)element.GetValue(ClassicModeProperty);
+    [Obsolete("ClassicMode is now obsolete and has no affect.")]
+    public static bool GetClassicMode(DependencyObject element)
+        => (bool)element.GetValue(ClassicModeProperty);
 
-        [Obsolete("ClassicMode is now obsolete and has no affect.")]
-        public static void SetClassicMode(DependencyObject element, bool value)
-            => element.SetValue(ClassicModeProperty, value);
-        #endregion
+    [Obsolete("ClassicMode is now obsolete and has no affect.")]
+    public static void SetClassicMode(DependencyObject element, bool value)
+        => element.SetValue(ClassicModeProperty, value);
+    #endregion
 
-        #region AttachedProperty : ShowSelectedItem
-        /// <summary>
-        /// By default the selected item is displayed in the drop down list, as per Material Design specifications.
-        /// To change this to a behavior of hiding the selected item from the drop down list, set this attached property to false.
-        /// </summary>
-        public static readonly DependencyProperty ShowSelectedItemProperty = DependencyProperty.RegisterAttached(
-            "ShowSelectedItem",
-            typeof(bool),
-            typeof(ComboBoxAssist),
-            new FrameworkPropertyMetadata(true,
-                FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
+    #region AttachedProperty : ShowSelectedItem
+    /// <summary>
+    /// By default the selected item is displayed in the drop down list, as per Material Design specifications.
+    /// To change this to a behavior of hiding the selected item from the drop down list, set this attached property to false.
+    /// </summary>
+    public static readonly DependencyProperty ShowSelectedItemProperty = DependencyProperty.RegisterAttached(
+        "ShowSelectedItem",
+        typeof(bool),
+        typeof(ComboBoxAssist),
+        new FrameworkPropertyMetadata(true,
+            FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
 
-        public static bool GetShowSelectedItem(DependencyObject element)
-            => (bool)element.GetValue(ShowSelectedItemProperty);
+    public static bool GetShowSelectedItem(DependencyObject element)
+        => (bool)element.GetValue(ShowSelectedItemProperty);
 
-        public static void SetShowSelectedItem(DependencyObject element, bool value)
-            => element.SetValue(ShowSelectedItemProperty, value);
-        #endregion
+    public static void SetShowSelectedItem(DependencyObject element, bool value)
+        => element.SetValue(ShowSelectedItemProperty, value);
+    #endregion
 
-        #region AttachedProperty : MaxLength
-        /// <summary>
-        /// Gets or sets the maximum number of characters that can be manually entered into the text box. <br />
-        /// <remarks>
-        /// <see cref="TextBox.MaxLength"/> cannot be set for an editable ComboBox. That's why this attached property exists.
-        /// </remarks>
-        /// </summary>
-        public static readonly DependencyProperty MaxLengthProperty =
-           DependencyProperty.RegisterAttached(
-               name: "MaxLength",
-               propertyType: typeof(int),
-               ownerType: typeof(ComboBoxAssist),
-               defaultMetadata: new FrameworkPropertyMetadata(
-                   defaultValue: 0,
-                   propertyChangedCallback: OnMaxLenghtChanged)
-               );
-        private static void OnMaxLenghtChanged(DependencyObject obj, DependencyPropertyChangedEventArgs args)
-        {
-            if (obj is ComboBox comboBox)
-            {
-                comboBox.Loaded +=
-                  (s, e) =>
-                  {
-                      DependencyObject? textBox = comboBox.FindChild<TextBox>("PART_EditableTextBox");
-                      if (textBox == null)
-                      {
-                          return;
-                      }
-
-                      textBox.SetValue(TextBox.MaxLengthProperty, args.NewValue);
-                  };
-            }
-        }
-        public static int GetMaxLength(DependencyObject element) => (int)element.GetValue(MaxLengthProperty);
-        public static void SetMaxLength(DependencyObject element, int value) => element.SetValue(MaxLengthProperty, value);
-        #endregion
-    }
+    #region AttachedProperty : MaxLength
+    /// <summary>
+    /// Gets or sets the maximum number of characters that can be manually entered into the text box. <br />
+    /// <remarks>
+    /// <see cref="TextBox.MaxLength"/> cannot be set for an editable ComboBox. That's why this attached property exists.
+    /// </remarks>
+    /// </summary>
+    public static readonly DependencyProperty MaxLengthProperty =
+       DependencyProperty.RegisterAttached(
+           name: "MaxLength",
+           propertyType: typeof(int),
+           ownerType: typeof(ComboBoxAssist),
+           defaultMetadata: new FrameworkPropertyMetadata(defaultValue: 0)
+           );
+    public static int GetMaxLength(DependencyObject element) => (int)element.GetValue(MaxLengthProperty);
+    public static void SetMaxLength(DependencyObject element, int value) => element.SetValue(MaxLengthProperty, value);
+    #endregion
 }

--- a/MaterialDesignThemes.Wpf/Constants.cs
+++ b/MaterialDesignThemes.Wpf/Constants.cs
@@ -1,14 +1,13 @@
 using System.Windows;
 
-namespace MaterialDesignThemes.Wpf
+namespace MaterialDesignThemes.Wpf;
+
+public static class Constants
 {
-    public static class Constants
-    {
-        public static readonly Thickness TextBoxDefaultPadding = new Thickness(0, 4, 0, 4);
-        public static readonly Thickness DefaultTextBoxViewMargin = new Thickness(1, 0, 1, 0);
-        public static readonly Thickness DefaultTextBoxViewMarginEmbedded = new Thickness(0);
-        public const double TextBoxNotEnabledOpacity = 0.56;
-        public const double TextBoxInnerButtonSpacing = 2;
-        public const double ComboBoxArrowSize = 8;
-    }
+    public static readonly Thickness TextBoxDefaultPadding = new Thickness(0, 4, 0, 4);
+    public static readonly Thickness DefaultTextBoxViewMargin = new Thickness(1, 0, 1, 0);
+    public static readonly Thickness DefaultTextBoxViewMarginEmbedded = new Thickness(0);
+    public const double TextBoxNotEnabledOpacity = 0.56;
+    public const double TextBoxInnerButtonSpacing = 2;
+    public const double ComboBoxArrowSize = 8;
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -360,7 +360,6 @@
                                     ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                                     IsHitTestVisible="False"
                                     Margin="{TemplateBinding wpf:TextFieldAssist.TextBoxViewMargin}" />
-                                <!-- This TextBox is used in the ComboBoxAssist class. Be careful when applying changes here. -->
                                 <TextBox
                                     x:Name="PART_EditableTextBox"
                                     Grid.Column="1"
@@ -368,6 +367,7 @@
                                     IsReadOnly="{TemplateBinding IsReadOnly}"
                                     HorizontalAlignment="Stretch"
                                     HorizontalContentAlignment="Stretch"
+                                    MaxLength="{Binding Path=(wpf:ComboBoxAssist.MaxLength), RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                     Style="{StaticResource MaterialDesignComboBoxEditableTextBox}"
                                     CaretBrush="{TemplateBinding BorderBrush}"
                                     Visibility="Collapsed" />


### PR DESCRIPTION
Uses relative source binding to avoid looking up elements by name.
Added example to the demo project.

Related: #2442 