### PR TITLE
Fix2658

### DIFF
--- a/MainDemo.Wpf/Cards.xaml
+++ b/MainDemo.Wpf/Cards.xaml
@@ -84,6 +84,68 @@
         </smtx:XamlDisplay>
 
         <smtx:XamlDisplay
+            UniqueKey="cards_1b"
+            Margin="4 4 0 16"
+            VerticalContentAlignment="Top">
+            <materialDesign:Card Width="200" Style="{StaticResource MaterialDesignOutlinedCard}">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="140" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Image
+                        Source="Resources/Chartridge046_small.jpg"
+                        Height="140"
+                        Width="196"
+                        Stretch="UniformToFill"/>
+                    <Button
+                        Grid.Row="0"
+                        Style="{StaticResource MaterialDesignFloatingActionMiniAccentButton}" 
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Bottom"
+                        Margin="0 0 16 -20">
+                        <materialDesign:PackIcon Kind="Bike" />
+                    </Button>
+                    <StackPanel Grid.Row="1" Margin="8 24 8 0" >
+                        <TextBlock FontWeight="Bold">Outlined style</TextBlock>
+                        <TextBlock
+                            TextWrapping="Wrap"
+                            VerticalAlignment="Center"
+                            Text="Removes the drop shadow and flattens the look of the card."/>
+                    </StackPanel>
+                    <StackPanel
+                        HorizontalAlignment="Right"
+                        Grid.Row="2"
+                        Orientation="Horizontal"
+                        Margin="8">
+                        <Button
+                            Style="{StaticResource MaterialDesignToolButton}"
+                            Width="30" Padding="2 0 2 0"
+                            materialDesign:RippleAssist.IsCentered="True">
+                            <materialDesign:PackIcon Kind="ShareVariant" />
+                        </Button>
+                        <Button
+                            Style="{StaticResource MaterialDesignToolButton}"
+                            Width="30"
+                            Padding="2 0 2 0"
+                            materialDesign:RippleAssist.IsCentered="True">
+                            <materialDesign:PackIcon Kind="Heart" />
+                        </Button>
+                        <materialDesign:PopupBox
+                            Style="{StaticResource MaterialDesignToolPopupBox}"
+                            Padding="2 0 2 0">
+                            <StackPanel>
+                                <Button Content="More"/>
+                                <Button Content="Options"/>
+                            </StackPanel>
+                        </materialDesign:PopupBox>
+                    </StackPanel>
+                </Grid>
+            </materialDesign:Card>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay
             UniqueKey="cards_2"
             Margin="4 4 0 16"
             VerticalContentAlignment="Top">

--- a/MaterialDesignThemes.UITests/WPF/Cards/OutlinedCardTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/Cards/OutlinedCardTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Windows.Media;
+
+namespace MaterialDesignThemes.UITests.WPF.Cards;
+
+public class OutlinedCardTests : TestBase
+{
+    public OutlinedCardTests(ITestOutputHelper output)
+        : base(output)
+    { }
+
+    [Fact]
+    public async Task OutlinedCard_UsesThemeColorForBorder()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        //Arrange
+        IVisualElement<Card> card = await LoadXaml<Card>(
+            @"<materialDesign:Card Content=""Hello World"" Style=""{StaticResource MaterialDesignOutlinedCard}""/>");
+        Color dividerColor = await GetThemeColor("MaterialDesignDivider");
+        IVisualElement<Border> internalBorder = await card.GetElement<Border>();
+
+        //Act
+        Color? internalBorderColor = await internalBorder.GetBorderBrushColor();
+
+        //Assert
+        Assert.Equal(dividerColor, internalBorderColor);
+
+        recorder.Success();
+    }
+}

--- a/MaterialDesignThemes.UITests/WPF/Cards/OutlinedCardTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/Cards/OutlinedCardTests.cs
@@ -27,4 +27,26 @@ public class OutlinedCardTests : TestBase
 
         recorder.Success();
     }
+
+    [Fact]
+    public async Task OutlinedCard_UniformCornerRadiusApplied_AppliesCornerRadiusOnBorder()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        //Arrange
+        IVisualElement<Card> card = await LoadXaml<Card>(
+            @"<materialDesign:Card Content=""Hello World"" Style=""{StaticResource MaterialDesignOutlinedCard}"" UniformCornerRadius=""5"" />");
+        IVisualElement<Border> internalBorder = await card.GetElement<Border>();
+
+        //Act
+        CornerRadius? internalBorderCornerRadius = await internalBorder.GetCornerRadius();
+
+        //Assert
+        Assert.Equal(5, internalBorderCornerRadius.Value.TopLeft);
+        Assert.Equal(5, internalBorderCornerRadius.Value.TopRight);
+        Assert.Equal(5, internalBorderCornerRadius.Value.BottomRight);
+        Assert.Equal(5, internalBorderCornerRadius.Value.BottomLeft);
+
+        recorder.Success();
+    }
 }

--- a/MaterialDesignThemes.UITests/XamlTestMixins.cs
+++ b/MaterialDesignThemes.UITests/XamlTestMixins.cs
@@ -29,6 +29,7 @@ xmlns:materialDesign=""http://materialdesigninxaml.net/winfx/xaml/themes"">
     <ResourceDictionary.MergedDictionaries>
         <materialDesign:BundledTheme BaseTheme=""{baseTheme}"" PrimaryColor=""{primary}"" SecondaryColor=""{secondary}"" {colorAdjustString}/>
 
+        <ResourceDictionary Source = ""pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/Generic.xaml"" />
         <ResourceDictionary Source = ""pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml"" />
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>";

--- a/MaterialDesignThemes.Wpf.Tests/Converters/DoubleToCornerRadiusConverterTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/Converters/DoubleToCornerRadiusConverterTests.cs
@@ -1,0 +1,26 @@
+﻿using System.Globalization;
+using MaterialDesignThemes.Wpf.Converters;
+using Xunit;
+
+namespace MaterialDesignThemes.Wpf.Tests.Converters;
+
+public class DoubleToCornerRadiusConverterTests
+{
+    [Theory]
+    [InlineData(-0.16, 0.0)]
+    [InlineData(0.16, 0.16)]
+    [InlineData(5.0, 5.0)]
+    public void AllCultureParseParameterCorrectly(object parameter, double expectedCornerRadius)
+    {
+        var converter = new DoubleToCornerRadiusConverter();
+        foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures))
+        {
+            var cornerRadius = (CornerRadius?)converter.Convert(parameter, typeof(CornerRadius), parameter, culture);
+
+            Assert.Equal(expectedCornerRadius, cornerRadius.Value.TopLeft);
+            Assert.Equal(expectedCornerRadius, cornerRadius.Value.TopRight);
+            Assert.Equal(expectedCornerRadius, cornerRadius.Value.BottomRight);
+            Assert.Equal(expectedCornerRadius, cornerRadius.Value.BottomLeft);
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/Converters/DoubleToCornerRadiusConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/DoubleToCornerRadiusConverter.cs
@@ -1,0 +1,13 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+
+namespace MaterialDesignThemes.Wpf.Converters;
+
+internal class DoubleToCornerRadiusConverter : IValueConverter
+{
+    public static readonly DoubleToCornerRadiusConverter Instance = new();
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => new CornerRadius((double)value);
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+}

--- a/MaterialDesignThemes.Wpf/Converters/DoubleToCornerRadiusConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/DoubleToCornerRadiusConverter.cs
@@ -7,7 +7,7 @@ internal class DoubleToCornerRadiusConverter : IValueConverter
 {
     public static readonly DoubleToCornerRadiusConverter Instance = new();
 
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => new CornerRadius((double)value);
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => new CornerRadius(Math.Max(0, (double)value));
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
 }

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -33,6 +33,7 @@
     <!-- set up default styles for our custom Material Design in XAML Toolkit controls -->
     <Style TargetType="{x:Type local:Clock}" BasedOn="{StaticResource MaterialDesignClock}" />
     <Style TargetType="{x:Type local:Badged}" BasedOn="{StaticResource MaterialDesignBadge}" />
+    <Style TargetType="{x:Type local:Card}" BasedOn="{StaticResource MaterialDesignElevatedCard}" />
     <Style TargetType="{x:Type local:PopupBox}" BasedOn="{StaticResource MaterialDesignPopupBox}" />
     <Style TargetType="{x:Type local:TimePicker}" BasedOn="{StaticResource MaterialDesignTimePicker}" />
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -7,47 +7,78 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <ControlTemplate TargetType="{x:Type wpf:Card}" x:Key="CardTemplate">
-        <ControlTemplate.Resources>
-            <converters:ShadowEdgeConverter x:Key="ShadowEdgeConverter" />
-        </ControlTemplate.Resources>
-        <Grid Background="Transparent">
-            <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
-                <AdornerDecorator.OpacityMask>
-                    <MultiBinding Converter="{StaticResource ShadowEdgeConverter}">
-                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualWidth"/>
-                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualHeight"/>
-                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:ShadowAssist.ShadowDepth)" />
-                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:ShadowAssist.ShadowEdges)" />
-                    </MultiBinding>
-                </AdornerDecorator.OpacityMask>
-                <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
-                        CornerRadius="{TemplateBinding UniformCornerRadius}">
-                    <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" 
-                            x:Name="PART_ClipBorder"
-                            Clip="{TemplateBinding ContentClip}" />
-                </Border>
-            </AdornerDecorator>
-            <ContentPresenter 
-                x:Name="ContentPresenter"
-                Margin="{TemplateBinding Padding}"
-                Content="{TemplateBinding ContentControl.Content}" 
-                ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}" 
-                ContentTemplateSelector="{TemplateBinding ContentControl.ContentTemplateSelector}" 
-                ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}">
-            </ContentPresenter>
-        </Grid>
-        <ControlTemplate.Triggers>
-            <Trigger Property="ClipContent" Value="True">
-                <Setter Property="Clip" TargetName="ContentPresenter" Value="{Binding ContentClip, RelativeSource={RelativeSource TemplatedParent}}" />
-            </Trigger>
-        </ControlTemplate.Triggers>
-    </ControlTemplate>
-    <Style TargetType="{x:Type wpf:Card}">
-        <Setter Property="Template" Value="{StaticResource CardTemplate}" />
+    <Style x:Key="MaterialDesignElevatedCard" TargetType="{x:Type wpf:Card}">
         <Setter Property="Background" Value="{DynamicResource MaterialDesignCardBackground}" />
         <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth2" />
         <Setter Property="Focusable" Value="False"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type wpf:Card}">
+                    <ControlTemplate.Resources>
+                        <converters:ShadowEdgeConverter x:Key="ShadowEdgeConverter" />
+                    </ControlTemplate.Resources>
+                    <Grid Background="Transparent">
+                        <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
+                            <AdornerDecorator.OpacityMask>
+                                <MultiBinding Converter="{StaticResource ShadowEdgeConverter}">
+                                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualWidth"/>
+                                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualHeight"/>
+                                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:ShadowAssist.ShadowDepth)" />
+                                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:ShadowAssist.ShadowEdges)" />
+                                </MultiBinding>
+                            </AdornerDecorator.OpacityMask>
+                            <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
+                                    CornerRadius="{TemplateBinding UniformCornerRadius}">
+                                <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" 
+                                        x:Name="PART_ClipBorder"
+                                        Clip="{TemplateBinding ContentClip}" />
+                            </Border>
+                        </AdornerDecorator>
+                        <ContentPresenter x:Name="ContentPresenter"
+                                          Margin="{TemplateBinding Padding}"
+                                          Content="{TemplateBinding ContentControl.Content}"
+                                          ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}"
+                                          ContentTemplateSelector="{TemplateBinding ContentControl.ContentTemplateSelector}"
+                                          ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="ClipContent" Value="True">
+                            <Setter Property="Clip" TargetName="ContentPresenter" Value="{Binding ContentClip, RelativeSource={RelativeSource TemplatedParent}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
+
+    <Style x:Key="MaterialDesignOutlinedCard" TargetType="{x:Type wpf:Card}">
+        <Setter Property="Background" Value="{DynamicResource MaterialDesignCardBackground}" />
+        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type wpf:Card}">
+                    <Grid Background="Transparent">
+                        <Border BorderThickness="1" CornerRadius="{TemplateBinding UniformCornerRadius, Converter={x:Static converters:DoubleToCornerRadiusConverter.Instance}}" BorderBrush="{DynamicResource MaterialDesignDivider}">
+                            <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" 
+                                        x:Name="PART_ClipBorder"
+                                        Clip="{TemplateBinding ContentClip}">
+                                <ContentPresenter x:Name="ContentPresenter"
+                                          Margin="{TemplateBinding Padding}"
+                                          Content="{TemplateBinding ContentControl.Content}"
+                                          ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}"
+                                          ContentTemplateSelector="{TemplateBinding ContentControl.ContentTemplateSelector}"
+                                          ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}" />
+                            </Border>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="ClipContent" Value="True">
+                            <Setter Property="Clip" TargetName="ContentPresenter" Value="{Binding ContentClip, RelativeSource={RelativeSource TemplatedParent}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>        
 
 </ResourceDictionary>


### PR DESCRIPTION
Fix for #2658

Split Card template into 2 styles: Elevated and Outlined.

For the outlined style, I was unsure whether to add a new color or use an existing one. It was not 100% clear where I should add that color if I wanted it, so I opted to reuse the MaterialDesignDivider brush which seems to resemble the dimmed look from the material.io design pretty well.

Added unit test for newly added converter and UI tests for newly added card style.

In order to get the UI tests to run, I had to include Generic.xaml in the merged resources dictionary. I think this "happens automatically" when running a WPF app, but for the test it seemed necessary to add manually. Perhaps this is something that should be included in the XAMLTest library instead?