### PR TITLE
IBeam in EditableComboBox of DataGrid now aligns with the TextBrush

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
@@ -299,6 +299,7 @@
       </Setter.Value>
     </Setter>
     <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
+    <Setter Property="CaretBrush" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
   </Style>
 
   <ControlTemplate x:Key="MaterialDesignDataGridComboBoxEditableTemplate" TargetType="{x:Type ComboBox}">


### PR DESCRIPTION
Fixes #2951 

Adds @mkrauter's suggestion to the `MaterialDesignDataGridComboBoxEditableTextBox` style used for editable `ComboBox` in `DataGrid`.

This was easily reproducable in the demo app.

Before:
![image](https://user-images.githubusercontent.com/19572699/202694085-ead8c2b8-b7f1-407c-a7bd-9ff31937ce8a.png)

After:
![image](https://user-images.githubusercontent.com/19572699/202693616-9d5b5db2-17a5-434c-94cc-3a120c205d7b.png)
