### PR TITLE
Added CornerRadius to DialogHost

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
@@ -26,7 +26,7 @@ namespace MaterialDesignThemes.UITests.WPF.DialogHosts
             await using var recorder = new TestRecorder(App);
 
             IVisualElement dialogHost = await LoadUserControl<WithCounter>();
-            var overlay = await dialogHost.GetElement<Border>("ContentCoverBorder");
+            var overlay = await dialogHost.GetElement<Grid>("PART_ContentCoverGrid");
 
             var resultTextBlock = await dialogHost.GetElement<TextBlock>("ResultTextBlock");
             await Wait.For(async () => await resultTextBlock.GetText() == "Clicks: 0");

--- a/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
@@ -255,5 +255,39 @@ namespace MaterialDesignThemes.UITests.WPF.DialogHosts
 
             recorder.Success();
         }
+
+        [Fact]
+        [Description("Issue 2772")]
+        public async Task CornerRadius_AppliedToContentCoverBorder_WhenSetOnDialogHost()
+        {
+            await using var recorder = new TestRecorder(App);
+
+            IVisualElement grid = await LoadXaml<Grid>(@"
+<Grid>
+  <materialDesign:DialogHost x:Name=""DialogHost"" CornerRadius=""1,2,3,4"">
+    <materialDesign:DialogHost.DialogContent>
+      <TextBlock Text=""Some Text"" />
+    </materialDesign:DialogHost.DialogContent>
+    <Button Content=""Show Dialog"" x:Name=""ShowButton"" Command=""{x:Static materialDesign:DialogHost.OpenDialogCommand}"" />
+  </materialDesign:DialogHost>
+</Grid>");
+
+            var showButton = await grid.GetElement<Button>("ShowButton");
+            var dialogHost = await grid.GetElement<DialogHost>("DialogHost");
+
+            await showButton.LeftClick();
+
+            await Wait.For(async () =>
+            {
+                var contentCoverBorder = await dialogHost.GetElement<Border>("ContentCoverBorder");
+
+                Assert.Equal(1, (await contentCoverBorder.GetCornerRadius()).TopLeft);
+                Assert.Equal(2, (await contentCoverBorder.GetCornerRadius()).TopRight);
+                Assert.Equal(3, (await contentCoverBorder.GetCornerRadius()).BottomRight);
+                Assert.Equal(4, (await contentCoverBorder.GetCornerRadius()).BottomLeft);
+            });
+
+            recorder.Success();
+        }
     }
 }

--- a/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
@@ -26,7 +26,7 @@ namespace MaterialDesignThemes.UITests.WPF.DialogHosts
             await using var recorder = new TestRecorder(App);
 
             IVisualElement dialogHost = await LoadUserControl<WithCounter>();
-            var overlay = await dialogHost.GetElement<Grid>("PART_ContentCoverGrid");
+            var overlay = await dialogHost.GetElement<Border>("ContentCoverBorder");
 
             var resultTextBlock = await dialogHost.GetElement<TextBlock>("ResultTextBlock");
             await Wait.For(async () => await resultTextBlock.GetText() == "Clicks: 0");

--- a/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
@@ -289,5 +289,39 @@ namespace MaterialDesignThemes.UITests.WPF.DialogHosts
 
             recorder.Success();
         }
+
+        [Fact]
+        [Description("Issue 2772")]
+        public async Task CornerRadius_AppliedToContentCoverBorder_WhenSetOnEmbeddedDialogHost()
+        {
+            await using var recorder = new TestRecorder(App);
+
+            IVisualElement grid = await LoadXaml<Grid>(@"
+<Grid>
+  <materialDesign:DialogHost x:Name=""DialogHost"" Style=""{StaticResource MaterialDesignEmbeddedDialogHost}"" CornerRadius=""1,2,3,4"">
+    <materialDesign:DialogHost.DialogContent>
+      <TextBlock Text=""Some Text"" />
+    </materialDesign:DialogHost.DialogContent>
+    <Button Content=""Show Dialog"" x:Name=""ShowButton"" Command=""{x:Static materialDesign:DialogHost.OpenDialogCommand}"" />
+  </materialDesign:DialogHost>
+</Grid>");
+
+            var showButton = await grid.GetElement<Button>("ShowButton");
+            var dialogHost = await grid.GetElement<DialogHost>("DialogHost");
+
+            await showButton.LeftClick();
+
+            await Wait.For(async () =>
+            {
+                var contentCoverBorder = await dialogHost.GetElement<Border>("ContentCoverBorder");
+
+                Assert.Equal(1, (await contentCoverBorder.GetCornerRadius()).TopLeft);
+                Assert.Equal(2, (await contentCoverBorder.GetCornerRadius()).TopRight);
+                Assert.Equal(3, (await contentCoverBorder.GetCornerRadius()).BottomRight);
+                Assert.Equal(4, (await contentCoverBorder.GetCornerRadius()).BottomLeft);
+            });
+
+            recorder.Success();
+        }
     }
 }

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -405,6 +405,15 @@ namespace MaterialDesignThemes.Wpf
             set => SetValue(PlacementProperty, value);
         }
 
+        public static readonly DependencyProperty CornerRadiusProperty = DependencyProperty.Register(
+            nameof(CornerRadius), typeof(CornerRadius), typeof(DialogHost), new PropertyMetadata(default(CornerRadius)));
+
+        public CornerRadius CornerRadius
+        {
+            get { return (CornerRadius) GetValue(CornerRadiusProperty); }
+            set { SetValue(CornerRadiusProperty, value); }
+        }
+
         public static readonly DependencyProperty DialogContentProperty = DependencyProperty.Register(
             nameof(DialogContent), typeof(object), typeof(DialogHost), new PropertyMetadata(default(object)));
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -30,7 +30,7 @@
                                             <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup" Storyboard.TargetProperty="IsOpen">
                                                 <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
                                             </BooleanAnimationUsingKeyFrames>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_ContentCoverGrid" Storyboard.TargetProperty="Opacity">
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentCoverBorder" Storyboard.TargetProperty="Opacity">
                                                 <EasingDoubleKeyFrame Value="0" KeyTime="0" />
                                                 <EasingDoubleKeyFrame Value="0.56" KeyTime="0:0:0.3">
                                                     <EasingDoubleKeyFrame.EasingFunction>
@@ -69,7 +69,7 @@
                                             <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup" Storyboard.TargetProperty="IsOpen">
                                                 <DiscreteBooleanKeyFrame Value="False" KeyTime="0:0:0.3" />
                                             </BooleanAnimationUsingKeyFrames>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_ContentCoverGrid" Storyboard.TargetProperty="Opacity">
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentCoverBorder" Storyboard.TargetProperty="Opacity">
                                                 <EasingDoubleKeyFrame Value="0.56" KeyTime="0" />
                                                 <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.3">
                                                     <EasingDoubleKeyFrame.EasingFunction>
@@ -113,7 +113,7 @@
                                                                         Duration="0">
                                             <DiscreteBooleanKeyFrame Value="True" KeyTime="0" />
                                         </BooleanAnimationUsingKeyFrames>
-                                        <DoubleAnimation Storyboard.TargetName="PART_ContentCoverGrid" Storyboard.TargetProperty="Opacity"
+                                        <DoubleAnimation Storyboard.TargetName="ContentCoverBorder" Storyboard.TargetProperty="Opacity"
                                                          Duration="0"
                                                          To=".56" />
                                         <DoubleAnimation Storyboard.TargetName="PART_PopupContentElement" Storyboard.TargetProperty="Opacity"
@@ -132,7 +132,7 @@
                                         <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup" Storyboard.TargetProperty="IsOpen">
                                             <DiscreteBooleanKeyFrame Value="False" KeyTime="0" />
                                         </BooleanAnimationUsingKeyFrames>
-                                        <DoubleAnimation Storyboard.TargetName="PART_ContentCoverGrid" Storyboard.TargetProperty="Opacity"
+                                        <DoubleAnimation Storyboard.TargetName="ContentCoverBorder" Storyboard.TargetProperty="Opacity"
                                                          To="0" Duration="0"/>
                                     </Storyboard>
                                 </VisualState>
@@ -193,17 +193,21 @@
                             <ContentPresenter x:Name="ContentPresenter" Opacity="1" Content="{TemplateBinding ContentControl.Content}" 
                                               ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}" ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}" />
                         </AdornerDecorator>
-                        <Grid x:Name="PART_ContentCoverGrid" Background="{Binding OverlayBackground, RelativeSource={RelativeSource TemplatedParent}}" 
-                              Opacity="0" IsHitTestVisible="False" Focusable="False">
-                            <Grid.Style>
-                                <Style TargetType="Grid">
-                                    <Style.Triggers>
-                                        <Trigger Property="Opacity" Value="0">
-                                            <Setter Property="Visibility" Value="Hidden" />
-                                        </Trigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Grid.Style>
+                        <Grid x:Name="PART_ContentCoverGrid" Background="Transparent" IsHitTestVisible="False" Focusable="False">
+                            <Grid.OpacityMask>
+                                <VisualBrush Visual="{Binding ElementName=ContentCoverBorder}" />
+                            </Grid.OpacityMask>
+                            <Border x:Name="ContentCoverBorder" Opacity="0" CornerRadius="{TemplateBinding CornerRadius}" Background="{Binding OverlayBackground, RelativeSource={RelativeSource TemplatedParent}}" IsHitTestVisible="False">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Style.Triggers>
+                                            <Trigger Property="Opacity" Value="0">
+                                                <Setter Property="Visibility" Value="Hidden" />
+                                            </Trigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                            </Border>
                         </Grid>
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -234,7 +238,7 @@
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup" Storyboard.TargetProperty="Visibility">
                                                 <DiscreteObjectKeyFrame Value="{x:Static Visibility.Visible}" KeyTime="0" />
                                             </ObjectAnimationUsingKeyFrames>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_ContentCoverGrid" Storyboard.TargetProperty="Opacity">
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentCoverBorder" Storyboard.TargetProperty="Opacity">
                                                 <EasingDoubleKeyFrame Value="0" KeyTime="0" />
                                                 <EasingDoubleKeyFrame Value="0.56" KeyTime="0:0:0.3">
                                                     <EasingDoubleKeyFrame.EasingFunction>
@@ -273,7 +277,7 @@
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup" Storyboard.TargetProperty="Visibility">
                                                 <DiscreteObjectKeyFrame Value="{x:Static Visibility.Collapsed}" KeyTime="0:0:0.3" />
                                             </ObjectAnimationUsingKeyFrames>
-                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_ContentCoverGrid" Storyboard.TargetProperty="Opacity">
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentCoverBorder" Storyboard.TargetProperty="Opacity">
                                                 <EasingDoubleKeyFrame Value="0.56" KeyTime="0" />
                                                 <EasingDoubleKeyFrame Value="0" KeyTime="0:0:0.3">
                                                     <EasingDoubleKeyFrame.EasingFunction>
@@ -317,7 +321,7 @@
                                                                        Duration="0">
                                             <DiscreteObjectKeyFrame Value="{x:Static Visibility.Visible}" KeyTime="0" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimation Storyboard.TargetName="PART_ContentCoverGrid" Storyboard.TargetProperty="Opacity"
+                                        <DoubleAnimation Storyboard.TargetName="ContentCoverBorder" Storyboard.TargetProperty="Opacity"
                                                          Duration="0"
                                                          To=".56" />
                                         <DoubleAnimation Storyboard.TargetName="PART_PopupContentElement" Storyboard.TargetProperty="Opacity"
@@ -337,7 +341,7 @@
                                                                        Duration="0">
                                             <DiscreteObjectKeyFrame Value="{x:Static Visibility.Collapsed}" KeyTime="0" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimation Storyboard.TargetName="PART_ContentCoverGrid" Storyboard.TargetProperty="Opacity"
+                                        <DoubleAnimation Storyboard.TargetName="ContentCoverBorder" Storyboard.TargetProperty="Opacity"
                                                          To="0" />
                                     </Storyboard>
                                 </VisualState>
@@ -347,18 +351,21 @@
                             x:Name="ContentPresenter" Opacity="1"
                             Content="{TemplateBinding ContentControl.Content}" ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}" ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}" />
 
-                        <Grid x:Name="PART_ContentCoverGrid"
-                              Background="{Binding OverlayBackground, RelativeSource={RelativeSource TemplatedParent}}" 
-                              Opacity="0" IsHitTestVisible="False" Focusable="False">
-                            <Grid.Style>
-                                <Style TargetType="Grid">
-                                    <Style.Triggers>
-                                        <Trigger Property="Opacity" Value="0">
-                                            <Setter Property="Visibility" Value="Hidden" />
-                                        </Trigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Grid.Style>
+                        <Grid x:Name="PART_ContentCoverGrid" Background="Transparent" IsHitTestVisible="False" Focusable="False">
+                            <Grid.OpacityMask>
+                                <VisualBrush Visual="{Binding ElementName=ContentCoverBorder}" />
+                            </Grid.OpacityMask>
+                            <Border x:Name="ContentCoverBorder" Opacity="0" CornerRadius="{TemplateBinding CornerRadius}" Background="{Binding OverlayBackground, RelativeSource={RelativeSource TemplatedParent}}" IsHitTestVisible="False">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Style.Triggers>
+                                            <Trigger Property="Opacity" Value="0">
+                                                <Setter Property="Visibility" Value="Hidden" />
+                                            </Trigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                            </Border>
                         </Grid>
 
                         <Grid x:Name="PART_Popup" wpf:ThemeAssist.Theme="{TemplateBinding DialogTheme}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -193,7 +193,7 @@
                             <ContentPresenter x:Name="ContentPresenter" Opacity="1" Content="{TemplateBinding ContentControl.Content}" 
                                               ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}" ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}" />
                         </AdornerDecorator>
-                        <Grid x:Name="PART_ContentCoverGrid" Background="Transparent" IsHitTestVisible="False" Focusable="False">
+                        <Grid x:Name="PART_ContentCoverGrid" Background="Transparent" IsHitTestVisible="False" Focusable="False" Visibility="{Binding ElementName=ContentCoverBorder, Path=Visibility}">
                             <Grid.OpacityMask>
                                 <VisualBrush Visual="{Binding ElementName=ContentCoverBorder}" />
                             </Grid.OpacityMask>
@@ -351,7 +351,7 @@
                             x:Name="ContentPresenter" Opacity="1"
                             Content="{TemplateBinding ContentControl.Content}" ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}" ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}" />
 
-                        <Grid x:Name="PART_ContentCoverGrid" Background="Transparent" IsHitTestVisible="False" Focusable="False">
+                        <Grid x:Name="PART_ContentCoverGrid" Background="Transparent" IsHitTestVisible="False" Focusable="False" Visibility="{Binding ElementName=ContentCoverBorder, Path=Visibility}">
                             <Grid.OpacityMask>
                                 <VisualBrush Visual="{Binding ElementName=ContentCoverBorder}" />
                             </Grid.OpacityMask>


### PR DESCRIPTION
Fix for #2772 

Introduces a `CornerRadius` DP on `DialogHost` which is then used to round the corners of the `PART_ContentCoverGrid` (ie. the grid which shows a dimmed overlay covering the area that should be disabled while the dialog is open).

In order to support a `CornerRadius`, I introduced a `Border`. Ideally I guess the `PART_ContentCoverGrid` could have been **changed** to a `Border` but that could potentially break back-compat in case someone is doing their own template and providing a `Grid` named `PART_ContentCoverGrid`. To (hopefully) avoid introducing a breaking change, I simple placed a `Border` inside of the `PART_ContentCoverGrid`, and then use the `OpacityMask` on the `PART_ContentCoverGrid` to enforce the masking out of content that is not within the bounds of the contained `Border`.

My initial approach was to wrap `PART_ContentCoverGrid` in a `Border`, and the set `ClipToBounds` on the `Border`, but that **does not work**; the `PART_ContentCoverGrid` is still allowed to render its background in the corner area which is "trimmed away" by the `Border`, and thus it basically has no effect.

I added a simple UI test just to verify that the DP is correctly applied to the newly introduced `Border` (named `ContentCoverBorder`).

**UPDATE**
I did not actually update the demo application to showcase this, because I didn't really think it made a lot of sense in the uses that are showcased. But to test it out, you can just set the DP on any of the `DialogHost` instances in there.