### PR TITLE
Add LTR/RTL toggle to demo tool for easy testing of RTL layouts

### DIFF
--- a/MainDemo.Wpf/MainWindow.xaml
+++ b/MainDemo.Wpf/MainWindow.xaml
@@ -153,6 +153,7 @@
                                     <Grid.RowDefinitions>
                                         <RowDefinition />
                                         <RowDefinition />
+                                        <RowDefinition />
                                     </Grid.RowDefinitions>
                                     <TextBlock
                                         Text="Light"
@@ -175,6 +176,22 @@
                                         IsChecked="{Binding ControlsEnabled}"
                                         Grid.Row="1"
                                         Grid.Column="1"/>
+
+                                    <TextBlock
+                                        Text="LTR"
+                                        Margin="0 10 10 0"
+                                        Grid.Row="2"/>
+                                    <ToggleButton
+                                        x:Name="FlowDirectionToggleButton"
+                                        Click="FlowDirectionButton_Click"
+                                        Margin="0 10 0 0"
+                                        Grid.Column="1"
+                                        Grid.Row="2"/>
+                                    <TextBlock
+                                        Text="RTL"
+                                        Margin="10 10 0 0"
+                                        Grid.Column="2"
+                                        Grid.Row="2"/>
                                 </Grid>
 
                                 <Separator/>

--- a/MainDemo.Wpf/MainWindow.xaml.cs
+++ b/MainDemo.Wpf/MainWindow.xaml.cs
@@ -86,6 +86,11 @@ namespace MaterialDesignDemo
         private void MenuDarkModeButton_Click(object sender, RoutedEventArgs e) 
             => ModifyTheme(DarkModeToggleButton.IsChecked == true);
 
+        private void FlowDirectionButton_Click(object sender, RoutedEventArgs e)
+            => FlowDirection = FlowDirectionToggleButton.IsChecked.GetValueOrDefault(false)
+                ? FlowDirection.RightToLeft
+                : FlowDirection.LeftToRight;
+
         private static void ModifyTheme(bool isDarkTheme)
         {
             var paletteHelper = new PaletteHelper();


### PR DESCRIPTION
Adds a toggle button in the demo tool to easily switch between LRT/RTL `FlowDirection` of the `MainWindow`.

<img width="167" alt="image" src="https://user-images.githubusercontent.com/19572699/195060633-49d7da3e-ce55-4c20-841b-f4e37f1de18c.png">
