### PR TITLE
Fix for 2596 - Align left margin for error message on outlined TextBox with helper text left margin

### DIFF
--- a/MainDemo.Wpf/Domain/FieldsViewModel.cs
+++ b/MainDemo.Wpf/Domain/FieldsViewModel.cs
@@ -4,6 +4,10 @@
     {
         private string? _name;
         private string? _name2;
+        private string? _text1;
+        private string? _text2;
+        private string? _password1 = "password";
+        private string? _password2 = "password";
 
         public string? Name
         {
@@ -15,6 +19,40 @@
         {
             get => _name2;
             set => SetProperty(ref _name2, value);
+        }
+
+        public string? Text1
+        {
+            get => _text1;
+            set => SetProperty(ref _text1, value);
+        }
+
+        public string? Text2
+        {
+            get => _text2;
+            set => SetProperty(ref _text2, value);
+        }
+
+        public string? Password1
+        {
+            get => _password1;
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                    throw new ArgumentException("Password cannot be empty");
+                SetProperty(ref _password1, value);
+            }
+        }
+
+        public string? Password2
+        {
+            get => _password2;
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                    throw new ArgumentException("Password cannot be empty");
+                SetProperty(ref _password2, value);
+            }
         }
 
         public FieldsTestObject TestObject => new() { Name = "Mr. Test" };

--- a/MainDemo.Wpf/Domain/PasswordHelper.cs
+++ b/MainDemo.Wpf/Domain/PasswordHelper.cs
@@ -1,0 +1,69 @@
+﻿namespace MaterialDesignDemo.Domain;
+
+/// <summary>
+/// Simple helper class to enable data-binding for <see cref="PasswordBox.Password"/> which is not a <see cref="DependencyProperty"/>
+/// </summary>
+internal static class PasswordHelper
+{
+    public static readonly DependencyProperty PasswordProperty =
+        DependencyProperty.RegisterAttached("Password",
+        typeof(string), typeof(PasswordHelper),
+        new FrameworkPropertyMetadata(string.Empty, OnPasswordPropertyChanged));
+
+    public static readonly DependencyProperty AttachProperty =
+        DependencyProperty.RegisterAttached("Attach",
+        typeof(bool), typeof(PasswordHelper), new PropertyMetadata(false, Attach));
+
+    private static readonly DependencyProperty IsUpdatingProperty =
+       DependencyProperty.RegisterAttached("IsUpdating", typeof(bool),
+       typeof(PasswordHelper));
+    
+    public static void SetAttach(DependencyObject dp, bool value) => dp.SetValue(AttachProperty, value);
+
+    public static bool GetAttach(DependencyObject dp) => (bool)dp.GetValue(AttachProperty);
+
+    public static string GetPassword(DependencyObject dp) => (string)dp.GetValue(PasswordProperty);
+
+    public static void SetPassword(DependencyObject dp, string value) => dp.SetValue(PasswordProperty, value);
+
+    private static bool GetIsUpdating(DependencyObject dp) => (bool)dp.GetValue(IsUpdatingProperty);
+
+    private static void SetIsUpdating(DependencyObject dp, bool value) => dp.SetValue(IsUpdatingProperty, value);
+
+    private static void OnPasswordPropertyChanged(DependencyObject sender,
+        DependencyPropertyChangedEventArgs e)
+    {
+        PasswordBox passwordBox = (PasswordBox) sender;
+        passwordBox.PasswordChanged -= PasswordChanged;
+
+        if (!GetIsUpdating(passwordBox))
+        {
+            passwordBox.Password = (string)e.NewValue;
+        }
+        passwordBox.PasswordChanged += PasswordChanged;
+    }
+
+    private static void Attach(DependencyObject sender,
+        DependencyPropertyChangedEventArgs e)
+    {
+        PasswordBox passwordBox = (PasswordBox) sender;
+
+        if ((bool)e.OldValue)
+        {
+            passwordBox.PasswordChanged -= PasswordChanged;
+        }
+
+        if ((bool)e.NewValue)
+        {
+            passwordBox.PasswordChanged += PasswordChanged;
+        }
+    }
+
+    private static void PasswordChanged(object sender, RoutedEventArgs e)
+    {
+        PasswordBox passwordBox = (PasswordBox) sender;
+        SetIsUpdating(passwordBox, true);
+        SetPassword(passwordBox, passwordBox.Password);
+        SetIsUpdating(passwordBox, false);
+    }
+}

--- a/MainDemo.Wpf/Fields.xaml
+++ b/MainDemo.Wpf/Fields.xaml
@@ -402,6 +402,7 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
             <Grid.Resources>
@@ -486,13 +487,33 @@
 
             <smtx:XamlDisplay
                 Grid.Row="1"
-                Grid.Column="4"
+                Grid.Column="3"
                 UniqueKey="passwordOutlined1"
                 Margin="0 34 0 0">
                 <PasswordBox
                         Style="{StaticResource MaterialDesignOutlinedPasswordBox}"
                         materialDesign:HintAssist.Hint="Password"
                         materialDesign:HintAssist.HelperText="Helper text"/>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
+                Grid.Row="1"
+                Grid.Column="4"
+                UniqueKey="fields_with_validation"
+                Margin="0 34 0 0">
+                <TextBox
+                    Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                    VerticalAlignment="Top"
+                    materialDesign:HintAssist.Hint="Start typing to show helper text"
+                    materialDesign:HintAssist.HelperText="Helper text and validation text should align">
+                    <TextBox.Text>
+                        <Binding Path="Name" UpdateSourceTrigger="PropertyChanged">
+                            <Binding.ValidationRules>
+                                <domain1:NotEmptyValidationRule ValidatesOnTargetUpdated="True"/>
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </TextBox.Text>
+                </TextBox>
             </smtx:XamlDisplay>
         </Grid>
 

--- a/MainDemo.Wpf/Fields.xaml
+++ b/MainDemo.Wpf/Fields.xaml
@@ -296,6 +296,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition/>
                 <RowDefinition/>
+                <RowDefinition/>
             </Grid.RowDefinitions>
 
             <Grid.ColumnDefinitions>
@@ -381,7 +382,7 @@
 
             <smtx:XamlDisplay
                 Grid.Row="1"
-                Grid.Column="4"
+                Grid.Column="3"
                 UniqueKey="passwordFilled1"
                 VerticalAlignment="Bottom">
                 <PasswordBox
@@ -389,10 +390,49 @@
                         materialDesign:HintAssist.Hint="Password"
                         materialDesign:HintAssist.HelperText="Helper text"/>
             </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
+                Grid.Row="2"
+                Grid.Column="2"
+                UniqueKey="fieldFilled_with_validation"
+                HorizontalAlignment="Left"
+                Margin="0 24 0 0">
+                <TextBox
+                    Style="{StaticResource MaterialDesignFilledTextBox}"
+                    VerticalAlignment="Top"
+                    materialDesign:HintAssist.Hint="Text (validated)"
+                    materialDesign:HintAssist.HelperText="Helper text">
+                    <TextBox.Text>
+                        <Binding Path="Text1" UpdateSourceTrigger="PropertyChanged">
+                            <Binding.ValidationRules>
+                                <domain1:NotEmptyValidationRule ValidatesOnTargetUpdated="True"/>
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </TextBox.Text>
+                </TextBox>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
+                Grid.Row="2"
+                Grid.Column="3"
+                UniqueKey="passwordFilled_with_validation"
+                HorizontalAlignment="Left"
+                Margin="0 24 0 0">
+                <StackPanel Orientation="Vertical">
+                    <PasswordBox
+                        Style="{StaticResource MaterialDesignFilledPasswordBox}"
+                        materialDesign:HintAssist.Hint="Password (validated)"
+                        materialDesign:HintAssist.HelperText="Helper text"
+                        domain1:PasswordHelper.Attach="True"
+                        domain1:PasswordHelper.Password="{Binding Path=Password1, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnExceptions=True}">
+                    </PasswordBox>
+                </StackPanel>
+            </smtx:XamlDisplay>
         </Grid>
 
         <Grid Margin="0 48 0 0">
             <Grid.RowDefinitions>
+                <RowDefinition/>
                 <RowDefinition/>
                 <RowDefinition/>
             </Grid.RowDefinitions>
@@ -427,6 +467,7 @@
 
             <smtx:XamlDisplay
                 Grid.Row="1"
+                Grid.RowSpan="2"
                 Grid.Column="0"
                 UniqueKey="fields_26">
 
@@ -449,6 +490,7 @@
 
             <smtx:XamlDisplay
                 Grid.Row="1"
+                Grid.RowSpan="2"
                 Grid.Column="1"
                 UniqueKey="fields_29">
                 <StackPanel>
@@ -497,23 +539,41 @@
             </smtx:XamlDisplay>
 
             <smtx:XamlDisplay
-                Grid.Row="1"
-                Grid.Column="4"
-                UniqueKey="fields_with_validation"
-                Margin="0 34 0 0">
+                Grid.Row="2"
+                Grid.Column="2"
+                UniqueKey="fieldOutlined_with_validation"
+                HorizontalAlignment="Left"
+                Margin="0 24 0 0">
                 <TextBox
                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
                     VerticalAlignment="Top"
-                    materialDesign:HintAssist.Hint="Start typing to show helper text"
-                    materialDesign:HintAssist.HelperText="Helper text and validation text should align">
+                    materialDesign:HintAssist.Hint="Text (validated)"
+                    materialDesign:HintAssist.HelperText="Helper text">
                     <TextBox.Text>
-                        <Binding Path="Name" UpdateSourceTrigger="PropertyChanged">
+                        <Binding Path="Text2" UpdateSourceTrigger="PropertyChanged">
                             <Binding.ValidationRules>
                                 <domain1:NotEmptyValidationRule ValidatesOnTargetUpdated="True"/>
                             </Binding.ValidationRules>
                         </Binding>
                     </TextBox.Text>
                 </TextBox>
+            </smtx:XamlDisplay>
+
+            <smtx:XamlDisplay
+                Grid.Row="2"
+                Grid.Column="3"
+                UniqueKey="passwordOutlined_with_validation"
+                HorizontalAlignment="Left"
+                Margin="0 24 0 0">
+                <StackPanel Orientation="Vertical">
+                    <PasswordBox
+                        Style="{StaticResource MaterialDesignOutlinedPasswordBox}"
+                        materialDesign:HintAssist.Hint="Password (validated)"
+                        materialDesign:HintAssist.HelperText="Helper text"
+                        domain1:PasswordHelper.Attach="True"
+                        domain1:PasswordHelper.Password="{Binding Path=Password2, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnExceptions=True}">
+                    </PasswordBox>
+                </StackPanel>
             </smtx:XamlDisplay>
         </Grid>
 

--- a/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
@@ -443,6 +443,44 @@ namespace MaterialDesignThemes.UITests.WPF.TextBoxes
 
             recorder.Success();
         }
+
+        [Fact]
+        [Description("Issue 2596")]
+        public async Task FilledTextBox_ValidationErrorMargin_MatchesHelperTextMargin()
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var stackPanel = await LoadXaml<StackPanel>(@"
+<StackPanel>
+    <TextBox Style=""{StaticResource MaterialDesignFilledTextBox}""
+        materialDesign:HintAssist.Hint=""Hint text""
+        materialDesign:HintAssist.HelperText=""Helper text"">
+        <TextBox.Text>
+            <Binding RelativeSource=""{RelativeSource Self}"" Path=""Tag"" UpdateSourceTrigger=""PropertyChanged"">
+                <Binding.ValidationRules>
+                    <local:NotEmptyValidationRule ValidatesOnTargetUpdated=""True""/>
+                </Binding.ValidationRules>
+            </Binding>
+        </TextBox.Text>
+    </TextBox>
+</StackPanel>
+", ("local", typeof(NotEmptyValidationRule)));
+
+            var textBox = await stackPanel.GetElement<TextBox>("/TextBox");
+
+            var errorViewer = await textBox.GetElement<Border>("DefaultErrorViewer");
+            var helperTextTextBlock = await textBox.GetElement<TextBlock>("HelperTextTextBlock");
+
+            Thickness? errorMargin = await errorViewer.GetProperty<Thickness>(FrameworkElement.MarginProperty);
+            Thickness? helperTextMargin = await helperTextTextBlock.GetProperty<Thickness>(FrameworkElement.MarginProperty);
+
+            Assert.True(errorMargin.HasValue);
+            Assert.True(helperTextMargin.HasValue);
+            Assert.True(Math.Abs(errorMargin.Value.Left - helperTextMargin.Value.Left) < double.Epsilon,
+                $"Error text and helper text do not have the same Margin.Left values: Error text Margin.Left ({errorMargin.Value.Left}) == Helper text Margin.Left ({helperTextMargin.Value.Left})");
+
+            recorder.Success();
+        }
     }
 
     public class NotEmptyValidationRule : ValidationRule

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
@@ -100,6 +100,10 @@
                 <Setter TargetName="DefaultErrorViewer" Property="Margin" Value="16,2,0,0"/>
                 <Setter TargetName="ValidationPopup" Property="VerticalOffset" Value="2"/>
             </DataTrigger>
+
+            <DataTrigger Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:TextFieldAssist.HasFilledTextField)}" Value="True">
+                <Setter TargetName="DefaultErrorViewer" Property="Margin" Value="16,2,0,0"/>
+            </DataTrigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
@@ -102,7 +102,7 @@
             </DataTrigger>
 
             <DataTrigger Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:TextFieldAssist.HasFilledTextField)}" Value="True">
-                <Setter TargetName="DefaultErrorViewer" Property="Margin" Value="16,2,0,0"/>
+                <Setter TargetName="DefaultErrorViewer" Property="Margin" Value="16,2,0,2"/>
             </DataTrigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
@@ -97,7 +97,7 @@
             </DataTrigger>
 
             <DataTrigger Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:TextFieldAssist.HasOutlinedTextField)}" Value="True">
-                <Setter TargetName="DefaultErrorViewer" Property="Margin" Value="0,2,0,0"/>
+                <Setter TargetName="DefaultErrorViewer" Property="Margin" Value="16,2,0,0"/>
                 <Setter TargetName="ValidationPopup" Property="VerticalOffset" Value="2"/>
             </DataTrigger>
         </ControlTemplate.Triggers>


### PR DESCRIPTION
Fix for #2596

The error message and helper text should have the same Margin.Left value. Updated control template trigger to use the 16px left margin like the helper text. This is applied for _Outlined_ and _Filled_ styles for the following controls:
* TextBox
* PasswordBox
* ComboBox
* DatePicker
* TimePicker

Added UI tests to ensure these stay in sync for the _Outlined_ and _Filled_ TextBoxes (which should cover all controls above).