### PR TITLE
Let DataGridCell handle mouse events itself when already editing

### DIFF
--- a/MaterialDesignThemes.Wpf/DataGridAssist.cs
+++ b/MaterialDesignThemes.Wpf/DataGridAssist.cs
@@ -242,6 +242,11 @@ namespace MaterialDesignThemes.Wpf
                     {
                         return;
                     }
+                    if (dataGridCell.IsEditing)
+                    {
+                        // If the cell is already being edited, we let the cell itself handle the mouse event
+                        return;
+                    }
 
                     dataGrid.CurrentCell = new DataGridCellInfo(dataGridCell);
                     dataGrid.BeginEdit();


### PR DESCRIPTION
Possible fix for #2722.

**UPDATE** There is another PR (#2824) which refactors this part. This PR only addresses the single problem mentioned in issue #2722 but @Xaalek pointed out that the `DataGrid` mouse behavior in general was kinda strange. Thus I ended up doing the other PR, just to see if I could make the UX of the `DataGrid` mouse/keyboard interactions a little smoother and intuitive. Have a look at the other one first, and if that is accepted, this PR should not be needed.

---

@Xaalek Could you please verify if this is the desired behavior?

The change is quite simple, we bail out of the (tunneling) event `PreviewMouseLeftButtonDown` in case the `DataGridCell` receiving the click is already editing. This way the cell itself handles the (bubbling) event `MouseLeftButtonDown` and does what it needs to. I think this is what is desired.

The effect you get when you single click the column is that cell editing starts and the I-cursor is placed at the position of the click. If you double-click, it first starts the editing and then the "second click" (handled by the cell itself) ends up highlighting/selecting the word at the position of the mouse. Seems intuitive to me, but let me know what you think.