### PR TITLE
Allow MenuAssist.TopLevelMenuItemHeight to change the height of top level items (with no sub items)

### DIFF
--- a/MainDemo.Wpf/MenusAndToolBars.xaml
+++ b/MainDemo.Wpf/MenusAndToolBars.xaml
@@ -93,16 +93,17 @@
             HorizontalAlignment="Left"
             Margin="0 0 0 15">
             <Menu materialDesign:MenuAssist.TopLevelMenuItemHeight="25">
+                <MenuItem Header="Very">
+                    <MenuItem Header="Item 1"/>
+                    <MenuItem Header="Item 2"/>
+                    <MenuItem Header="Item 3"/>
+                </MenuItem>
                 <MenuItem Header="Small">
                     <MenuItem Header="Item 1"/>
                     <MenuItem Header="Item 2"/>
                     <MenuItem Header="Item 3"/>
                 </MenuItem>
-                <MenuItem Header="Menu">
-                    <MenuItem Header="Item 1"/>
-                    <MenuItem Header="Item 2"/>
-                    <MenuItem Header="Item 3"/>
-                </MenuItem>
+                <MenuItem Header="Menu" />
             </Menu>
         </smtx:XamlDisplay>
 
@@ -110,16 +111,17 @@
             UniqueKey="customHeightMenu2"
             HorizontalAlignment="Left">
             <Menu materialDesign:MenuAssist.TopLevelMenuItemHeight="80">
+                <MenuItem Header="Very">
+                    <MenuItem Header="Item 1"/>
+                    <MenuItem Header="Item 2"/>
+                    <MenuItem Header="Item 3"/>
+                </MenuItem>
                 <MenuItem Header="Big">
                     <MenuItem Header="Item 1"/>
                     <MenuItem Header="Item 2"/>
                     <MenuItem Header="Item 3"/>
                 </MenuItem>
-                <MenuItem Header="Menu">
-                    <MenuItem Header="Item 1"/>
-                    <MenuItem Header="Item 2"/>
-                    <MenuItem Header="Item 3"/>
-                </MenuItem>
+                <MenuItem Header="Menu" />
             </Menu>
         </smtx:XamlDisplay>
 
@@ -143,16 +145,17 @@
                 HorizontalAlignment="Left">
                 <materialDesign:Card>
                     <Menu materialDesign:MenuAssist.TopLevelMenuItemHeight="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type materialDesign:Card}},Path=ActualHeight}">
-                        <MenuItem Header="Adaptive">
+                        <MenuItem Header="File">
                             <MenuItem Header="Item 1"/>
                             <MenuItem Header="Item 2"/>
                             <MenuItem Header="Item 3"/>
                         </MenuItem>
-                        <MenuItem Header="Menu">
+                        <MenuItem Header="Edit">
                             <MenuItem Header="Item 1"/>
                             <MenuItem Header="Item 2"/>
                             <MenuItem Header="Item 3"/>
                         </MenuItem>
+                        <MenuItem Header="About" />
                     </Menu>
                 </materialDesign:Card>
             </smtx:XamlDisplay>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
@@ -359,7 +359,7 @@
                                 Value="16 0" />
                             <Setter
                                 Property="Height"
-                                Value="48" />
+                                Value="{Binding Path=(wpf:MenuAssist.TopLevelMenuItemHeight), RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=MenuBase}}" />
                             <Setter
                                 TargetName="templateRoot"
                                 Property="CornerRadius"


### PR DESCRIPTION
I made the changes mentioned in #2794 

The `MenuAssist.TopLevelMenuItemHeight` property now also affects `MenuItem`s that have now sub items.