### PR TITLE
Delete HeaderSite Style attribute that will be overridden from ControlTemplate.Triggers

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
@@ -276,7 +276,6 @@
                             IsChecked="{Binding Path=IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                             IsTabStop="False"
                             Opacity="0.87"
-                            Style="{StaticResource MaterialDesignHorizontalHeaderStyle}"
                             TextElement.FontSize="{TemplateBinding wpf:ExpanderAssist.HeaderFontSize}" />
 
               <Border Name="ContentSite">


### PR DESCRIPTION
Fixes #2920

Here's a solution with cloned styles demonstrating that `MaterialDesignExpander` functions normally with `HeaderSite.Style` set only from `ControlTemplate.Triggers`.

[ExpanderTest.zip](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/files/9954951/ExpanderTest.zip)
