### PR TITLE
Added UniformCornerRadius to Flipper

### DIFF
--- a/MainDemo.Wpf/Cards.xaml
+++ b/MainDemo.Wpf/Cards.xaml
@@ -551,6 +551,62 @@
                 </materialDesign:Flipper.BackContent>
             </materialDesign:Flipper>
         </smtx:XamlDisplay>
+
+        <StackPanel>
+            <smtx:XamlDisplay
+                UniqueKey="cards_10"
+                Margin="4 4 0 0"
+                VerticalContentAlignment="Top">
+                <materialDesign:Flipper
+                    IsFlippedChanged="Flipper_OnIsFlippedChanged">
+                    <materialDesign:Flipper.FrontContent>
+                        <Button
+                            Style="{StaticResource MaterialDesignFlatButton}"
+                            materialDesign:ButtonAssist.CornerRadius="8"
+                            Command="{x:Static materialDesign:Flipper.FlipCommand}"
+                            Margin="8"
+                            Width="184"
+                            Content="Rounded Flipper"/>
+                    </materialDesign:Flipper.FrontContent>
+                    <materialDesign:Flipper.BackContent>
+                        <Button
+                            Style="{StaticResource MaterialDesignFlatButton}"
+                            materialDesign:ButtonAssist.CornerRadius="8"
+                            Command="{x:Static materialDesign:Flipper.FlipCommand}"
+                            Margin="8"
+                            Width="184"
+                            Content="GO BACK"/>
+                    </materialDesign:Flipper.BackContent>
+                </materialDesign:Flipper>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
+                UniqueKey="cards_11"
+                Margin="4 4 0 0"
+                VerticalContentAlignment="Top">
+                <materialDesign:Flipper
+                    Style="{StaticResource MaterialDesignCardFlipper}"
+                    IsFlippedChanged="Flipper_OnIsFlippedChanged"
+                    UniformCornerRadius="8">
+                    <materialDesign:Flipper.FrontContent>
+                        <Button
+                            Style="{StaticResource MaterialDesignFlatButton}"
+                            Command="{x:Static materialDesign:Flipper.FlipCommand}"
+                            Margin="8"
+                            Width="184"
+                            Content="Rounded Card Flipper"/>
+                    </materialDesign:Flipper.FrontContent>
+                    <materialDesign:Flipper.BackContent>
+                        <Button
+                            Style="{StaticResource MaterialDesignFlatButton}"
+                            Command="{x:Static materialDesign:Flipper.FlipCommand}"
+                            Margin="8"
+                            Width="184"
+                            Content="GO BACK"/>
+                    </materialDesign:Flipper.BackContent>
+                </materialDesign:Flipper>
+            </smtx:XamlDisplay>
+        </StackPanel>
     </WrapPanel>
 </UserControl>
 

--- a/MaterialDesignThemes.Wpf/Flipper.cs
+++ b/MaterialDesignThemes.Wpf/Flipper.cs
@@ -143,6 +143,18 @@ namespace MaterialDesignThemes.Wpf
             instance.RaiseEvent(args);
         }
 
+        public static readonly DependencyProperty UniformCornerRadiusProperty = DependencyProperty.Register(
+            nameof(UniformCornerRadius), typeof(double), typeof(Flipper), new PropertyMetadata(default(double)));
+
+        /// <summary>
+        /// Gets or sets the (uniform) corner radius applied the the <see cref="Flipper"/> when the MaterialDesignCardFlipper style is applied.
+        /// </summary>
+        public double UniformCornerRadius
+        {
+            get => (double)GetValue(UniformCornerRadiusProperty);
+            set => SetValue(UniformCornerRadiusProperty, value);
+        }
+
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Flipper.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Flipper.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
@@ -162,7 +162,7 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                         <wpf:Plane3D x:Name="PART_Plane3D" RotationY="0" ZFactor="2.055">
-                            <wpf:Card wpf:ShadowAssist.ShadowDepth="{TemplateBinding wpf:ShadowAssist.ShadowDepth}">
+                            <wpf:Card wpf:ShadowAssist.ShadowDepth="{TemplateBinding wpf:ShadowAssist.ShadowDepth}" UniformCornerRadius="{TemplateBinding UniformCornerRadius}">
                                 <Grid>
                                     <ContentPresenter x:Name="FrontContentPresenter"                    
                                                       Margin="{TemplateBinding Padding}"                            


### PR DESCRIPTION
Fix for #2689

The new DP is only used in the MaterialDesignCardFlipper style. For the default style, calling code can simply add rounded corners to the content that is put in.

Kind of feels like there there should be a UniformCornerRadius attached property for the Card instead. This would avoid exposing a DP on Flipper.cs that is not used in all styles? Would this go into a CardAssist.cs file or would the attached property go directly in the Card.cs file alongside the "real" DP? 