### PR TITLE
Fixed GitHub links

### DIFF
--- a/MainDemo.Wpf/App.config
+++ b/MainDemo.Wpf/App.config
@@ -4,6 +4,6 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
   <appSettings>
-    <add key="GitHub" value="https://github.com/ButchersBoy/MaterialDesignInXamlToolkit"/>
+    <add key="GitHub" value="https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/"/>
   </appSettings>
 </configuration>

--- a/MainDemo.Wpf/Domain/Link.cs
+++ b/MainDemo.Wpf/Domain/Link.cs
@@ -7,12 +7,9 @@ namespace MaterialDesignDemo.Domain
     {
         public static void OpenInBrowser(string? url)
         {
-            if (url is null) return;
-            //https://github.com/dotnet/corefx/issues/10361
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (url is not null && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                url = url.Replace("&", "^&");
-                Process.Start(new ProcessStartInfo("cmd", $"/c start {url}") { CreateNoWindow = true });
+                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
             }
         }
     }

--- a/MaterialDesign3.Demo.Wpf/App.config
+++ b/MaterialDesign3.Demo.Wpf/App.config
@@ -4,6 +4,6 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
   <appSettings>
-    <add key="GitHub" value="https://github.com/ButchersBoy/MaterialDesignInXamlToolkit"/>
+    <add key="GitHub" value="https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit"/>
   </appSettings>
 </configuration>

--- a/MaterialDesign3.Demo.Wpf/Domain/DocumentationLink.cs
+++ b/MaterialDesign3.Demo.Wpf/Domain/DocumentationLink.cs
@@ -75,7 +75,7 @@ namespace MaterialDesign3Demo.Domain
 
             return new DocumentationLink(
                 DocumentationLinkType.DemoPageSource,
-                $"{ConfigurationManager.AppSettings["GitHub"]}/blob/master/MainDemo.Wpf/{(string.IsNullOrWhiteSpace(@namespace) ? "" : "/" + @namespace + "/")}{typeof(TDemoPage).Name}.{ext}",
+                $"{ConfigurationManager.AppSettings["GitHub"]}/blob/master/MaterialDesign3.Demo.Wpf/{(string.IsNullOrWhiteSpace(@namespace) ? "" : "/" + @namespace + "/")}{typeof(TDemoPage).Name}.{ext}",
                 label ?? typeof(TDemoPage).Name);
         }
 

--- a/MaterialDesign3.Demo.Wpf/Domain/DocumentationLink.cs
+++ b/MaterialDesign3.Demo.Wpf/Domain/DocumentationLink.cs
@@ -26,11 +26,13 @@ namespace MaterialDesign3Demo.Domain
                 $"{ConfigurationManager.AppSettings["GitHub"]}/wiki/" + page, label);
         }
 
-        public static DocumentationLink StyleLink(string nameChunk)
+        public static DocumentationLink StyleLink(string nameChunk, bool isMd3Style = false)
         {
+            var themesUrl = $"{ConfigurationManager.AppSettings["GitHub"]}/blob/master/MaterialDesignThemes.Wpf/Themes/";
+
             return new DocumentationLink(
                 DocumentationLinkType.StyleSource,
-                $"{ConfigurationManager.AppSettings["GitHub"]}/blob/master/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.{nameChunk}.xaml",
+                $"{themesUrl}MaterialDesign{(isMd3Style ? "3" : "Theme")}.{nameChunk}.xaml",
                 nameChunk);
         }
 

--- a/MaterialDesign3.Demo.Wpf/Domain/Link.cs
+++ b/MaterialDesign3.Demo.Wpf/Domain/Link.cs
@@ -7,12 +7,9 @@ namespace MaterialDesign3Demo.Domain
     {
         public static void OpenInBrowser(string? url)
         {
-            if (url is null) return;
-            //https://github.com/dotnet/corefx/issues/10361
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (url is not null && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                url = url.Replace("&", "^&");
-                Process.Start(new ProcessStartInfo("cmd", $"/c start {url}") { CreateNoWindow = true });
+                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
             }
         }
     }

--- a/MaterialDesign3.Demo.Wpf/Domain/MainWindowViewModel.cs
+++ b/MaterialDesign3.Demo.Wpf/Domain/MainWindowViewModel.cs
@@ -188,9 +188,8 @@ namespace MaterialDesign3Demo.Domain
                 new[]
                 {
                     DocumentationLink.DemoPageLink<Toggles>(),
-                    DocumentationLink.StyleLink("ToggleButton"),
-                    DocumentationLink.StyleLink("CheckBox"),
-                    DocumentationLink.ApiLink<Toggles>()
+                    DocumentationLink.StyleLink("ToggleButton", true),
+                    DocumentationLink.StyleLink("CheckBox")
                 },
                 selectedIcon: PackIconKind.ToggleSwitch,
                 unselectedIcon: PackIconKind.ToggleSwitchOffOutline);
@@ -281,7 +280,7 @@ namespace MaterialDesign3Demo.Domain
                 new[]
                 {
                     DocumentationLink.DemoPageLink<Typography>(),
-                    DocumentationLink.StyleLink("TextBlock")
+                    DocumentationLink.StyleLink("TextBlock", true)
                 },
                 selectedIcon: PackIconKind.FormatSize,
                 unselectedIcon: PackIconKind.FormatTitle)
@@ -416,7 +415,7 @@ namespace MaterialDesign3Demo.Domain
                 new[]
                 {
                     DocumentationLink.DemoPageLink<NavigationRail>(),
-                    DocumentationLink.StyleLink("NavigationRail"),
+                    DocumentationLink.StyleLink("NavigationRail", true),
                 },
                 selectedIcon: PackIconKind.NavigationVariant,
                 unselectedIcon: PackIconKind.NavigationVariantOutline)
@@ -430,7 +429,7 @@ namespace MaterialDesign3Demo.Domain
                 new[]
                 {
                     DocumentationLink.DemoPageLink<NavigationBar>(),
-                    DocumentationLink.StyleLink("NavigationBar"),
+                    DocumentationLink.StyleLink("NavigationBar", true),
                 },
                 selectedIcon: PackIconKind.NavigationVariant,
                 unselectedIcon: PackIconKind.NavigationVariantOutline)

--- a/MaterialDesignThemes.Wpf/Transitions/TransitioningContentBase.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/TransitioningContentBase.cs
@@ -126,7 +126,7 @@ namespace MaterialDesignThemes.Wpf.Transitions
 
         private FrameworkElement GetNameScopeRoot()
         {
-            //https://github.com/ButchersBoy/MaterialDesignInXamlToolkit/issues/950
+            //https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/950
             //Only set the NameScope if the child does not already have a TemplateNameScope set
             if (VisualChildrenCount > 0 && GetVisualChild(0) is FrameworkElement fe && NameScope.GetNameScope(fe) != null)
             {

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Comprehensive and easy to use Material Design theme and control library for the 
 
 # ![Alt text](web/images/MD4XAML28.png "In Action") See It In Action
 
-- Download a pre-compiled demo from the [releases](https://github.com/ButchersBoy/MaterialDesignInXamlToolkit/releases) page.
+- Download a pre-compiled demo from the [releases](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/releases) page.
 - Download the source and run the demo ([more information](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/wiki/Compiling-From-Source)).
 - Checkout [Keboo/MaterialDesign.Examples](https://github.com/Keboo/MaterialDesignInXaml.Examples)
 - Checkout [doobry](http://materialdesigninxaml.net/doobry).
@@ -63,7 +63,7 @@ To load the source project you will need Visual Studio 2022. Don't worry if you 
 - [ControlzEx](https://github.com/ControlzEx/ControlzEx) - Library used in MaterialDesignInXAML
 - [Ignace Maes](https://github.com/IgnaceMaes) - Whose [Material Skin](https://github.com/IgnaceMaes/MaterialSkin) project inspired the original material design theme for [Dragablz](https://github.com/ButchersBoy/Dragablz), which in turn led James Willock start this project
 - [Material Design Extensions](https://github.com/spiegelp/MaterialDesignExtensions) - A community repository based on this library that provides additional controls and features.
-- **[Contributors](https://github.com/ButchersBoy/MaterialDesignInXamlToolkit/graphs/contributors)** - A big thank you to all the contributors of the project!
+- **[Contributors](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/graphs/contributors)** - A big thank you to all the contributors of the project!
 
 # <a name="Screenshots"></a>![Alt text](web/images/MD4XAML28.png "Screenshots") Screenshots
 

--- a/web/PaletteBuilder.html
+++ b/web/PaletteBuilder.html
@@ -8,7 +8,7 @@
 	<body>
 		<div id="header">
 			<h1>Material Design in XAML Toolkit Palette Builder</h1>
-			<p>This isn't a web demo/style resource for Material Design, but is a tool for building a Material Design palette and ResourceDictionary for XAML applications using the <a href="https://github.com/ButchersBoy/MaterialDesignInXamlToolkit">Material Design in XAML Toolkit</a>.</p>
+			<p>This isn't a web demo/style resource for Material Design, but is a tool for building a Material Design palette and ResourceDictionary for XAML applications using the <a href="https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit">Material Design in XAML Toolkit</a>.</p>
 		</div>
 		<div id="huesContainer">
 			<div>


### PR DESCRIPTION
This fixes various issues with GitHub links in `README.md`, the MD3 demo, and in comments:
- Updates `ButchersBoy` links to `MaterialDesignInXAML`
- Removes the need for the demos to open a `cmd` window when opening URLs in the browser (tested on all target frameworks)
- Fixes MD3 style links and MD3 demo links that were pointing to MD2 versions
- Removed invalid `Toggles` API link