### PR TITLE
TabControl disconnects TabItem.DataContext for HorizontalContentAlignment="Stretch"

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/TabControls/TabControlTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TabControls/TabControlTests.cs
@@ -47,13 +47,19 @@ public class TabControlTests : TestBase
         recorder.Success();
     }
 
+    [Description("Issue 2983")]
     [Theory]
-    [InlineData("Center")]
-    [InlineData("Left")]
-    [InlineData("Right")]
-    [InlineData("Stretch")]
-    [InlineData("")]
-    public async Task TabItem_ShouldKeepDataContext_WhenContextMenuOpens(string horizontalContentAlignment)
+    [InlineData("Center", true)]
+    [InlineData("Center", false)]
+    [InlineData("Left", true)]
+    [InlineData("Left", false)]
+    [InlineData("Right", true)]
+    [InlineData("Right", false)]
+    [InlineData("Stretch", true)]
+    [InlineData("Stretch", false)]
+    [InlineData("", true)]
+    [InlineData("", false)]
+    public async Task TabItem_ShouldKeepDataContext_WhenContextMenuOpens(string horizontalContentAlignment, bool hasUniformTabWidth)
     {
         await using var recorder = new TestRecorder(App);
 
@@ -68,10 +74,11 @@ public class TabControlTests : TestBase
 <StackPanel Orientation=""Vertical"">
   <TabControl
           {alignment}
+          materialDesign:TabAssist.HasUniformTabWidth=""{hasUniformTabWidth}""
           materialDesign:ColorZoneAssist.Mode=""PrimaryMid""
           Style=""{{StaticResource MaterialDesignFilledTabControl}}"">
     <system:String>aaaa</system:String>
-    <system:String>bbbb</system:String>
+    <system:String>bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb</system:String>
     <TabControl.ItemTemplate>
       <DataTemplate DataType=""system:String"">
         <TextBlock Text=""{{Binding}}"" />

--- a/MaterialDesignThemes.UITests/WPF/TabControls/TabControlTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TabControls/TabControlTests.cs
@@ -76,8 +76,8 @@ public class TabControlTests : TestBase
       <DataTemplate DataType=""system:String"">
         <TextBlock Text=""{{Binding}}"" />
       </DataTemplate>
-      </TabControl.ItemTemplate>
-      <TabControl.ContentTemplate>
+    </TabControl.ItemTemplate>
+    <TabControl.ContentTemplate>
       <DataTemplate DataType=""system:String"">
         <TextBlock Text=""{{Binding}}"" />
       </DataTemplate>
@@ -97,7 +97,7 @@ public class TabControlTests : TestBase
 
         // Assert initial data context
         IVisualElement<TabItem> tabItem = await tabControl.GetElement<TabItem>();
-        object? dataContext = await tabItem.GetProperty<object?>(FrameworkElement.DataContextProperty);
+        object? dataContext = await tabItem.GetDataContext();
         Assert.Equal("aaaa", dataContext);
 
         // Act
@@ -105,11 +105,11 @@ public class TabControlTests : TestBase
         await button.RightClick();
         await tabControl.MoveCursorTo();
         await tabControl.LeftClick(Position.TopLeft);
-        await Task.Delay(50);   // allow a little time for the disconnect to occur
-
+        await Task.Delay(50); // allow a little time for the disconnect to occur
+        
         // Assert data context still present
         tabItem = await tabControl.GetElement<TabItem>();
-        dataContext = await tabItem.GetProperty<object?>(FrameworkElement.DataContextProperty);
+        dataContext = await tabItem.GetDataContext();
         Assert.Equal("aaaa", dataContext);
 
         recorder.Success();

--- a/MaterialDesignThemes.Wpf/TabAssist.cs
+++ b/MaterialDesignThemes.Wpf/TabAssist.cs
@@ -1,20 +1,35 @@
-﻿namespace MaterialDesignThemes.Wpf
+namespace MaterialDesignThemes.Wpf;
+
+public static class TabAssist
 {
-    public static class TabAssist
+    public static readonly DependencyProperty HasFilledTabProperty = DependencyProperty.RegisterAttached(
+        "HasFilledTab", typeof(bool), typeof(TabAssist), new PropertyMetadata(false));
+
+    public static void SetHasFilledTab(DependencyObject element, bool value) => element.SetValue(HasFilledTabProperty, value);
+
+    public static bool GetHasFilledTab(DependencyObject element) => (bool)element.GetValue(HasFilledTabProperty);
+
+    public static readonly DependencyProperty HasUniformTabWidthProperty = DependencyProperty.RegisterAttached(
+        "HasUniformTabWidth", typeof(bool), typeof(TabAssist), new PropertyMetadata(false));
+
+    public static void SetHasUniformTabWidth(DependencyObject element, bool value) => element.SetValue(HasUniformTabWidthProperty, value);
+
+    public static bool GetHasUniformTabWidth(DependencyObject element) => (bool)element.GetValue(HasUniformTabWidthProperty);
+
+    internal static bool GetBindableIsItemsHost(DependencyObject obj)
+        => (bool)obj.GetValue(BindableIsItemsHostProperty);
+
+    internal static void SetBindableIsItemsHost(DependencyObject obj, bool value)
+        => obj.SetValue(BindableIsItemsHostProperty, value);
+
+    internal static readonly DependencyProperty BindableIsItemsHostProperty =
+        DependencyProperty.RegisterAttached("BindableIsItemsHost", typeof(bool), typeof(TabAssist), new PropertyMetadata(false, OnBindableIsItemsHostChanged));
+
+    private static void OnBindableIsItemsHostChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        public static readonly DependencyProperty HasFilledTabProperty = DependencyProperty.RegisterAttached(
-            "HasFilledTab", typeof(bool), typeof(TabAssist), new PropertyMetadata(false));
-
-        public static void SetHasFilledTab(DependencyObject element, bool value) => element.SetValue(HasFilledTabProperty, value);
-
-        public static bool GetHasFilledTab(DependencyObject element) => (bool)element.GetValue(HasFilledTabProperty);
-
-        public static readonly DependencyProperty HasUniformTabWidthProperty = DependencyProperty.RegisterAttached(
-            "HasUniformTabWidth", typeof(bool), typeof(TabAssist), new PropertyMetadata(false));
-
-        public static void SetHasUniformTabWidth(DependencyObject element, bool value) => element.SetValue(HasUniformTabWidthProperty, value);
-
-        public static bool GetHasUniformTabWidth(DependencyObject element) => (bool)element.GetValue(HasUniformTabWidthProperty);
-
+        if (d is Panel panel)
+        {
+            panel.IsItemsHost = (bool)e.NewValue;
+        }
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -50,14 +50,14 @@
                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                Focusable="False"
-                               IsItemsHost="True"
+                               wpf:TabAssist.BindableIsItemsHost="{Binding IsVisible, RelativeSource={RelativeSource Self}}"
                                KeyboardNavigation.TabIndex="1"
                                Rows="1" />
                   <VirtualizingStackPanel x:Name="HeaderPanel"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                           Focusable="False"
-                                          IsItemsHost="True"
+                                          wpf:TabAssist.BindableIsItemsHost="{Binding IsVisible, RelativeSource={RelativeSource Self}}"
                                           KeyboardNavigation.TabIndex="1"
                                           Orientation="Horizontal" />
                 </StackPanel>
@@ -86,6 +86,7 @@
               <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
               <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
             </Trigger>
+            
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="HorizontalContentAlignment" Value="Center" />
@@ -127,6 +128,7 @@
                 <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
               </MultiTrigger.Setters>
             </MultiTrigger>
+            
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="HorizontalContentAlignment" Value="Right" />
@@ -147,6 +149,7 @@
                 <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
               </MultiTrigger.Setters>
             </MultiTrigger>
+            
             <Trigger Property="TabStripPlacement" Value="Bottom">
               <Setter Property="wpf:ShadowAssist.ShadowEdges" Value="Top" />
               <Setter TargetName="PART_HeaderZone" Property="DockPanel.Dock" Value="Bottom" />


### PR DESCRIPTION
Fixes #2983

You fixed this on your live stream. Ensures the `TabControl` only has one `Panel` with `IsItemsHost=True` at any given time.

---

For some reason, the `TabControl` disconnects the `TabItem.DataContext` when `TabControl.HorizontalContentAlignment` is (it's default) `Stretch` when a "window" is opened. This "window" can either be a `ToolTip` popping up, or a `ContextMenu` being shown.

I have added a UI test which reproduces the issue (it executes using all `HorizontalContentAlignment` options), but I really don't know how to go about solving it. This is not the type of issue I see every day... @Keboo feel free to give it a spin to see if you have any great ideas; I would love to follow your thought process for tackling something like this (hint hint: do it on a stream night 😄)

My best guess/gut feeling would be something related to the `VirtualizingStackPanel` named `HeaderPanel` (on the `TabControl` template) since that is an area where "disconnected items" is a thing. But that is related to the tab headers, and not so much the content so I really don't know where to start.

Here is a GIF of the issue:
![DataContextDisappears2](https://user-images.githubusercontent.com/19572699/204374948-85f872b1-e6a4-42aa-94e5-cedd4f036bb4.gif)

Here is a screenshot of a UI test run of the new test:
![image](https://user-images.githubusercontent.com/19572699/204374497-722c3ad2-f3d7-4f79-9cf2-dd051ef83030.png)
