### PR TITLE
Fix not able to style the calendar item of a calendar

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
@@ -651,7 +651,7 @@
         </Setter>
     </Style>
 
-    <Style x:Key="MaterialDesignCalendarPortrait" TargetType="{x:Type Calendar}">
+    <Style x:Key="MaterialDesignCalendarPortraitBase" TargetType="{x:Type Calendar}">
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}"/>
         <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
         <Setter Property="SnapsToDevicePixels" Value="true"/>
@@ -666,7 +666,7 @@
                 <ControlTemplate TargetType="{x:Type Calendar}">
                     <CalendarItem
                         x:Name="PART_CalendarItem"
-                        Style="{DynamicResource MaterialDesignCalendarItemPortrait}"
+                        Style="{TemplateBinding CalendarItemStyle}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         Background="{TemplateBinding Background}"
@@ -679,6 +679,10 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+    </Style>
+
+    <Style x:Key="MaterialDesignCalendarPortrait" TargetType="Calendar" BasedOn="{StaticResource MaterialDesignCalendarPortraitBase}">
+        <Setter Property="CalendarItemStyle" Value="{StaticResource MaterialDesignCalendarItemPortrait}" />
     </Style>
 
     <Style x:Key="MaterialDesignCalendarPortraitForeground" TargetType="Calendar" BasedOn="{StaticResource MaterialDesignCalendarPortrait}">


### PR DESCRIPTION
https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/65c80dadef263a3c54cadb71b9b0237c3ac44b47/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml#L667-L679

Since line 669 is bound to MaterialDesignCalendarItemPortrait it is not possible to overwrite this with the following code:


    <Style x:Key="...."
           BasedOn="{StaticResource MaterialDesignDatePicker}"
           TargetType="{x:Type DatePicker}">
        
        <Setter Property="CalendarStyle" Value="{StaticResource MyCustomCalendarStyle}" />
    </Style>

The changes in this PR addresses this issue