### PR TITLE
Fix for issue 2667 - Tab header drop shadow z-order

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -46,6 +46,7 @@
                                 wpf:ShadowAssist.ShadowEdges="{TemplateBinding wpf:ShadowAssist.ShadowEdges}"
                                 VerticalAlignment="Stretch"
                                 Background="{TemplateBinding wpf:ColorZoneAssist.Background}"
+                                Panel.ZIndex="1"
                                 DockPanel.Dock="Top"
                                 Focusable="False">
                             <ScrollViewer
@@ -77,6 +78,7 @@
                             Padding="{TemplateBinding Padding}"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
+                            Panel.ZIndex="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Panel.ZIndex)}"
                             Background="{x:Null}"
                             Focusable="False">
                             <ContentPresenter


### PR DESCRIPTION
Fix for #2667

This defaults the tab header of the `TabControl` to `Panel.ZIndex="1"` which makes the shadow appear on top of `TabItem`s as I believe is the desired default.

I also added a binding on the content such that you can have the content cover the drop shadow in case you desire to do so; that is accomplished simply by adding `Panel.ZIndex="2"` (or higher) on the `TabControl` itself.

Ideally I thought it would be cool if this behavior could be controlled per `TabItem`. To do that I wanted the `PropertyPath` on the binding in line 81 to look something akin to `Path='SelectedItem.(Panel.ZIndex)'`, which essentially would first pick out the `TabControl.SelectedItem`, on which it would then pick out the `Panel.ZIndex` attached property. However, I am not able to get a working syntax to accomplish that. Perhaps you know the syntax?

Another way to semi-accomplish it is by binding to `SelectedItem` in line 81 and then using a converter to pick out the value of the attached property `Panel.ZIndex`. However, this has the downside that changes to the `Panel.ZIndex` value on the `TabItems` will only be reflected when the user changes tab (because the `Path` of the binding does not change, only the attached property value which the converter picks out). Not really sure whether I prefer that over the current approach in the PR.