### PR TITLE
Implementation for uniform width tabs

### DIFF
--- a/MainDemo.Wpf/Tabs.xaml
+++ b/MainDemo.Wpf/Tabs.xaml
@@ -432,29 +432,76 @@
                 <materialDesign:Card>
                     <TabControl HorizontalContentAlignment="Left">
                         <TabItem Header="TAB1">
-                            <TextBlock Margin="8" Text="Not filled example tab 1" />
+                            <TextBlock Margin="8" Text="Not filled, required width, tab 1" />
                         </TabItem>
-                        <TabItem Header="TAB 2">
-                            <TextBlock Margin="8" Text="Not filled example tab 2" />
+                        <TabItem Header="TAB 2 Wide">
+                            <TextBlock Margin="8" Text="Not filled, required width, tab 2" />
+                        </TabItem>
+                        <TabItem Header="TAB 3 Extremely Wide">
+                            <TextBlock Margin="8" Text="Not filled, required width, tab 3" />
+                        </TabItem>
+                        <TabItem Header="TAB 4">
+                            <TextBlock Margin="8" Text="Not filled, required width, tab 4" />
                         </TabItem>
                     </TabControl>
                 </materialDesign:Card>
             </smtx:XamlDisplay>
-
             <smtx:XamlDisplay Margin="0,0,0,16" UniqueKey="tabs_20">
                 <materialDesign:Card>
-                    <TabControl HorizontalContentAlignment="Left" Style="{StaticResource MaterialDesignFilledTabControl}">
+                    <TabControl HorizontalContentAlignment="Left" Style="{StaticResource MaterialDesignUniformTabControl}">
                         <TabItem Header="TAB1">
-                            <TextBlock Margin="8" Text="Filled example tab 1" />
+                            <TextBlock Margin="8" Text="Not filled, uniform width, tab 1" />
                         </TabItem>
-                        <TabItem Header="TAB 2">
-                            <TextBlock Margin="8" Text="Filled example tab 2" />
+                        <TabItem Header="TAB 2 Wide">
+                            <TextBlock Margin="8" Text="Not filled, uniform width, tab 2" />
+                        </TabItem>
+                        <TabItem Header="TAB 3 Extremely Wide">
+                            <TextBlock Margin="8" Text="Not filled, uniform width, tab 3" />
+                        </TabItem>
+                        <TabItem Header="TAB 4">
+                            <TextBlock Margin="8" Text="Not filled, uniform width, tab 4" />
+                        </TabItem>
+                    </TabControl>
+                </materialDesign:Card>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay Margin="0,0,0,16" UniqueKey="tabs_21">
+                <materialDesign:Card>
+                    <TabControl HorizontalContentAlignment="Center" Style="{StaticResource MaterialDesignFilledTabControl}">
+                        <TabItem Header="TAB1">
+                            <TextBlock Margin="8" Text="Filled, centered, required width, tab 1" />
+                        </TabItem>
+                        <TabItem Header="TAB 2 Wide">
+                            <TextBlock Margin="8" Text="Filled, centered, required width, tab 2" />
+                        </TabItem>
+                        <TabItem Header="TAB 3 Extremely Wide">
+                            <TextBlock Margin="8" Text="Filled, centered, required width, tab 3" />
+                        </TabItem>
+                        <TabItem Header="TAB 4">
+                            <TextBlock Margin="8" Text="Filled, centered, required width, tab 4" />
+                        </TabItem>
+                    </TabControl>
+                </materialDesign:Card>
+            </smtx:XamlDisplay>
+            <smtx:XamlDisplay Margin="0,0,0,16" UniqueKey="tabs_22">
+                <materialDesign:Card>
+                    <TabControl HorizontalContentAlignment="Center" Style="{StaticResource MaterialDesignFilledUniformTabControl}">
+                        <TabItem Header="TAB1">
+                            <TextBlock Margin="8" Text="Filled, centered, uniform width, tab 1" />
+                        </TabItem>
+                        <TabItem Header="TAB 2 Wide">
+                            <TextBlock Margin="8" Text="Filled, centered, uniform width, tab 2" />
+                        </TabItem>
+                        <TabItem Header="TAB 3 Extremely Wide">
+                            <TextBlock Margin="8" Text="Filled, centered, uniform width, tab 3" />
+                        </TabItem>
+                        <TabItem Header="TAB 4">
+                            <TextBlock Margin="8" Text="Filled, centered, uniform width, tab 4" />
                         </TabItem>
                     </TabControl>
                 </materialDesign:Card>
             </smtx:XamlDisplay>
 
-            <smtx:XamlDisplay Margin="0,0,0,16" UniqueKey="tabs_21">
+            <smtx:XamlDisplay Margin="0,0,0,16" UniqueKey="tabs_23">
                 <materialDesign:Card>
                     <TabControl HorizontalContentAlignment="Left" materialDesign:ColorZoneAssist.Mode="SecondaryMid">
                         <TabItem Header="TAB1">
@@ -491,7 +538,7 @@
                 </materialDesign:Card>
             </smtx:XamlDisplay>
 
-            <smtx:XamlDisplay Margin="0,0,0,16" UniqueKey="tabs_22">
+            <smtx:XamlDisplay Margin="0,0,0,16" UniqueKey="tabs_24">
                 <materialDesign:Card>
                     <TabControl
                         HorizontalContentAlignment="Left"

--- a/MaterialDesignThemes.Wpf/TabAssist.cs
+++ b/MaterialDesignThemes.Wpf/TabAssist.cs
@@ -9,5 +9,12 @@
 
         public static bool GetHasFilledTab(DependencyObject element) => (bool)element.GetValue(HasFilledTabProperty);
 
+        public static readonly DependencyProperty HasUniformTabWidthProperty = DependencyProperty.RegisterAttached(
+            "HasUniformTabWidth", typeof(bool), typeof(TabAssist), new PropertyMetadata(false));
+
+        public static void SetHasUniformTabWidth(DependencyObject element, bool value) => element.SetValue(HasUniformTabWidthProperty, value);
+
+        public static bool GetHasUniformTabWidth(DependencyObject element) => (bool)element.GetValue(HasUniformTabWidthProperty);
+
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -36,6 +36,7 @@
         <Setter Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid" />
         <Setter Property="wpf:ElevationAssist.Elevation" Value="Dp4" />
         <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Bottom" />
+        <Setter Property="wpf:TabAssist.HasUniformTabWidth" Value="False"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabControl}">
@@ -100,18 +101,67 @@
                             <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
                         </Trigger>
-                        <Trigger Property="HorizontalContentAlignment" Value="Center">
-                            <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
-                            <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
-                        </Trigger>
-                        <Trigger Property="HorizontalContentAlignment" Value="Left">
-                            <Setter TargetName="HeaderPanel" Property="Visibility" Value="Visible" />
-                            <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Collapsed" />
-                        </Trigger>
-                        <Trigger Property="HorizontalContentAlignment" Value="Right">
-                            <Setter TargetName="HeaderPanel" Property="Visibility" Value="Visible" />
-                            <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Collapsed" />
-                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="HorizontalContentAlignment" Value="Center"/>
+                                <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="False"/>
+                            </MultiTrigger.Conditions>
+                            <MultiTrigger.Setters>
+                                <Setter TargetName="HeaderPanel" Property="Visibility" Value="Visible" />
+                                <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Collapsed" />
+                            </MultiTrigger.Setters>
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="HorizontalContentAlignment" Value="Center"/>
+                                <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="True"/>
+                            </MultiTrigger.Conditions>
+                            <MultiTrigger.Setters>
+                                <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
+                                <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
+                            </MultiTrigger.Setters>
+                        </MultiTrigger>
+
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="HorizontalContentAlignment" Value="Left"/>
+                                <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="False"/>
+                            </MultiTrigger.Conditions>
+                            <MultiTrigger.Setters>
+                                <Setter TargetName="HeaderPanel" Property="Visibility" Value="Visible" />
+                                <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Collapsed" />
+                            </MultiTrigger.Setters>
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="HorizontalContentAlignment" Value="Left"/>
+                                <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="True"/>
+                            </MultiTrigger.Conditions>
+                            <MultiTrigger.Setters>
+                                <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
+                                <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
+                            </MultiTrigger.Setters>
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="HorizontalContentAlignment" Value="Right"/>
+                                <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="False"/>
+                            </MultiTrigger.Conditions>
+                            <MultiTrigger.Setters>
+                                <Setter TargetName="HeaderPanel" Property="Visibility" Value="Visible" />
+                                <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Collapsed" />
+                            </MultiTrigger.Setters>
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="HorizontalContentAlignment" Value="Right"/>
+                                <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="True"/>
+                            </MultiTrigger.Conditions>
+                            <MultiTrigger.Setters>
+                                <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
+                                <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
+                            </MultiTrigger.Setters>
+                        </MultiTrigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
                             <Setter TargetName="PART_HeaderZone" Property="DockPanel.Dock" Value="Bottom" />
                             <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Top" />
@@ -142,6 +192,12 @@
         <Setter Property="wpf:ElevationAssist.Elevation" Value="Dp0" />
         <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="None" />
         <Setter Property="wpf:ColorZoneAssist.Background" Value="Transparent" />
+    </Style>
+
+    <Style x:Key="MaterialDesignUniformTabControl"
+        BasedOn="{StaticResource MaterialDesignTabControl}"
+        TargetType="{x:Type TabControl}">
+        <Setter Property="wpf:TabAssist.HasUniformTabWidth" Value="True"/>
     </Style>
 
     <Style x:Key="MaterialDesignFilledTabControl"
@@ -185,6 +241,12 @@
         </Style.Triggers>
     </Style>
 
+    <Style x:Key="MaterialDesignFilledUniformTabControl"
+        BasedOn="{StaticResource MaterialDesignFilledTabControl}"
+        TargetType="{x:Type TabControl}">
+        <Setter Property="wpf:TabAssist.HasUniformTabWidth" Value="True"/>
+    </Style>
+    
     <Style x:Key="MaterialDesignTabItem" TargetType="{x:Type TabItem}">
         <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}" />
         <Setter Property="Background" Value="Transparent" />


### PR DESCRIPTION
This is a solution for #2878 , it:

- does not change current default behaviours
- applies only to top and bottom placed tabs
- does not apply to tabcontrols with HorizontalContentAligment set to 'Stretch'

Two styles are added to achieve the result: 'MaterialDesignFilledTabControl', 'MaterialDesignFilledUniformTabControl', both styles are based on the existing styles and only set an extra attached property.

