### PR TITLE
Added DialogHost.DialogClosed event

### DIFF
--- a/MainDemo.Wpf/Dialogs.xaml
+++ b/MainDemo.Wpf/Dialogs.xaml
@@ -64,6 +64,7 @@
                 Grid.Row="1">
                 <materialDesign:DialogHost
                     DialogClosing="Sample1_DialogHost_OnDialogClosing"
+                    DialogClosed="Sample1_DialogHost_OnDialogClosed"
                     DialogTheme="Inherit">
                     <materialDesign:DialogHost.DialogContent>
                         <StackPanel Margin="16">
@@ -160,6 +161,7 @@
                     <Button
                         Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
                         materialDesign:DialogHost.DialogClosingAttached="Sample2_DialogHost_OnDialogClosing"
+                        materialDesign:DialogHost.DialogClosedAttached="Sample2_DialogHost_OnDialogClosed"
                         Width="128"
                         Content="PASS VIEW">
                         <Button.CommandParameter>
@@ -283,6 +285,7 @@
                 Margin="8 8 0 0">
                 <materialDesign:DialogHost
                     DialogClosing="Sample5_DialogHost_OnDialogClosing"
+                    DialogClosed="Sample5_DialogHost_OnDialogClosed"
                     Style="{StaticResource MaterialDesignEmbeddedDialogHost}"
                     DialogMargin="8">
                     <materialDesign:DialogHost.DialogContent>

--- a/MainDemo.Wpf/Dialogs.xaml.cs
+++ b/MainDemo.Wpf/Dialogs.xaml.cs
@@ -26,9 +26,26 @@ namespace MaterialDesignDemo
                 FruitListBox.Items.Add(FruitTextBox.Text.Trim());
         }
 
+        private void Sample1_DialogHost_OnDialogClosed(object sender, DialogClosedEventArgs eventArgs)
+        {
+            Debug.WriteLine($"SAMPLE 1: Closed dialog with parameter: {eventArgs.Parameter ?? string.Empty}");
+
+            //you can cancel the dialog close:
+            //eventArgs.Cancel();
+
+            if (!Equals(eventArgs.Parameter, true))
+                return;
+
+            if (!string.IsNullOrWhiteSpace(FruitTextBox.Text))
+                FruitListBox.Items.Add(FruitTextBox.Text.Trim());
+        }
+
         // Used for DialogHost.DialogClosingAttached
         private void Sample2_DialogHost_OnDialogClosing(object sender, DialogClosingEventArgs eventArgs)
             => Debug.WriteLine($"SAMPLE 2: Closing dialog with parameter: {eventArgs.Parameter ?? string.Empty}");
+
+        private void Sample2_DialogHost_OnDialogClosed(object sender, DialogClosedEventArgs eventArgs)
+            => Debug.WriteLine($"SAMPLE 2: Closed dialog with parameter: {eventArgs.Parameter ?? string.Empty}");
 
         private void Sample5_DialogHost_OnDialogClosing(object sender, DialogClosingEventArgs eventArgs)
         {
@@ -36,6 +53,17 @@ namespace MaterialDesignDemo
 
             //you can cancel the dialog close:
             //eventArgs.Cancel();
+
+            if (!Equals(eventArgs.Parameter, true))
+                return;
+
+            if (!string.IsNullOrWhiteSpace(AnimalTextBox.Text))
+                AnimalListBox.Items.Add(AnimalTextBox.Text.Trim());
+        }
+
+        private void Sample5_DialogHost_OnDialogClosed(object sender, DialogClosedEventArgs eventArgs)
+        {
+            Debug.WriteLine($"SAMPLE 5: Closed dialog with parameter: {eventArgs.Parameter ?? string.Empty}");
 
             if (!Equals(eventArgs.Parameter, true))
                 return;

--- a/MainDemo.Wpf/Domain/DialogsViewModel.cs
+++ b/MainDemo.Wpf/Domain/DialogsViewModel.cs
@@ -31,7 +31,7 @@ namespace MaterialDesignDemo.Domain
             };
 
             //show the dialog
-            var result = await DialogHost.Show(view, "RootDialog", ClosingEventHandler);
+            var result = await DialogHost.Show(view, "RootDialog", null, ClosingEventHandler, ClosedEventHandler);
 
             //check the result...
             Debug.WriteLine("Dialog was closed, the CommandParameter used to close it was: " + (result ?? "NULL"));
@@ -39,6 +39,9 @@ namespace MaterialDesignDemo.Domain
 
         private void ClosingEventHandler(object sender, DialogClosingEventArgs eventArgs)
             => Debug.WriteLine("You can intercept the closing event, and cancel here.");
+
+        private void ClosedEventHandler(object sender, DialogClosedEventArgs eventArgs)
+            => Debug.WriteLine("You can intercept the closed event here (1).");
 
         private async void ExecuteRunExtendedDialog(object? _)
         {
@@ -49,17 +52,18 @@ namespace MaterialDesignDemo.Domain
             };
 
             //show the dialog
-            var result = await DialogHost.Show(view, "RootDialog", ExtendedOpenedEventHandler, ExtendedClosingEventHandler);
+            var result = await DialogHost.Show(view, "RootDialog", ExtendedOpenedEventHandler, ExtendedClosingEventHandler, ExtendedClosedEventHandler);
 
             //check the result...
             Debug.WriteLine("Dialog was closed, the CommandParameter used to close it was: " + (result ?? "NULL"));
         }
 
-        private void ExtendedOpenedEventHandler(object sender, DialogOpenedEventArgs eventargs)
+        private void ExtendedOpenedEventHandler(object sender, DialogOpenedEventArgs eventArgs)
             => Debug.WriteLine("You could intercept the open and affect the dialog using eventArgs.Session.");
 
         private void ExtendedClosingEventHandler(object sender, DialogClosingEventArgs eventArgs)
         {
+            Debug.WriteLine("You can intercept the closing event, cancel it, and do our own close after a little while.");
             if (eventArgs.Parameter is bool parameter &&
                 parameter == false) return;
 
@@ -75,6 +79,9 @@ namespace MaterialDesignDemo.Domain
                 .ContinueWith((t, _) => eventArgs.Session.Close(false), null,
                     TaskScheduler.FromCurrentSynchronizationContext());
         }
+
+        private void ExtendedClosedEventHandler(object sender, DialogClosedEventArgs eventArgs)
+            => Debug.WriteLine("You could intercept the closed event here (2).");
 
         #endregion
 

--- a/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
@@ -284,7 +284,7 @@ namespace MaterialDesignThemes.Wpf.Tests
         {
             Guid closeParameter = Guid.NewGuid();
 
-            Task<object?> showTask = _dialogHost.ShowDialog("Content", (object sender, DialogClosedEventArgs args) =>
+            Task<object?> showTask = _dialogHost.ShowDialog("Content", null, null, (object sender, DialogClosedEventArgs args) =>
             {
                 args.Session.CloseParameter = closeParameter;
             });

--- a/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
@@ -284,7 +284,7 @@ namespace MaterialDesignThemes.Wpf.Tests
         {
             Guid closeParameter = Guid.NewGuid();
 
-            Task<object?> showTask = _dialogHost.ShowDialog("Content", null, null, (object sender, DialogClosedEventArgs args) =>
+            Task<object?> showTask = _dialogHost.ShowDialog("Content", (sender, args) => { }, (sender, args) => { }, (object sender, DialogClosedEventArgs args) =>
             {
                 args.Session.CloseParameter = closeParameter;
             });

--- a/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.ComponentModel;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
+﻿using System.ComponentModel;
 using Xunit;
 
 namespace MaterialDesignThemes.Wpf.Tests
@@ -190,6 +185,34 @@ namespace MaterialDesignThemes.Wpf.Tests
         }
 
         [StaFact]
+        public async Task WhenCancellingClosingEventClosedEventHandlerIsNotInvoked()
+        {
+            int closingInvokeCount = 0;
+            void ClosingHandler(object s, DialogClosingEventArgs e)
+            {
+                closingInvokeCount++;
+                if (closingInvokeCount == 1)
+                {
+                    e.Cancel();
+                }
+            }
+            int closedInvokeCount = 0;
+            void ClosedHandler(object s, DialogClosedEventArgs e)
+            {
+                closedInvokeCount++;
+            }
+
+            var dialogTask = DialogHost.Show("Content", null, ClosingHandler, ClosedHandler);
+            _dialogHost.CurrentSession?.Close("FirstResult");
+            _dialogHost.CurrentSession?.Close("SecondResult");
+            object? result = await dialogTask;
+
+            Assert.Equal("SecondResult", result);
+            Assert.Equal(2, closingInvokeCount);
+            Assert.Equal(1, closedInvokeCount);
+        }
+
+        [StaFact]
         [Description("Issue 1328")]
         public async Task WhenDoubleClickAwayDialogCloses()
         {
@@ -257,6 +280,21 @@ namespace MaterialDesignThemes.Wpf.Tests
         }
 
         [StaFact]
+        public async Task WhenClosingDialogReturnValueCanBeSpecifiedInClosedEventHandler()
+        {
+            Guid closeParameter = Guid.NewGuid();
+
+            Task<object?> showTask = _dialogHost.ShowDialog("Content", (object sender, DialogClosedEventArgs args) =>
+            {
+                args.Session.CloseParameter = closeParameter;
+            });
+
+            DialogHost.CloseDialogCommand.Execute(null, _dialogHost);
+
+            Assert.Equal(closeParameter, await showTask);
+        }
+
+        [StaFact]
         [Description("Pull Request 2029")]
         public void WhenClosingDialogItThrowsWhenNoInstancesLoaded()
         {
@@ -306,16 +344,24 @@ namespace MaterialDesignThemes.Wpf.Tests
         {
             object parameter = Guid.NewGuid();
             object? closingParameter = null;
+            object? closedParameter = null;
             _dialogHost.DialogClosing += DialogClosing;
+            _dialogHost.DialogClosed += DialogClosed;
             _dialogHost.IsOpen = true;
 
             DialogHost.Close(null, parameter);
 
             Assert.Equal(parameter, closingParameter);
+            Assert.Equal(parameter, closedParameter);
 
             void DialogClosing(object sender, DialogClosingEventArgs eventArgs)
             {
                 closingParameter = eventArgs.Parameter;
+            }
+
+            void DialogClosed(object sender, DialogClosedEventArgs eventArgs)
+            {
+                closedParameter = eventArgs.Parameter;
             }
         }
 

--- a/MaterialDesignThemes.Wpf/DialogClosedEventArgs.cs
+++ b/MaterialDesignThemes.Wpf/DialogClosedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace MaterialDesignThemes.Wpf;
+
+public class DialogClosedEventArgs : RoutedEventArgs
+{
+    public DialogClosedEventArgs(DialogSession session, RoutedEvent routedEvent)
+        : base(routedEvent)
+        => Session = session ?? throw new ArgumentNullException(nameof(session));
+
+    /// <summary>
+    /// Gets the parameter originally provided to <see cref="DialogHost.CloseDialogCommand"/>/
+    /// </summary>
+    public object? Parameter => Session.CloseParameter;
+
+    /// <summary>
+    /// Allows interaction with the current dialog session.
+    /// </summary>
+    public DialogSession Session { get; }
+}

--- a/MaterialDesignThemes.Wpf/DialogClosedEventHandler.cs
+++ b/MaterialDesignThemes.Wpf/DialogClosedEventHandler.cs
@@ -1,0 +1,3 @@
+﻿namespace MaterialDesignThemes.Wpf;
+
+public delegate void DialogClosedEventHandler(object sender, DialogClosedEventArgs eventArgs);

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -76,7 +76,7 @@ namespace MaterialDesignThemes.Wpf
         /// <param name="content">Content to show (can be a control or view model).</param>
         /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
         public static Task<object?> Show(object content)
-            => Show(content, null, null, null);
+            => Show(content, null, null);
 
         /// <summary>
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
@@ -85,7 +85,7 @@ namespace MaterialDesignThemes.Wpf
         /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>        
         /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
         public static Task<object?> Show(object content, DialogOpenedEventHandler openedEventHandler)
-            => Show(content, null, openedEventHandler, null, null);
+            => Show(content, null, openedEventHandler, null);
 
         /// <summary>
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
@@ -99,31 +99,12 @@ namespace MaterialDesignThemes.Wpf
         /// <summary>
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
         /// </summary>
-        /// <param name="content">Content to show (can be a control or view model).</param>
-        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
-        /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
-        public static Task<object?> Show(object content, DialogClosedEventHandler closedEventHandler)
-            => Show(content, null, null, closedEventHandler);
-
-        /// <summary>
-        /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
-        /// </summary>
         /// <param name="content">Content to show (can be a control or view model).</param>        
         /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
         /// <param name="closingEventHandler">Allows access to closing event which would otherwise have been subscribed to on a instance.</param>
         /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
         public static Task<object?> Show(object content, DialogOpenedEventHandler? openedEventHandler, DialogClosingEventHandler? closingEventHandler)
             => Show(content, null, openedEventHandler, closingEventHandler);
-
-        /// <summary>
-        /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
-        /// </summary>
-        /// <param name="content">Content to show (can be a control or view model).</param>        
-        /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
-        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
-        /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
-        public static Task<object?> Show(object content, DialogOpenedEventHandler? openedEventHandler, DialogClosedEventHandler? closedEventHandler)
-            => Show(content, null, openedEventHandler, null, closedEventHandler);
 
         /// <summary>
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
@@ -143,7 +124,7 @@ namespace MaterialDesignThemes.Wpf
         /// <param name="dialogIdentifier"><see cref="Identifier"/> of the instance where the dialog should be shown. Typically this will match an identifer set in XAML. <c>null</c> is allowed.</param>
         /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
         public static Task<object?> Show(object content, object dialogIdentifier)
-            => Show(content, dialogIdentifier, null, null, null);
+            => Show(content, dialogIdentifier, null, null);
 
         /// <summary>
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
@@ -153,7 +134,7 @@ namespace MaterialDesignThemes.Wpf
         /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
         /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
         public static Task<object?> Show(object content, object dialogIdentifier, DialogOpenedEventHandler openedEventHandler)
-            => Show(content, dialogIdentifier, openedEventHandler, null, null);
+            => Show(content, dialogIdentifier, openedEventHandler, null);
 
         /// <summary>
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
@@ -169,33 +150,12 @@ namespace MaterialDesignThemes.Wpf
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
         /// </summary>
         /// <param name="content">Content to show (can be a control or view model).</param>
-        /// <param name="dialogIdentifier"><see cref="Identifier"/> of the instance where the dialog should be shown. Typically this will match an identifer set in XAML. <c>null</c> is allowed.</param>        
-        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
-        /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
-        public static Task<object?> Show(object content, object dialogIdentifier, DialogClosedEventHandler closedEventHandler)
-            => Show(content, dialogIdentifier, null, null, closedEventHandler);
-
-        /// <summary>
-        /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
-        /// </summary>
-        /// <param name="content">Content to show (can be a control or view model).</param>
         /// <param name="dialogIdentifier"><see cref="Identifier"/> of the instance where the dialog should be shown. Typically this will match an identifer set in XAML. <c>null</c> is allowed.</param>
         /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
         /// <param name="closingEventHandler">Allows access to closing event which would otherwise have been subscribed to on a instance.</param>
         /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
         public static Task<object?> Show(object content, object? dialogIdentifier, DialogOpenedEventHandler? openedEventHandler, DialogClosingEventHandler? closingEventHandler)
             => Show(content, dialogIdentifier, openedEventHandler, closingEventHandler, null);
-
-        /// <summary>
-        /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
-        /// </summary>
-        /// <param name="content">Content to show (can be a control or view model).</param>
-        /// <param name="dialogIdentifier"><see cref="Identifier"/> of the instance where the dialog should be shown. Typically this will match an identifer set in XAML. <c>null</c> is allowed.</param>
-        /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
-        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
-        /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
-        public static Task<object?> Show(object content, object? dialogIdentifier, DialogOpenedEventHandler? openedEventHandler, DialogClosedEventHandler? closedEventHandler)
-            => Show(content, dialogIdentifier, openedEventHandler, null, closedEventHandler);
 
         /// <summary>
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -1,12 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
 using System.Windows.Data;
-using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
 
@@ -59,6 +51,7 @@ namespace MaterialDesignThemes.Wpf
 
         private DialogOpenedEventHandler? _asyncShowOpenedEventHandler;
         private DialogClosingEventHandler? _asyncShowClosingEventHandler;
+        private DialogClosedEventHandler? _asyncShowClosedEventHandler;
         private TaskCompletionSource<object?>? _dialogTaskCompletionSource;
 
         private Popup? _popup;
@@ -66,6 +59,7 @@ namespace MaterialDesignThemes.Wpf
         private Grid? _contentCoverGrid;
         private DialogOpenedEventHandler? _attachedDialogOpenedEventHandler;
         private DialogClosingEventHandler? _attachedDialogClosingEventHandler;
+        private DialogClosedEventHandler? _attachedDialogClosedEventHandler;
         private IInputElement? _restoreFocusDialogClose;
         private Action? _currentSnackbarMessageQueueUnPauseAction;
 
@@ -81,8 +75,8 @@ namespace MaterialDesignThemes.Wpf
         /// </summary>
         /// <param name="content">Content to show (can be a control or view model).</param>
         /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
-        public static async Task<object?> Show(object content)
-            => await Show(content, null, null);
+        public static Task<object?> Show(object content)
+            => Show(content, null, null, null);
 
         /// <summary>
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
@@ -90,8 +84,8 @@ namespace MaterialDesignThemes.Wpf
         /// <param name="content">Content to show (can be a control or view model).</param>        
         /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>        
         /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
-        public static async Task<object?> Show(object content, DialogOpenedEventHandler openedEventHandler)
-            => await Show(content, null, openedEventHandler, null);
+        public static Task<object?> Show(object content, DialogOpenedEventHandler openedEventHandler)
+            => Show(content, null, openedEventHandler, null, null);
 
         /// <summary>
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
@@ -99,8 +93,17 @@ namespace MaterialDesignThemes.Wpf
         /// <param name="content">Content to show (can be a control or view model).</param>
         /// <param name="closingEventHandler">Allows access to closing event which would otherwise have been subscribed to on a instance.</param>
         /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
-        public static async Task<object?> Show(object content, DialogClosingEventHandler closingEventHandler)
-            => await Show(content, null, null, closingEventHandler);
+        public static Task<object?> Show(object content, DialogClosingEventHandler closingEventHandler)
+            => Show(content, null, null, closingEventHandler);
+
+        /// <summary>
+        /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
+        /// </summary>
+        /// <param name="content">Content to show (can be a control or view model).</param>
+        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
+        /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
+        public static Task<object?> Show(object content, DialogClosedEventHandler closedEventHandler)
+            => Show(content, null, null, closedEventHandler);
 
         /// <summary>
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
@@ -109,8 +112,29 @@ namespace MaterialDesignThemes.Wpf
         /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
         /// <param name="closingEventHandler">Allows access to closing event which would otherwise have been subscribed to on a instance.</param>
         /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
-        public static async Task<object?> Show(object content, DialogOpenedEventHandler? openedEventHandler, DialogClosingEventHandler? closingEventHandler)
-            => await Show(content, null, openedEventHandler, closingEventHandler);
+        public static Task<object?> Show(object content, DialogOpenedEventHandler? openedEventHandler, DialogClosingEventHandler? closingEventHandler)
+            => Show(content, null, openedEventHandler, closingEventHandler);
+
+        /// <summary>
+        /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
+        /// </summary>
+        /// <param name="content">Content to show (can be a control or view model).</param>        
+        /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
+        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
+        /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
+        public static Task<object?> Show(object content, DialogOpenedEventHandler? openedEventHandler, DialogClosedEventHandler? closedEventHandler)
+            => Show(content, null, openedEventHandler, null, closedEventHandler);
+
+        /// <summary>
+        /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
+        /// </summary>
+        /// <param name="content">Content to show (can be a control or view model).</param>        
+        /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
+        /// <param name="closingEventHandler">Allows access to closing event which would otherwise have been subscribed to on a instance.</param>
+        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
+        /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
+        public static Task<object?> Show(object content, DialogOpenedEventHandler? openedEventHandler, DialogClosingEventHandler? closingEventHandler, DialogClosedEventHandler? closedEventHandler)
+            => Show(content, null, openedEventHandler, closingEventHandler, closedEventHandler);
 
         /// <summary>
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
@@ -118,8 +142,8 @@ namespace MaterialDesignThemes.Wpf
         /// <param name="content">Content to show (can be a control or view model).</param>
         /// <param name="dialogIdentifier"><see cref="Identifier"/> of the instance where the dialog should be shown. Typically this will match an identifer set in XAML. <c>null</c> is allowed.</param>
         /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
-        public static async Task<object?> Show(object content, object dialogIdentifier)
-            => await Show(content, dialogIdentifier, null, null);
+        public static Task<object?> Show(object content, object dialogIdentifier)
+            => Show(content, dialogIdentifier, null, null, null);
 
         /// <summary>
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
@@ -129,7 +153,7 @@ namespace MaterialDesignThemes.Wpf
         /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
         /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
         public static Task<object?> Show(object content, object dialogIdentifier, DialogOpenedEventHandler openedEventHandler)
-            => Show(content, dialogIdentifier, openedEventHandler, null);
+            => Show(content, dialogIdentifier, openedEventHandler, null, null);
 
         /// <summary>
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
@@ -145,14 +169,47 @@ namespace MaterialDesignThemes.Wpf
         /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
         /// </summary>
         /// <param name="content">Content to show (can be a control or view model).</param>
+        /// <param name="dialogIdentifier"><see cref="Identifier"/> of the instance where the dialog should be shown. Typically this will match an identifer set in XAML. <c>null</c> is allowed.</param>        
+        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
+        /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
+        public static Task<object?> Show(object content, object dialogIdentifier, DialogClosedEventHandler closedEventHandler)
+            => Show(content, dialogIdentifier, null, null, closedEventHandler);
+
+        /// <summary>
+        /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
+        /// </summary>
+        /// <param name="content">Content to show (can be a control or view model).</param>
         /// <param name="dialogIdentifier"><see cref="Identifier"/> of the instance where the dialog should be shown. Typically this will match an identifer set in XAML. <c>null</c> is allowed.</param>
         /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
         /// <param name="closingEventHandler">Allows access to closing event which would otherwise have been subscribed to on a instance.</param>
         /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
-        public static async Task<object?> Show(object content, object? dialogIdentifier, DialogOpenedEventHandler? openedEventHandler, DialogClosingEventHandler? closingEventHandler)
+        public static Task<object?> Show(object content, object? dialogIdentifier, DialogOpenedEventHandler? openedEventHandler, DialogClosingEventHandler? closingEventHandler)
+            => Show(content, dialogIdentifier, openedEventHandler, closingEventHandler, null);
+
+        /// <summary>
+        /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
+        /// </summary>
+        /// <param name="content">Content to show (can be a control or view model).</param>
+        /// <param name="dialogIdentifier"><see cref="Identifier"/> of the instance where the dialog should be shown. Typically this will match an identifer set in XAML. <c>null</c> is allowed.</param>
+        /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
+        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
+        /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
+        public static Task<object?> Show(object content, object? dialogIdentifier, DialogOpenedEventHandler? openedEventHandler, DialogClosedEventHandler? closedEventHandler)
+            => Show(content, dialogIdentifier, openedEventHandler, null, closedEventHandler);
+
+        /// <summary>
+        /// Shows a modal dialog. To use, a <see cref="DialogHost"/> instance must be in a visual tree (typically this may be specified towards the root of a Window's XAML).
+        /// </summary>
+        /// <param name="content">Content to show (can be a control or view model).</param>
+        /// <param name="dialogIdentifier"><see cref="Identifier"/> of the instance where the dialog should be shown. Typically this will match an identifer set in XAML. <c>null</c> is allowed.</param>
+        /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
+        /// <param name="closingEventHandler">Allows access to closing event which would otherwise have been subscribed to on a instance.</param>
+        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
+        /// <returns>Task result is the parameter used to close the dialog, typically what is passed to the <see cref="CloseDialogCommand"/> command.</returns>
+        public static async Task<object?> Show(object content, object? dialogIdentifier, DialogOpenedEventHandler? openedEventHandler, DialogClosingEventHandler? closingEventHandler, DialogClosedEventHandler? closedEventHandler)
         {
             if (content is null) throw new ArgumentNullException(nameof(content));
-            return await GetInstance(dialogIdentifier).ShowInternal(content, openedEventHandler, closingEventHandler);
+            return await GetInstance(dialogIdentifier).ShowInternal(content, openedEventHandler, closingEventHandler, closedEventHandler);
         }
 
         /// <summary>
@@ -226,7 +283,7 @@ namespace MaterialDesignThemes.Wpf
             return targets[0];
         }
 
-        internal async Task<object?> ShowInternal(object content, DialogOpenedEventHandler? openedEventHandler, DialogClosingEventHandler? closingEventHandler)
+        internal async Task<object?> ShowInternal(object content, DialogOpenedEventHandler? openedEventHandler, DialogClosingEventHandler? closingEventHandler, DialogClosedEventHandler? closedEventHandler)
         {
             if (IsOpen)
                 throw new InvalidOperationException("DialogHost is already open.");
@@ -240,12 +297,14 @@ namespace MaterialDesignThemes.Wpf
 
             _asyncShowOpenedEventHandler = openedEventHandler;
             _asyncShowClosingEventHandler = closingEventHandler;
+            _asyncShowClosedEventHandler = closedEventHandler;
             SetCurrentValue(IsOpenProperty, true);
 
             object? result = await _dialogTaskCompletionSource.Task;
 
             _asyncShowOpenedEventHandler = null;
             _asyncShowClosingEventHandler = null;
+            _asyncShowClosedEventHandler = null;
 
             return result;
         }
@@ -300,6 +359,18 @@ namespace MaterialDesignThemes.Wpf
                 object? closeParameter = null;
                 if (dialogHost.CurrentSession is { } session)
                 {
+                    //multiple ways of calling back that the dialog is closed:
+                    // * routed event
+                    // * the attached property (which should be applied to the button which opened the dialog
+                    // * straight forward IsOpen dependency property 
+                    // * handler provided to the async show method
+                    var dialogClosedEventArgs = new DialogClosedEventArgs(dialogHost.CurrentSession, DialogClosedEvent);
+                    dialogHost.OnDialogClosed(dialogClosedEventArgs);
+                    dialogHost._attachedDialogClosedEventHandler?.Invoke(dialogHost, dialogClosedEventArgs);
+                    dialogHost.DialogClosedCallback?.Invoke(dialogHost, dialogClosedEventArgs);
+                    dialogHost._asyncShowClosedEventHandler?.Invoke(dialogHost, dialogClosedEventArgs);
+                    dialogHost._attachedDialogClosedEventHandler = null;
+
                     if (!session.IsEnded)
                     {
                         session.Close(session.CloseParameter);
@@ -636,6 +707,49 @@ namespace MaterialDesignThemes.Wpf
         protected void OnDialogClosing(DialogClosingEventArgs eventArgs)
             => RaiseEvent(eventArgs);
 
+        public static readonly RoutedEvent DialogClosedEvent =
+            EventManager.RegisterRoutedEvent(
+                "DialogClosed",
+                RoutingStrategy.Bubble,
+                typeof(DialogClosedEventHandler),
+                typeof(DialogHost));
+
+        /// <summary>
+        /// Raised when a dialog is closed.
+        /// </summary>
+        public event DialogClosedEventHandler DialogClosed
+        {
+            add { AddHandler(DialogClosedEvent, value); }
+            remove { RemoveHandler(DialogClosedEvent, value); }
+        }
+
+        /// <summary>
+        /// Attached property which can be used on the <see cref="Button"/> which instigated the <see cref="OpenDialogCommand"/> to process the closed event.
+        /// </summary>
+        public static readonly DependencyProperty DialogClosedAttachedProperty = DependencyProperty.RegisterAttached(
+            "DialogClosedAttached", typeof(DialogClosedEventHandler), typeof(DialogHost), new PropertyMetadata(default(DialogClosedEventHandler)));
+
+        public static void SetDialogClosedAttached(DependencyObject element, DialogClosedEventHandler value)
+            => element.SetValue(DialogClosedAttachedProperty, value);
+
+        public static DialogClosedEventHandler GetDialogClosedAttached(DependencyObject element)
+            => (DialogClosedEventHandler)element.GetValue(DialogClosedAttachedProperty);
+
+        public static readonly DependencyProperty DialogClosedCallbackProperty = DependencyProperty.Register(
+            nameof(DialogClosedCallback), typeof(DialogClosedEventHandler), typeof(DialogHost), new PropertyMetadata(default(DialogClosedEventHandler)));
+
+        /// <summary>
+        /// Callback fired when the <see cref="DialogClosed"/> event is fired, allowing the event to be processed from a binding/view model.
+        /// </summary>
+        public DialogClosedEventHandler? DialogClosedCallback
+        {
+            get => (DialogClosedEventHandler?)GetValue(DialogClosedCallbackProperty);
+            set => SetValue(DialogClosedCallbackProperty, value);
+        }
+
+        protected void OnDialogClosed(DialogClosedEventArgs eventArgs)
+            => RaiseEvent(eventArgs);
+
         #endregion
 
         internal void AssertTargetableContent()
@@ -716,6 +830,7 @@ namespace MaterialDesignThemes.Wpf
             {
                 _attachedDialogOpenedEventHandler = GetDialogOpenedAttached(dependencyObject);
                 _attachedDialogClosingEventHandler = GetDialogClosingAttached(dependencyObject);
+                _attachedDialogClosedEventHandler = GetDialogClosedAttached(dependencyObject);
             }
 
             if (executedRoutedEventArgs.Parameter != null)

--- a/MaterialDesignThemes.Wpf/DialogHostEx.cs
+++ b/MaterialDesignThemes.Wpf/DialogHostEx.cs
@@ -23,7 +23,7 @@ namespace MaterialDesignThemes.Wpf
         /// </remarks>
         /// <returns></returns>
         public static async Task<object?> ShowDialog(this Window window, object content)
-            => await GetFirstDialogHost(window).ShowInternal(content, null, null);
+            => await GetFirstDialogHost(window).ShowInternal(content, null, null, null);
 
         /// <summary>
         /// Shows a dialog using the first found <see cref="DialogHost"/> in a given <see cref="Window"/>.
@@ -39,7 +39,7 @@ namespace MaterialDesignThemes.Wpf
         /// </remarks>
         /// <returns></returns>
         public static async Task<object?> ShowDialog(this Window window, object content, DialogOpenedEventHandler openedEventHandler)
-            => await GetFirstDialogHost(window).ShowInternal(content, openedEventHandler, null);
+            => await GetFirstDialogHost(window).ShowInternal(content, openedEventHandler, null, null);
 
         /// <summary>
         /// Shows a dialog using the first found <see cref="DialogHost"/> in a given <see cref="Window"/>.
@@ -55,7 +55,23 @@ namespace MaterialDesignThemes.Wpf
         /// </remarks>
         /// <returns></returns>
         public static async Task<object?> ShowDialog(this Window window, object content, DialogClosingEventHandler closingEventHandler)
-            => await GetFirstDialogHost(window).ShowInternal(content, null, closingEventHandler);
+            => await GetFirstDialogHost(window).ShowInternal(content, null, closingEventHandler, null);
+
+        /// <summary>
+        /// Shows a dialog using the first found <see cref="DialogHost"/> in a given <see cref="Window"/>.
+        /// </summary>
+        /// <param name="window">Window on which the modal dialog should be displayed. Must contain a <see cref="DialogHost"/>.</param>
+        /// <param name="content">Content to show (can be a control or view model).</param>
+        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
+        /// </exception>
+        /// <remarks>
+        /// As a depth first traversal of the window's visual tree is performed, it is not safe to use this method in a situtation where a screen has multiple <see cref="DialogHost"/>s.
+        /// </remarks>
+        /// <returns></returns>
+        public static async Task<object?> ShowDialog(this Window window, object content, DialogClosedEventHandler closedEventHandler)
+            => await GetFirstDialogHost(window).ShowInternal(content, null, null, closedEventHandler);
 
         /// <summary>
         /// Shows a dialog using the first found <see cref="DialogHost"/> in a given <see cref="Window"/>.
@@ -72,7 +88,42 @@ namespace MaterialDesignThemes.Wpf
         /// </remarks>
         /// <returns></returns>
         public static async Task<object?> ShowDialog(this Window window, object content, DialogOpenedEventHandler openedEventHandler, DialogClosingEventHandler closingEventHandler)
-            => await GetFirstDialogHost(window).ShowInternal(content, openedEventHandler, closingEventHandler);
+            => await GetFirstDialogHost(window).ShowInternal(content, openedEventHandler, closingEventHandler, null);
+
+        /// <summary>
+        /// Shows a dialog using the first found <see cref="DialogHost"/> in a given <see cref="Window"/>.
+        /// </summary>
+        /// <param name="window">Window on which the modal dialog should be displayed. Must contain a <see cref="DialogHost"/>.</param>
+        /// <param name="content">Content to show (can be a control or view model).</param>
+        /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
+        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
+        /// </exception>
+        /// <remarks>
+        /// As a depth first traversal of the window's visual tree is performed, it is not safe to use this method in a situtation where a screen has multiple <see cref="DialogHost"/>s.
+        /// </remarks>
+        /// <returns></returns>
+        public static async Task<object?> ShowDialog(this Window window, object content, DialogOpenedEventHandler openedEventHandler, DialogClosedEventHandler closedEventHandler)
+            => await GetFirstDialogHost(window).ShowInternal(content, openedEventHandler, null, closedEventHandler);
+
+        /// <summary>
+        /// Shows a dialog using the first found <see cref="DialogHost"/> in a given <see cref="Window"/>.
+        /// </summary>
+        /// <param name="window">Window on which the modal dialog should be displayed. Must contain a <see cref="DialogHost"/>.</param>
+        /// <param name="content">Content to show (can be a control or view model).</param>
+        /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
+        /// <param name="closingEventHandler">Allows access to closing event which would otherwise have been subscribed to on a instance.</param>
+        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
+        /// </exception>
+        /// <remarks>
+        /// As a depth first traversal of the window's visual tree is performed, it is not safe to use this method in a situtation where a screen has multiple <see cref="DialogHost"/>s.
+        /// </remarks>
+        /// <returns></returns>
+        public static async Task<object?> ShowDialog(this Window window, object content, DialogOpenedEventHandler openedEventHandler, DialogClosingEventHandler closingEventHandler, DialogClosedEventHandler closedEventHandler)
+            => await GetFirstDialogHost(window).ShowInternal(content, openedEventHandler, closingEventHandler, closedEventHandler);
 
         /// <summary>
         /// Shows a dialog using the parent/ancestor <see cref="DialogHost"/> of the a given <see cref="DependencyObject"/>.
@@ -84,7 +135,7 @@ namespace MaterialDesignThemes.Wpf
         /// </exception>
         /// <returns></returns>
         public static async Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content)
-            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, null, null);
+            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, null, null, null);
 
         /// <summary>
         /// Shows a dialog using the parent/ancestor <see cref="DialogHost"/> of the a given <see cref="DependencyObject"/>.
@@ -97,7 +148,7 @@ namespace MaterialDesignThemes.Wpf
         /// </exception>
         /// <returns></returns>
         public static async Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogOpenedEventHandler openedEventHandler)
-            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, openedEventHandler, null);
+            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, openedEventHandler, null, null);
 
         /// <summary>
         /// Shows a dialog using the parent/ancestor <see cref="DialogHost"/> of the a given <see cref="DependencyObject"/>.
@@ -110,7 +161,20 @@ namespace MaterialDesignThemes.Wpf
         /// </exception>
         /// <returns></returns>
         public static async Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogClosingEventHandler closingEventHandler)
-            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, null, closingEventHandler);
+            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, null, closingEventHandler, null);
+
+        /// <summary>
+        /// Shows a dialog using the parent/ancestor <see cref="DialogHost"/> of the a given <see cref="DependencyObject"/>.
+        /// </summary>
+        /// <param name="childDependencyObject">Dependency object which should be a visual child of a <see cref="DialogHost"/>, where the dialog will be shown.</param>
+        /// <param name="content">Content to show (can be a control or view model).</param>
+        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
+        /// </exception>
+        /// <returns></returns>
+        public static async Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogClosedEventHandler closedEventHandler)
+            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, null, null, closedEventHandler);
 
         /// <summary>
         /// Shows a dialog using the parent/ancestor <see cref="DialogHost"/> of the a given <see cref="DependencyObject"/>.
@@ -124,7 +188,36 @@ namespace MaterialDesignThemes.Wpf
         /// </exception>
         /// <returns></returns>
         public static async Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogOpenedEventHandler openedEventHandler, DialogClosingEventHandler closingEventHandler)
-            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, openedEventHandler, closingEventHandler);
+            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, openedEventHandler, closingEventHandler, null);
+
+        /// <summary>
+        /// Shows a dialog using the parent/ancestor <see cref="DialogHost"/> of the a given <see cref="DependencyObject"/>.
+        /// </summary>
+        /// <param name="childDependencyObject">Dependency object which should be a visual child of a <see cref="DialogHost"/>, where the dialog will be shown.</param>
+        /// <param name="content">Content to show (can be a control or view model).</param>
+        /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
+        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
+        /// </exception>
+        /// <returns></returns>
+        public static async Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogOpenedEventHandler openedEventHandler, DialogClosedEventHandler closedEventHandler)
+            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, openedEventHandler, null, closedEventHandler);
+
+        /// <summary>
+        /// Shows a dialog using the parent/ancestor <see cref="DialogHost"/> of the a given <see cref="DependencyObject"/>.
+        /// </summary>
+        /// <param name="childDependencyObject">Dependency object which should be a visual child of a <see cref="DialogHost"/>, where the dialog will be shown.</param>
+        /// <param name="content">Content to show (can be a control or view model).</param>
+        /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
+        /// <param name="closingEventHandler">Allows access to closing event which would otherwise have been subscribed to on a instance.</param>
+        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
+        /// </exception>
+        /// <returns></returns>
+        public static async Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogOpenedEventHandler openedEventHandler, DialogClosingEventHandler closingEventHandler, DialogClosedEventHandler closedEventHandler)
+            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, openedEventHandler, closingEventHandler, closedEventHandler);
 
         private static DialogHost GetFirstDialogHost(Window window)
         {

--- a/MaterialDesignThemes.Wpf/DialogHostEx.cs
+++ b/MaterialDesignThemes.Wpf/DialogHostEx.cs
@@ -22,8 +22,8 @@ namespace MaterialDesignThemes.Wpf
         /// As a depth first traversal of the window's visual tree is performed, it is not safe to use this method in a situtation where a screen has multiple <see cref="DialogHost"/>s.
         /// </remarks>
         /// <returns></returns>
-        public static async Task<object?> ShowDialog(this Window window, object content)
-            => await GetFirstDialogHost(window).ShowInternal(content, null, null, null);
+        public static Task<object?> ShowDialog(this Window window, object content)
+            => GetFirstDialogHost(window).ShowInternal(content, null, null, null);
 
         /// <summary>
         /// Shows a dialog using the first found <see cref="DialogHost"/> in a given <see cref="Window"/>.
@@ -38,8 +38,8 @@ namespace MaterialDesignThemes.Wpf
         /// As a depth first traversal of the window's visual tree is performed, it is not safe to use this method in a situtation where a screen has multiple <see cref="DialogHost"/>s.
         /// </remarks>
         /// <returns></returns>
-        public static async Task<object?> ShowDialog(this Window window, object content, DialogOpenedEventHandler openedEventHandler)
-            => await GetFirstDialogHost(window).ShowInternal(content, openedEventHandler, null, null);
+        public static Task<object?> ShowDialog(this Window window, object content, DialogOpenedEventHandler openedEventHandler)
+            => GetFirstDialogHost(window).ShowInternal(content, openedEventHandler, null, null);
 
         /// <summary>
         /// Shows a dialog using the first found <see cref="DialogHost"/> in a given <see cref="Window"/>.
@@ -54,24 +54,8 @@ namespace MaterialDesignThemes.Wpf
         /// As a depth first traversal of the window's visual tree is performed, it is not safe to use this method in a situtation where a screen has multiple <see cref="DialogHost"/>s.
         /// </remarks>
         /// <returns></returns>
-        public static async Task<object?> ShowDialog(this Window window, object content, DialogClosingEventHandler closingEventHandler)
-            => await GetFirstDialogHost(window).ShowInternal(content, null, closingEventHandler, null);
-
-        /// <summary>
-        /// Shows a dialog using the first found <see cref="DialogHost"/> in a given <see cref="Window"/>.
-        /// </summary>
-        /// <param name="window">Window on which the modal dialog should be displayed. Must contain a <see cref="DialogHost"/>.</param>
-        /// <param name="content">Content to show (can be a control or view model).</param>
-        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
-        /// </exception>
-        /// <remarks>
-        /// As a depth first traversal of the window's visual tree is performed, it is not safe to use this method in a situtation where a screen has multiple <see cref="DialogHost"/>s.
-        /// </remarks>
-        /// <returns></returns>
-        public static async Task<object?> ShowDialog(this Window window, object content, DialogClosedEventHandler closedEventHandler)
-            => await GetFirstDialogHost(window).ShowInternal(content, null, null, closedEventHandler);
+        public static Task<object?> ShowDialog(this Window window, object content, DialogClosingEventHandler closingEventHandler)
+            => GetFirstDialogHost(window).ShowInternal(content, null, closingEventHandler, null);
 
         /// <summary>
         /// Shows a dialog using the first found <see cref="DialogHost"/> in a given <see cref="Window"/>.
@@ -87,25 +71,8 @@ namespace MaterialDesignThemes.Wpf
         /// As a depth first traversal of the window's visual tree is performed, it is not safe to use this method in a situtation where a screen has multiple <see cref="DialogHost"/>s.
         /// </remarks>
         /// <returns></returns>
-        public static async Task<object?> ShowDialog(this Window window, object content, DialogOpenedEventHandler openedEventHandler, DialogClosingEventHandler closingEventHandler)
-            => await GetFirstDialogHost(window).ShowInternal(content, openedEventHandler, closingEventHandler, null);
-
-        /// <summary>
-        /// Shows a dialog using the first found <see cref="DialogHost"/> in a given <see cref="Window"/>.
-        /// </summary>
-        /// <param name="window">Window on which the modal dialog should be displayed. Must contain a <see cref="DialogHost"/>.</param>
-        /// <param name="content">Content to show (can be a control or view model).</param>
-        /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
-        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
-        /// </exception>
-        /// <remarks>
-        /// As a depth first traversal of the window's visual tree is performed, it is not safe to use this method in a situtation where a screen has multiple <see cref="DialogHost"/>s.
-        /// </remarks>
-        /// <returns></returns>
-        public static async Task<object?> ShowDialog(this Window window, object content, DialogOpenedEventHandler openedEventHandler, DialogClosedEventHandler closedEventHandler)
-            => await GetFirstDialogHost(window).ShowInternal(content, openedEventHandler, null, closedEventHandler);
+        public static Task<object?> ShowDialog(this Window window, object content, DialogOpenedEventHandler openedEventHandler, DialogClosingEventHandler closingEventHandler)
+            => GetFirstDialogHost(window).ShowInternal(content, openedEventHandler, closingEventHandler, null);
 
         /// <summary>
         /// Shows a dialog using the first found <see cref="DialogHost"/> in a given <see cref="Window"/>.
@@ -122,8 +89,8 @@ namespace MaterialDesignThemes.Wpf
         /// As a depth first traversal of the window's visual tree is performed, it is not safe to use this method in a situtation where a screen has multiple <see cref="DialogHost"/>s.
         /// </remarks>
         /// <returns></returns>
-        public static async Task<object?> ShowDialog(this Window window, object content, DialogOpenedEventHandler openedEventHandler, DialogClosingEventHandler closingEventHandler, DialogClosedEventHandler closedEventHandler)
-            => await GetFirstDialogHost(window).ShowInternal(content, openedEventHandler, closingEventHandler, closedEventHandler);
+        public static Task<object?> ShowDialog(this Window window, object content, DialogOpenedEventHandler openedEventHandler, DialogClosingEventHandler closingEventHandler, DialogClosedEventHandler closedEventHandler)
+            => GetFirstDialogHost(window).ShowInternal(content, openedEventHandler, closingEventHandler, closedEventHandler);
 
         /// <summary>
         /// Shows a dialog using the parent/ancestor <see cref="DialogHost"/> of the a given <see cref="DependencyObject"/>.
@@ -134,8 +101,8 @@ namespace MaterialDesignThemes.Wpf
         /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
         /// </exception>
         /// <returns></returns>
-        public static async Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content)
-            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, null, null, null);
+        public static Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content)
+            => GetOwningDialogHost(childDependencyObject).ShowInternal(content, null, null, null);
 
         /// <summary>
         /// Shows a dialog using the parent/ancestor <see cref="DialogHost"/> of the a given <see cref="DependencyObject"/>.
@@ -147,8 +114,8 @@ namespace MaterialDesignThemes.Wpf
         /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
         /// </exception>
         /// <returns></returns>
-        public static async Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogOpenedEventHandler openedEventHandler)
-            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, openedEventHandler, null, null);
+        public static Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogOpenedEventHandler openedEventHandler)
+            => GetOwningDialogHost(childDependencyObject).ShowInternal(content, openedEventHandler, null, null);
 
         /// <summary>
         /// Shows a dialog using the parent/ancestor <see cref="DialogHost"/> of the a given <see cref="DependencyObject"/>.
@@ -160,21 +127,8 @@ namespace MaterialDesignThemes.Wpf
         /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
         /// </exception>
         /// <returns></returns>
-        public static async Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogClosingEventHandler closingEventHandler)
-            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, null, closingEventHandler, null);
-
-        /// <summary>
-        /// Shows a dialog using the parent/ancestor <see cref="DialogHost"/> of the a given <see cref="DependencyObject"/>.
-        /// </summary>
-        /// <param name="childDependencyObject">Dependency object which should be a visual child of a <see cref="DialogHost"/>, where the dialog will be shown.</param>
-        /// <param name="content">Content to show (can be a control or view model).</param>
-        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
-        /// </exception>
-        /// <returns></returns>
-        public static async Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogClosedEventHandler closedEventHandler)
-            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, null, null, closedEventHandler);
+        public static Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogClosingEventHandler closingEventHandler)
+            => GetOwningDialogHost(childDependencyObject).ShowInternal(content, null, closingEventHandler, null);
 
         /// <summary>
         /// Shows a dialog using the parent/ancestor <see cref="DialogHost"/> of the a given <see cref="DependencyObject"/>.
@@ -187,22 +141,8 @@ namespace MaterialDesignThemes.Wpf
         /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
         /// </exception>
         /// <returns></returns>
-        public static async Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogOpenedEventHandler openedEventHandler, DialogClosingEventHandler closingEventHandler)
-            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, openedEventHandler, closingEventHandler, null);
-
-        /// <summary>
-        /// Shows a dialog using the parent/ancestor <see cref="DialogHost"/> of the a given <see cref="DependencyObject"/>.
-        /// </summary>
-        /// <param name="childDependencyObject">Dependency object which should be a visual child of a <see cref="DialogHost"/>, where the dialog will be shown.</param>
-        /// <param name="content">Content to show (can be a control or view model).</param>
-        /// <param name="openedEventHandler">Allows access to opened event which would otherwise have been subscribed to on a instance.</param>
-        /// <param name="closedEventHandler">Allows access to closed event which would otherwise have been subscribed to on a instance.</param>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
-        /// </exception>
-        /// <returns></returns>
-        public static async Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogOpenedEventHandler openedEventHandler, DialogClosedEventHandler closedEventHandler)
-            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, openedEventHandler, null, closedEventHandler);
+        public static Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogOpenedEventHandler openedEventHandler, DialogClosingEventHandler closingEventHandler)
+            => GetOwningDialogHost(childDependencyObject).ShowInternal(content, openedEventHandler, closingEventHandler, null);
 
         /// <summary>
         /// Shows a dialog using the parent/ancestor <see cref="DialogHost"/> of the a given <see cref="DependencyObject"/>.
@@ -216,8 +156,8 @@ namespace MaterialDesignThemes.Wpf
         /// Thrown is a <see cref="DialogHost"/> is not found when conducting a depth first traversal of visual tree.  
         /// </exception>
         /// <returns></returns>
-        public static async Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogOpenedEventHandler openedEventHandler, DialogClosingEventHandler closingEventHandler, DialogClosedEventHandler closedEventHandler)
-            => await GetOwningDialogHost(childDependencyObject).ShowInternal(content, openedEventHandler, closingEventHandler, closedEventHandler);
+        public static Task<object?> ShowDialog(this DependencyObject childDependencyObject, object content, DialogOpenedEventHandler openedEventHandler, DialogClosingEventHandler closingEventHandler, DialogClosedEventHandler closedEventHandler)
+            => GetOwningDialogHost(childDependencyObject).ShowInternal(content, openedEventHandler, closingEventHandler, closedEventHandler);
 
         private static DialogHost GetFirstDialogHost(Window window)
         {


### PR DESCRIPTION
Fix for #1181 

Adds DialogClosing event to DialogHost with the same hooks as the DialogOpening and DialogClosing events.

Works the same way as DialogClosing, except it cannot be cancelled, and it is only fired once IsOpen changes to False.

Updated samples to include the DialogClosing event hooks and also updated/added some unit tests to ensure the event is fired correctly.

**IMPORTANT**:
There is a slight risk that the `DialogHost.Show(...)` and `DialogHostEx.ShowDialog(...)` overloads is a breaking change. This could potentially cause ambiguity in existing code using the toolkit, or even worse it could end up calling another overload than the intended one. It might be better to remove the overloads with fewer parameters and thus only extending with the new overload taking the extra "closed handler" parameter?