### PR TITLE
Various changes for cards and shadows

### DIFF
--- a/MainDemo.Wpf/Shadows.xaml
+++ b/MainDemo.Wpf/Shadows.xaml
@@ -55,12 +55,33 @@
                     materialDesign:ShadowAssist.ShadowDepth="Depth5"
                     Content="DEPTH 5"/>
             </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay UniqueKey="shadow_6" Margin="16 0 0 0">
+                <Button
+                    Style="{StaticResource MaterialDesignRaisedButton}"
+                    materialDesign:ShadowAssist.ShadowDepth="Depth6"
+                    Content="DEPTH 6"/>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay UniqueKey="shadow_7" Margin="16 0 0 0">
+                <Button
+                    Style="{StaticResource MaterialDesignRaisedButton}"
+                    materialDesign:ShadowAssist.ShadowDepth="Depth7"
+                    Content="DEPTH 7"/>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay UniqueKey="shadow_8" Margin="16 0 0 0">
+                <Button
+                    Style="{StaticResource MaterialDesignRaisedButton}"
+                    materialDesign:ShadowAssist.ShadowDepth="Depth8"
+                    Content="DEPTH 8"/>
+            </smtx:XamlDisplay>
         </StackPanel>
         
         <StackPanel
             Orientation="Horizontal"
             Margin="0 32 0 0">
-            <smtx:XamlDisplay UniqueKey="shadow_6">
+            <smtx:XamlDisplay UniqueKey="shadow_9">
                 <Button
                     Style="{StaticResource MaterialDesignFloatingActionMiniButton}"
                     materialDesign:ShadowAssist.ShadowDepth="Depth1"
@@ -68,7 +89,7 @@
             </smtx:XamlDisplay>
             
             <smtx:XamlDisplay
-                UniqueKey="shadow_7"
+                UniqueKey="shadow_10"
                 Margin="16 0 0 0">
                 <Button
                     Style="{StaticResource MaterialDesignFloatingActionMiniButton}"
@@ -77,7 +98,7 @@
             </smtx:XamlDisplay>
             
             <smtx:XamlDisplay
-                UniqueKey="shadow_8"
+                UniqueKey="shadow_11"
                 Margin="16 0 0 0">
                 <Button
                     Style="{StaticResource MaterialDesignFloatingActionMiniButton}"
@@ -86,7 +107,7 @@
             </smtx:XamlDisplay>
             
             <smtx:XamlDisplay
-                UniqueKey="shadow_9"
+                UniqueKey="shadow_12"
                 Margin="16 0 0 0">
                 <Button
                     Style="{StaticResource MaterialDesignFloatingActionMiniButton}"
@@ -95,19 +116,46 @@
             </smtx:XamlDisplay>
             
             <smtx:XamlDisplay
-                UniqueKey="shadow_10"
+                UniqueKey="shadow_13"
                 Margin="16 0 0 0">
                 <Button
                     Style="{StaticResource MaterialDesignFloatingActionMiniButton}"
                     materialDesign:ShadowAssist.ShadowDepth="Depth5"
                     Content="5"/>
             </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
+                UniqueKey="shadow_14"
+                Margin="16 0 0 0">
+                <Button
+                    Style="{StaticResource MaterialDesignFloatingActionMiniButton}"
+                    materialDesign:ShadowAssist.ShadowDepth="Depth6"
+                    Content="6"/>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
+                UniqueKey="shadow_15"
+                Margin="16 0 0 0">
+                <Button
+                    Style="{StaticResource MaterialDesignFloatingActionMiniButton}"
+                    materialDesign:ShadowAssist.ShadowDepth="Depth7"
+                    Content="7"/>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
+                UniqueKey="shadow_16"
+                Margin="16 0 0 0">
+                <Button
+                    Style="{StaticResource MaterialDesignFloatingActionMiniButton}"
+                    materialDesign:ShadowAssist.ShadowDepth="Depth8"
+                    Content="8"/>
+            </smtx:XamlDisplay>
         </StackPanel>
         
         <StackPanel
             Orientation="Horizontal"
             Margin="0 32 0 0">
-            <smtx:XamlDisplay UniqueKey="shadow_11">
+            <smtx:XamlDisplay UniqueKey="shadow_17">
                 <materialDesign:Card
                     materialDesign:ShadowAssist.ShadowDepth="Depth1"
                     Padding="32"
@@ -115,7 +163,7 @@
             </smtx:XamlDisplay>
             
             <smtx:XamlDisplay
-                UniqueKey="shadow_12"
+                UniqueKey="shadow_18"
                 Margin="16 0 0 0">
                 <materialDesign:Card
                     materialDesign:ShadowAssist.ShadowDepth="Depth2"
@@ -124,7 +172,7 @@
             </smtx:XamlDisplay>
             
             <smtx:XamlDisplay
-                UniqueKey="shadow_13"
+                UniqueKey="shadow_19"
                 Margin="16 0 0 0">
                 <materialDesign:Card
                     materialDesign:ShadowAssist.ShadowDepth="Depth3"
@@ -133,7 +181,7 @@
             </smtx:XamlDisplay>
             
             <smtx:XamlDisplay
-                UniqueKey="shadow_14"
+                UniqueKey="shadow_20"
                 Margin="16 0 0 0">
                 <materialDesign:Card
                     materialDesign:ShadowAssist.ShadowDepth="Depth4"
@@ -142,19 +190,46 @@
             </smtx:XamlDisplay>
             
             <smtx:XamlDisplay
-                UniqueKey="shadow_15"
+                UniqueKey="shadow_21"
                 Margin="16 0 0 0">
                 <materialDesign:Card
                     materialDesign:ShadowAssist.ShadowDepth="Depth5"
                     Padding="32"
                     Content="DEPTH 5"/>
             </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
+                UniqueKey="shadow_22"
+                Margin="16 0 0 0">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth6"
+                    Padding="32"
+                    Content="DEPTH 6"/>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
+                UniqueKey="shadow_23"
+                Margin="16 0 0 0">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth7"
+                    Padding="32"
+                    Content="DEPTH 7"/>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
+                UniqueKey="shadow_24"
+                Margin="16 0 0 0">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth8"
+                    Padding="32"
+                    Content="DEPTH 8"/>
+            </smtx:XamlDisplay>
         </StackPanel>
         
         <StackPanel
             Orientation="Horizontal"
             Margin="0 32 0 0">
-            <smtx:XamlDisplay UniqueKey="shadow_16">
+            <smtx:XamlDisplay UniqueKey="shadow_26">
                 <materialDesign:Card
                     materialDesign:ShadowAssist.ShadowDepth="Depth3"
                     materialDesign:ShadowAssist.ShadowEdges="Bottom,Right"
@@ -163,7 +238,7 @@
             </smtx:XamlDisplay>
             
             <smtx:XamlDisplay
-                UniqueKey="shadow_17"
+                UniqueKey="shadow_27"
                 Margin="16 0 0 0">
                 <materialDesign:Card
                     materialDesign:ShadowAssist.ShadowDepth="Depth3"
@@ -173,7 +248,7 @@
             </smtx:XamlDisplay>
             
             <smtx:XamlDisplay
-                UniqueKey="shadow_18"
+                UniqueKey="shadow_28"
                 Margin="16 0 0 0">
                 <materialDesign:Card
                     materialDesign:ShadowAssist.ShadowDepth="Depth3"

--- a/MainDemo.Wpf/Shadows.xaml
+++ b/MainDemo.Wpf/Shadows.xaml
@@ -48,33 +48,12 @@
                     materialDesign:ShadowAssist.ShadowDepth="Depth4"
                     Content="DEPTH 4"/>
             </smtx:XamlDisplay>
-            
+
             <smtx:XamlDisplay UniqueKey="shadow_5" Margin="16 0 0 0">
                 <Button
                     Style="{StaticResource MaterialDesignRaisedButton}"
                     materialDesign:ShadowAssist.ShadowDepth="Depth5"
                     Content="DEPTH 5"/>
-            </smtx:XamlDisplay>
-
-            <smtx:XamlDisplay UniqueKey="shadow_6" Margin="16 0 0 0">
-                <Button
-                    Style="{StaticResource MaterialDesignRaisedButton}"
-                    materialDesign:ShadowAssist.ShadowDepth="Depth6"
-                    Content="DEPTH 6"/>
-            </smtx:XamlDisplay>
-
-            <smtx:XamlDisplay UniqueKey="shadow_7" Margin="16 0 0 0">
-                <Button
-                    Style="{StaticResource MaterialDesignRaisedButton}"
-                    materialDesign:ShadowAssist.ShadowDepth="Depth7"
-                    Content="DEPTH 7"/>
-            </smtx:XamlDisplay>
-
-            <smtx:XamlDisplay UniqueKey="shadow_8" Margin="16 0 0 0">
-                <Button
-                    Style="{StaticResource MaterialDesignRaisedButton}"
-                    materialDesign:ShadowAssist.ShadowDepth="Depth8"
-                    Content="DEPTH 8"/>
             </smtx:XamlDisplay>
         </StackPanel>
         
@@ -114,7 +93,7 @@
                     materialDesign:ShadowAssist.ShadowDepth="Depth4"
                     Content="4"/>
             </smtx:XamlDisplay>
-            
+
             <smtx:XamlDisplay
                 UniqueKey="shadow_13"
                 Margin="16 0 0 0">
@@ -122,33 +101,6 @@
                     Style="{StaticResource MaterialDesignFloatingActionMiniButton}"
                     materialDesign:ShadowAssist.ShadowDepth="Depth5"
                     Content="5"/>
-            </smtx:XamlDisplay>
-
-            <smtx:XamlDisplay
-                UniqueKey="shadow_14"
-                Margin="16 0 0 0">
-                <Button
-                    Style="{StaticResource MaterialDesignFloatingActionMiniButton}"
-                    materialDesign:ShadowAssist.ShadowDepth="Depth6"
-                    Content="6"/>
-            </smtx:XamlDisplay>
-
-            <smtx:XamlDisplay
-                UniqueKey="shadow_15"
-                Margin="16 0 0 0">
-                <Button
-                    Style="{StaticResource MaterialDesignFloatingActionMiniButton}"
-                    materialDesign:ShadowAssist.ShadowDepth="Depth7"
-                    Content="7"/>
-            </smtx:XamlDisplay>
-
-            <smtx:XamlDisplay
-                UniqueKey="shadow_16"
-                Margin="16 0 0 0">
-                <Button
-                    Style="{StaticResource MaterialDesignFloatingActionMiniButton}"
-                    materialDesign:ShadowAssist.ShadowDepth="Depth8"
-                    Content="8"/>
             </smtx:XamlDisplay>
         </StackPanel>
         
@@ -188,7 +140,7 @@
                     Padding="32"
                     Content="DEPTH 4"/>
             </smtx:XamlDisplay>
-            
+
             <smtx:XamlDisplay
                 UniqueKey="shadow_21"
                 Margin="16 0 0 0">
@@ -196,33 +148,6 @@
                     materialDesign:ShadowAssist.ShadowDepth="Depth5"
                     Padding="32"
                     Content="DEPTH 5"/>
-            </smtx:XamlDisplay>
-
-            <smtx:XamlDisplay
-                UniqueKey="shadow_22"
-                Margin="16 0 0 0">
-                <materialDesign:Card
-                    materialDesign:ShadowAssist.ShadowDepth="Depth6"
-                    Padding="32"
-                    Content="DEPTH 6"/>
-            </smtx:XamlDisplay>
-
-            <smtx:XamlDisplay
-                UniqueKey="shadow_23"
-                Margin="16 0 0 0">
-                <materialDesign:Card
-                    materialDesign:ShadowAssist.ShadowDepth="Depth7"
-                    Padding="32"
-                    Content="DEPTH 7"/>
-            </smtx:XamlDisplay>
-
-            <smtx:XamlDisplay
-                UniqueKey="shadow_24"
-                Margin="16 0 0 0">
-                <materialDesign:Card
-                    materialDesign:ShadowAssist.ShadowDepth="Depth8"
-                    Padding="32"
-                    Content="DEPTH 8"/>
             </smtx:XamlDisplay>
         </StackPanel>
         

--- a/MainDemo.Wpf/Shadows.xaml
+++ b/MainDemo.Wpf/Shadows.xaml
@@ -182,6 +182,180 @@
                     Content="CUSTOM CLIP"/>
             </smtx:XamlDisplay>
         </StackPanel>
+        <TextBlock Style="{DynamicResource MaterialDesignHeadline5TextBlock}" Margin="0,45,0,10">
+            New Depth Shadow System
+        </TextBlock>
+        <Separator Style="{DynamicResource MaterialDesignSeparator}" Margin="0,0,0,16"/>
+        <WrapPanel Orientation="Horizontal">
+            <smtx:XamlDisplay
+                UniqueKey="new_shadow_card_0dp"
+                Margin="0,0,16,32">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth_0dp"
+                    Width="150"
+                    Height="80">
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                        Depth 0dp
+                    </TextBlock>
+                </materialDesign:Card>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay
+                UniqueKey="new_shadow_card_1dp"
+                Margin="0,0,16,32">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth_1dp"
+                    Width="150"
+                    Height="80">
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                        Depth 1dp
+                    </TextBlock>
+                </materialDesign:Card>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay
+                UniqueKey="new_shadow_card_2dp"
+                Margin="0,0,16,32">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth_2dp"
+                    Width="150"
+                    Height="80">
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                        Depth 2dp
+                    </TextBlock>
+                </materialDesign:Card>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay
+                UniqueKey="new_shadow_card_3dp"
+                Margin="0,0,16,32">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth_3dp"
+                    Width="150"
+                    Height="80">
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                        Depth 3dp
+                    </TextBlock>
+                </materialDesign:Card>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay
+                UniqueKey="new_shadow_card_4dp"
+                Margin="0,0,16,32">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth_4dp"
+                    Width="150"
+                    Height="80">
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                        Depth 4dp
+                    </TextBlock>
+                </materialDesign:Card>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay
+                UniqueKey="new_shadow_card_5dp"
+                Margin="0,0,16,32">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth_5dp"
+                    Width="150"
+                    Height="80">
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                        Depth 5dp
+                    </TextBlock>
+                </materialDesign:Card>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay
+                UniqueKey="new_shadow_card_6dp"
+                Margin="0,0,16,32">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth_6dp"
+                    Width="150"
+                    Height="80">
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                        Depth 6dp
+                    </TextBlock>
+                </materialDesign:Card>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay
+                UniqueKey="new_shadow_card_7dp"
+                Margin="0,0,16,32">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth_7dp"
+                    Width="150"
+                    Height="80">
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                        Depth 7dp
+                    </TextBlock>
+                </materialDesign:Card>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay
+                UniqueKey="new_shadow_card_8dp"
+                Margin="0,0,16,32">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth_8dp"
+                    Width="150"
+                    Height="80">
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                        Depth 8dp
+                    </TextBlock>
+                </materialDesign:Card>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay
+                UniqueKey="new_shadow_card_12dp"
+                Margin="0,0,16,32">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth_12dp"
+                    Width="150"
+                    Height="80">
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                        Depth 12dp
+                    </TextBlock>
+                </materialDesign:Card>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay
+                UniqueKey="new_shadow_card_16"
+                Margin="0,0,16,32">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth_16dp"
+                    Width="150"
+                    Height="80">
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                        Depth 16dp
+                    </TextBlock>
+                </materialDesign:Card>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay
+                UniqueKey="new_shadow_card_24"
+                Margin="0,0,16,32">
+                <materialDesign:Card
+                    materialDesign:ShadowAssist.ShadowDepth="Depth_24dp"
+                    Width="150"
+                    Height="80">
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                        Depth 24dp
+                    </TextBlock>
+                </materialDesign:Card>
+            </smtx:XamlDisplay>
+        </WrapPanel>
     </StackPanel>
 </UserControl>
 

--- a/MaterialDesignThemes.Wpf/Card.cs
+++ b/MaterialDesignThemes.Wpf/Card.cs
@@ -9,7 +9,7 @@ namespace MaterialDesignThemes.Wpf
     public class Card : ContentControl
     {
         private Border? _clipBorder;
-        private const double DefaultUniformCornerRadius = 2.0;
+        private const double DefaultUniformCornerRadius = 4.0;
         public const string ClipBorderPartName = "PART_ClipBorder";
 
         #region DependencyProperty : UniformCornerRadiusProperty

--- a/MaterialDesignThemes.Wpf/Converters/ShadowInfo.cs
+++ b/MaterialDesignThemes.Wpf/Converters/ShadowInfo.cs
@@ -21,6 +21,9 @@ namespace MaterialDesignThemes.Wpf.Converters
                 { ShadowDepth.Depth3, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth3"] },
                 { ShadowDepth.Depth4, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth4"] },
                 { ShadowDepth.Depth5, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth5"] },
+                { ShadowDepth.Depth6, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth6"] },
+                { ShadowDepth.Depth7, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth7"] },
+                { ShadowDepth.Depth8, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth8"] },
             };
         }
 

--- a/MaterialDesignThemes.Wpf/Converters/ShadowInfo.cs
+++ b/MaterialDesignThemes.Wpf/Converters/ShadowInfo.cs
@@ -15,15 +15,28 @@ namespace MaterialDesignThemes.Wpf.Converters
 
             ShadowsDictionary = new Dictionary<ShadowDepth, DropShadowEffect?>
             {
+                // Obselete
+                #region ObseleteDepth
                 { ShadowDepth.Depth0, null },
                 { ShadowDepth.Depth1, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth1"] },
                 { ShadowDepth.Depth2, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth2"] },
                 { ShadowDepth.Depth3, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth3"] },
                 { ShadowDepth.Depth4, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth4"] },
                 { ShadowDepth.Depth5, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth5"] },
-                { ShadowDepth.Depth6, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth6"] },
-                { ShadowDepth.Depth7, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth7"] },
-                { ShadowDepth.Depth8, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth8"] },
+                #endregion
+                
+                { ShadowDepth.Depth_0dp, null },
+                { ShadowDepth.Depth_1dp, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth_1dp"] },
+                { ShadowDepth.Depth_2dp, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth_2dp"] },
+                { ShadowDepth.Depth_3dp, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth_3dp"] },
+                { ShadowDepth.Depth_4dp, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth_4dp"] },
+                { ShadowDepth.Depth_5dp, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth_5dp"] },
+                { ShadowDepth.Depth_6dp, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth_6dp"] },
+                { ShadowDepth.Depth_7dp, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth_7dp"] },
+                { ShadowDepth.Depth_8dp, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth_8dp"] },
+                { ShadowDepth.Depth_12dp, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth_12dp"] },
+                { ShadowDepth.Depth_16dp, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth_16dp"] },
+                { ShadowDepth.Depth_24dp, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth_24dp"] }
             };
         }
 

--- a/MaterialDesignThemes.Wpf/Converters/ShadowInfo.cs
+++ b/MaterialDesignThemes.Wpf/Converters/ShadowInfo.cs
@@ -17,14 +17,16 @@ namespace MaterialDesignThemes.Wpf.Converters
             {
                 // Obselete
                 #region ObseleteDepth
+                #pragma warning disable CS0618 // Type or member is obsolete
                 { ShadowDepth.Depth0, null },
                 { ShadowDepth.Depth1, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth1"] },
                 { ShadowDepth.Depth2, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth2"] },
                 { ShadowDepth.Depth3, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth3"] },
                 { ShadowDepth.Depth4, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth4"] },
                 { ShadowDepth.Depth5, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth5"] },
+                #pragma warning restore CS0618 // Type or member is obsolete
                 #endregion
-                
+
                 { ShadowDepth.Depth_0dp, null },
                 { ShadowDepth.Depth_1dp, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth_1dp"] },
                 { ShadowDepth.Depth_2dp, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth_2dp"] },

--- a/MaterialDesignThemes.Wpf/ShadowAssist.cs
+++ b/MaterialDesignThemes.Wpf/ShadowAssist.cs
@@ -11,14 +11,18 @@ namespace MaterialDesignThemes.Wpf
 
     public enum ShadowDepth
     {
-        #region ObseleteDepth
+        [Obsolete("Use Depth_0dp instead")]
         Depth0,
+        [Obsolete("Considersing Depth_2dp instead")]
         Depth1,
+        [Obsolete("Considersing Depth_3dp instead")]
         Depth2,
+        [Obsolete("Considersing Depth_7dp instead")]
         Depth3,
+        [Obsolete("Considersing Depth_12dp instead")]
         Depth4,
+        [Obsolete("Considersing Depth_24dp instead")]
         Depth5,
-        #endregion
 
         Depth_0dp,
         Depth_1dp,

--- a/MaterialDesignThemes.Wpf/ShadowAssist.cs
+++ b/MaterialDesignThemes.Wpf/ShadowAssist.cs
@@ -16,7 +16,10 @@ namespace MaterialDesignThemes.Wpf
         Depth2,
         Depth3,
         Depth4,
-        Depth5
+        Depth5,
+        Depth6,
+        Depth7,
+        Depth8
     }
 
     [Flags]

--- a/MaterialDesignThemes.Wpf/ShadowAssist.cs
+++ b/MaterialDesignThemes.Wpf/ShadowAssist.cs
@@ -11,15 +11,27 @@ namespace MaterialDesignThemes.Wpf
 
     public enum ShadowDepth
     {
-        Depth0,
-        Depth1,
-        Depth2,
-        Depth3,
-        Depth4,
-        Depth5,
-        Depth6,
-        Depth7,
-        Depth8
+        #region ObseleteDepth
+        [Obsolete] Depth0,
+        [Obsolete] Depth1,
+        [Obsolete] Depth2,
+        [Obsolete] Depth3,
+        [Obsolete] Depth4,
+        [Obsolete] Depth5,
+        #endregion
+
+        Depth_0dp,
+        Depth_1dp,
+        Depth_2dp,
+        Depth_3dp,
+        Depth_4dp,
+        Depth_5dp,
+        Depth_6dp,
+        Depth_7dp,
+        Depth_8dp,
+        Depth_12dp,
+        Depth_16dp,
+        Depth_24dp
     }
 
     [Flags]

--- a/MaterialDesignThemes.Wpf/ShadowAssist.cs
+++ b/MaterialDesignThemes.Wpf/ShadowAssist.cs
@@ -12,12 +12,12 @@ namespace MaterialDesignThemes.Wpf
     public enum ShadowDepth
     {
         #region ObseleteDepth
-        [Obsolete] Depth0,
-        [Obsolete] Depth1,
-        [Obsolete] Depth2,
-        [Obsolete] Depth3,
-        [Obsolete] Depth4,
-        [Obsolete] Depth5,
+        Depth0,
+        Depth1,
+        Depth2,
+        Depth3,
+        Depth4,
+        Depth5,
         #endregion
 
         Depth_0dp,

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -9,7 +9,7 @@
 
     <Style x:Key="MaterialDesignElevatedCard" TargetType="{x:Type wpf:Card}">
         <Setter Property="Background" Value="{DynamicResource MaterialDesignCardBackground}" />
-        <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth2" />
+        <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth1" />
         <Setter Property="Focusable" Value="False"/>
         <Setter Property="Template">
             <Setter.Value>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -9,7 +9,7 @@
 
     <Style x:Key="MaterialDesignElevatedCard" TargetType="{x:Type wpf:Card}">
         <Setter Property="Background" Value="{DynamicResource MaterialDesignCardBackground}" />
-        <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth1" />
+        <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth_1dp" />
         <Setter Property="Focusable" Value="False"/>
         <Setter Property="Template">
             <Setter.Value>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Shadows.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Shadows.xaml
@@ -4,13 +4,16 @@
     
     <!--  thanks: http://marcangers.com/material-design-shadows-in-wpf/ -->
 
-    <Color x:Key="MaterialDesignShadow">#AA000000</Color>
+    <Color x:Key="MaterialDesignShadow">#000000</Color>
     <SolidColorBrush x:Key="MaterialDesignShadowBrush" Color="{StaticResource MaterialDesignShadow}"/>
-
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth1" BlurRadius="5" ShadowDepth="1" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth2" BlurRadius="8" ShadowDepth="1.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth3" BlurRadius="14" ShadowDepth="4.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth4" BlurRadius="25" ShadowDepth="8" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth5" BlurRadius="35" ShadowDepth="13" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+     
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth1" BlurRadius="2" ShadowDepth="1" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True"/>
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth2" BlurRadius="4" ShadowDepth="1.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth3" BlurRadius="6" ShadowDepth="2" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth4" BlurRadius="8" ShadowDepth="2.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth5" BlurRadius="10" ShadowDepth="3" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth6" BlurRadius="12" ShadowDepth="3.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth7" BlurRadius="14" ShadowDepth="4" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth8" BlurRadius="16" ShadowDepth="4.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
 	
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Shadows.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Shadows.xaml
@@ -7,13 +7,23 @@
     <Color x:Key="MaterialDesignShadow">#000000</Color>
     <SolidColorBrush x:Key="MaterialDesignShadowBrush" Color="{StaticResource MaterialDesignShadow}"/>
      
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth1" BlurRadius="2" ShadowDepth="1" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True"/>
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth2" BlurRadius="4" ShadowDepth="1.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth3" BlurRadius="6" ShadowDepth="2" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth4" BlurRadius="8" ShadowDepth="2.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth5" BlurRadius="10" ShadowDepth="3" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth6" BlurRadius="12" ShadowDepth="3.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth7" BlurRadius="14" ShadowDepth="4" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth8" BlurRadius="16" ShadowDepth="4.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
-	
+    <!--#region Obselete-->
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth1" BlurRadius="5" ShadowDepth="1" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth2" BlurRadius="8" ShadowDepth="1.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth3" BlurRadius="14" ShadowDepth="4.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth4" BlurRadius="25" ShadowDepth="8" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth5" BlurRadius="35" ShadowDepth="13" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <!--#endregion-->
+    
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_1dp" BlurRadius="2" ShadowDepth="1" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True"/>
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_2dp" BlurRadius="4" ShadowDepth="1.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_3dp" BlurRadius="6" ShadowDepth="2" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_4dp" BlurRadius="8" ShadowDepth="2.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_5dp" BlurRadius="10" ShadowDepth="3" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_6dp" BlurRadius="12" ShadowDepth="3.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_7dp" BlurRadius="14" ShadowDepth="4" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_8dp" BlurRadius="16" ShadowDepth="4.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_12dp" BlurRadius="24" ShadowDepth="6.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_16dp" BlurRadius="32" ShadowDepth="8.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_24dp" BlurRadius="48" ShadowDepth="12.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Shadows.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Shadows.xaml
@@ -15,15 +15,15 @@
     <DropShadowEffect x:Key="MaterialDesignShadowDepth5" BlurRadius="35" ShadowDepth="13" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
     <!--#endregion-->
     
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth_1dp" BlurRadius="2" ShadowDepth="1" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True"/>
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth_2dp" BlurRadius="4" ShadowDepth="1.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth_3dp" BlurRadius="6" ShadowDepth="2" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth_4dp" BlurRadius="8" ShadowDepth="2.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth_5dp" BlurRadius="10" ShadowDepth="3" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth_6dp" BlurRadius="12" ShadowDepth="3.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth_7dp" BlurRadius="14" ShadowDepth="4" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth_8dp" BlurRadius="16" ShadowDepth="4.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth_12dp" BlurRadius="24" ShadowDepth="6.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth_16dp" BlurRadius="32" ShadowDepth="8.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth_24dp" BlurRadius="48" ShadowDepth="12.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.5" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_1dp" BlurRadius="3" ShadowDepth="1" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.45" RenderingBias="Performance" po:Freeze="True"/>
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_2dp" BlurRadius="5" ShadowDepth="1.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.45" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_3dp" BlurRadius="7" ShadowDepth="2" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.45" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_4dp" BlurRadius="9" ShadowDepth="2.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.45" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_5dp" BlurRadius="11" ShadowDepth="3" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.45" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_6dp" BlurRadius="13" ShadowDepth="3.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.45" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_7dp" BlurRadius="15" ShadowDepth="4" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.45" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_8dp" BlurRadius="17" ShadowDepth="4.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.45" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_12dp" BlurRadius="25" ShadowDepth="6.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.45" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_16dp" BlurRadius="33" ShadowDepth="8.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.45" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth_24dp" BlurRadius="49" ShadowDepth="12.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity="0.45" RenderingBias="Performance" po:Freeze="True" />
 </ResourceDictionary>


### PR DESCRIPTION
# Changes
- Changed the default UniformCornerRadius of the Cards: 4px
- Changed the default ShadowDepth of the Cards: Depth1
- Changed the DropShadowEffect on Shadows (changed the BlurRadius and ShadowDepth for each depth level)
- Added 3 depth levels (total of 9)

**Consequences:**
- Shadow on cards is different by default
- Shadow on elevated buttons is different by default
- The depth levels are totally different

I tried to match the specs as much as possible. 
Please tell me if you like the changes.
I can adjust the shadow opacity if necessary.

# Specs
![image](https://user-images.githubusercontent.com/54487782/177588401-44dc1cb3-92b1-4ae8-af18-43607d909b63.png)
![image](https://user-images.githubusercontent.com/54487782/177588631-6133259e-154d-4073-9534-6cc95fd710d6.png)


# Results
![image](https://user-images.githubusercontent.com/54487782/177585140-f8bddeca-f33d-4d4c-826f-314f98b6419f.png)

![image](https://user-images.githubusercontent.com/54487782/177587182-a1e6691d-b4c3-4b4a-b11d-630dc48090fb.png)

Examples with the same Background as the specs:
![image](https://user-images.githubusercontent.com/54487782/177590556-53d64550-c48a-4e43-9629-ad887257c3c4.png)

