### PR TITLE
ToolBar: Dock the overflow grid to bottom when Orientation=Vertical

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/ToolBars/ToolBarTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/ToolBars/ToolBarTests.cs
@@ -1,0 +1,37 @@
+﻿using System.ComponentModel;
+
+namespace MaterialDesignThemes.UITests.WPF.ToolBars;
+
+public class ToolBarTests : TestBase
+{
+    public ToolBarTests(ITestOutputHelper output)
+        : base(output)
+    {
+    }
+
+    [Description("Issue 2991")]
+    [Theory]
+    [InlineData(Orientation.Horizontal, Dock.Right)]
+    [InlineData(Orientation.Vertical, Dock.Bottom)]
+    public async Task ToolBar_OverflowGrid_RespectsOrientation(Orientation orientation, Dock expectedOverflowGridDock)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        //Arrange
+        var toolBarTray = await LoadXaml<ToolBarTray>($@"
+<ToolBarTray Orientation=""{orientation}"" DockPanel.Dock=""Top"">
+  <ToolBar Style=""{{StaticResource MaterialDesignToolBar}}"">
+    <Button Content=""{{materialDesign:PackIcon Kind=File}}""/>
+  </ToolBar>
+</ToolBarTray>");
+        var overflowGrid = await toolBarTray.GetElement<Grid>("OverflowGrid");
+
+        //Act
+        Dock dock = await overflowGrid.GetProperty<Dock>(DockPanel.DockProperty);
+
+        //Assert
+        Assert.Equal(expectedOverflowGridDock, dock);
+
+        recorder.Success();
+    }
+}

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBar.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
@@ -260,6 +260,7 @@
               <Setter TargetName="OverflowButton" Property="Style" Value="{StaticResource MaterialDesignToolBarVerticalOverflowButtonStyle}" />
               <Setter TargetName="OverflowGrid" Property="HorizontalAlignment" Value="Stretch" />
               <Setter TargetName="OverflowGrid" Property="VerticalAlignment" Value="Bottom" />
+              <Setter TargetName="OverflowGrid" Property="DockPanel.Dock" Value="Bottom" />
               <Setter TargetName="OverflowPopup" Property="Placement" Value="Right" />
               <Setter TargetName="PART_ToolBarPanel" Property="Margin" Value="1,0,2,2" />
               <Setter TargetName="ToolBarHeader" Property="DockPanel.Dock" Value="Top" />


### PR DESCRIPTION
Fixes #2991 

This ensures the "overflow grid" is correctly placed in the vertical/horizontal scenarios. The overflow grid is a grid with the button opening a `Popup` containing the items which could not fit in the visible content area.

Location of the overflow grid/button **before** the fix:
![image](https://user-images.githubusercontent.com/19572699/208751300-b5634853-f4aa-4f8a-ab0e-1088473c65f4.png)

Location **after** the fix:
![image](https://user-images.githubusercontent.com/19572699/208751437-f4518db1-fa89-4321-9698-e29a5c859f4d.png)
