### PR TITLE
Handle ColorPicker mouse move event only with captured thumb (#2896)

### DIFF
--- a/MaterialDesignThemes.Wpf/ColorPicker.cs
+++ b/MaterialDesignThemes.Wpf/ColorPicker.cs
@@ -152,6 +152,9 @@ namespace MaterialDesignThemes.Wpf
 
         private void SaturationBrightnessCanvasMouseMove(object sender, MouseEventArgs e)
         {
+            if (Mouse.Captured is null || Mouse.Captured != _saturationBrightnessThumb)
+                return;
+
             if (e.LeftButton == MouseButtonState.Pressed)
             {
                 var position = e.GetPosition(_saturationBrightnessCanvas);


### PR DESCRIPTION
Fixes #2896 

https://user-images.githubusercontent.com/63662834/193915577-53614eae-9885-457f-8240-31cbefeb1d2e.mp4

