### PR TITLE
Respect MaxLength of PasswordBox in the reveal TextBox using a template binding

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
@@ -163,6 +163,28 @@ namespace MaterialDesignThemes.UITests.WPF.PasswordBoxes
             Assert.Equal("2", password2);
 
             recorder.Success();
-        } 
+        }
+
+        [Fact]
+        [Description("Issue 2998")]
+        public async Task PasswordBox_WithRevealStyle_RespectsMaxLength()
+        {
+            await using var recorder = new TestRecorder(App);
+
+            var grid = await LoadXaml<Grid>(@"
+<Grid Margin=""30"">
+    <PasswordBox MaxLength=""5"" Style=""{StaticResource MaterialDesignFloatingHintRevealPasswordBox}"" />
+</Grid>");
+            var passwordBox = await grid.GetElement<PasswordBox>("/PasswordBox");
+            var revealPasswordTextBox = await passwordBox.GetElement<TextBox>("RevealPasswordTextBox");
+
+            int maxLength1 = await passwordBox.GetMaxLength();
+            int maxLength2 = await revealPasswordTextBox.GetMaxLength();
+
+            // Assert
+            Assert.Equal(maxLength1, maxLength2);
+
+            recorder.Success();
+        }
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -634,6 +634,7 @@
                                Padding="{Binding ElementName=PART_ContentHost, Path=Padding}"
                                CaretBrush="{TemplateBinding CaretBrush}"
                                Cursor="{TemplateBinding Cursor, Converter={StaticResource IBeamCursorConverter}}"
+                               MaxLength="{TemplateBinding MaxLength}"
                                Foreground="{TemplateBinding Foreground}"
                                SelectionBrush="{TemplateBinding SelectionBrush}"
                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"


### PR DESCRIPTION
Fixes #2998 

Respect the `MaxLength` of the "parent" `PasswordBox` using a `TemplateBinding` to ensure the same max length limitation is applied.