### PR TITLE
Add virtualization on ComboBoxes and DataGridComboBoxColumn

### DIFF
--- a/MainDemo.Wpf/ComboBoxes.xaml
+++ b/MainDemo.Wpf/ComboBoxes.xaml
@@ -152,7 +152,7 @@
             Fill="{DynamicResource MaterialDesignDivider}" />
         <TextBlock
             Style="{StaticResource SectionTitle}"
-            Text="Virtualised ComboBoxes"/>
+            Text="ComboBoxes with long lists"/>
 
         <StackPanel Orientation="Horizontal">
 
@@ -160,7 +160,7 @@
                 <ComboBox
                     materialDesign:HintAssist.Hint="Virtualisation"
                     MinWidth="72"
-                    ItemsSource="{Binding LongListToTestComboVirtualization}"
+                    ItemsSource="{Binding LongIntegerList}"
                     SelectedValue="{Binding SelectedValueOne}">
 
                     <ComboBox.SelectedItem>
@@ -174,12 +174,6 @@
                             </Binding.ValidationRules>
                         </Binding>
                     </ComboBox.SelectedItem>
-                    
-                    <ComboBox.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <VirtualizingStackPanel />
-                        </ItemsPanelTemplate>
-                    </ComboBox.ItemsPanel>
                 </ComboBox>
             </smtx:XamlDisplay>
 
@@ -188,7 +182,7 @@
                 <ComboBox materialDesign:HintAssist.Hint="(editable)"
                           MinWidth="72"
                           IsEditable="True"
-                          ItemsSource="{Binding LongListToTestComboVirtualization}">
+                          ItemsSource="{Binding LongIntegerList}">
                     <ComboBox.Text>
                         <Binding Path="SelectedTextTwo" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
                             <Binding.ValidationRules>
@@ -196,22 +190,12 @@
                             </Binding.ValidationRules>
                         </Binding>
                     </ComboBox.Text>
-                    <ComboBox.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <VirtualizingStackPanel />
-                        </ItemsPanelTemplate>
-                    </ComboBox.ItemsPanel>
                 </ComboBox>
             </smtx:XamlDisplay>
             <smtx:XamlDisplay UniqueKey="comboboxes_7">
                 <ComboBox materialDesign:HintAssist.Hint="(float hint)"
-                          ItemsSource="{Binding LongListToTestComboVirtualization}"
+                          ItemsSource="{Binding LongIntegerList}"
                           Style="{StaticResource MaterialDesignFloatingHintComboBox}">
-                    <ComboBox.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <VirtualizingStackPanel />
-                        </ItemsPanelTemplate>
-                    </ComboBox.ItemsPanel>
                 </ComboBox>
             </smtx:XamlDisplay>
             <smtx:XamlDisplay UniqueKey="comboboxes_8">
@@ -219,32 +203,27 @@
                           materialDesign:HintAssist.FloatingScale="1.5"
                           materialDesign:HintAssist.FloatingOffset="0, -24"
                           MinWidth="72"
-                          ItemsSource="{Binding LongListToTestComboVirtualization}"
+                          ItemsSource="{Binding LongIntegerList}"
                           Style="{StaticResource MaterialDesignFloatingHintComboBox}">
-                    <ComboBox.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <VirtualizingStackPanel />
-                        </ItemsPanelTemplate>
-                    </ComboBox.ItemsPanel>
                 </ComboBox>
             </smtx:XamlDisplay>
             <smtx:XamlDisplay UniqueKey="comboboxes_12">
                 <ComboBox materialDesign:HintAssist.Hint="(Change fontfamily float hint)"
                           materialDesign:HintAssist.FontFamily="Verdana"
                           MinWidth="72"
-                          ItemsSource="{Binding LongListToTestComboVirtualization}"
+                          ItemsSource="{Binding LongStringList}"
                           Style="{StaticResource MaterialDesignFloatingHintComboBox}">
-                    <ComboBox.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <VirtualizingStackPanel />
-                        </ItemsPanelTemplate>
-                    </ComboBox.ItemsPanel>
                 </ComboBox>
             </smtx:XamlDisplay>
         </StackPanel>
 
+        <StackPanel Orientation="Horizontal" Margin="0,40,0,0">
+            <materialDesign:PackIcon Kind="Information" Margin="0 0 5 0"/>
+            <TextBlock>ComboBoxes are virtualized by default in the library</TextBlock>
+        </StackPanel>
+
         <Rectangle
-            Margin="0 32 0 0"
+            Margin="0 15 0 0"
             Height="1"
             Fill="{DynamicResource MaterialDesignDivider}" />
         <TextBlock

--- a/MainDemo.Wpf/DataGrids.xaml
+++ b/MainDemo.Wpf/DataGrids.xaml
@@ -131,9 +131,20 @@
                         </materialDesign:MaterialDataGridComboBoxColumn.EditingElementStyle>
                         -->
                     </materialDesign:DataGridComboBoxColumn>
+                    <materialDesign:DataGridComboBoxColumn
+                        Header="ComboBox with long list"
+                        SelectedValueBinding="{Binding Files}"
+                        ItemsSourceBinding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type DataGrid}}, Path=DataContext.Files}">
+
+                    </materialDesign:DataGridComboBoxColumn>
                 </DataGrid.Columns>
             </DataGrid>
         </smtx:XamlDisplay>
+
+        <StackPanel Orientation="Horizontal" Margin="0,15,0,0">
+            <materialDesign:PackIcon Kind="Information" Margin="0 0 5 0"/>
+            <TextBlock>DataGridComboBoxColumns are virtualized by default in the library</TextBlock>
+        </StackPanel>
         
         <TextBlock
             Style="{StaticResource MaterialDesignHeadline5TextBlock}"

--- a/MainDemo.Wpf/Domain/ComboBoxesViewModel.cs
+++ b/MainDemo.Wpf/Domain/ComboBoxesViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace MaterialDesignDemo.Domain
@@ -12,7 +13,7 @@ namespace MaterialDesignDemo.Domain
 
         public ComboBoxesViewModel()
         {
-            LongListToTestComboVirtualization = new List<int>(Enumerable.Range(0, 1000));
+            LongIntegerList = new List<int>(Enumerable.Range(0, 1000));
             ShortStringList = new[]
             {
                 "Item 1",
@@ -20,8 +21,15 @@ namespace MaterialDesignDemo.Domain
                 "Item 3"
             };
 
-            SelectedValueOne = LongListToTestComboVirtualization.Skip(2).First();
+            SelectedValueOne = LongIntegerList.Skip(2).First();
             SelectedTextTwo = null;
+
+            LongStringList = new List<string>();
+
+            for(int i = 0; i < 1000; i++)
+            {
+                LongStringList.Add(Path.GetRandomFileName());
+            }
         }
 
         public int? SelectedValueOne
@@ -48,7 +56,8 @@ namespace MaterialDesignDemo.Domain
             set => SetProperty(ref _selectedValidationOutlined, value);
         }
 
-        public IList<int> LongListToTestComboVirtualization { get; }
+        public IList<int> LongIntegerList { get; }
         public IList<string> ShortStringList { get; }
+        public IList<string> LongStringList { get; }
     }
 }

--- a/MainDemo.Wpf/Domain/ListsAndGridsViewModel.cs
+++ b/MainDemo.Wpf/Domain/ListsAndGridsViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 
 namespace MaterialDesignDemo.Domain
@@ -19,6 +20,13 @@ namespace MaterialDesignDemo.Domain
                     if (args.PropertyName == nameof(SelectableViewModel.IsSelected))
                         OnPropertyChanged(nameof(IsAllItems1Selected));
                 };
+            }
+
+            Files = new List<string>();
+
+            for (int i = 0; i < 1000; i++)
+            {
+                Files.Add(Path.GetRandomFileName());
             }
         }
 
@@ -78,5 +86,8 @@ namespace MaterialDesignDemo.Domain
         public ObservableCollection<SelectableViewModel> Items3 { get; }
 
         public IEnumerable<string> Foods => new[] { "Burger", "Fries", "Shake", "Lettuce" };
+
+        public IList<string> Files { get; }
+
     }
 }

--- a/MainDemo.Wpf/Domain/SelectableViewModel.cs
+++ b/MainDemo.Wpf/Domain/SelectableViewModel.cs
@@ -8,6 +8,7 @@
         private char _code;
         private double _numeric;
         private string? _food;
+        private string? _files;
 
         public bool IsSelected
         {
@@ -43,6 +44,12 @@
         {
             get => _food;
             set => SetProperty(ref _food, value);
+        }
+
+        public string? Files
+        {
+            get => _files;
+            set => SetProperty(ref _files, value);
         }
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -1347,6 +1347,14 @@
         <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
         <Setter Property="Template" Value="{StaticResource MaterialDesignFloatingHintComboBoxTemplate}" />
         <Setter Property="internal:ClearText.HandlesClearCommand" Value="True" />
+        <!--Virtualization-->
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
         <Style.Triggers>
             <Trigger Property="IsEditable" Value="True">
                 <Setter Property="IsTabStop" Value="False" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
@@ -413,6 +413,14 @@
         <Setter Property="ScrollViewer.PanningMode" Value="Both"/>
         <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
         <Setter Property="Template" Value="{StaticResource MaterialDesignDataGridComboBoxTemplate}"/>
+        <!--Virtualization-->
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
         <Style.Triggers>
             <Trigger Property="IsEditable" Value="true">
                 <Setter Property="IsTabStop" Value="false"/>


### PR DESCRIPTION
Issue related: https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2725

**Changes made**
- [x] Add virtualization on:

- `ComboBox`
- `DataGridComboBoxColumn`

- [x] Add examples in the demo app

**Additional information**

I've just noticed something: the foreground color seems incorrect in `DataGridComboBoxColumn` when there is a `ScrollBar`

**With ScrollBar:**

![image](https://user-images.githubusercontent.com/54487782/171417096-48482c30-465c-4f0a-ad27-cee8c41042e0.png)

**Without ScrollBar:**

![image](https://user-images.githubusercontent.com/54487782/171417614-a32712de-dce3-48c6-a468-143ace332c77.png)

I don't think this is related to the changes made but it's something that will have to be corrected in the future