### PR TITLE
Fix for issue 2831

### DIFF
--- a/MaterialDesignThemes.Wpf/Converters/CursorConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/CursorConverter.cs
@@ -1,0 +1,17 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+using Cursor = System.Windows.Input.Cursor;
+
+namespace MaterialDesignThemes.Wpf.Converters;
+
+/// <summary>
+/// Value converter that uses the Cursor from the bound property if set, otherwise it returns the <see cref="FallbackCursor"/>.
+/// </summary>
+public sealed class CursorConverter : IValueConverter
+{
+    public Cursor FallbackCursor { get; set; } = Cursors.Arrow;
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => value as Cursor ?? FallbackCursor;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+}

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -16,6 +16,8 @@
     <converters:NotConverter x:Key="NotConverter" />
     <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
     <converters:FloatingHintOffsetCalculationConverter x:Key="FloatingHintOffsetCalculationConverter" />
+    <converters:CursorConverter x:Key="ArrowCursorConverter" FallbackCursor="Arrow" />
+    <converters:CursorConverter x:Key="IBeamCursorConverter" FallbackCursor="IBeam" />
 
     <Style
         x:Key="MaterialDesignCharacterCounterTextBlock"
@@ -57,7 +59,6 @@
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="AllowDrop" Value="true" />
-        <Setter Property="Cursor" Value="Arrow" />
         <Setter Property="Padding" Value="{x:Static wpf:Constants.TextBoxDefaultPadding}" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
@@ -74,7 +75,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TextBoxBase}">
-                    <Grid>
+                    <Grid Cursor="{TemplateBinding Cursor, Converter={StaticResource ArrowCursorConverter}}">
                         <Border
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
@@ -148,7 +149,7 @@
                                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                 Panel.ZIndex="1"
                                                 wpf:ScrollViewerAssist.IgnorePadding="True"
-                                                Cursor="IBeam"
+                                                Cursor="{TemplateBinding Cursor, Converter={StaticResource IBeamCursorConverter}}"
                                                 Focusable="false"
                                                 HorizontalScrollBarVisibility="Hidden"
                                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"


### PR DESCRIPTION
Fix for #2831 

Setting the `Cursor` on the style as the old code did causes that cursor to be applied when selecting text.

This PR changes the behavior such that a default is not set on the style, but rather on the contents - `Arrow` is used in general, but `IBeam` on the text content itself (as it was before). An `IValueConverter` was added in order to respect if a `Cursor` was explicitly set from the caller, in which case that cursor should be used. I initially tried simply using a regular binding (with relative source=templated parent) with a TargetNullValue/FallbackValue, but that only partially fixes the problem; this approach seems to work better.

**NOTE:** Using that converter for the text content (`PART_ContentHost`) is a minor change of behavior being that if an explicit cursor is set from the outside, it **also** affects the text content where the `IBeam` was previously hardcoded. I think this is a fair assumption to make when a user explicitly sets the cursor on a `TextBox`. I would assume the user wants that ´Cursor´ on "all" the `TextBox` including all the "edges" around the actual text area. But I'll let you be the judge of that.