### PR TITLE
Removed unneeded MaxWidth of TabItem

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -244,7 +244,6 @@
     <!-- Foreground is for the content, not the header -->
     <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, Path=(TextElement.Foreground)}" />
     <Setter Property="Height" Value="48" />
-    <Setter Property="MaxWidth" Value="360" />
     <Setter Property="MinWidth" Value="90" />
     <Setter Property="Padding" Value="16,12" />
     <Setter Property="Template">


### PR DESCRIPTION
Fixes #2942

Removes `MaxWidth` definition of `TabItem` as it creates issues in some cases and is not necessary.