### PR TITLE
Add ExpanderAssist.CanToggle, which enables/disables expanding/collapsing an expander

### DIFF
--- a/MainDemo.Wpf/Expander.xaml
+++ b/MainDemo.Wpf/Expander.xaml
@@ -2,14 +2,14 @@
     x:Class="MaterialDesignDemo.Expander"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
     xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
-    mc:Ignorable="d" 
+    mc:Ignorable="d"
     d:DesignHeight="400"
     d:DesignWidth="600">
-    
+
     <UserControl.Resources>
         <Style TargetType="{x:Type TextBlock}" x:Key="HorizontalExpanderContentTextBlock">
             <Setter Property="Opacity" Value=".68"/>
@@ -20,7 +20,7 @@
         <Style TargetType="{x:Type TextBlock}" x:Key="VerticalExpanderContentTextBlock" BasedOn="{StaticResource HorizontalExpanderContentTextBlock}">
             <Setter Property="MaxWidth" Value="180"/>
         </Style>
-        
+
         <Style TargetType="{x:Type Border}" x:Key="HorizontalDividerBorder">
             <Setter Property="Background" Value="{DynamicResource MaterialDesignDivider}"/>
             <Setter Property="UseLayoutRounding" Value="True"/>
@@ -34,7 +34,7 @@
             <Setter Property="Width" Value="1"/>
         </Style>
     </UserControl.Resources>
-    
+
     <ScrollViewer
         VerticalScrollBarVisibility="Auto"
         HorizontalScrollBarVisibility="Auto">
@@ -42,8 +42,9 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
-            
+
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="800" />
                 <ColumnDefinition Width="Auto" />
@@ -57,11 +58,11 @@
                             Orientation="Vertical"
                             TextBlock.Foreground="{DynamicResource MaterialDesignBody}"
                             Margin="24,8,24,16">
-                            <TextBlock Text="Your Content"/>                            
+                            <TextBlock Text="Your Content"/>
                             <TextBlock Style="{StaticResource HorizontalExpanderContentTextBlock}"/>
                         </StackPanel>
                     </Expander>
-                    
+
                     <Expander
                         HorizontalAlignment="Stretch"
                         Header="Expander Example 1b"
@@ -74,7 +75,7 @@
                             <TextBlock Style="{StaticResource HorizontalExpanderContentTextBlock}"/>
                         </StackPanel>
                     </Expander>
-                    
+
                     <Expander
                         HorizontalAlignment="Stretch"
                         Header="Expander Example 1c">
@@ -82,11 +83,11 @@
                             Orientation="Vertical"
                             TextBlock.Foreground="{DynamicResource MaterialDesignBody}"
                             Margin="24,8,24,16">
-                            <TextBlock Text="Your Content"/>                            
+                            <TextBlock Text="Your Content"/>
                             <TextBlock Style="{StaticResource HorizontalExpanderContentTextBlock}"/>
                         </StackPanel>
                     </Expander>
-                    
+
                     <Expander
                         HorizontalAlignment="Stretch"
                         Header="Custom Header Padding"
@@ -95,7 +96,7 @@
                             Orientation="Vertical"
                             TextBlock.Foreground="{DynamicResource MaterialDesignBody}"
                             Margin="24,8,24,16">
-                            <TextBlock Text="Your Content"/>                            
+                            <TextBlock Text="Your Content"/>
                             <TextBlock Style="{StaticResource HorizontalExpanderContentTextBlock}"/>
                         </StackPanel>
                     </Expander>
@@ -120,9 +121,9 @@
                                 <TextBlock Style="{StaticResource HorizontalExpanderContentTextBlock}"/>
                             </StackPanel>
                         </Expander>
-                        
+
                         <Border Style="{StaticResource HorizontalDividerBorder}"/>
-                        
+
                         <Expander
                             HorizontalAlignment="Stretch"
                             Header="Expander Example 2b">
@@ -172,7 +173,7 @@
                                 </TextBlock.LayoutTransform>
                             </TextBlock>
                         </Expander.Header>
-                        
+
                         <StackPanel
                             Orientation="Vertical"
                             TextBlock.Foreground="{DynamicResource MaterialDesignBody}"
@@ -194,12 +195,12 @@
                                 </TextBlock.LayoutTransform>
                             </TextBlock>
                         </Expander.Header>
-                        
+
                         <StackPanel
                             Orientation="Vertical"
                             TextBlock.Foreground="{DynamicResource MaterialDesignBody}"
                             Margin="8,24,16,24">
-                            <TextBlock Text="Your Content"/>                            
+                            <TextBlock Text="Your Content"/>
                             <TextBlock Style="{StaticResource VerticalExpanderContentTextBlock}"/>
                         </StackPanel>
                     </Expander>
@@ -216,7 +217,7 @@
                                 </TextBlock.LayoutTransform>
                             </TextBlock>
                         </Expander.Header>
-                        
+
                         <StackPanel
                             Orientation="Vertical"
                             TextBlock.Foreground="{DynamicResource MaterialDesignBody}"
@@ -240,7 +241,7 @@
                                 </TextBlock.LayoutTransform>
                             </TextBlock>
                         </Expander.Header>
-                        
+
                         <StackPanel
                             Orientation="Vertical"
                             TextBlock.Foreground="{DynamicResource MaterialDesignBody}"
@@ -250,6 +251,47 @@
                         </StackPanel>
                     </Expander>
                 </StackPanel>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
+                UniqueKey="expander_4"
+                Grid.Column="0"
+                Grid.Row="2"
+                Margin="4 24 0 0">
+                <materialDesign:Card>
+                    <StackPanel>
+                        <Expander
+                            HorizontalAlignment="Stretch"
+                            Header="Expander Example 4"
+                            IsExpanded="True"
+                            materialDesign:ExpanderAssist.CanToggle="False" >
+                            <StackPanel
+                                Orientation="Vertical"
+                                TextBlock.Foreground="{DynamicResource MaterialDesignBody}"
+                                Margin="24,8,24,16">
+                                <TextBlock Text="Your Content"/>
+                                <TextBlock Style="{StaticResource HorizontalExpanderContentTextBlock}"
+                                           Text="This expander cannot be collapsed, since ExpanderAssist.CanToggle is set to False."
+                                />
+                            </StackPanel>
+                        </Expander>
+
+                        <Expander
+                            HorizontalAlignment="Stretch"
+                            Header="And this one can't be expanded."
+                            materialDesign:ExpanderAssist.CanToggle="False" >
+                            <StackPanel
+                                Orientation="Vertical"
+                                TextBlock.Foreground="{DynamicResource MaterialDesignBody}"
+                                Margin="24,8,24,16">
+                                <TextBlock Text="Your Content"/>
+                                <TextBlock Style="{StaticResource HorizontalExpanderContentTextBlock}"
+                                           Text="You'll never see this text until ExpanderAssist.CanToggle gets set to True"
+                                />
+                            </StackPanel>
+                        </Expander>
+                    </StackPanel>
+                </materialDesign:Card>
             </smtx:XamlDisplay>
         </Grid>
     </ScrollViewer>

--- a/MaterialDesignThemes.Wpf/ExpanderAssist.cs
+++ b/MaterialDesignThemes.Wpf/ExpanderAssist.cs
@@ -52,5 +52,15 @@ namespace MaterialDesignThemes.Wpf
         public static void SetHeaderBackground(Expander element, Brush? value)
             => element.SetValue(HeaderBackgroundProperty, value);
         #endregion
+
+        #region AttachedProperty : CanToggleProperty
+        public static readonly DependencyProperty CanToggleProperty
+            = DependencyProperty.RegisterAttached("CanToggle", typeof(bool), typeof(ExpanderAssist), new PropertyMetadata(true));
+
+        public static bool GetCanToggle(Expander element)
+            => (bool)element.GetValue(CanToggleProperty);
+        public static void SetCanToggle(Expander element, bool value)
+            => element.SetValue(CanToggleProperty, value);
+        #endregion
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
@@ -271,6 +271,7 @@
                                           Opacity="0.87"
                                           Foreground="{TemplateBinding Foreground}"
                                           Background="{TemplateBinding wpf:ExpanderAssist.HeaderBackground}"
+                                          IsHitTestVisible="{TemplateBinding wpf:ExpanderAssist.CanToggle}"
                                           Content="{TemplateBinding Header}"
                                           ContentTemplate="{TemplateBinding HeaderTemplate}"
                                           ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"


### PR DESCRIPTION
This attached property, `ExpanderAssist.CanToggle`, gives you the ability to control whether or not an `Expander` can be expanded/collapsed.

- Default value: `true` (i.e., no change in behavior from current)
- Implementation: When set to `false`, sets `IsHitTestVisible` to `false` on the `HeaderSite` `ToggleButton` (the one that encompasses the _entire_ header - not just the arrow/chevron)
- The user cannot expand/collapse the expander by clicking on the header.
- The user does not get any mouseover indications they can click on the header

----

While this behavior may seem counter-intuitive at first, it has its uses.  

I recently developed an `Accordion` control, where each item was represented by an `Expander`.  When the user clicks the header of a collapsed item, the currently opened item will close, and the clicked-on item will open.  With the built-in `Expander` control, the user would be able to collapse the current item, and then all items would be closed.  I did not want to allow this behavior.

Either way, it's a very low-impact change.  Implementing it in the library would mean I don't need to re-implement the `ControlTemplate`.

Thanks in advance!