### PR TITLE
Add attached property to allow slider tool tip formatting

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/Converters/SliderToolTipConverterTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/Converters/SliderToolTipConverterTests.cs
@@ -15,22 +15,22 @@ namespace MaterialDesignThemes.Wpf.Tests.Converters
             Wpf.Converters.SliderToolTipConverter converter = new Wpf.Converters.SliderToolTipConverter();
 
             //test a valid case
-            var result = converter.Convert(new object[] { value, "Test String Format {0}" }, typeof(string), null, CultureInfo.CurrentCulture);
+            var result = converter.Convert(new object?[] { value, "Test String Format {0}" }, typeof(string), null, CultureInfo.CurrentCulture);
             Assert.Equal($"Test String Format {value}", result);
 
             //test too many placeholders in format string
-            result = converter.Convert(new object[] { value, "{0} {1}" }, typeof(string), null, CultureInfo.CurrentCulture);
+            result = converter.Convert(new object?[] { value, "{0} {1}" }, typeof(string), null, CultureInfo.CurrentCulture);
             Assert.Equal(value.ToString(), result);
 
-            result = converter.Convert(new object[] { value, "{0} {1} {2}" }, typeof(string), null, CultureInfo.CurrentCulture);
+            result = converter.Convert(new object?[] { value, "{0} {1} {2}" }, typeof(string), null, CultureInfo.CurrentCulture);
             Assert.Equal(value.ToString(), result);
 
             //test empty format string
-            result = converter.Convert(new object[] { value, "" }, typeof(string), null, CultureInfo.CurrentCulture);
+            result = converter.Convert(new object?[] { value, "" }, typeof(string), null, CultureInfo.CurrentCulture);
             Assert.Equal(value.ToString(), result);
 
             //test null format string
-            result = converter.Convert(new object[] { value, null }, typeof(string), null, CultureInfo.CurrentCulture);
+            result = converter.Convert(new object?[] { value, null }, typeof(string), null, CultureInfo.CurrentCulture);
             Assert.Equal(value.ToString(), result);
         }
     }

--- a/MaterialDesignThemes.Wpf.Tests/Converters/SliderToolTipConverterTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/Converters/SliderToolTipConverterTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Globalization;
+using Xunit;
+
+namespace MaterialDesignThemes.Wpf.Tests.Converters
+{
+    public class SliderToolTipConverterTests
+    {
+        [Theory]
+        [InlineData(1.4)]
+        [InlineData(-47.4)]
+        [InlineData(128.678)]
+        [InlineData(42)]
+        public void SliderConverterTest(object value)
+        {
+            Wpf.Converters.SliderToolTipConverter converter = new Wpf.Converters.SliderToolTipConverter();
+
+            //test a valid case
+            var result = converter.Convert(new object[] { value, "Test String Format {0}" }, typeof(string), null, CultureInfo.CurrentCulture);
+            Assert.Equal($"Test String Format {value}", result);
+
+            //test too many placeholders in format string
+            result = converter.Convert(new object[] { value, "{0} {1}" }, typeof(string), null, CultureInfo.CurrentCulture);
+            Assert.Equal(value.ToString(), result);
+
+            result = converter.Convert(new object[] { value, "{0} {1} {2}" }, typeof(string), null, CultureInfo.CurrentCulture);
+            Assert.Equal(value.ToString(), result);
+
+            //test empty format string
+            result = converter.Convert(new object[] { value, "" }, typeof(string), null, CultureInfo.CurrentCulture);
+            Assert.Equal(value.ToString(), result);
+
+            //test null format string
+            result = converter.Convert(new object[] { value, null }, typeof(string), null, CultureInfo.CurrentCulture);
+            Assert.Equal(value.ToString(), result);
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/Converters/SliderToolTipConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/SliderToolTipConverter.cs
@@ -1,24 +1,24 @@
 ﻿using System;
 using System.Globalization;
-using System.Text.RegularExpressions;
 using System.Windows.Data;
 
-namespace MaterialDesignThemes.Wpf.Converters
-{
-    public class SliderToolTipConverter : IMultiValueConverter
-    {
-        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (values.Length >= 2 && values[1] is string format && !string.IsNullOrEmpty(format))
-                try
-                {
-                    return string.Format(culture, format, values[0]);
-                }
-                catch (FormatException) { }
-            return System.Convert.ChangeType(values[0], targetType, culture);
-        }
+namespace MaterialDesignThemes.Wpf.Converters;
 
-        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
-            => throw new NotImplementedException();
+internal class SliderToolTipConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values.Length >= 2 && values[1] is string format && !string.IsNullOrEmpty(format))
+        {
+            try
+            {
+                return string.Format(culture, format, values[0]);
+            }
+            catch (FormatException) { }
+        }
+        return System.Convert.ChangeType(values[0], targetType, culture);
     }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }

--- a/MaterialDesignThemes.Wpf/Converters/SliderToolTipConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/SliderToolTipConverter.cs
@@ -1,14 +1,15 @@
 ﻿using System;
 using System.Globalization;
+using System.Windows;
 using System.Windows.Data;
 
 namespace MaterialDesignThemes.Wpf.Converters;
 
 internal class SliderToolTipConverter : IMultiValueConverter
 {
-    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object?[]? values, Type? targetType, object? parameter, CultureInfo? culture)
     {
-        if (values.Length >= 2 && values[1] is string format && !string.IsNullOrEmpty(format))
+        if (values?.Length >= 2 && values[1] is string format && !string.IsNullOrEmpty(format))
         {
             try
             {
@@ -16,7 +17,11 @@ internal class SliderToolTipConverter : IMultiValueConverter
             }
             catch (FormatException) { }
         }
-        return System.Convert.ChangeType(values[0], targetType, culture);
+        if (values?.Length >= 1 && targetType is not null)
+        {
+            return System.Convert.ChangeType(values[0], targetType, culture);
+        }
+        return DependencyProperty.UnsetValue;
     }
 
     public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)

--- a/MaterialDesignThemes.Wpf/Converters/SliderToolTipConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/SliderToolTipConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Windows.Data;
+
+namespace MaterialDesignThemes.Wpf.Converters
+{
+    public class SliderToolTipConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Length >= 2 && values[1] is string format && !string.IsNullOrEmpty(format))
+                try
+                {
+                    return string.Format(culture, format, values[0]);
+                }
+                catch (FormatException) { }
+            return System.Convert.ChangeType(values[0], targetType, culture);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+            => throw new NotImplementedException();
+    }
+}

--- a/MaterialDesignThemes.Wpf/SliderAssist.cs
+++ b/MaterialDesignThemes.Wpf/SliderAssist.cs
@@ -17,5 +17,18 @@ namespace MaterialDesignThemes.Wpf
 
         public static bool GetOnlyShowFocusVisualWhileDragging(RangeBase element)
             => (bool)element.GetValue(OnlyShowFocusVisualWhileDraggingProperty);
+
+        public static readonly DependencyProperty ToolTipFormatProperty
+            = DependencyProperty.RegisterAttached(
+                "ToolTipFormat",
+                typeof(string),
+                typeof(SliderAssist),
+                new PropertyMetadata(null));
+
+        public static void SetToolTipFormat(RangeBase element, string value)
+            => element.SetValue(ToolTipFormatProperty, value);
+
+        public static string GetToolTipFormat(RangeBase element)
+            => (string)element.GetValue(ToolTipFormatProperty);
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
@@ -10,6 +10,7 @@
     <converters:SliderValueLabelPositionConverter x:Key="SliderValueLabelPositionConverter" />
     <converters:BooleanAllConverter x:Key="BooleanAllConverter" />
     <converters:InvertBooleanConverter x:Key="InvertBooleanConverter" />
+    <converters:SliderToolTipConverter x:Key="SliderToolTipConverter" />
 
     <Style x:Key="MaterialDesignRepeatButton" TargetType="{x:Type RepeatButton}">
         <Setter Property="OverridesDefaultStyle" Value="True"/>
@@ -267,9 +268,15 @@
                     <TextBlock
                         Foreground="{DynamicResource MaterialDesignPaper}"
                         Margin="12,0,12,5"
-                        Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=Value}"
                         TextAlignment="Center"
-                        VerticalAlignment="Center" />
+                        VerticalAlignment="Center">
+                        <TextBlock.Text >
+                            <MultiBinding Converter="{StaticResource SliderToolTipConverter}" ValidatesOnDataErrors="True" NotifyOnValidationError="True" TargetNullValue="">
+                                <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" Path="Value" TargetNullValue="" />
+                                <Binding Path="(wpf:SliderAssist.ToolTipFormat)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
+                            </MultiBinding>
+                        </TextBlock.Text>
+                    </TextBlock>
                 </Grid>
             </Canvas>
             <AdornerDecorator>
@@ -451,9 +458,15 @@
                     <TextBlock
                         Foreground="{DynamicResource MaterialDesignPaper}"
                         Margin="12,0,17,0"
-                        Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=Value}"
                         TextAlignment="Center"
-                        VerticalAlignment="Center" />
+                        VerticalAlignment="Center">
+                        <TextBlock.Text >
+                            <MultiBinding Converter="{StaticResource SliderToolTipConverter}" ValidatesOnDataErrors="True" NotifyOnValidationError="True" TargetNullValue="">
+                                <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" Path="Value" TargetNullValue="" />
+                                <Binding Path="(wpf:SliderAssist.ToolTipFormat)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
+                            </MultiBinding>
+                        </TextBlock.Text>
+                    </TextBlock>
                 </Grid>
             </Canvas>
             <AdornerDecorator>


### PR DESCRIPTION
This feature can work around issue #2685 and it's also useful to have.

The attached property allows a string format to be spcified as per below:

```
    <Slider  
        wpf:SliderAssist.ToolTipFormat="a value of {0} is selected"
        Maximum="100"
        Minimum="0"
        Style="{StaticResource MaterialDesignDiscreteSlider}"
        TickFrequency="10"
        TickPlacement="BottomRight"
        Value="{Binding Value}"/>
```

Which look ssomething like this
![image](https://user-images.githubusercontent.com/2868949/168281265-d970b331-a64e-4079-ae32-234c46318ba7.png)

With nothing specified or an invalid format, the value is shown raw and unformatted.