### PR TITLE
Enable use of TextFieldAssist.CharacterCounterVisibility on PasswordBox

### DIFF
--- a/MainDemo.Wpf/Fields.xaml
+++ b/MainDemo.Wpf/Fields.xaml
@@ -340,7 +340,7 @@
                         VerticalAlignment="Bottom"
                         UniqueKey="passwordFilled1">
         <StackPanel>
-          <CheckBox x:Name="MaterialDesignFilledPasswordBoxTextCountComboBox" Content="View Pwd Input Count" />
+          <CheckBox x:Name="MaterialDesignFilledPasswordBoxTextCountComboBox" Content="View Password Input Count" />
 
           <PasswordBox materialDesign:HintAssist.HelperText="Helper text"
                        materialDesign:HintAssist.Hint="Password"

--- a/MainDemo.Wpf/Fields.xaml
+++ b/MainDemo.Wpf/Fields.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="MaterialDesignDemo.Fields"
+<UserControl x:Class="MaterialDesignDemo.Fields"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -339,9 +339,14 @@
                         Grid.Column="3"
                         VerticalAlignment="Bottom"
                         UniqueKey="passwordFilled1">
-        <PasswordBox materialDesign:HintAssist.HelperText="Helper text"
-                     materialDesign:HintAssist.Hint="Password"
-                     Style="{StaticResource MaterialDesignFilledPasswordBox}" />
+        <StackPanel>
+          <CheckBox x:Name="MaterialDesignFilledPasswordBoxTextCountComboBox" Content="View Pwd Input Count" />
+
+          <PasswordBox materialDesign:HintAssist.HelperText="Helper text"
+                       materialDesign:HintAssist.Hint="Password"
+                       materialDesign:TextFieldAssist.CharacterCounterVisibility="{Binding Path=IsChecked, ElementName=MaterialDesignFilledPasswordBoxTextCountComboBox, Converter={StaticResource BooleanToVisibilityConverter}}"
+                       Style="{StaticResource MaterialDesignFilledPasswordBox}" />
+        </StackPanel>
       </smtx:XamlDisplay>
 
       <smtx:XamlDisplay Grid.Row="2"

--- a/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -263,7 +263,31 @@ namespace MaterialDesignThemes.Wpf
 
         public static readonly DependencyProperty CharacterCounterVisibilityProperty =
             DependencyProperty.RegisterAttached("CharacterCounterVisibility", typeof(Visibility), typeof(TextFieldAssist),
-                new PropertyMetadata(Visibility.Visible));
+                new PropertyMetadata(Visibility.Collapsed, CharacterCounterVisibilityChanged));
+
+        private static void CharacterCounterVisibilityChanged(DependencyObject element, DependencyPropertyChangedEventArgs e)
+        {
+            if (element is PasswordBox passwordBox)
+            {
+                passwordBox.PasswordChanged -= PasswordBoxOnPasswordChanged;
+                if (Equals(Visibility.Visible, e.NewValue))
+                {
+                    SetPasswordBoxCharacterCount(passwordBox, passwordBox.SecurePassword.Length);
+                    passwordBox.PasswordChanged += PasswordBoxOnPasswordChanged;
+                }
+            }
+        }
+
+        private static void PasswordBoxOnPasswordChanged(object sender, RoutedEventArgs e)
+        {
+            PasswordBox passwordBox = (PasswordBox)sender;
+            SetPasswordBoxCharacterCount(passwordBox, passwordBox.SecurePassword.Length);
+        }
+
+        internal static readonly DependencyProperty PasswordBoxCharacterCountProperty = DependencyProperty.RegisterAttached(
+            "PasswordBoxCharacterCount", typeof(int), typeof(TextFieldAssist), new PropertyMetadata(default(int)));
+        internal static void SetPasswordBoxCharacterCount(DependencyObject element, int value) => element.SetValue(PasswordBoxCharacterCountProperty, value);
+        internal static int GetPasswordBoxCharacterCount(DependencyObject element) => (int) element.GetValue(PasswordBoxCharacterCountProperty);
 
         #region Methods
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -20,6 +20,32 @@
   <converters:CursorConverter x:Key="ArrowCursorConverter" FallbackCursor="Arrow" />
   <converters:CursorConverter x:Key="IBeamCursorConverter" FallbackCursor="IBeam" />
 
+  <Style x:Key="MaterialDesignPasswordCharacterCounterTextBlock"
+         TargetType="TextBlock"
+         BasedOn="{StaticResource {x:Type TextBlock}}">
+    <Setter Property="FontSize" Value="10" />
+    <Setter Property="Margin" Value="0,0,16,0" />
+    <Setter Property="Opacity" Value="0.56" />
+    <Setter Property="Text">
+      <Setter.Value>
+        <MultiBinding StringFormat="{}{0} / {1}">
+          <Binding Path="(wpf:TextFieldAssist.PasswordBoxCharacterCount)" RelativeSource="{RelativeSource FindAncestor, AncestorType=PasswordBox}" />
+          <Binding Path="MaxLength" RelativeSource="{RelativeSource FindAncestor, AncestorType=PasswordBox}" />
+        </MultiBinding>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="Visibility" Value="{Binding Path=(wpf:TextFieldAssist.CharacterCounterVisibility), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type PasswordBox}}}" />
+  </Style>
+
+  <Style x:Key="MaterialDesignPasswordHelperTextBlock"
+         TargetType="TextBlock"
+         BasedOn="{StaticResource {x:Type TextBlock}}">
+    <Setter Property="FontSize" Value="{Binding Path=(wpf:HintAssist.HelperTextFontSize), RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+    <Setter Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+    <Setter Property="Text" Value="{Binding Path=(wpf:HintAssist.HelperText), RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+  </Style>
+
   <Style x:Key="MaterialDesignPasswordBox" TargetType="{x:Type PasswordBox}">
     <Setter Property="AllowDrop" Value="true" />
     <Setter Property="Background" Value="Transparent" />
@@ -185,12 +211,19 @@
                            Background="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
                            CornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
                            Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}" />
-            <Canvas x:Name="HelperTextWrapper" VerticalAlignment="Bottom">
-              <TextBlock Canvas.Top="2"
-                         MaxWidth="{Binding ActualWidth, ElementName=border}"
-                         FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
-                         Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                         Text="{TemplateBinding wpf:HintAssist.HelperText}" />
+            <Canvas VerticalAlignment="Bottom">
+              <Grid x:Name="FooterGrid"
+                    Canvas.Top="2"
+                    Width="{Binding ActualWidth, ElementName=border}">
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition />
+                  <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock x:Name="HelperTextTextBlock" Style="{Binding Path=(wpf:HintAssist.HelperTextStyle), RelativeSource={RelativeSource TemplatedParent}}" />
+                <Border x:Name="CharacterCounterContainer" Grid.Column="1">
+                  <TextBlock x:Name="CharacterCounterTextBlock" Style="{Binding Path=(wpf:TextFieldAssist.CharacterCounterStyle), RelativeSource={RelativeSource TemplatedParent}}" />
+                </Border>
+              </Grid>
             </Canvas>
           </Grid>
           <ControlTemplate.Triggers>
@@ -232,7 +265,7 @@
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
               <Setter Property="Padding" Value="16,8,12,8" />
               <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
-              <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
+              <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
@@ -240,7 +273,7 @@
               <Setter Property="Padding" Value="16,16,12,16" />
               <Setter Property="VerticalContentAlignment" Value="Top" />
               <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
-              <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
+              <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
@@ -394,6 +427,7 @@
               </MultiTrigger.Conditions>
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignValidationErrorBrush}" />
               <Setter Property="BorderThickness" Value="2" />
+              <Setter TargetName="FooterGrid" Property="Margin" Value="0,0,1,0" />
               <Setter TargetName="border" Property="Margin" Value="-1" />
             </MultiTrigger>
           </ControlTemplate.Triggers>
@@ -404,8 +438,11 @@
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="internal:ClearText.HandlesClearCommand" Value="True" />
     <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+    <Setter Property="wpf:HintAssist.HelperTextStyle" Value="{StaticResource MaterialDesignPasswordHelperTextBlock}" />
     <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMargin}" />
     <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+    <Setter Property="wpf:TextFieldAssist.CharacterCounterStyle" Value="{StaticResource MaterialDesignPasswordCharacterCounterTextBlock}" />
+    <Setter Property="wpf:TextFieldAssist.CharacterCounterVisibility" Value="Hidden" />
   </Style>
 
   <Style x:Key="MaterialDesignFloatingHintPasswordBox"
@@ -661,12 +698,19 @@
                            Background="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
                            CornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
                            Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}" />
-            <Canvas x:Name="HelperTextWrapper" VerticalAlignment="Bottom">
-              <TextBlock Canvas.Top="2"
-                         MaxWidth="{Binding ActualWidth, ElementName=border}"
-                         FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
-                         Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                         Text="{TemplateBinding wpf:HintAssist.HelperText}" />
+            <Canvas VerticalAlignment="Bottom">
+              <Grid x:Name="FooterGrid"
+                    Canvas.Top="2"
+                    Width="{Binding ActualWidth, ElementName=border}">
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition />
+                  <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock x:Name="HelperTextTextBlock" Style="{Binding Path=(wpf:HintAssist.HelperTextStyle), RelativeSource={RelativeSource TemplatedParent}}" />
+                <Border x:Name="CharacterCounterContainer" Grid.Column="1">
+                  <TextBlock x:Name="CharacterCounterTextBlock" Style="{Binding Path=(wpf:TextFieldAssist.CharacterCounterStyle), RelativeSource={RelativeSource TemplatedParent}}" />
+                </Border>
+              </Grid>
             </Canvas>
           </Grid>
           <ControlTemplate.Triggers>
@@ -717,7 +761,7 @@
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
               <Setter Property="Padding" Value="16,8,12,8" />
               <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
-              <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
+              <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
@@ -725,7 +769,7 @@
               <Setter Property="Padding" Value="16,16,12,16" />
               <Setter Property="VerticalContentAlignment" Value="Top" />
               <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
-              <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
+              <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
@@ -880,6 +924,7 @@
               </MultiTrigger.Conditions>
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignValidationErrorBrush}" />
               <Setter Property="BorderThickness" Value="2" />
+              <Setter TargetName="FooterGrid" Property="Margin" Value="0,0,1,0" />
               <Setter TargetName="border" Property="Margin" Value="-1" />
             </MultiTrigger>
 
@@ -900,11 +945,14 @@
     <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="internal:ClearText.HandlesClearCommand" Value="True" />
     <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+    <Setter Property="wpf:HintAssist.HelperTextStyle" Value="{StaticResource MaterialDesignPasswordHelperTextBlock}" />
     <Setter Property="wpf:PasswordBoxAssist.InitialPassword" Value="" />
     <Setter Property="wpf:PasswordBoxAssist.IsPasswordRevealed" Value="False" />
     <Setter Property="wpf:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:PasswordBoxAssist.InitialPassword)}" />
     <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMargin}" />
     <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+    <Setter Property="wpf:TextFieldAssist.CharacterCounterStyle" Value="{StaticResource MaterialDesignPasswordCharacterCounterTextBlock}" />
+    <Setter Property="wpf:TextFieldAssist.CharacterCounterVisibility" Value="Hidden" />
   </Style>
 
   <Style x:Key="MaterialDesignFloatingHintRevealPasswordBox"


### PR DESCRIPTION
Fix for #2935 

This copies over the "character counter" feature from `TextBox` the the `PasswordBox` styles. In order to monitor the change in password length, a new internal attached property was introduced (`TextFieldAssist.PasswordBoxCharacterCount`). The value is updated whenever the password changes; the event handler listening for the changes is wired up when the `TextFieldAssist.CharacterCounterVisibility` changes.

**Note:** I changed the default value of `TextFieldAssist.CharacterCounterVisibility` to `Hidden` in order to detect the change to `Visible`. You can consider this somewhat of a behavioral breaking change, but the base `TextBox` style explicitly sets it to `Visible` anyway (I find that a bit odd, I would assume this was opt-in functionality!).