### PR TITLE
Possible fix for multi-thread usage of DialogHost.GetInstance()

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Threading;
+using System.Windows.Threading;
 using Xunit;
 
 namespace MaterialDesignThemes.Wpf.Tests
@@ -414,6 +415,7 @@ namespace MaterialDesignThemes.Wpf.Tests
             DialogHost dialogHost = new();
             DialogHost dialogHostOnOtherUiThread;
             ManualResetEventSlim sync1 = new ManualResetEventSlim();
+            Dispatcher? otherUiThreadDispatcher = null;
 
             // Load dialogHost on current UI thread
             dialogHost.ApplyDefaultStyle();
@@ -426,8 +428,9 @@ namespace MaterialDesignThemes.Wpf.Tests
                 dialogHostOnOtherUiThread.ApplyDefaultStyle();
                 dialogHostOnOtherUiThread.Identifier = dialogHostOnOtherUiThreadIdentifier;
                 dialogHostOnOtherUiThread.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+                otherUiThreadDispatcher = Dispatcher.CurrentDispatcher;
                 sync1.Set();
-                System.Windows.Threading.Dispatcher.Run();
+                Dispatcher.Run();
             });
             thread.SetApartmentState(ApartmentState.STA);
             thread.Start();
@@ -438,7 +441,7 @@ namespace MaterialDesignThemes.Wpf.Tests
             DialogHost.GetDialogSession(dialogHostOnOtherUiThreadIdentifier);
 
             // Cleanup
-            thread.Abort();
+            otherUiThreadDispatcher?.InvokeShutdown();
         }
     }
 }

--- a/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
@@ -3,419 +3,422 @@ using System.Threading;
 using System.Windows.Threading;
 using Xunit;
 
-namespace MaterialDesignThemes.Wpf.Tests
+namespace MaterialDesignThemes.Wpf.Tests;
+
+public class DialogHostTests : IDisposable
 {
-    public class DialogHostTests : IDisposable
+    private readonly DialogHost _dialogHost;
+
+    public DialogHostTests()
     {
-        private readonly DialogHost _dialogHost;
+        _dialogHost = new DialogHost();
+        _dialogHost.ApplyDefaultStyle();
+        _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+    }
 
-        public DialogHostTests()
-        {
-            _dialogHost = new DialogHost();
-            _dialogHost.ApplyDefaultStyle();
-            _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
-        }
+    public void Dispose()
+    {
+        _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
+    }
 
-        public void Dispose()
-        {
-            _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
-        }
+    [StaFact]
+    public void CanOpenAndCloseDialogWithIsOpen()
+    {
+        _dialogHost.IsOpen = true;
+        DialogSession? session = _dialogHost.CurrentSession;
+        Assert.False(session?.IsEnded);
+        _dialogHost.IsOpen = false;
 
-        [StaFact]
-        public void CanOpenAndCloseDialogWithIsOpen()
-        {
-            _dialogHost.IsOpen = true;
-            DialogSession? session = _dialogHost.CurrentSession;
-            Assert.False(session?.IsEnded);
-            _dialogHost.IsOpen = false;
+        Assert.False(_dialogHost.IsOpen);
+        Assert.Null(_dialogHost.CurrentSession);
+        Assert.True(session?.IsEnded);
+    }
 
-            Assert.False(_dialogHost.IsOpen);
-            Assert.Null(_dialogHost.CurrentSession);
-            Assert.True(session?.IsEnded);
-        }
+    [StaFact]
+    public async Task CanOpenAndCloseDialogWithShowMethod()
+    {
+        var id = Guid.NewGuid();
+        _dialogHost.Identifier = id;
 
-        [StaFact]
-        public async Task CanOpenAndCloseDialogWithShowMethod()
-        {
-            var id = Guid.NewGuid();
-            _dialogHost.Identifier = id;
+        object? result = await DialogHost.Show("Content", id,
+            new DialogOpenedEventHandler(((sender, args) => { args.Session.Close(42); })));
 
-            object? result = await DialogHost.Show("Content", id,
-                new DialogOpenedEventHandler(((sender, args) => { args.Session.Close(42); })));
+        Assert.Equal(42, result);
+        Assert.False(_dialogHost.IsOpen);
+    }
 
-            Assert.Equal(42, result);
-            Assert.False(_dialogHost.IsOpen);
-        }
+    [StaFact]
+    public async Task CanOpenDialogWithShowMethodAndCloseWithIsOpen()
+    {
+        var id = Guid.NewGuid();
+        _dialogHost.Identifier = id;
 
-        [StaFact]
-        public async Task CanOpenDialogWithShowMethodAndCloseWithIsOpen()
-        {
-            var id = Guid.NewGuid();
-            _dialogHost.Identifier = id;
+        object? result = await DialogHost.Show("Content", id,
+            new DialogOpenedEventHandler(((sender, args) => { _dialogHost.IsOpen = false; })));
 
-            object? result = await DialogHost.Show("Content", id,
-                new DialogOpenedEventHandler(((sender, args) => { _dialogHost.IsOpen = false; })));
+        Assert.Null(result);
+        Assert.False(_dialogHost.IsOpen);
+    }
 
-            Assert.Null(result);
-            Assert.False(_dialogHost.IsOpen);
-        }
+    [StaFact]
+    public async Task CanCloseDialogWithRoutedEvent()
+    {
+        Guid closeParameter = Guid.NewGuid();
+        Task<object?> showTask = _dialogHost.ShowDialog("Content");
+        DialogSession? session = _dialogHost.CurrentSession;
+        Assert.False(session?.IsEnded);
 
-        [StaFact]
-        public async Task CanCloseDialogWithRoutedEvent()
-        {
-            Guid closeParameter = Guid.NewGuid();
-            Task<object?> showTask = _dialogHost.ShowDialog("Content");
-            DialogSession? session = _dialogHost.CurrentSession;
-            Assert.False(session?.IsEnded);
+        DialogHost.CloseDialogCommand.Execute(closeParameter, _dialogHost);
 
-            DialogHost.CloseDialogCommand.Execute(closeParameter, _dialogHost);
+        Assert.False(_dialogHost.IsOpen);
+        Assert.Null(_dialogHost.CurrentSession);
+        Assert.True(session?.IsEnded);
+        Assert.Equal(closeParameter, await showTask);
+    }
 
-            Assert.False(_dialogHost.IsOpen);
-            Assert.Null(_dialogHost.CurrentSession);
-            Assert.True(session?.IsEnded);
-            Assert.Equal(closeParameter, await showTask);
-        }
+    [StaFact]
+    public async Task DialogHostExposesSessionAsProperty()
+    {
+        var id = Guid.NewGuid();
+        _dialogHost.Identifier = id;
 
-        [StaFact]
-        public async Task DialogHostExposesSessionAsProperty()
-        {
-            var id = Guid.NewGuid();
-            _dialogHost.Identifier = id;
-
-            await DialogHost.Show("Content", id,
-                new DialogOpenedEventHandler(((sender, args) =>
-                {
-                    Assert.True(ReferenceEquals(args.Session, _dialogHost.CurrentSession));
-                    args.Session.Close();
-                })));
-        }
-
-        [StaFact]
-        public async Task CannotShowDialogWhileItIsAlreadyOpen()
-        {
-            var id = Guid.NewGuid();
-            _dialogHost.Identifier = id;
-
-            await DialogHost.Show("Content", id,
-                new DialogOpenedEventHandler((async (sender, args) =>
-                {
-                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => DialogHost.Show("Content", id));
-                    args.Session.Close();
-                    Assert.Equal("DialogHost is already open.", ex.Message);
-                })));
-        }
-
-        [StaFact]
-        public async Task WhenNoDialogsAreOpenItThrows()
-        {
-            var id = Guid.NewGuid();
-            _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
-
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => DialogHost.Show("Content", id));
-
-            Assert.Equal("No loaded DialogHost instances.", ex.Message);
-        }
-
-        [StaFact]
-        public async Task WhenNoDialogsMatchIdentifierItThrows()
-        {
-            var id = Guid.NewGuid();
-
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => DialogHost.Show("Content", id));
-
-            Assert.Equal($"No loaded DialogHost have an {nameof(DialogHost.Identifier)} property matching dialogIdentifier ('{id}') argument.", ex.Message);
-        }
-
-        [StaFact]
-        public async Task WhenMultipleDialogHostsHaveTheSameIdentifierItThrows()
-        {
-            var id = Guid.NewGuid();
-            _dialogHost.Identifier = id;
-            var otherDialogHost = new DialogHost { Identifier = id };
-            otherDialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
-
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => DialogHost.Show("Content", id));
-
-            otherDialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
-
-
-            Assert.Equal("Multiple viable DialogHosts. Specify a unique Identifier on each DialogHost, especially where multiple Windows are a concern.", ex.Message);
-        }
-
-        [StaFact]
-        public async Task WhenNoIdentifierIsSpecifiedItUsesSingleDialogHost()
-        {
-            bool isOpen = false;
-            await DialogHost.Show("Content", new DialogOpenedEventHandler(((sender, args) =>
+        await DialogHost.Show("Content", id,
+            new DialogOpenedEventHandler(((sender, args) =>
             {
-                isOpen = _dialogHost.IsOpen;
+                Assert.True(ReferenceEquals(args.Session, _dialogHost.CurrentSession));
                 args.Session.Close();
             })));
+    }
 
-            Assert.True(isOpen);
-        }
+    [StaFact]
+    public async Task CannotShowDialogWhileItIsAlreadyOpen()
+    {
+        var id = Guid.NewGuid();
+        _dialogHost.Identifier = id;
 
-        [StaFact]
-        public async Task WhenContentIsNullItThrows()
-        {
-            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => DialogHost.Show(null!));
-
-            Assert.Equal("content", ex.ParamName);
-        }
-
-        [StaFact]
-        [Description("Issue 1212")]
-        public async Task WhenContentIsUpdatedClosingEventHandlerIsInvoked()
-        {
-            int closeInvokeCount = 0;
-            void ClosingHandler(object s, DialogClosingEventArgs e)
+        await DialogHost.Show("Content", id,
+            new DialogOpenedEventHandler((async (sender, args) =>
             {
-                closeInvokeCount++;
-                if (closeInvokeCount == 1)
-                {
-                    e.Cancel();
-                }
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => DialogHost.Show("Content", id));
+                args.Session.Close();
+                Assert.Equal("DialogHost is already open.", ex.Message);
+            })));
+    }
+
+    [StaFact]
+    public async Task WhenNoDialogsAreOpenItThrows()
+    {
+        var id = Guid.NewGuid();
+        _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => DialogHost.Show("Content", id));
+
+        Assert.Equal("No loaded DialogHost instances.", ex.Message);
+    }
+
+    [StaFact]
+    public async Task WhenNoDialogsMatchIdentifierItThrows()
+    {
+        var id = Guid.NewGuid();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => DialogHost.Show("Content", id));
+
+        Assert.Equal($"No loaded DialogHost have an {nameof(DialogHost.Identifier)} property matching dialogIdentifier ('{id}') argument.", ex.Message);
+    }
+
+    [StaFact]
+    public async Task WhenMultipleDialogHostsHaveTheSameIdentifierItThrows()
+    {
+        var id = Guid.NewGuid();
+        _dialogHost.Identifier = id;
+        var otherDialogHost = new DialogHost { Identifier = id };
+        otherDialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => DialogHost.Show("Content", id));
+
+        otherDialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
+
+
+        Assert.Equal("Multiple viable DialogHosts. Specify a unique Identifier on each DialogHost, especially where multiple Windows are a concern.", ex.Message);
+    }
+
+    [StaFact]
+    public async Task WhenNoIdentifierIsSpecifiedItUsesSingleDialogHost()
+    {
+        bool isOpen = false;
+        await DialogHost.Show("Content", new DialogOpenedEventHandler(((sender, args) =>
+        {
+            isOpen = _dialogHost.IsOpen;
+            args.Session.Close();
+        })));
+
+        Assert.True(isOpen);
+    }
+
+    [StaFact]
+    public async Task WhenContentIsNullItThrows()
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => DialogHost.Show(null!));
+
+        Assert.Equal("content", ex.ParamName);
+    }
+
+    [StaFact]
+    [Description("Issue 1212")]
+    public async Task WhenContentIsUpdatedClosingEventHandlerIsInvoked()
+    {
+        int closeInvokeCount = 0;
+        void ClosingHandler(object s, DialogClosingEventArgs e)
+        {
+            closeInvokeCount++;
+            if (closeInvokeCount == 1)
+            {
+                e.Cancel();
             }
-
-            var dialogTask = DialogHost.Show("Content", ClosingHandler);
-            _dialogHost.CurrentSession?.Close("FirstResult");
-            _dialogHost.CurrentSession?.Close("SecondResult");
-            object? result = await dialogTask;
-
-            Assert.Equal("SecondResult", result);
-            Assert.Equal(2, closeInvokeCount);
         }
 
-        [StaFact]
-        public async Task WhenCancellingClosingEventClosedEventHandlerIsNotInvoked()
+        var dialogTask = DialogHost.Show("Content", ClosingHandler);
+        _dialogHost.CurrentSession?.Close("FirstResult");
+        _dialogHost.CurrentSession?.Close("SecondResult");
+        object? result = await dialogTask;
+
+        Assert.Equal("SecondResult", result);
+        Assert.Equal(2, closeInvokeCount);
+    }
+
+    [StaFact]
+    public async Task WhenCancellingClosingEventClosedEventHandlerIsNotInvoked()
+    {
+        int closingInvokeCount = 0;
+        void ClosingHandler(object s, DialogClosingEventArgs e)
         {
-            int closingInvokeCount = 0;
-            void ClosingHandler(object s, DialogClosingEventArgs e)
+            closingInvokeCount++;
+            if (closingInvokeCount == 1)
             {
-                closingInvokeCount++;
-                if (closingInvokeCount == 1)
-                {
-                    e.Cancel();
-                }
+                e.Cancel();
             }
-            int closedInvokeCount = 0;
-            void ClosedHandler(object s, DialogClosedEventArgs e)
-            {
-                closedInvokeCount++;
-            }
-
-            var dialogTask = DialogHost.Show("Content", null, ClosingHandler, ClosedHandler);
-            _dialogHost.CurrentSession?.Close("FirstResult");
-            _dialogHost.CurrentSession?.Close("SecondResult");
-            object? result = await dialogTask;
-
-            Assert.Equal("SecondResult", result);
-            Assert.Equal(2, closingInvokeCount);
-            Assert.Equal(1, closedInvokeCount);
+        }
+        int closedInvokeCount = 0;
+        void ClosedHandler(object s, DialogClosedEventArgs e)
+        {
+            closedInvokeCount++;
         }
 
-        [StaFact]
-        [Description("Issue 1328")]
-        public async Task WhenDoubleClickAwayDialogCloses()
+        var dialogTask = DialogHost.Show("Content", null, ClosingHandler, ClosedHandler);
+        _dialogHost.CurrentSession?.Close("FirstResult");
+        _dialogHost.CurrentSession?.Close("SecondResult");
+        object? result = await dialogTask;
+
+        Assert.Equal("SecondResult", result);
+        Assert.Equal(2, closingInvokeCount);
+        Assert.Equal(1, closedInvokeCount);
+    }
+
+    [StaFact]
+    [Description("Issue 1328")]
+    public async Task WhenDoubleClickAwayDialogCloses()
+    {
+        _dialogHost.CloseOnClickAway = true;
+        Grid contentCover = _dialogHost.FindVisualChild<Grid>(DialogHost.ContentCoverGridName);
+
+        int closingCount = 0;
+        Task shownDialog = _dialogHost.ShowDialog("Content", new DialogClosingEventHandler((sender, args) =>
         {
-            _dialogHost.CloseOnClickAway = true;
-            Grid contentCover = _dialogHost.FindVisualChild<Grid>(DialogHost.ContentCoverGridName);
+            closingCount++;
+        }));
 
-            int closingCount = 0;
-            Task shownDialog = _dialogHost.ShowDialog("Content", new DialogClosingEventHandler((sender, args) =>
-            {
-                closingCount++;
-            }));
-
-            contentCover.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 1, MouseButton.Left)
-            {
-                RoutedEvent = UIElement.MouseLeftButtonUpEvent
-            });
-            contentCover.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 1, MouseButton.Left)
-            {
-                RoutedEvent = UIElement.MouseLeftButtonUpEvent
-            });
-
-            await shownDialog;
-
-            Assert.Equal(1, closingCount);
-        }
-
-        [StaFact]
-        [Description("Issue 1618")]
-        public void WhenDialogHostIsUnloadedIsOpenRemainsTrue()
+        contentCover.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 1, MouseButton.Left)
         {
-            _dialogHost.IsOpen = true;
-            _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
-
-            Assert.True(_dialogHost.IsOpen);
-        }
-
-        [StaFact]
-        [Description("Issue 1750")]
-        public async Task WhenSettingIsOpenToFalseItReturnsClosingParameterToShow()
+            RoutedEvent = UIElement.MouseLeftButtonUpEvent
+        });
+        contentCover.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 1, MouseButton.Left)
         {
-            Guid closeParameter = Guid.NewGuid();
+            RoutedEvent = UIElement.MouseLeftButtonUpEvent
+        });
 
-            Task<object?> showTask = _dialogHost.ShowDialog("Content");
-            _dialogHost.CurrentSession!.CloseParameter = closeParameter;
+        await shownDialog;
 
-            _dialogHost.IsOpen = false;
+        Assert.Equal(1, closingCount);
+    }
 
-            Assert.Equal(closeParameter, await showTask);
-        }
+    [StaFact]
+    [Description("Issue 1618")]
+    public void WhenDialogHostIsUnloadedIsOpenRemainsTrue()
+    {
+        _dialogHost.IsOpen = true;
+        _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
 
-        [StaFact]
-        [Description("Issue 1750")]
-        public async Task WhenClosingDialogReturnValueCanBeSpecifiedInClosingEventHandler()
+        Assert.True(_dialogHost.IsOpen);
+    }
+
+    [StaFact]
+    [Description("Issue 1750")]
+    public async Task WhenSettingIsOpenToFalseItReturnsClosingParameterToShow()
+    {
+        Guid closeParameter = Guid.NewGuid();
+
+        Task<object?> showTask = _dialogHost.ShowDialog("Content");
+        _dialogHost.CurrentSession!.CloseParameter = closeParameter;
+
+        _dialogHost.IsOpen = false;
+
+        Assert.Equal(closeParameter, await showTask);
+    }
+
+    [StaFact]
+    [Description("Issue 1750")]
+    public async Task WhenClosingDialogReturnValueCanBeSpecifiedInClosingEventHandler()
+    {
+        Guid closeParameter = Guid.NewGuid();
+
+        Task<object?> showTask = _dialogHost.ShowDialog("Content", (object sender, DialogClosingEventArgs args) =>
         {
-            Guid closeParameter = Guid.NewGuid();
+            args.Session.CloseParameter = closeParameter;
+        });
 
-            Task<object?> showTask = _dialogHost.ShowDialog("Content", (object sender, DialogClosingEventArgs args) =>
-            {
-                args.Session.CloseParameter = closeParameter;
-            });
+        DialogHost.CloseDialogCommand.Execute(null, _dialogHost);
 
-            DialogHost.CloseDialogCommand.Execute(null, _dialogHost);
+        Assert.Equal(closeParameter, await showTask);
+    }
 
-            Assert.Equal(closeParameter, await showTask);
-        }
+    [StaFact]
+    public async Task WhenClosingDialogReturnValueCanBeSpecifiedInClosedEventHandler()
+    {
+        Guid closeParameter = Guid.NewGuid();
 
-        [StaFact]
-        public async Task WhenClosingDialogReturnValueCanBeSpecifiedInClosedEventHandler()
+        Task<object?> showTask = _dialogHost.ShowDialog("Content", (sender, args) => { }, (sender, args) => { }, (object sender, DialogClosedEventArgs args) =>
         {
-            Guid closeParameter = Guid.NewGuid();
+            args.Session.CloseParameter = closeParameter;
+        });
 
-            Task<object?> showTask = _dialogHost.ShowDialog("Content", (sender, args) => { }, (sender, args) => { }, (object sender, DialogClosedEventArgs args) =>
-            {
-                args.Session.CloseParameter = closeParameter;
-            });
+        DialogHost.CloseDialogCommand.Execute(null, _dialogHost);
 
-            DialogHost.CloseDialogCommand.Execute(null, _dialogHost);
+        Assert.Equal(closeParameter, await showTask);
+    }
 
-            Assert.Equal(closeParameter, await showTask);
-        }
+    [StaFact]
+    [Description("Pull Request 2029")]
+    public void WhenClosingDialogItThrowsWhenNoInstancesLoaded()
+    {
+        _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
 
-        [StaFact]
-        [Description("Pull Request 2029")]
-        public void WhenClosingDialogItThrowsWhenNoInstancesLoaded()
+        var ex = Assert.Throws<InvalidOperationException>(() => DialogHost.Close(null!));
+        Assert.Equal("No loaded DialogHost instances.", ex.Message);
+    }
+
+    [StaFact]
+    [Description("Pull Request 2029")]
+    public void WhenClosingDialogWithInvalidIdentifierItThrowsWhenNoMatchingInstances()
+    {
+        object id = Guid.NewGuid();
+        var ex = Assert.Throws<InvalidOperationException>(() => DialogHost.Close(id));
+        Assert.Equal($"No loaded DialogHost have an Identifier property matching dialogIdentifier ('{id}') argument.", ex.Message);
+    }
+
+    [StaFact]
+    [Description("Pull Request 2029")]
+    public void WhenClosingDialogWithMultipleDialogHostsItThrowsTooManyMatchingInstances()
+    {
+        var secondInstance = new DialogHost();
+        try
         {
-            _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
-
+            secondInstance.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
             var ex = Assert.Throws<InvalidOperationException>(() => DialogHost.Close(null!));
-            Assert.Equal("No loaded DialogHost instances.", ex.Message);
+            Assert.Equal("Multiple viable DialogHosts. Specify a unique Identifier on each DialogHost, especially where multiple Windows are a concern.", ex.Message);
         }
-
-        [StaFact]
-        [Description("Pull Request 2029")]
-        public void WhenClosingDialogWithInvalidIdentifierItThrowsWhenNoMatchingInstances()
+        finally
         {
-            object id = Guid.NewGuid();
-            var ex = Assert.Throws<InvalidOperationException>(() => DialogHost.Close(id));
-            Assert.Equal($"No loaded DialogHost have an Identifier property matching dialogIdentifier ('{id}') argument.", ex.Message);
+            secondInstance.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
         }
+    }
 
-        [StaFact]
-        [Description("Pull Request 2029")]
-        public void WhenClosingDialogWithMultipleDialogHostsItThrowsTooManyMatchingInstances()
+    [StaFact]
+    [Description("Pull Request 2029")]
+    public void WhenClosingDialogThatIsNotOpenItThrowsDialogNotOpen()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => DialogHost.Close(null!));
+        Assert.Equal("DialogHost is not open.", ex.Message);
+    }
+
+    [StaFact]
+    [Description("Pull Request 2029")]
+    public void WhenClosingDialogWithParameterItPassesParameterToHandlers()
+    {
+        object parameter = Guid.NewGuid();
+        object? closingParameter = null;
+        object? closedParameter = null;
+        _dialogHost.DialogClosing += DialogClosing;
+        _dialogHost.DialogClosed += DialogClosed;
+        _dialogHost.IsOpen = true;
+
+        DialogHost.Close(null, parameter);
+
+        Assert.Equal(parameter, closingParameter);
+        Assert.Equal(parameter, closedParameter);
+
+        void DialogClosing(object sender, DialogClosingEventArgs eventArgs)
         {
-            var secondInstance = new DialogHost();
-            try
-            {
-                secondInstance.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
-                var ex = Assert.Throws<InvalidOperationException>(() => DialogHost.Close(null!));
-                Assert.Equal("Multiple viable DialogHosts. Specify a unique Identifier on each DialogHost, especially where multiple Windows are a concern.", ex.Message);
-            }
-            finally
-            {
-                secondInstance.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
-            }
+            closingParameter = eventArgs.Parameter;
         }
 
-        [StaFact]
-        [Description("Pull Request 2029")]
-        public void WhenClosingDialogThatIsNotOpenItThrowsDialogNotOpen()
+        void DialogClosed(object sender, DialogClosedEventArgs eventArgs)
         {
-            var ex = Assert.Throws<InvalidOperationException>(() => DialogHost.Close(null!));
-            Assert.Equal("DialogHost is not open.", ex.Message);
+            closedParameter = eventArgs.Parameter;
         }
+    }
 
-        [StaFact]
-        [Description("Pull Request 2029")]
-        public void WhenClosingDialogWithParameterItPassesParameterToHandlers()
+    [StaFact]
+    public void WhenOpenDialogsAreOpenIsExist()
+    {
+        object id = Guid.NewGuid();
+        _dialogHost.Identifier = id;
+        bool isExist = false;
+        _ = _dialogHost.ShowDialog("Content", new DialogOpenedEventHandler((sender, arg) =>
         {
-            object parameter = Guid.NewGuid();
-            object? closingParameter = null;
-            object? closedParameter = null;
-            _dialogHost.DialogClosing += DialogClosing;
-            _dialogHost.DialogClosed += DialogClosed;
-            _dialogHost.IsOpen = true;
+            isExist = DialogHost.IsDialogOpen(id);
+        }));
+        Assert.True(isExist);
+        DialogHost.Close(id);
+        Assert.False(DialogHost.IsDialogOpen(id));
+    }
 
-            DialogHost.Close(null, parameter);
+    [StaFact]
+    [Description("Issue 2262")]
+    public async Task WhenOnlySingleDialogHostIdentifierIsNullItShowsDialog()
+    {
+        DialogHost dialogHost2 = new();
+        dialogHost2.ApplyDefaultStyle();
+        dialogHost2.Identifier = Guid.NewGuid();
 
-            Assert.Equal(parameter, closingParameter);
-            Assert.Equal(parameter, closedParameter);
-
-            void DialogClosing(object sender, DialogClosingEventArgs eventArgs)
-            {
-                closingParameter = eventArgs.Parameter;
-            }
-
-            void DialogClosed(object sender, DialogClosedEventArgs eventArgs)
-            {
-                closedParameter = eventArgs.Parameter;
-            }
-        }
-
-        [StaFact]
-        public void WhenOpenDialogsAreOpenIsExist()
+        try
         {
-            object id = Guid.NewGuid();
-            _dialogHost.Identifier = id;
-            bool isExist = false;
-            _ = _dialogHost.ShowDialog("Content", new DialogOpenedEventHandler((sender, arg) =>
-            {
-                isExist = DialogHost.IsDialogOpen(id);
-            }));
-            Assert.True(isExist);
-            DialogHost.Close(id);
-            Assert.False(DialogHost.IsDialogOpen(id));
+            dialogHost2.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+            Task showTask = DialogHost.Show("Content");
+            Assert.True(DialogHost.IsDialogOpen(null));
+            Assert.False(DialogHost.IsDialogOpen(dialogHost2.Identifier));
+            DialogHost.Close(null);
+            await showTask;
         }
-
-        [StaFact]
-        [Description("Issue 2262")]
-        public async Task WhenOnlySingleDialogHostIdentifierIsNullItShowsDialog()
+        finally
         {
-            DialogHost dialogHost2 = new();
-            dialogHost2.ApplyDefaultStyle();
-            dialogHost2.Identifier = Guid.NewGuid();
-
-            try
-            {
-                dialogHost2.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
-                Task showTask = DialogHost.Show("Content");
-                Assert.True(DialogHost.IsDialogOpen(null));
-                Assert.False(DialogHost.IsDialogOpen(dialogHost2.Identifier));
-                DialogHost.Close(null);
-                await showTask;
-            }
-            finally
-            {
-                dialogHost2.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
-            }
+            dialogHost2.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
         }
+    }
 
-        [StaFact]
-        [Description("Issue 2844")]
-        public void GetDialogSession_ShouldAllowAccessFromMultipleUIThreads()
+    [StaFact]
+    [Description("Issue 2844")]
+    public void GetDialogSession_ShouldAllowAccessFromMultipleUIThreads()
+    {
+        DialogHost? dialogHost = null;
+        DialogHost? dialogHostOnOtherUiThread = null;
+        Dispatcher? otherUiThreadDispatcher = null;
+        try
         {
             // Arrange
             Guid dialogHostIdentifier = Guid.NewGuid();
             Guid dialogHostOnOtherUiThreadIdentifier = Guid.NewGuid();
-            DialogHost dialogHost = new();
-            DialogHost dialogHostOnOtherUiThread;
-            ManualResetEventSlim sync1 = new ManualResetEventSlim();
-            Dispatcher? otherUiThreadDispatcher = null;
+            dialogHost = new DialogHost();
+            ManualResetEventSlim sync1 = new();
 
             // Load dialogHost on current UI thread
             dialogHost.ApplyDefaultStyle();
@@ -439,9 +442,14 @@ namespace MaterialDesignThemes.Wpf.Tests
             // Act & Assert
             DialogHost.GetDialogSession(dialogHostIdentifier);
             DialogHost.GetDialogSession(dialogHostOnOtherUiThreadIdentifier);
-
+        }
+        finally
+        {
             // Cleanup 
             otherUiThreadDispatcher?.InvokeShutdown();
+            
+            dialogHost?.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
+            dialogHostOnOtherUiThread?.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
         }
     }
 }

--- a/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
@@ -440,7 +440,7 @@ namespace MaterialDesignThemes.Wpf.Tests
             DialogHost.GetDialogSession(dialogHostIdentifier);
             DialogHost.GetDialogSession(dialogHostOnOtherUiThreadIdentifier);
 
-            // Cleanup
+            // Cleanup 
             otherUiThreadDispatcher?.InvokeShutdown();
         }
     }

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -232,7 +232,7 @@ namespace MaterialDesignThemes.Wpf
                     else
                     {
                         // Retrieve the identifier using the Dispatcher on the owning thread (effectively replaces the VerifyAccess() call previously used)
-                        dialogInstance.Dispatcher.Invoke(() => identifier = dialogInstance.Identifier);
+                        identifier = dialogInstance.Dispatcher.Invoke(() => dialogInstance.Identifier);
                     }
                     if (Equals(dialogIdentifier, identifier))
                     {

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Windows.Data;
 using System.Windows.Media;
 using System.Windows.Threading;
@@ -223,8 +224,17 @@ namespace MaterialDesignThemes.Wpf
             {
                 if (instance.TryGetTarget(out DialogHost? dialogInstance))
                 {
-                    dialogInstance.Dispatcher.VerifyAccess();
-                    if (Equals(dialogIdentifier, dialogInstance.Identifier))
+                    object? identifier = null;
+                    if (dialogInstance.CheckAccess())
+                    {
+                        identifier = dialogInstance.Identifier;
+                    }
+                    else
+                    {
+                        // Retrieve the identifier using the Dispatcher on the owning thread (effectively replaces the VerifyAccess() call previously used)
+                        dialogInstance.Dispatcher.Invoke(() => identifier = dialogInstance.Identifier);
+                    }
+                    if (Equals(dialogIdentifier, identifier))
                     {
                         targets.Add(dialogInstance);
                     }


### PR DESCRIPTION
Possible fix for #2844 

I added a unit test which initially failed with the same exception as reported in the issue. Slight modifications to the `DialogHost.GetInstance()` were added in order to retrieve the identifier using the `Dispatcher` associated with the owning thread. This makes the test run green. This change effectively replaces the `Dispatcher.VerifyAccess()` call by using the owning thread when needed.

As mentioned in the bug, the `Dispatcher.VerifyAccess()` guard was to some extent unnecessary because the following `dialogInstance.Identifier` DP-getter would result in the same exception being thrown.

I am a bit unsure whether there could be other areas where a similar approach would be needed.