### PR TITLE
PasswordBox - Set vertical alignment of reveal button

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -632,7 +632,7 @@
                                         <wpf:PackIcon
                                             x:Name="RevealPasswordIcon"
                                             Foreground="{Binding ElementName=PART_ClearButton, Path=Foreground}"
-                                            HorizontalAlignment="Right" />
+                                            VerticalAlignment="Center" />
                                     </ToggleButton>
                                     <Button
                                         x:Name="PART_ClearButton"


### PR DESCRIPTION
Fix for issue mentioned [here](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2812#issuecomment-1250587904).

Setting `VerticalAlignment=Center` to align with `PART_ClearButton` (default value).

This threw me off initially, because the demo application overrides the style for `PackIcon` in Fields.xaml, and explicitly sets `VerticalAlignment=Center`. The default however is `Top`, which is not correct. Instead of changing it directly on the `PackIcon` style - which potentially is a bit too intrusive - I simply apply it directly on the `PackIcon` instance used in the reveal button.

Also, the `HorizontalAlignment` being removed was a leftover from earlier, and is no longer needed.