### PR TITLE
Fixed embedded dialog host style (#2826)

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -341,7 +341,7 @@
                                                                        Duration="0">
                                             <DiscreteObjectKeyFrame Value="{x:Static Visibility.Collapsed}" KeyTime="0" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <DoubleAnimation Storyboard.TargetName="ContentCoverBorder" Storyboard.TargetProperty="Opacity"
+                                        <DoubleAnimation Storyboard.TargetName="ContentCoverBorder" Storyboard.TargetProperty="Opacity" Duration="0"
                                                          To="0" />
                                     </Storyboard>
                                 </VisualState>


### PR DESCRIPTION
Using materialDesign:TransitionAssist.DisableTransitions="true" duration of animation for content cover opacity should be set to 0 to skip animations at all on close dialog host