### PR TITLE
Extend PreviewMouseDown of DialogHost to also consider owned windows

### DIFF
--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -787,7 +787,7 @@ namespace MaterialDesignThemes.Wpf
 
         protected override void OnPreviewMouseDown(MouseButtonEventArgs e)
         {
-            if (Window.GetWindow(this) is { } window && !window.IsActive)
+            if (Window.GetWindow(this) is { } window && !window.IsActive && window.OwnedWindows.OfType<Window>().All(x => !x.IsActive))
             {
                 window.Activate();
             }


### PR DESCRIPTION
Fixes #2982 

Extends the `DialogHost.OnPreviewMouseDown()` to also consider owned windows. This fixes the issue seen when wrapping a DevExpress `DataGrid` inside of a `DiaglogHost`.