### PR TITLE
Restored inactive calendar buttons

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
@@ -114,7 +114,7 @@ public class ComboBoxTests : TestBase
 
         IVisualElement<ContextMenu>? contextMenu = await comboBox.GetContextMenu();
         Assert.True(contextMenu is not null, "No context menu set on the ComboBox");
-
+        await Wait.For(async () => await contextMenu!.GetIsVisible());
         await AssertMenu("Cut");
         await AssertMenu("Copy");
         await AssertMenu("Paste");

--- a/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Threading.Tasks;
 using System.Windows.Controls;
 using XamlTest;
@@ -41,9 +42,10 @@ namespace MaterialDesignThemes.UITests.WPF.DatePickers
         {
             await using var recorder = new TestRecorder(App);
 
+            string dateString = DateTime.Today.ToString("d", CultureInfo.GetCultureInfoByIetfLanguageTag("en-US"));
             var stackPanel = await LoadXaml<StackPanel>($@"
 <StackPanel>
-    <DatePicker SelectedDate=""{DateTime.Today:d}"" materialDesign:TextFieldAssist.HasClearButton=""True""/>
+    <DatePicker SelectedDate=""{dateString}"" materialDesign:TextFieldAssist.HasClearButton=""True""/>
 </StackPanel>");
             var datePicker = await stackPanel.GetElement<DatePicker>("/DatePicker");
             var clearButton = await datePicker.GetElement<Button>("PART_ClearButton");

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
@@ -42,7 +42,7 @@
                                 <VisualState x:Name="Disabled">
                                     <Storyboard>
                                         <DoubleAnimation Duration="0" To="0" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="HighlightBackground"/>
-                                        <DoubleAnimation Duration="0" To=".35" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="NormalText"/>
+                                        <DoubleAnimation Duration="0" To=".38" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="NormalText"/>
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
@@ -116,22 +116,16 @@
                                  StrokeThickness="1" RadiusX="15" RadiusY="15" Height="30"/>
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsFocused" Value="False">
+                        <Trigger Property="HasSelectedDays" Value="False">
                             <Setter TargetName="NormalText" Property="TextElement.Foreground" Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}}"/>
+                        </Trigger>
+                        <Trigger Property="IsInactive" Value="True">
+                            <Setter TargetName="NormalText" Property="Opacity" Value="0.56" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-        <Style.Triggers>
-            <Trigger Property="IsInactive"
-                     Value="True">
-                <Setter Property="MinHeight"
-                        Value="0" />
-                <Setter Property="MaxHeight"
-                        Value="0" />
-            </Trigger>
-        </Style.Triggers>
     </Style>
 
     <Style x:Key="MaterialDesignCalendarDayButton" TargetType="{x:Type CalendarDayButton}">
@@ -233,11 +227,7 @@
                                         <DoubleAnimation Duration="0"
                                                          To="0"
                                                          Storyboard.TargetProperty="Opacity"
-                                                         Storyboard.TargetName="HighlightingBorder"/>
-                                        <DoubleAnimation Duration="0"
-                                                         To="0.38"
-                                                         Storyboard.TargetProperty="Opacity" 
-                                                         Storyboard.TargetName="NormalText" />
+                                                         Storyboard.TargetName="HighlightBackground"/>
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
@@ -274,22 +264,19 @@
                         <Trigger Property="IsSelected" Value="False">
                             <Setter TargetName="NormalText" Property="TextElement.Foreground" Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}}"/>
                         </Trigger>
+                        <Trigger Property="IsInactive" Value="True">
+                            <Setter TargetName="NormalText" Property="Opacity" Value="0.56" />
+                        </Trigger>
+                        <Trigger Property="IsBlackedOut" Value="True">
+                            <Setter TargetName="NormalText" Property="Opacity" Value="0.38" />
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Style.Triggers>
-            <Trigger Property="IsInactive"
-                     Value="True">
-                <Setter Property="MinHeight"
-                        Value="0" />
-                <Setter Property="MaxHeight"
-                        Value="0" />
-            </Trigger>
-            <Trigger Property="IsBlackedOut"
-                     Value="True">
-                <Setter Property="Cursor"
-                        Value="No" />
+            <Trigger Property="IsBlackedOut" Value="True">
+                <Setter Property="Cursor" Value="Arrow" />
             </Trigger>
         </Style.Triggers>
     </Style>


### PR DESCRIPTION
Fixes #2799

This PR restores the missing calendar buttons. Both years that are not within the selected decade and days that are not within the selected month are restored by this fix. WPF refers to these buttons as Inactive, but are meant to be clickable.

The cause of this "bug" can be traced all the way back to #142, where a choice was made to hide the inactive buttons because they can be confused with [Blackout Dates](https://docs.microsoft.com/en-us/dotnet/api/system.windows.controls.calendar.blackoutdates). I opted to instead use different levels of foreground opacity, where the blackout dates appear disabled. To make the blackout dates behave more like disabled elements I also set `Cursor` to `Arrow` and hid the highlight background. In my opinion these changes make inactive and blackout dates different enough, especially if we can assume that the blackout dates feature is not used very often.

An option would be to hide the inactive buttons on the month view, and only show them in the year view. Personally I like instead opting for the default WPF behavior. The [MD specs](https://material.io/components/date-pickers) seem to be inconsistent on this, as some screenshots show days in neighboring months and others don't.

![CalendarYears](https://user-images.githubusercontent.com/1404846/182038937-d3952c8f-5582-4e46-aa77-fc5ec7fec1a7.png) ![CalendarDays](https://user-images.githubusercontent.com/1404846/182039077-fa6da8ee-d97a-422d-90f1-41a23076ca2c.png)

### Notes
- I switched to using template triggers instead of visual states for the text opacity, to fix an issue where blackout dates would in a few cases get the wrong opacity
- Changed trigger property from `IsFocused` to `HasSelectedDays` to fix issue where the wrong months text would be changed
- I fixed a `DatePicker` test that failed on my PC, due to my local culture settings using `dd.MM.yyyy` instead of `MM.dd.yyyy`, it now works regardless of local settings
