### PR TITLE
Fix HelperText margin/padding #2738

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -209,7 +209,8 @@
                             Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}"
                             CornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
                             Background="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}" />
-                        <Canvas VerticalAlignment="Bottom">
+                        <Canvas x:Name="HelperTextWrapper"
+                                VerticalAlignment="Bottom">
                             <TextBlock
                                 Canvas.Top="2"
                                 FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
@@ -254,14 +255,15 @@
                             </Setter>
                         </MultiTrigger>
                         <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
-                            <Setter Property="Padding" Value="16 8" />
+                            <Setter Property="Padding" Value="16 8 12 8" />
                             <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
+                            <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16 0 0 0" />
                         </Trigger>
                         <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
                             <Setter Property="VerticalContentAlignment" Value="Top" />
                             <Setter Property="BorderThickness" Value="1" />
                             <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
-                            <Setter Property="Padding" Value="16" />
+                            <Setter Property="Padding" Value="16 16 12 16" />
                             <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
                             <Setter TargetName="HintWrapper" Property="Opacity"
@@ -277,6 +279,7 @@
                                     </MultiBinding>
                                 </Setter.Value>
                             </Setter>
+                            <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16 0 0 0" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>


### PR DESCRIPTION
Fix #2738 

- [x] Fix for  `HasFilledTextField`
- [x] Fix for  `HasOutlinedTextField`

![image](https://user-images.githubusercontent.com/54487782/173868417-2239f084-db1b-40ba-8b20-24e591a3798e.png)
