### PR TITLE
Fix TabControl styles

### DIFF
--- a/MainDemo.Wpf/Tabs.xaml
+++ b/MainDemo.Wpf/Tabs.xaml
@@ -433,7 +433,7 @@
                             <TextBlock Margin="8" Text="Not filled example tab 1" />
                         </TabItem>
                         <TabItem Header="TAB 2">
-                            <TextBlock Margin="8" Text="No filled example tab 2" />
+                            <TextBlock Margin="8" Text="Not filled example tab 2" />
                         </TabItem>
                     </TabControl>
                 </materialDesign:Card>
@@ -443,10 +443,10 @@
                 <materialDesign:Card>
                     <TabControl HorizontalContentAlignment="Left" Style="{StaticResource MaterialDesignFilledTabControl}">
                         <TabItem Header="TAB1">
-                            <TextBlock Margin="8" Text="Full-width filled example tab 1" />
+                            <TextBlock Margin="8" Text="Filled example tab 1" />
                         </TabItem>
                         <TabItem Header="TAB 2">
-                            <TextBlock Margin="8" Text="Full-width filled example tab 2" />
+                            <TextBlock Margin="8" Text="Filled example tab 2" />
                         </TabItem>
                     </TabControl>
                 </materialDesign:Card>
@@ -462,28 +462,28 @@
                             <TextBlock Margin="8" Text="Not filled secondary example tab 2" />
                         </TabItem>
                         <TabItem Header="TAB 3333">
-                            <TextBlock Margin="8" Text="Full-width secondary example tab 3333" />
+                            <TextBlock Margin="8" Text="Secondary example tab 3333" />
                         </TabItem>
                         <TabItem Header="TAB4 Wide">
-                            <TextBlock Margin="8" Text="Full-width secondary example tab 4 wide" />
+                            <TextBlock Margin="8" Text="Secondary example tab 4 wide" />
                         </TabItem>
                         <TabItem Header="TABbbbbbbbbbbxxxxx 5">
-                            <TextBlock Margin="8" Text="Full-width secondary example tab 5" />
+                            <TextBlock Margin="8" Text="Secondary example tab 5" />
                         </TabItem>
                         <TabItem Header="TAB 6 Different Width">
-                            <TextBlock Margin="8" Text="Full-width secondary example tab 6 different width" />
+                            <TextBlock Margin="8" Text="Secondary example tab 6 different width" />
                         </TabItem>
                         <TabItem Header="TAB 7 Looooong">
-                            <TextBlock Margin="8" Text="Full-width secondary example tab 7 looooong" />
+                            <TextBlock Margin="8" Text="Secondary example tab 7 looooong" />
                         </TabItem>
                         <TabItem Header="TAB 8 Width">
-                            <TextBlock Margin="8" Text="Full-width secondary example tab 8 width" />
+                            <TextBlock Margin="8" Text="Secondary example tab 8 width" />
                         </TabItem>
                         <TabItem Header="TAAX999">
-                            <TextBlock Margin="8" Text="Full-width secondary example tab 9" />
+                            <TextBlock Margin="8" Text="Secondary example tab 9" />
                         </TabItem>
                         <TabItem Header="Tab10">
-                            <TextBlock Margin="8" Text="Full-width secondary example tab 10" />
+                            <TextBlock Margin="8" Text="Secondary example tab 10" />
                         </TabItem>
                     </TabControl>
                 </materialDesign:Card>
@@ -496,10 +496,10 @@
                         materialDesign:ColorZoneAssist.Mode="SecondaryMid"
                         Style="{StaticResource MaterialDesignFilledTabControl}">
                         <TabItem Header="TAB1">
-                            <TextBlock Margin="8" Text="Full-width secondary filled example tab 1" />
+                            <TextBlock Margin="8" Text="Secondary filled example tab 1" />
                         </TabItem>
                         <TabItem Header="TAB 2">
-                            <TextBlock Margin="8" Text="Full-width secondary filled example tab 2" />
+                            <TextBlock Margin="8" Text="Secondary filled example tab 2" />
                         </TabItem>
                     </TabControl>
                 </materialDesign:Card>

--- a/MainDemo.Wpf/Tabs.xaml
+++ b/MainDemo.Wpf/Tabs.xaml
@@ -20,6 +20,32 @@
             Style="{StaticResource MaterialDesignHeadline5TextBlock}"
             Text="Default style" />
 
+        <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_1_default" HorizontalAlignment="Left">
+            <TabControl Width="300">
+                <TabItem Header="TAB 1">
+                    <TextBlock Margin="8" Text="PrimaryLight Tab 1" />
+                </TabItem>
+                <TabItem Header="TAB 2">
+                    <TextBlock Margin="8" Text="PrimaryLight Tab 2" />
+                </TabItem>
+            </TabControl>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_custom_1" HorizontalAlignment="Left">
+            <TabControl Width="300"
+                        Style="{StaticResource MaterialDesignFilledTabControl}"
+                        materialDesign:ColorZoneAssist.Mode="Custom"
+                        materialDesign:ColorZoneAssist.Foreground="{DynamicResource PrimaryHueMidBrush}"
+                        materialDesign:ColorZoneAssist.Background="{DynamicResource MaterialDesignCardBackground}">
+                <TabItem Header="TAB 1">
+                    <TextBlock Margin="8" Text="PrimaryLight Tab 1" />
+                </TabItem>
+                <TabItem Header="TAB 2">
+                    <TextBlock Margin="8" Text="PrimaryLight Tab 2" />
+                </TabItem>
+            </TabControl>
+        </smtx:XamlDisplay>
+
         <WrapPanel Margin="0,0,0,16">
             <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_1">
                 <materialDesign:Card>

--- a/MainDemo.Wpf/Tabs.xaml
+++ b/MainDemo.Wpf/Tabs.xaml
@@ -10,59 +10,37 @@
     d:DesignWidth="1920"
     mc:Ignorable="d">
     <StackPanel Margin="0,0,8,8">
-        <TextBlock
-            Margin="0,0,0,16"
-            Style="{StaticResource MaterialDesignHeadline4TextBlock}"
-            Text="Tabs" />
 
         <TextBlock
-            Margin="0,0,0,8"
+            Margin="0,0,0,20"
             Style="{StaticResource MaterialDesignHeadline5TextBlock}"
             Text="Default style" />
 
         <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_1_default" HorizontalAlignment="Left">
             <TabControl Width="300">
                 <TabItem Header="TAB 1">
-                    <TextBlock Margin="8" Text="PrimaryLight Tab 1" />
+                    <TextBlock Margin="8" Text="Default Tab 1" />
                 </TabItem>
                 <TabItem Header="TAB 2">
-                    <TextBlock Margin="8" Text="PrimaryLight Tab 2" />
-                </TabItem>
-            </TabControl>
-        </smtx:XamlDisplay>
-
-        <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_custom_1" HorizontalAlignment="Left">
-            <TabControl Width="300"
-                        Style="{StaticResource MaterialDesignFilledTabControl}"
-                        materialDesign:ColorZoneAssist.Mode="Custom"
-                        materialDesign:ColorZoneAssist.Foreground="{DynamicResource PrimaryHueMidBrush}"
-                        materialDesign:ColorZoneAssist.Background="{DynamicResource MaterialDesignCardBackground}">
-                <TabItem Header="TAB 1">
-                    <TextBlock Margin="8" Text="PrimaryLight Tab 1" />
-                </TabItem>
-                <TabItem Header="TAB 2">
-                    <TextBlock Margin="8" Text="PrimaryLight Tab 2" />
+                    <TextBlock Margin="8" Text="Default Tab 2" />
                 </TabItem>
             </TabControl>
         </smtx:XamlDisplay>
 
         <WrapPanel Margin="0,0,0,16">
             <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_1">
-                <materialDesign:Card>
-                    <TabControl Width="300" materialDesign:ColorZoneAssist.Mode="PrimaryLight">
-                        <TabItem Header="TAB 1">
-                            <TextBlock Margin="8" Text="PrimaryLight Tab 1" />
-                        </TabItem>
-                        <TabItem Header="TAB 2">
-                            <TextBlock Margin="8" Text="PrimaryLight Tab 2" />
-                        </TabItem>
-                    </TabControl>
-                </materialDesign:Card>
+                <TabControl Width="300" materialDesign:ColorZoneAssist.Mode="PrimaryLight">
+                    <TabItem Header="TAB 1">
+                        <TextBlock Margin="8" Text="PrimaryLight Tab 1" />
+                    </TabItem>
+                    <TabItem Header="TAB 2">
+                        <TextBlock Margin="8" Text="PrimaryLight Tab 2" />
+                    </TabItem>
+                </TabControl>
             </smtx:XamlDisplay>
 
             <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_2">
-                <materialDesign:Card>
-                    <TabControl Width="300" materialDesign:ColorZoneAssist.Mode="PrimaryMid">
+                <TabControl Width="300" materialDesign:ColorZoneAssist.Mode="PrimaryMid">
                         <TabItem Header="TAB 1">
                             <TextBlock Margin="8" Text="PrimaryMid Tab 1" />
                         </TabItem>
@@ -70,69 +48,62 @@
                             <TextBlock Margin="8" Text="PrimaryMid Tab 2" />
                         </TabItem>
                     </TabControl>
-                </materialDesign:Card>
             </smtx:XamlDisplay>
 
             <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_3">
-                <materialDesign:Card>
-                    <TabControl Width="300" materialDesign:ColorZoneAssist.Mode="PrimaryDark">
-                        <TabItem Header="TAB 1">
-                            <TextBlock Margin="8" Text="PrimaryDark Tab 1" />
-                        </TabItem>
-                        <TabItem Header="TAB 2">
-                            <TextBlock Margin="8" Text="PrimaryDark Tab 2" />
-                        </TabItem>
-                    </TabControl>
-
-                </materialDesign:Card>
+                <TabControl Width="300" materialDesign:ColorZoneAssist.Mode="PrimaryDark">
+                    <TabItem Header="TAB 1">
+                        <TextBlock Margin="8" Text="PrimaryDark Tab 1" />
+                    </TabItem>
+                    <TabItem Header="TAB 2">
+                        <TextBlock Margin="8" Text="PrimaryDark Tab 2" />
+                    </TabItem>
+                </TabControl>
             </smtx:XamlDisplay>
         </WrapPanel>
 
-        <WrapPanel Margin="0,0,0,16">
+        <WrapPanel>
             <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_4">
-                <materialDesign:Card>
-                    <TabControl Width="300" materialDesign:ColorZoneAssist.Mode="SecondaryLight">
-                        <TabItem Header="TAB 1">
-                            <TextBlock Margin="8" Text="SecondaryLight Tab 1" />
-                        </TabItem>
-                        <TabItem Header="TAB 2">
-                            <TextBlock Margin="8" Text="SecondaryLight Tab 2" />
-                        </TabItem>
-                    </TabControl>
-                </materialDesign:Card>
+                <TabControl Width="300" materialDesign:ColorZoneAssist.Mode="SecondaryLight">
+                    <TabItem Header="TAB 1">
+                        <TextBlock Margin="8" Text="SecondaryLight Tab 1" />
+                    </TabItem>
+                    <TabItem Header="TAB 2">
+                        <TextBlock Margin="8" Text="SecondaryLight Tab 2" />
+                    </TabItem>
+                </TabControl>
             </smtx:XamlDisplay>
 
             <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_5">
-                <materialDesign:Card>
-                    <TabControl Width="300" materialDesign:ColorZoneAssist.Mode="SecondaryMid">
-                        <TabItem Header="TAB 1">
-                            <TextBlock Margin="8" Text="SecondaryMid Tab 1" />
-                        </TabItem>
-                        <TabItem Header="TAB 2">
-                            <TextBlock Margin="8" Text="SecondaryMid Tab 2" />
-                        </TabItem>
-                    </TabControl>
-                </materialDesign:Card>
+                <TabControl Width="300" materialDesign:ColorZoneAssist.Mode="SecondaryMid">
+                    <TabItem Header="TAB 1">
+                        <TextBlock Margin="8" Text="SecondaryMid Tab 1" />
+                    </TabItem>
+                    <TabItem Header="TAB 2">
+                        <TextBlock Margin="8" Text="SecondaryMid Tab 2" />
+                    </TabItem>
+                </TabControl>
             </smtx:XamlDisplay>
 
             <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_6">
-                <materialDesign:Card>
-                    <TabControl Width="300" materialDesign:ColorZoneAssist.Mode="SecondaryDark">
-                        <TabItem Header="TAB 1">
-                            <TextBlock Margin="8" Text="SecondaryDark Tab 1" />
-                        </TabItem>
-                        <TabItem Header="TAB 2">
-                            <TextBlock Margin="8" Text="SecondaryDark Tab 2" />
-                        </TabItem>
-                    </TabControl>
-                </materialDesign:Card>
+                <TabControl Width="300" materialDesign:ColorZoneAssist.Mode="SecondaryDark">
+                    <TabItem Header="TAB 1">
+                        <TextBlock Margin="8" Text="SecondaryDark Tab 1" />
+                    </TabItem>
+                    <TabItem Header="TAB 2">
+                        <TextBlock Margin="8" Text="SecondaryDark Tab 2" />
+                    </TabItem>
+                </TabControl>
             </smtx:XamlDisplay>
         </WrapPanel>
 
+        <Separator Style="{DynamicResource MaterialDesignSeparator}"/>
+
         <TextBlock
-            Margin="0,0,0,8"
+            Margin="0,15,0,20"
             Style="{StaticResource MaterialDesignHeadline5TextBlock}"
             Text="Filled style" />
+
 
         <WrapPanel Margin="0,0,0,16">
             <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_7">
@@ -185,7 +156,7 @@
             </smtx:XamlDisplay>
         </WrapPanel>
 
-        <WrapPanel Margin="0,0,0,16">
+        <WrapPanel>
             <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_10">
                 <materialDesign:Card>
                     <TabControl
@@ -235,58 +206,152 @@
             </smtx:XamlDisplay>
         </WrapPanel>
 
+        <Separator Style="{DynamicResource MaterialDesignSeparator}"/>
+
         <TextBlock
-            Margin="0,0,0,8"
+            Margin="0,15,0,20"
+            Style="{StaticResource MaterialDesignHeadline5TextBlock}"
+            Text="Custom style" />
+
+        <WrapPanel>
+            <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_custom_1" HorizontalAlignment="Left">
+                <TabControl Width="300"
+                        Style="{StaticResource MaterialDesignFilledTabControl}"
+                        materialDesign:ColorZoneAssist.Mode="Custom"
+                        materialDesign:ColorZoneAssist.Foreground="{DynamicResource PrimaryHueMidBrush}"
+                        materialDesign:ColorZoneAssist.Background="{DynamicResource MaterialDesignCardBackground}">
+                    <TabItem Header="TAB 1">
+                        <TextBlock Margin="8" Text="Custom Tab 1" />
+                    </TabItem>
+                    <TabItem Header="TAB 2">
+                        <TextBlock Margin="8" Text="Custom Tab 2" />
+                    </TabItem>
+                </TabControl>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_custom_2" HorizontalAlignment="Left">
+                <TabControl Width="300"
+                        Style="{StaticResource MaterialDesignFilledTabControl}"
+                        materialDesign:ColorZoneAssist.Mode="Custom"
+                        materialDesign:ColorZoneAssist.Foreground="Crimson"
+                        materialDesign:ColorZoneAssist.Background="{DynamicResource MaterialDesignCardBackground}">
+                    <TabItem Header="TAB 1">
+                        <TextBlock Margin="8" Text="Custom Tab 1" />
+                    </TabItem>
+                    <TabItem Header="TAB 2">
+                        <TextBlock Margin="8" Text="Custom Tab 2" />
+                    </TabItem>
+                </TabControl>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_custom_3" HorizontalAlignment="Left">
+                <TabControl Width="300"
+                        Style="{StaticResource MaterialDesignFilledTabControl}"
+                        materialDesign:ColorZoneAssist.Mode="Custom"
+                        materialDesign:ColorZoneAssist.Foreground="White"
+                        materialDesign:ColorZoneAssist.Background="Crimson">
+                    <TabItem Header="TAB 1">
+                        <TextBlock Margin="8" Text="Custom Tab 1" />
+                    </TabItem>
+                    <TabItem Header="TAB 2">
+                        <TextBlock Margin="8" Text="Custom Tab 2" />
+                    </TabItem>
+                </TabControl>
+            </smtx:XamlDisplay>
+
+        </WrapPanel>
+
+        <WrapPanel>
+            <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_custom_4" HorizontalAlignment="Left">
+                <TabControl Width="300"
+                        materialDesign:ColorZoneAssist.Mode="Custom"
+                        materialDesign:ColorZoneAssist.Foreground="Crimson">
+                    <TabItem Header="TAB 1">
+                        <TextBlock Margin="8" Text="Custom Tab 1" />
+                    </TabItem>
+                    <TabItem Header="TAB 2">
+                        <TextBlock Margin="8" Text="Custom Tab 2" />
+                    </TabItem>
+                </TabControl>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_custom_5" HorizontalAlignment="Left">
+                <TabControl Width="300"
+                        materialDesign:ColorZoneAssist.Mode="Custom"
+                        materialDesign:ColorZoneAssist.Foreground="Gold">
+                    <TabItem Header="TAB 1">
+                        <TextBlock Margin="8" Text="Custom Tab 1" />
+                    </TabItem>
+                    <TabItem Header="TAB 2">
+                        <TextBlock Margin="8" Text="Custom Tab 2" />
+                    </TabItem>
+                </TabControl>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_custom_6" HorizontalAlignment="Left">
+                <TabControl Width="300"
+                        materialDesign:ColorZoneAssist.Mode="Custom"
+                        materialDesign:ColorZoneAssist.Foreground="DeepSkyBlue">
+                    <TabItem Header="TAB 1">
+                        <TextBlock Margin="8" Text="Custom Tab 1" />
+                    </TabItem>
+                    <TabItem Header="TAB 2">
+                        <TextBlock Margin="8" Text="Custom Tab 2" />
+                    </TabItem>
+                </TabControl>
+            </smtx:XamlDisplay>
+
+        </WrapPanel>
+
+        <Separator Style="{DynamicResource MaterialDesignSeparator}"/>
+
+        <TextBlock
+            Margin="0,15,0,20"
             Style="{StaticResource MaterialDesignHeadline5TextBlock}"
             Text="Placement" />
 
+
         <WrapPanel>
             <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_13">
-                <materialDesign:Card>
-                    <TabControl
+                <TabControl
                         Width="300"
                         Height="150"
                         TabStripPlacement="Left">
-                        <TabItem Header="TAB 1">
-                            <TextBlock Margin="8" Text="Left placement" />
-                        </TabItem>
-                        <TabItem Header="TAB 2">
-                            <TextBlock Margin="8" Text="Left placement" />
-                        </TabItem>
-                    </TabControl>
-                </materialDesign:Card>
+                    <TabItem Header="TAB 1">
+                        <TextBlock Margin="8" Text="Left placement" />
+                    </TabItem>
+                    <TabItem Header="TAB 2">
+                        <TextBlock Margin="8" Text="Left placement" />
+                    </TabItem>
+                </TabControl>
             </smtx:XamlDisplay>
 
             <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_14">
-                <materialDesign:Card>
-                    <TabControl
+                <TabControl
                         Width="300"
                         Height="150"
                         TabStripPlacement="Right">
-                        <TabItem Header="TAB 1">
-                            <TextBlock Margin="8" Text="Right placement tab 1" />
-                        </TabItem>
-                        <TabItem Header="TAB 2">
-                            <TextBlock Margin="8" Text="Right placement tab 2" />
-                        </TabItem>
-                    </TabControl>
-                </materialDesign:Card>
+                    <TabItem Header="TAB 1">
+                        <TextBlock Margin="8" Text="Right placement tab 1" />
+                    </TabItem>
+                    <TabItem Header="TAB 2">
+                        <TextBlock Margin="8" Text="Right placement tab 2" />
+                    </TabItem>
+                </TabControl>
             </smtx:XamlDisplay>
 
             <smtx:XamlDisplay Margin="0,0,16,16" UniqueKey="tabs_15">
-                <materialDesign:Card>
-                    <TabControl
+                <TabControl
                         Width="300"
                         Height="150"
                         TabStripPlacement="Bottom">
-                        <TabItem Header="TAB 1">
-                            <TextBlock Margin="8" Text="Bottom placement tab 1" />
-                        </TabItem>
-                        <TabItem Header="TAB 2">
-                            <TextBlock Margin="8" Text="Bottom placement tab 2" />
-                        </TabItem>
-                    </TabControl>
-                </materialDesign:Card>
+                    <TabItem Header="TAB 1">
+                        <TextBlock Margin="8" Text="Bottom placement tab 1" />
+                    </TabItem>
+                    <TabItem Header="TAB 2">
+                        <TextBlock Margin="8" Text="Bottom placement tab 2" />
+                    </TabItem>
+                </TabControl>
             </smtx:XamlDisplay>
         </WrapPanel>
 
@@ -352,10 +417,13 @@
             </smtx:XamlDisplay>
         </WrapPanel>
 
+        <Separator Style="{DynamicResource MaterialDesignSeparator}"/>
+
         <TextBlock
-            Margin="0,0,0,8"
+            Margin="0,15,0,20"
             Style="{StaticResource MaterialDesignHeadline5TextBlock}"
             Text="Different sizes" />
+
 
         <StackPanel>
             <smtx:XamlDisplay Margin="0,0,0,16" UniqueKey="tabs_19">

--- a/MaterialDesignThemes.Wpf/TabAssist.cs
+++ b/MaterialDesignThemes.Wpf/TabAssist.cs
@@ -1,0 +1,13 @@
+﻿namespace MaterialDesignThemes.Wpf
+{
+    public static class TabAssist
+    {
+        public static readonly DependencyProperty HasFilledTabProperty = DependencyProperty.RegisterAttached(
+            "HasFilledTab", typeof(bool), typeof(TabAssist), new PropertyMetadata(false));
+
+        public static void SetHasFilledTab(DependencyObject element, bool value) => element.SetValue(HasFilledTabProperty, value);
+
+        public static bool GetHasFilledTab(DependencyObject element) => (bool)element.GetValue(HasFilledTabProperty);
+
+    }
+}

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -27,13 +27,14 @@
     </Style>
 
     <Style x:Key="MaterialDesignTabControlBase" TargetType="{x:Type TabControl}">
+        <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesignFlatButtonRipple}" />
-        <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth3" />
         <Setter Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid" />
+        <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth3" />
         <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Bottom" />
         <Setter Property="Template">
             <Setter.Value>
@@ -140,37 +141,16 @@
         BasedOn="{StaticResource MaterialDesignTabControlBase}"
         TargetType="{x:Type TabControl}">
         <Setter Property="Background" Value="Transparent" />
+        <Setter Property="wpf:TabAssist.HasFilledTab" Value="False" />
         <Setter Property="wpf:ColorZoneAssist.Background" Value="Transparent" />
-
-        <Style.Triggers>
-            <Trigger Property="wpf:ColorZoneAssist.Mode" Value="Standard">
-                <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource MaterialDesignBody}" />
-            </Trigger>
-            <Trigger Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid">
-                <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
-            </Trigger>
-            <Trigger Property="wpf:ColorZoneAssist.Mode" Value="PrimaryLight">
-                <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
-            </Trigger>
-            <Trigger Property="wpf:ColorZoneAssist.Mode" Value="PrimaryDark">
-                <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
-            </Trigger>
-            <Trigger Property="wpf:ColorZoneAssist.Mode" Value="SecondaryLight">
-                <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource SecondaryHueLightBrush}" />
-            </Trigger>
-            <Trigger Property="wpf:ColorZoneAssist.Mode" Value="SecondaryMid">
-                <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource SecondaryHueMidBrush}" />
-            </Trigger>
-            <Trigger Property="wpf:ColorZoneAssist.Mode" Value="SecondaryDark">
-                <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource SecondaryHueDarkBrush}" />
-            </Trigger>
-        </Style.Triggers>
+        <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource MaterialDesignBody}" />
     </Style>
 
     <Style
         x:Key="MaterialDesignFilledTabControl"
         BasedOn="{StaticResource MaterialDesignTabControlBase}"
         TargetType="{x:Type TabControl}">
+        <Setter Property="wpf:TabAssist.HasFilledTab" Value="True" />
 
         <Style.Triggers>
             <Trigger Property="wpf:ColorZoneAssist.Mode" Value="Standard">
@@ -206,19 +186,18 @@
 
     <Style x:Key="MaterialDesignTabItem" TargetType="{x:Type TabItem}">
         <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}" />
-
-        <Setter Property="Background" Value="{x:Null}" />
+        <Setter Property="Background" Value="Transparent" />
         <!--  Foreground is for the content, not the header  -->
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
-
         <Setter Property="Padding" Value="16,12" />
         <Setter Property="Height" Value="48" />
         <Setter Property="MinWidth" Value="90" />
         <Setter Property="MaxWidth" Value="360" />
         <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesignFlatButtonRipple}" />
         <Setter Property="wpf:ColorZoneAssist.Mode" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(wpf:ColorZoneAssist.Mode)}" />
-        <Setter Property="wpf:ColorZoneAssist.Background" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(wpf:ColorZoneAssist.Background)}" />
+        <Setter Property="wpf:ColorZoneAssist.Background" Value="Transparent" />
         <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(wpf:ColorZoneAssist.Foreground)}" />
+        <Setter Property="wpf:TabAssist.HasFilledTab" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(wpf:TabAssist.HasFilledTab)}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabItem}">
@@ -228,7 +207,9 @@
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
                             Focusable="False"
-                            Mode="{TemplateBinding wpf:ColorZoneAssist.Mode}"
+                            wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
+                            wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}"
+                            Mode="Custom"
                             x:Name="ColorZoneHeader">
                             <wpf:Ripple
                                 x:Name="contentPresenter"
@@ -320,6 +301,57 @@
                         <DataTrigger Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right">
                             <Setter TargetName="SelectionHighlightBorder" Property="BorderThickness" Value="2,0,0,0" />
                         </DataTrigger>
+
+                        <!--  Header foreground color change when focused -->
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                                <Condition Property="IsSelected" Value="True" />
+                                <Condition Property="wpf:ColorZoneAssist.Mode" Value="Standard" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource MaterialDesignBody}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                                <Condition Property="IsSelected" Value="True" />
+                                <Condition Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                                <Condition Property="IsSelected" Value="True" />
+                                <Condition Property="wpf:ColorZoneAssist.Mode" Value="PrimaryDark" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                                <Condition Property="IsSelected" Value="True" />
+                                <Condition Property="wpf:ColorZoneAssist.Mode" Value="SecondaryLight" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource SecondaryHueLightBrush}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                                <Condition Property="IsSelected" Value="True" />
+                                <Condition Property="wpf:ColorZoneAssist.Mode" Value="SecondaryMid" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource SecondaryHueMidBrush}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                                <Condition Property="IsSelected" Value="True" />
+                                <Condition Property="wpf:ColorZoneAssist.Mode" Value="SecondaryDark" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource SecondaryHueDarkBrush}" />
+                        </MultiTrigger>
+                        
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -138,8 +138,9 @@
         TargetType="{x:Type TabControl}">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="wpf:TabAssist.HasFilledTab" Value="False" />
+        <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth0" />
+        <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="None" />
         <Setter Property="wpf:ColorZoneAssist.Background" Value="Transparent" />
-        <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource MaterialDesignBody}" />
     </Style>
 
     <Style
@@ -176,6 +177,10 @@
             <Trigger Property="wpf:ColorZoneAssist.Mode" Value="SecondaryDark">
                 <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource SecondaryHueDarkForegroundBrush}" />
                 <Setter Property="wpf:ColorZoneAssist.Background" Value="{DynamicResource SecondaryHueDarkBrush}" />
+            </Trigger>
+            <Trigger Property="wpf:ColorZoneAssist.Mode" Value="Custom">
+                <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}" />
+                <Setter Property="wpf:ColorZoneAssist.Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}" />
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -298,7 +303,12 @@
                             <Setter TargetName="SelectionHighlightBorder" Property="BorderThickness" Value="2,0,0,0" />
                         </DataTrigger>
 
-                        <!--  Header foreground color change when focused -->
+                        <!--  Force the header foreground do be MaterialDesignBody by default (only for not filled tabs) -->
+                        <Trigger Property="wpf:TabAssist.HasFilledTab" Value="False">
+                            <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource MaterialDesignBody}" />
+                        </Trigger>
+
+                        <!-- The header foreground color change when focused (only for not filled tabs) -->
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
@@ -347,7 +357,14 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource SecondaryHueDarkBrush}" />
                         </MultiTrigger>
-                        
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                                <Condition Property="IsSelected" Value="True" />
+                                <Condition Property="wpf:ColorZoneAssist.Mode" Value="Custom" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}" />
+                        </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -34,29 +34,26 @@
         <Setter Property="Padding" Value="0" />
         <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesignFlatButtonRipple}" />
         <Setter Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid" />
-        <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth3" />
+        <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth2" />
         <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Bottom" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabControl}">
                     <DockPanel KeyboardNavigation.TabNavigation="Local">
-                        <wpf:Card
-                            x:Name="PART_HeaderCard"
-                            VerticalAlignment="Stretch"
-                            wpf:ShadowAssist.ShadowDepth="{TemplateBinding wpf:ShadowAssist.ShadowDepth}"
-                            wpf:ShadowAssist.ShadowEdges="{TemplateBinding wpf:ShadowAssist.ShadowEdges}"
-                            DockPanel.Dock="Top"
-                            Focusable="False">
-                            <wpf:ColorZone
+                        <wpf:ColorZone
+                                x:Name="PART_HeaderZone"
+                                wpf:ShadowAssist.ShadowDepth="{TemplateBinding wpf:ShadowAssist.ShadowDepth}"
+                                wpf:ShadowAssist.ShadowEdges="{TemplateBinding wpf:ShadowAssist.ShadowEdges}"
                                 VerticalAlignment="Stretch"
                                 Background="{TemplateBinding wpf:ColorZoneAssist.Background}"
+                                DockPanel.Dock="Top"
                                 Focusable="False">
-                                <ScrollViewer
+                            <ScrollViewer
                                     wpf:ScrollViewerAssist.SupportHorizontalScroll="True"
                                     HorizontalScrollBarVisibility="Hidden"
                                     VerticalScrollBarVisibility="Hidden">
-                                    <StackPanel>
-                                        <UniformGrid
+                                <StackPanel>
+                                    <UniformGrid
                                             x:Name="CenteredHeaderPanel"
                                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -64,7 +61,7 @@
                                             IsItemsHost="True"
                                             KeyboardNavigation.TabIndex="1"
                                             Rows="1" />
-                                        <VirtualizingStackPanel
+                                    <VirtualizingStackPanel
                                             x:Name="HeaderPanel"
                                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -72,10 +69,9 @@
                                             IsItemsHost="True"
                                             KeyboardNavigation.TabIndex="1"
                                             Orientation="Horizontal" />
-                                    </StackPanel>
-                                </ScrollViewer>
-                            </wpf:ColorZone>
-                        </wpf:Card>
+                                </StackPanel>
+                            </ScrollViewer>
+                        </wpf:ColorZone>
                         <Border
                             x:Name="PART_BorderSelectedContent"
                             Padding="{TemplateBinding Padding}"
@@ -115,17 +111,17 @@
                             <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Collapsed" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
-                            <Setter TargetName="PART_HeaderCard" Property="DockPanel.Dock" Value="Bottom" />
+                            <Setter TargetName="PART_HeaderZone" Property="DockPanel.Dock" Value="Bottom" />
                             <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Top" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Left">
-                            <Setter TargetName="PART_HeaderCard" Property="DockPanel.Dock" Value="Left" />
+                            <Setter TargetName="PART_HeaderZone" Property="DockPanel.Dock" Value="Left" />
                             <Setter TargetName="CenteredHeaderPanel" Property="Rows" Value="0" />
                             <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Right" />
                             <Setter TargetName="CenteredHeaderPanel" Property="Columns" Value="1" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
-                            <Setter TargetName="PART_HeaderCard" Property="DockPanel.Dock" Value="Right" />
+                            <Setter TargetName="PART_HeaderZone" Property="DockPanel.Dock" Value="Right" />
                             <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Left" />
                             <Setter TargetName="CenteredHeaderPanel" Property="Rows" Value="0" />
                             <Setter TargetName="CenteredHeaderPanel" Property="Columns" Value="1" />


### PR DESCRIPTION
Fix https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2666 and https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2660

This task was painful because of the ColorZone. I think it would have been easier to use attached properties (for example: Background, Foreground and ShadowDepth).
In the end, I kept the ColorZone system and managed to fix the problems. I also modified a few things. Here are the changes:
- The background color was applied to the TabControl header and the TabItem header. I corrected this so that the color is only applied on the TabControl header.

- Concerning the style, I remake the default style (not filled)

- As you can see in the specs, the colored foreground in only apply on the focused item.
![image](https://user-images.githubusercontent.com/54487782/178934213-9841c08f-546d-49e4-85c4-df0935d3d554.png)
It was not the case in MDIX, so I fixed that.

- I added the possibility to use custom colors

- I reduced the shadow depth

- I added examples in the demo

# Final result
[![Result](https://yt-embed.herokuapp.com/embed?v=YVzpWNdc-TI)](https://www.youtube.com/watch?v=YVzpWNdc-TI "Result")