### PR TITLE
PasswordBox (reveal) - Position RevealPasswordButton in the same way as PART_ClearButton

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -546,6 +546,7 @@
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition />
                                         <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
                                     <Grid
                                         x:Name="grid"
@@ -569,10 +570,6 @@
                                             Grid.Column="1"
                                             Panel.ZIndex="1">
 
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="Auto" />
-                                            </Grid.ColumnDefinitions>
                                             <ScrollViewer
                                                 x:Name="PART_ContentHost"
                                                 wpf:ScrollViewerAssist.IgnorePadding="True"
@@ -596,16 +593,6 @@
                                                 Padding="{Binding ElementName=PART_ContentHost, Path=Padding}"
                                                 Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:PasswordBoxAssist.Password), UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                                                 Visibility="{Binding ElementName=ContentGrid, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed), Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                                            <ToggleButton
-                                                x:Name="RevealPasswordButton"
-                                                Grid.Column="1"
-                                                IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed), Mode=TwoWay}"
-                                                Style="{StaticResource MaterialDesignRawToggleButton}">
-                                                <wpf:PackIcon
-                                                    x:Name="RevealPasswordIcon"
-                                                    Foreground="{Binding ElementName=PART_ClearButton, Path=Foreground}"
-                                                    HorizontalAlignment="Right" />
-                                            </ToggleButton>
                                         </Grid>
                                         
                                         <wpf:SmartHint
@@ -635,9 +622,21 @@
                                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                             Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />
                                     </Grid>
+                                    <ToggleButton
+                                        x:Name="RevealPasswordButton"
+                                        Grid.Column="1"
+                                        Height="Auto"
+                                        Padding="2,0,0,0"
+                                        IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed), Mode=TwoWay}"
+                                        Style="{StaticResource MaterialDesignRawToggleButton}">
+                                        <wpf:PackIcon
+                                            x:Name="RevealPasswordIcon"
+                                            Foreground="{Binding ElementName=PART_ClearButton, Path=Foreground}"
+                                            HorizontalAlignment="Right" />
+                                    </ToggleButton>
                                     <Button
                                         x:Name="PART_ClearButton"
-                                        Grid.Column="1"
+                                        Grid.Column="2"
                                         Height="Auto"
                                         Padding="2,0,0,0"
                                         Command="{x:Static internal:ClearText.ClearCommand}"
@@ -769,9 +768,6 @@
                                 </Setter.Value>
                             </Setter>
                         </MultiTrigger>
-                        <Trigger Property="wpf:HintAssist.IsFloating" Value="True">
-                            <Setter TargetName="RevealPasswordButton" Property="Margin" Value="0 -12 0 0" />
-                        </Trigger>
                         <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
                             <Setter Property="Padding" Value="16 8 12 8" />
                             <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
@@ -800,7 +796,6 @@
                             </Setter>
                             <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16 0 0 0" />
                             <Setter TargetName="RevealPasswordTextBox" Property="Margin" Value="2 0 0 0"></Setter>
-                            <Setter TargetName="RevealPasswordButton" Property="Margin" Value="0" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>


### PR DESCRIPTION
Fix for misalignment mentioned in #2812 

Ensures the `RevealPasswordButton` now sits in the VisualTree in the same manner as the `PART_ClearButton` to ensure they align.