### PR TITLE
Added BorderThickness attached DP for outlined date/time pickers

### DIFF
--- a/MainDemo.Wpf/Pickers.xaml
+++ b/MainDemo.Wpf/Pickers.xaml
@@ -198,6 +198,60 @@
                             materialDesign:HintAssist.HelperText="Helper text"
                             Style="{StaticResource MaterialDesignOutlinedDatePicker}"/>
                     </smtx:XamlDisplay>
+
+                    <smtx:XamlDisplay
+                        UniqueKey="pickers_unchanging_borderthickness"
+                        HorizontalAlignment="Left"
+                        Margin="0 16 0 0">
+                        <DatePicker
+                            Width="140"
+                            materialDesign:HintAssist.Hint="Pick Date"
+                            materialDesign:HintAssist.HelperText="Helper text"
+                            materialDesign:DatePickerAssist.OutlinedBorderInactiveThickness="2"
+                            materialDesign:HintAssist.FloatingOffset="0,-22"
+                            Style="{StaticResource MaterialDesignOutlinedDatePicker}"/>
+                    </smtx:XamlDisplay>
+
+                    <smtx:XamlDisplay
+                        UniqueKey="pickers_14_custom_borderthickness"
+                        HorizontalAlignment="Left"
+                        Margin="0 16 0 0">
+                        <DatePicker
+                            Width="140"
+                            materialDesign:HintAssist.Hint="Pick Date"
+                            materialDesign:HintAssist.HelperText="Helper text"
+                            materialDesign:HintAssist.FloatingOffset="0,-23"
+                            materialDesign:DatePickerAssist.OutlinedBorderInactiveThickness="3"
+                            materialDesign:DatePickerAssist.OutlinedBorderActiveThickness="3"
+                            Style="{StaticResource MaterialDesignOutlinedDatePicker}"/>
+                    </smtx:XamlDisplay>
+
+                    <smtx:XamlDisplay
+                        UniqueKey="pickers_time"
+                        HorizontalAlignment="Left"
+                        Margin="0 16 0 0">
+                        <materialDesign:TimePicker
+                            Is24Hours="True"
+                            Width="140"
+                            materialDesign:HintAssist.Hint="Pick Time"
+                            materialDesign:HintAssist.HelperText="Helper text"
+                            Style="{StaticResource MaterialDesignOutlinedTimePicker}"/>
+                    </smtx:XamlDisplay>
+
+                    <smtx:XamlDisplay
+                        UniqueKey="pickers_time_custom_borderthickness"
+                        HorizontalAlignment="Left"
+                        Margin="0 16 0 0">
+                        <materialDesign:TimePicker
+                            Is24Hours="True"
+                            Width="140"
+                            materialDesign:HintAssist.Hint="Pick Time"
+                            materialDesign:HintAssist.HelperText="Helper text"
+                            materialDesign:HintAssist.FloatingOffset="0,-23"
+                            materialDesign:TimePickerAssist.OutlinedBorderInactiveThickness="3"
+                            materialDesign:TimePickerAssist.OutlinedBorderActiveThickness="3"
+                            Style="{StaticResource MaterialDesignOutlinedTimePicker}"/>
+                    </smtx:XamlDisplay>
                 </StackPanel>
 
                 <smtx:XamlDisplay

--- a/MaterialDesignThemes.UITests/TestBase.cs
+++ b/MaterialDesignThemes.UITests/TestBase.cs
@@ -24,10 +24,10 @@ public abstract class TestBase : IAsyncLifetime
         return resource.GetAs<Color?>() ?? throw new Exception($"Failed to convert resource '{name}' to color");
     }
 
-    protected async Task<IVisualElement<T>> LoadXaml<T>(string xaml)
+    protected async Task<IVisualElement<T>> LoadXaml<T>(string xaml, params (string namespacePrefix, Type type)[] additionalNamespaceDeclarations)
     {
         await App.InitializeWithMaterialDesign();
-        return await App.CreateWindowWith<T>(xaml);
+        return await App.CreateWindowWith<T>(xaml, additionalNamespaceDeclarations);
     }
 
     protected async Task<IVisualElement> LoadUserControl<TControl>()

--- a/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
@@ -79,17 +79,21 @@ namespace MaterialDesignThemes.UITests.WPF.DatePickers
     <DatePicker Style=""{{StaticResource MaterialDesignOutlinedDatePicker}}""
       materialDesign:DatePickerAssist.OutlinedBorderInactiveThickness=""{expectedInactiveBorderThickness}""
       materialDesign:DatePickerAssist.OutlinedBorderActiveThickness=""{expectedActiveBorderThickness}""/>
+    <Button x:Name=""Button"" Content=""Some Button"" />
 </StackPanel>");
             var datePicker = await stackPanel.GetElement<DatePicker>("/DatePicker");
             var datePickerTextBox = await datePicker.GetElement<TextBox>("PART_TextBox");
+            var button = await stackPanel.GetElement<Button>("Button");
 
             // Act
+            await button.MoveCursorTo();
+            await Task.Delay(50);   // Wait for the visual change
             var inactiveBorderThickness = await datePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
             await datePickerTextBox.MoveCursorTo();
-            await Task.Delay(100);   // Wait for the visual change
+            await Task.Delay(50);   // Wait for the visual change
             var hoverBorderThickness = await datePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
             await datePickerTextBox.LeftClick();
-            await Task.Delay(100);   // Wait for the visual change
+            await Task.Delay(50);   // Wait for the visual change
             var focusedBorderThickness = await datePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
 
             // TODO: How can I mark the element as invalid? Perhaps XAMLTest should have a MarkInvalid(DP, ValidationError) extension method, since I cannot access the element itself here and appropriately set the ValidationError

--- a/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
@@ -86,10 +86,10 @@ namespace MaterialDesignThemes.UITests.WPF.DatePickers
             // Act
             var inactiveBorderThickness = await datePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
             await datePickerTextBox.MoveCursorTo();
-            await Task.Delay(50);   // Wait for the visual change
+            await Task.Delay(100);   // Wait for the visual change
             var hoverBorderThickness = await datePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
             await datePickerTextBox.LeftClick();
-            await Task.Delay(50);   // Wait for the visual change
+            await Task.Delay(100);   // Wait for the visual change
             var focusedBorderThickness = await datePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
 
             // TODO: How can I mark the element as invalid? Perhaps XAMLTest should have a MarkInvalid(DP, ValidationError) extension method, since I cannot access the element itself here and appropriately set the ValidationError

--- a/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
@@ -92,7 +92,7 @@ namespace MaterialDesignThemes.UITests.WPF.DatePickers
             await Task.Delay(50);   // Wait for the visual change
             var focusedBorderThickness = await datePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
 
-            // TODO: How can I mark the element as invalid? Perhaps XAMLTest should have a MarkInvalid(DP, ValidationError) extension method, since I cannot access the element itself here at appropriately set the ValidationError
+            // TODO: How can I mark the element as invalid? Perhaps XAMLTest should have a MarkInvalid(DP, ValidationError) extension method, since I cannot access the element itself here and appropriately set the ValidationError
             var withErrorBorderThickness = await datePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
 
             // Assert

--- a/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
@@ -352,17 +352,21 @@ public class TimePickerTests : TestBase
     <materialDesign:TimePicker Style=""{{StaticResource MaterialDesignOutlinedTimePicker}}""
       materialDesign:TimePickerAssist.OutlinedBorderInactiveThickness=""{expectedInactiveBorderThickness}""
       materialDesign:TimePickerAssist.OutlinedBorderActiveThickness=""{expectedActiveBorderThickness}""/>
+    <Button x:Name=""Button"" Content=""Some Button"" />
 </StackPanel>");
         var timePicker = await stackPanel.GetElement<TimePicker>("/TimePicker");
         var timePickerTextBox = await timePicker.GetElement<TimePickerTextBox>("/TimePickerTextBox");
+        var button = await stackPanel.GetElement<Button>("Button");
 
         // Act
+        await button.MoveCursorTo();
+        await Task.Delay(50);   // Wait for the visual change
         var inactiveBorderThickness = await timePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
         await timePickerTextBox.MoveCursorTo();
-        await Task.Delay(100);   // Wait for the visual change
+        await Task.Delay(50);   // Wait for the visual change
         var hoverBorderThickness = await timePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
         await timePickerTextBox.LeftClick();
-        await Task.Delay(100);   // Wait for the visual change
+        await Task.Delay(50);   // Wait for the visual change
         var focusedBorderThickness = await timePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
 
         // TODO: How can I mark the element as invalid? Perhaps XAMLTest should have a MarkInvalid(DP, ValidationError) extension method, since I cannot access the element itself here and appropriately set the ValidationError

--- a/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
@@ -359,10 +359,10 @@ public class TimePickerTests : TestBase
         // Act
         var inactiveBorderThickness = await timePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
         await timePickerTextBox.MoveCursorTo();
-        await Task.Delay(50);   // Wait for the visual change
+        await Task.Delay(100);   // Wait for the visual change
         var hoverBorderThickness = await timePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
         await timePickerTextBox.LeftClick();
-        await Task.Delay(50);   // Wait for the visual change
+        await Task.Delay(100);   // Wait for the visual change
         var focusedBorderThickness = await timePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
 
         // TODO: How can I mark the element as invalid? Perhaps XAMLTest should have a MarkInvalid(DP, ValidationError) extension method, since I cannot access the element itself here and appropriately set the ValidationError

--- a/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
@@ -365,7 +365,7 @@ public class TimePickerTests : TestBase
         await Task.Delay(50);   // Wait for the visual change
         var focusedBorderThickness = await timePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
 
-        // TODO: How can I mark the element as invalid? Perhaps XAMLTest should have a MarkInvalid(DP, ValidationError) extension method, since I cannot access the element itself here at appropriately set the ValidationError
+        // TODO: How can I mark the element as invalid? Perhaps XAMLTest should have a MarkInvalid(DP, ValidationError) extension method, since I cannot access the element itself here and appropriately set the ValidationError
         var withErrorBorderThickness = await timePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
 
         // Assert

--- a/MaterialDesignThemes.UITests/XamlTestMixins.cs
+++ b/MaterialDesignThemes.UITests/XamlTestMixins.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows.Controls;
 using MaterialDesignColors;
+using MaterialDesignThemes.UITests.WPF.DatePickers;
 using MaterialDesignThemes.Wpf;
 using XamlTest;
 
@@ -40,14 +41,21 @@ xmlns:materialDesign=""http://materialdesigninxaml.net/winfx/xaml/themes"">
                 Assembly.GetExecutingAssembly().Location);
         }
 
-        public static async Task<IVisualElement<T>> CreateWindowWith<T>(this IApp app, string xaml)
+        public static async Task<IVisualElement<T>> CreateWindowWith<T>(this IApp app, string xaml, params (string namespacePrefix, Type type)[] additionalNamespaceDeclarations)
         {
+            var extraNamespaceDeclarations = new StringBuilder("");
+            foreach ((string namespacePrefix, Type type) in additionalNamespaceDeclarations)
+            {
+                extraNamespaceDeclarations.AppendLine($@"xmlns:{namespacePrefix}=""clr-namespace:{type.Namespace};assembly={type.Assembly.GetName().Name}""");
+            }
+
             string windowXaml = @$"<Window
         xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
         xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
         xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
         xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
         xmlns:materialDesign=""http://materialdesigninxaml.net/winfx/xaml/themes""
+        {extraNamespaceDeclarations}
         mc:Ignorable=""d""
         Height=""800"" Width=""1100""
         TextElement.Foreground=""{{DynamicResource MaterialDesignBody}}""

--- a/MaterialDesignThemes.Wpf/Converters/OutlinedDateTimePickerActiveBorderThicknessConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/OutlinedDateTimePickerActiveBorderThicknessConverter.cs
@@ -1,0 +1,24 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+
+namespace MaterialDesignThemes.Wpf.Converters;
+
+public class OutlinedDateTimePickerActiveBorderThicknessConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values.Length == 2
+            && values[0] is Thickness baseThickness
+            && values[1] is Thickness thicknessToSubtract)
+        {
+            var thickness = new Thickness(baseThickness.Left - thicknessToSubtract.Left,
+                baseThickness.Top - thicknessToSubtract.Top,
+                baseThickness.Right - thicknessToSubtract.Right,
+                baseThickness.Bottom - thicknessToSubtract.Bottom);
+            return thickness;
+        }
+        return default(Thickness);
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => throw new NotImplementedException();
+}

--- a/MaterialDesignThemes.Wpf/DatePickerAssist.cs
+++ b/MaterialDesignThemes.Wpf/DatePickerAssist.cs
@@ -1,0 +1,33 @@
+﻿namespace MaterialDesignThemes.Wpf;
+
+public static class DatePickerAssist
+{
+    private static Thickness DefaultOutlinedBorderInactiveThickness { get; } = new(1);
+    private static Thickness DefaultOutlinedBorderActiveThickness { get; } = new(2);
+
+    public static readonly DependencyProperty OutlinedBorderInactiveThicknessProperty = DependencyProperty.RegisterAttached(
+        "OutlinedBorderInactiveThickness", typeof(Thickness), typeof(DatePickerAssist), new FrameworkPropertyMetadata(DefaultOutlinedBorderInactiveThickness, FrameworkPropertyMetadataOptions.Inherits));
+
+    public static void SetOutlinedBorderInactiveThickness(DependencyObject element, Thickness value)
+    {
+        element.SetValue(OutlinedBorderInactiveThicknessProperty, value);
+    }
+
+    public static Thickness GetOutlinedBorderInactiveThickness(DependencyObject element)
+    {
+        return (Thickness) element.GetValue(OutlinedBorderInactiveThicknessProperty);
+    }
+
+    public static readonly DependencyProperty OutlinedBorderActiveThicknessProperty = DependencyProperty.RegisterAttached(
+        "OutlinedBorderActiveThickness", typeof(Thickness), typeof(DatePickerAssist), new FrameworkPropertyMetadata(DefaultOutlinedBorderActiveThickness, FrameworkPropertyMetadataOptions.Inherits));
+
+    public static void SetOutlinedBorderActiveThickness(DependencyObject element, Thickness value)
+    {
+        element.SetValue(OutlinedBorderActiveThicknessProperty, value);
+    }
+
+    public static Thickness GetOutlinedBorderActiveThickness(DependencyObject element)
+    {
+        return (Thickness) element.GetValue(OutlinedBorderActiveThicknessProperty);
+    }
+}

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -17,6 +17,7 @@
     <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
     <converters:FloatingHintOffsetCalculationConverter x:Key="FloatingHintOffsetCalculationConverter" />
     <converters:PickerInnerPaddingConverter x:Key="PickerInnerPaddingConverter" />
+    <converters:OutlinedDateTimePickerActiveBorderThicknessConverter x:Key="OutlinedDateTimePickerActiveBorderThicknessConverter" />
 
     <Style x:Key="MaterialDesignDatePickerTextBox" TargetType="{x:Type DatePickerTextBox}">
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
@@ -264,7 +265,7 @@
                         </Trigger>
                         <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
                             <Setter Property="VerticalContentAlignment" Value="Top" />
-                            <Setter Property="BorderThickness" Value="1" />
+                            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:DatePickerAssist.OutlinedBorderInactiveThickness)}" />
                             <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
                             <Setter Property="Padding" Value="16 16 12 16" />
                             <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
@@ -359,8 +360,15 @@
                                 <Condition Property="IsKeyboardFocused" Value="True" />
                                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="border" Property="Margin" Value="-1" />
-                            <Setter Property="BorderThickness" Value="2" />
+                            <Setter TargetName="border" Property="Margin">
+                                <Setter.Value>
+                                    <MultiBinding Converter="{StaticResource OutlinedDateTimePickerActiveBorderThicknessConverter}">
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:DatePickerAssist.OutlinedBorderInactiveThickness)" />
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:DatePickerAssist.OutlinedBorderActiveThickness)" />
+                                    </MultiBinding>
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:DatePickerAssist.OutlinedBorderActiveThickness)}" />
                             <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
                         </MultiTrigger>
                         <MultiTrigger>
@@ -400,8 +408,15 @@
                                 <Condition Property="IsMouseOver" Value="True" />
                                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="border" Property="Margin" Value="-1" />
-                            <Setter Property="BorderThickness" Value="2" />
+                            <Setter TargetName="border" Property="Margin">
+                                <Setter.Value>
+                                    <MultiBinding Converter="{StaticResource OutlinedDateTimePickerActiveBorderThicknessConverter}">
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:DatePickerAssist.OutlinedBorderInactiveThickness)" />
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:DatePickerAssist.OutlinedBorderActiveThickness)" />
+                                    </MultiBinding>
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:DatePickerAssist.OutlinedBorderActiveThickness)}" />
                         </MultiTrigger>
 
                         <!-- Validation.HasError -->
@@ -414,8 +429,15 @@
                                 <Condition Property="Validation.HasError" Value="True" />
                                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="border" Property="Margin" Value="-1" />
-                            <Setter Property="BorderThickness" Value="2" />
+                            <Setter TargetName="border" Property="Margin">
+                                <Setter.Value>
+                                    <MultiBinding Converter="{StaticResource OutlinedDateTimePickerActiveBorderThicknessConverter}">
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:DatePickerAssist.OutlinedBorderInactiveThickness)" />
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:DatePickerAssist.OutlinedBorderActiveThickness)" />
+                                    </MultiBinding>
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:DatePickerAssist.OutlinedBorderActiveThickness)}" />
                             <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignValidationErrorBrush}" />
                         </MultiTrigger>
                     </ControlTemplate.Triggers>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
@@ -14,6 +14,7 @@
     <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
     <converters:FloatingHintOffsetCalculationConverter x:Key="FloatingHintOffsetCalculationConverter" />
     <converters:PickerInnerPaddingConverter x:Key="PickerInnerPaddingConverter" />
+    <converters:OutlinedDateTimePickerActiveBorderThicknessConverter x:Key="OutlinedDateTimePickerActiveBorderThicknessConverter" />
 
     <Style x:Key="MaterialDesignTimePickerTextBox" TargetType="{x:Type wpf:TimePickerTextBox}">
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
@@ -261,7 +262,7 @@
                         </Trigger>
                         <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
                             <Setter Property="VerticalContentAlignment" Value="Top" />
-                            <Setter Property="BorderThickness" Value="1" />
+                            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TimePickerAssist.OutlinedBorderInactiveThickness)}" />
                             <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
                             <Setter Property="Padding" Value="16 16 12 16" />
                             <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
@@ -356,8 +357,15 @@
                                 <Condition Property="IsKeyboardFocused" Value="True" />
                                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="border" Property="Margin" Value="-1" />
-                            <Setter Property="BorderThickness" Value="2" />
+                            <Setter TargetName="border" Property="Margin">
+                                <Setter.Value>
+                                    <MultiBinding Converter="{StaticResource OutlinedDateTimePickerActiveBorderThicknessConverter}">
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TimePickerAssist.OutlinedBorderInactiveThickness)" />
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TimePickerAssist.OutlinedBorderActiveThickness)" />
+                                    </MultiBinding>
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TimePickerAssist.OutlinedBorderActiveThickness)}" />
                             <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
                         </MultiTrigger>
                         <MultiTrigger>
@@ -397,8 +405,15 @@
                                 <Condition Property="IsMouseOver" Value="True" />
                                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="border" Property="Margin" Value="-1" />
-                            <Setter Property="BorderThickness" Value="2" />
+                            <Setter TargetName="border" Property="Margin">
+                                <Setter.Value>
+                                    <MultiBinding Converter="{StaticResource OutlinedDateTimePickerActiveBorderThicknessConverter}">
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TimePickerAssist.OutlinedBorderInactiveThickness)" />
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TimePickerAssist.OutlinedBorderActiveThickness)" />
+                                    </MultiBinding>
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TimePickerAssist.OutlinedBorderActiveThickness)}" />
                         </MultiTrigger>
 
                         <!-- Validation.HasError -->
@@ -411,8 +426,15 @@
                                 <Condition Property="Validation.HasError" Value="True" />
                                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="border" Property="Margin" Value="-1" />
-                            <Setter Property="BorderThickness" Value="2" />
+                            <Setter TargetName="border" Property="Margin">
+                                <Setter.Value>
+                                    <MultiBinding Converter="{StaticResource OutlinedDateTimePickerActiveBorderThicknessConverter}">
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TimePickerAssist.OutlinedBorderInactiveThickness)" />
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TimePickerAssist.OutlinedBorderActiveThickness)" />
+                                    </MultiBinding>
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TimePickerAssist.OutlinedBorderActiveThickness)}" />
                             <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignValidationErrorBrush}" />
                         </MultiTrigger>
                     </ControlTemplate.Triggers>

--- a/MaterialDesignThemes.Wpf/TimePickerAssist.cs
+++ b/MaterialDesignThemes.Wpf/TimePickerAssist.cs
@@ -1,0 +1,33 @@
+﻿namespace MaterialDesignThemes.Wpf;
+
+public static class TimePickerAssist
+{
+    private static Thickness DefaultOutlinedBorderInactiveThickness { get; } = new(1);
+    private static Thickness DefaultOutlinedBorderActiveThickness { get; } = new(2);
+
+    public static readonly DependencyProperty OutlinedBorderInactiveThicknessProperty = DependencyProperty.RegisterAttached(
+        "OutlinedBorderInactiveThickness", typeof(Thickness), typeof(TimePickerAssist), new FrameworkPropertyMetadata(DefaultOutlinedBorderInactiveThickness, FrameworkPropertyMetadataOptions.Inherits));
+
+    public static void SetOutlinedBorderInactiveThickness(DependencyObject element, Thickness value)
+    {
+        element.SetValue(OutlinedBorderInactiveThicknessProperty, value);
+    }
+
+    public static Thickness GetOutlinedBorderInactiveThickness(DependencyObject element)
+    {
+        return (Thickness)element.GetValue(OutlinedBorderInactiveThicknessProperty);
+    }
+
+    public static readonly DependencyProperty OutlinedBorderActiveThicknessProperty = DependencyProperty.RegisterAttached(
+        "OutlinedBorderActiveThickness", typeof(Thickness), typeof(TimePickerAssist), new FrameworkPropertyMetadata(DefaultOutlinedBorderActiveThickness, FrameworkPropertyMetadataOptions.Inherits));
+
+    public static void SetOutlinedBorderActiveThickness(DependencyObject element, Thickness value)
+    {
+        element.SetValue(OutlinedBorderActiveThicknessProperty, value);
+    }
+
+    public static Thickness GetOutlinedBorderActiveThickness(DependencyObject element)
+    {
+        return (Thickness)element.GetValue(OutlinedBorderActiveThicknessProperty);
+    }
+}


### PR DESCRIPTION
Fix for #2737

This PR introduces 2 new assists types (`DatePickerAssist` and `TimePickerAssist`) which both contain attached DPs which can be used to set the inactive and active `BorderThickness` on the `DatePicker`/`TimePicker` using the outlined styles (`MaterialDesignOutlinedDatePicker`/`MaterialDesignOutlinedTimePicker`). "Inactive" is when there is no mouse/keyboard interaction with the element, and "Active" is when the element is either hovered or has keyboard focus.

For the `TimePicker`, I could have just added the new attached DPs directly as normal DPs on the `TimePicker` type, but since the properties only apply for the outlined style, I thought it was better to keep them in a `TimePickerAssist` type.

I updated the demo app to include some samples of this because using `Thickness` values that vary from the default values may require the caller to also set the `HintAssist.FloatingOffset` in order for the hint to be correctly placed.

The `IMultiValueConverter` that I added is needed to calculate a "margin diff" which ensures the UI does not "jump" between the inactive/active states. This was previously hardcoded to -1 because the of the defaults being inactive=1 and active=2.

**NOTE**: In the UI tests I have left a **TODO** because I would have liked to be able to mark a `ValidationError` on the contained `TextBox` without too much overhead. Perhaps this is something that could be added as a feature in XAMLTest? For now, the tests include an actual `ValidationRule` and the value is changed during the test to force the validation error. I added a [PR](https://github.com/Keboo/XAMLTest/pull/83) with proof-of-concept for this in the XAMLTest project.