### PR TITLE
Refactor fix for 2689 to use attached properties

### DIFF
--- a/MainDemo.Wpf/Cards.xaml
+++ b/MainDemo.Wpf/Cards.xaml
@@ -649,14 +649,42 @@
                 <materialDesign:Flipper
                     Style="{StaticResource MaterialDesignCardFlipper}"
                     IsFlippedChanged="Flipper_OnIsFlippedChanged"
-                    UniformCornerRadius="8">
+                    materialDesign:CardAssist.UniformCornerRadius="8">
                     <materialDesign:Flipper.FrontContent>
                         <Button
                             Style="{StaticResource MaterialDesignFlatButton}"
                             Command="{x:Static materialDesign:Flipper.FlipCommand}"
                             Margin="8"
                             Width="184"
-                            Content="Rounded Card Flipper"/>
+                            Content="Rounded Card Flipper 1"/>
+                    </materialDesign:Flipper.FrontContent>
+                    <materialDesign:Flipper.BackContent>
+                        <Button
+                            Style="{StaticResource MaterialDesignFlatButton}"
+                            Command="{x:Static materialDesign:Flipper.FlipCommand}"
+                            Margin="8"
+                            Width="184"
+                            Content="GO BACK"/>
+                    </materialDesign:Flipper.BackContent>
+                </materialDesign:Flipper>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
+                UniqueKey="cards_12"
+                Margin="4 4 0 0"
+                VerticalContentAlignment="Top">
+                <materialDesign:Flipper
+                    Style="{StaticResource MaterialDesignCardFlipper}"
+                    IsFlippedChanged="Flipper_OnIsFlippedChanged"
+                    materialDesign:CardAssist.UniformCornerRadius="8"
+                    materialDesign:CardAssist.CardStyle="{StaticResource MaterialDesignOutlinedCard}">
+                    <materialDesign:Flipper.FrontContent>
+                        <Button
+                            Style="{StaticResource MaterialDesignFlatButton}"
+                            Command="{x:Static materialDesign:Flipper.FlipCommand}"
+                            Margin="8"
+                            Width="184"
+                            Content="Rounded Card Flipper 2"/>
                     </materialDesign:Flipper.FrontContent>
                     <materialDesign:Flipper.BackContent>
                         <Button

--- a/MaterialDesignThemes.UITests/WPF/Cards/ElevatedCardTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/Cards/ElevatedCardTests.cs
@@ -1,0 +1,30 @@
+﻿namespace MaterialDesignThemes.UITests.WPF.Cards;
+
+public class ElevatedCardTests : TestBase
+{
+    public ElevatedCardTests(ITestOutputHelper output)
+        : base(output)
+    { }
+
+    [Fact]
+    public async Task ElevatedCard_UniformCornerRadiusApplied_AppliesCornerRadiusOnBorder()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        //Arrange
+        IVisualElement<Card> card = await LoadXaml<Card>(
+            @"<materialDesign:Card Content=""Hello World"" Style=""{StaticResource MaterialDesignElevatedCard}"" UniformCornerRadius=""5"" />");
+        IVisualElement<Border> internalBorder = await card.GetElement<Border>();
+
+        //Act
+        CornerRadius? internalBorderCornerRadius = await internalBorder.GetCornerRadius();
+
+        //Assert
+        Assert.Equal(5, internalBorderCornerRadius.Value.TopLeft);
+        Assert.Equal(5, internalBorderCornerRadius.Value.TopRight);
+        Assert.Equal(5, internalBorderCornerRadius.Value.BottomRight);
+        Assert.Equal(5, internalBorderCornerRadius.Value.BottomLeft);
+
+        recorder.Success();
+    }
+}

--- a/MaterialDesignThemes.UITests/WPF/Flippers/FlipperTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/Flippers/FlipperTests.cs
@@ -1,0 +1,54 @@
+﻿namespace MaterialDesignThemes.UITests.WPF.Flippers;
+
+public class FlipperTests : TestBase
+{
+    public FlipperTests(ITestOutputHelper output)
+        : base(output)
+    { }
+
+    [Fact]
+    public async Task Flipper_UniformCornerRadiusAndOutlinedCardStyleAttachedPropertiesApplied_AppliesCornerRadiusOnBorder()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        //Arrange
+        IVisualElement<Flipper> flipper = await LoadXaml<Flipper>(
+            @"<materialDesign:Flipper Style=""{StaticResource MaterialDesignCardFlipper}"" materialDesign:CardAssist.CardStyle=""{StaticResource MaterialDesignOutlinedCard}"" materialDesign:CardAssist.UniformCornerRadius=""5"" />");
+        IVisualElement<Card> internalCard = await flipper.GetElement<Card>();
+        IVisualElement<Border> internalBorder = await internalCard.GetElement<Border>();
+
+        //Act
+        CornerRadius? internalBorderCornerRadius = await internalBorder.GetCornerRadius();
+
+        //Assert
+        Assert.Equal(5, internalBorderCornerRadius.Value.TopLeft);
+        Assert.Equal(5, internalBorderCornerRadius.Value.TopRight);
+        Assert.Equal(5, internalBorderCornerRadius.Value.BottomRight);
+        Assert.Equal(5, internalBorderCornerRadius.Value.BottomLeft);
+
+        recorder.Success();
+    }
+
+    [Fact]
+    public async Task Flipper_UniformCornerRadiusAndElevatedCardStyleAttachedPropertiesApplied_AppliesCornerRadiusOnBorder()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        //Arrange
+        IVisualElement<Flipper> flipper = await LoadXaml<Flipper>(
+            @"<materialDesign:Flipper Style=""{StaticResource MaterialDesignCardFlipper}"" materialDesign:CardAssist.CardStyle=""{StaticResource MaterialDesignElevatedCard}"" materialDesign:CardAssist.UniformCornerRadius=""5"" />");
+        IVisualElement<Card> internalCard = await flipper.GetElement<Card>();
+        IVisualElement<Border> internalBorder = await internalCard.GetElement<Border>();
+
+        //Act
+        CornerRadius? internalBorderCornerRadius = await internalBorder.GetCornerRadius();
+
+        //Assert
+        Assert.Equal(5, internalBorderCornerRadius.Value.TopLeft);
+        Assert.Equal(5, internalBorderCornerRadius.Value.TopRight);
+        Assert.Equal(5, internalBorderCornerRadius.Value.BottomRight);
+        Assert.Equal(5, internalBorderCornerRadius.Value.BottomLeft);
+
+        recorder.Success();
+    }
+}

--- a/MaterialDesignThemes.Wpf/CardAssist.cs
+++ b/MaterialDesignThemes.Wpf/CardAssist.cs
@@ -1,0 +1,28 @@
+﻿namespace MaterialDesignThemes.Wpf;
+
+public static class CardAssist
+{
+    #region AttachedProperty : UniformCornerRadiusProperty
+    /// <summary>
+    /// Controls the (uniform) corner radius of the contained card
+    /// </summary>
+    public static readonly DependencyProperty UniformCornerRadiusProperty
+        = DependencyProperty.RegisterAttached("UniformCornerRadius", typeof(double), typeof(CardAssist),
+            new FrameworkPropertyMetadata(default(double), FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
+
+    public static void SetUniformCornerRadius(DependencyObject element, double value) => element.SetValue(UniformCornerRadiusProperty, value);
+    public static double GetUniformCornerRadius(DependencyObject element) => (double)element.GetValue(UniformCornerRadiusProperty);
+    #endregion
+
+    #region AttachedProperty : CardStyleProperty
+    /// <summary>
+    /// Controls the style of the contained card
+    /// </summary>
+    public static readonly DependencyProperty CardStyleProperty
+        = DependencyProperty.RegisterAttached("CardStyle", typeof(Style), typeof(CardAssist),
+            new FrameworkPropertyMetadata(default(Style), FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
+
+    public static void SetCardStyle(DependencyObject element, Style value) => element.SetValue(CardStyleProperty, value);
+    public static Style GetCardStyle(DependencyObject element) => (Style)element.GetValue(CardStyleProperty);
+    #endregion
+}

--- a/MaterialDesignThemes.Wpf/Flipper.cs
+++ b/MaterialDesignThemes.Wpf/Flipper.cs
@@ -143,18 +143,6 @@ namespace MaterialDesignThemes.Wpf
             instance.RaiseEvent(args);
         }
 
-        public static readonly DependencyProperty UniformCornerRadiusProperty = DependencyProperty.Register(
-            nameof(UniformCornerRadius), typeof(double), typeof(Flipper), new PropertyMetadata(default(double)));
-
-        /// <summary>
-        /// Gets or sets the (uniform) corner radius applied the the <see cref="Flipper"/> when the MaterialDesignCardFlipper style is applied.
-        /// </summary>
-        public double UniformCornerRadius
-        {
-            get => (double)GetValue(UniformCornerRadiusProperty);
-            set => SetValue(UniformCornerRadiusProperty, value);
-        }
-
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -28,7 +28,7 @@
                                 </MultiBinding>
                             </AdornerDecorator.OpacityMask>
                             <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
-                                    CornerRadius="{TemplateBinding UniformCornerRadius}">
+                                    CornerRadius="{TemplateBinding UniformCornerRadius, Converter={x:Static converters:DoubleToCornerRadiusConverter.Instance}}">
                                 <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" 
                                         x:Name="PART_ClipBorder"
                                         Clip="{TemplateBinding ContentClip}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Flipper.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Flipper.xaml
@@ -162,7 +162,9 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                         <wpf:Plane3D x:Name="PART_Plane3D" RotationY="0" ZFactor="2.055">
-                            <wpf:Card wpf:ShadowAssist.ShadowDepth="{TemplateBinding wpf:ShadowAssist.ShadowDepth}" UniformCornerRadius="{TemplateBinding UniformCornerRadius}">
+                            <wpf:Card wpf:ShadowAssist.ShadowDepth="{TemplateBinding wpf:ShadowAssist.ShadowDepth}"
+                                      UniformCornerRadius="{TemplateBinding wpf:CardAssist.UniformCornerRadius}"
+                                      Style="{TemplateBinding wpf:CardAssist.CardStyle}">
                                 <Grid>
                                     <ContentPresenter x:Name="FrontContentPresenter"                    
                                                       Margin="{TemplateBinding Padding}"                            


### PR DESCRIPTION
Refactoring of previous fix for #2689

Added attached properties for UniformCornerRadius and Style. These properties are inherited and can thus be used to manipulate a Card located inside of another UIElement (eg. the Flipper). I decided to put them in a CardAssist file to align with the other attached properties in the toolkit. It could be moved to the Card type if that is more desirable.

Added more UI tests for this as well. Also fixed a bug in the original elevated card style (UniformCornerRadius binding) caught by these tests.