### PR TITLE
Fix default elevation of Card Flipper

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/Flippers/FlipperTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/Flippers/FlipperTests.cs
@@ -1,4 +1,4 @@
-﻿namespace MaterialDesignThemes.UITests.WPF.Flippers;
+namespace MaterialDesignThemes.UITests.WPF.Flippers;
 
 public class FlipperTests : TestBase
 {
@@ -48,6 +48,26 @@ public class FlipperTests : TestBase
         Assert.Equal(5, internalBorderCornerRadius.Value.TopRight);
         Assert.Equal(5, internalBorderCornerRadius.Value.BottomRight);
         Assert.Equal(5, internalBorderCornerRadius.Value.BottomLeft);
+
+        recorder.Success();
+    }
+
+    [Fact]
+    public async Task Flipper_ElevatedCardStyleApplied_AppliesDefaultElevation()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        //Arrange
+        IVisualElement<Flipper> flipper = await LoadXaml<Flipper>(
+            @"<materialDesign:Flipper Style=""{StaticResource MaterialDesignCardFlipper}"" materialDesign:FlipperAssist.CardStyle=""{StaticResource MaterialDesignElevatedCard}"" />");
+        IVisualElement<Card> internalCard = await flipper.GetElement<Card>();
+
+        //Act
+        // TODO: This throws an exception because it fails to load the 'MaterialDesignTheme.Shadows.xaml' resource dictionary in the ElevationAssist static ctor
+        Elevation? defaultElevation = await internalCard.GetProperty<Elevation>(ElevationAssist.ElevationProperty);
+
+        //Assert
+        Assert.Equal(Elevation.Dp1, defaultElevation);
 
         recorder.Success();
     }

--- a/MaterialDesignThemes.Wpf/ElevationAssist.cs
+++ b/MaterialDesignThemes.Wpf/ElevationAssist.cs
@@ -18,17 +18,11 @@ public enum Elevation
     Dp24
 }
 
-public static class ElevationAssist
+internal static class ElevationInfo
 {
     private static readonly IDictionary<Elevation, DropShadowEffect?> ShadowsDictionary;
 
-    public static readonly DependencyProperty ElevationProperty = DependencyProperty.RegisterAttached(
-        "Elevation",
-        typeof(Elevation),
-        typeof(ElevationAssist),
-        new FrameworkPropertyMetadata(default(Elevation), FrameworkPropertyMetadataOptions.AffectsRender));
-
-    static ElevationAssist()
+    static ElevationInfo()
     {
         const string shadowsUri = "pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml";
         var resourceDictionary = new ResourceDictionary { Source = new Uri(shadowsUri, UriKind.Absolute) };
@@ -50,8 +44,20 @@ public static class ElevationAssist
         };
     }
 
+    public static DropShadowEffect? GetDropShadow(Elevation elevation) => ShadowsDictionary[elevation];
+}
+
+public static class ElevationAssist
+{
+
+    public static readonly DependencyProperty ElevationProperty = DependencyProperty.RegisterAttached(
+        "Elevation",
+        typeof(Elevation),
+        typeof(ElevationAssist),
+        new FrameworkPropertyMetadata(default(Elevation), FrameworkPropertyMetadataOptions.AffectsRender));
+
     public static void SetElevation(DependencyObject element, Elevation value) => element.SetValue(ElevationProperty, value);
     public static Elevation GetElevation(DependencyObject element) => (Elevation)element.GetValue(ElevationProperty);
 
-    public static DropShadowEffect? GetDropShadow(Elevation elevation) => ShadowsDictionary[elevation];
+    public static DropShadowEffect? GetDropShadow(Elevation elevation) => ElevationInfo.GetDropShadow(elevation);
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Flipper.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Flipper.xaml
@@ -97,6 +97,7 @@
     </Style>
 
     <Style x:Key="MaterialDesignCardFlipper" TargetType="{x:Type wpf:Flipper}" BasedOn="{StaticResource {x:Type wpf:Flipper}}">
+        <Setter Property="wpf:ElevationAssist.Elevation" Value="Dp1" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type wpf:Flipper}">


### PR DESCRIPTION
Partial fix for #2729

This fixes the broken default elevation of the (Card) Flipper. It was a simple matter of a default elevation not being set on the MaterialDesignCardFlipper style.

I added a UI test to ensure this default is applied, but it fails because of the static constructor in FlipperAssist. I was unable to get this to work and may need some input on how to get it to locate the resource with the Uri when executing in the MaterialDesignThemes.UITests context.