### PR TITLE
Add option for custom popup placement for ComboBox

### DIFF
--- a/MainDemo.Wpf/ComboBoxes.xaml
+++ b/MainDemo.Wpf/ComboBoxes.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="MaterialDesignDemo.ComboBoxes"
+<UserControl x:Class="MaterialDesignDemo.ComboBoxes"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:colorsDomain="clr-namespace:MaterialDesignDemo.Domain"
@@ -8,6 +8,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
              xmlns:converters="clr-namespace:MaterialDesignDemo.Converters"
+             xmlns:materialDesignDemo="clr-namespace:MaterialDesignDemo"
              d:DataContext="{d:DesignInstance colorsDomain:ComboBoxesViewModel,
                                               IsDesignTimeCreatable=False}"
              d:DesignHeight="300"
@@ -348,7 +349,8 @@
       <StackPanel Margin="16,15,0,0" Orientation="Horizontal">
 
         <smtx:XamlDisplay UniqueKey="clockwise_1" Margin="0">
-          <ComboBox Style="{StaticResource MaterialDesignFloatingHintComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item">
+          <ComboBox Style="{StaticResource MaterialDesignFloatingHintComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item"
+                    materialDesign:ComboBoxAssist.CustomPopupPlacementCallback="{x:Static materialDesignDemo:ComboBoxes.Rotate90DegreesClockWiseCallback}">
             <ComboBox.LayoutTransform>
               <RotateTransform Angle="90"/>
             </ComboBox.LayoutTransform>
@@ -369,7 +371,8 @@
         </smtx:XamlDisplay>
 
         <smtx:XamlDisplay UniqueKey="clockwise_2" Margin="150,0">
-          <ComboBox Style="{StaticResource MaterialDesignFilledComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item">
+          <ComboBox Style="{StaticResource MaterialDesignFilledComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item"
+                    materialDesign:ComboBoxAssist.CustomPopupPlacementCallback="{x:Static materialDesignDemo:ComboBoxes.Rotate90DegreesClockWiseCallback}">
             <ComboBox.LayoutTransform>
               <RotateTransform Angle="90"/>
             </ComboBox.LayoutTransform>
@@ -390,7 +393,8 @@
         </smtx:XamlDisplay>
 
         <smtx:XamlDisplay UniqueKey="clockwise_3" Margin="0">
-          <ComboBox Style="{StaticResource MaterialDesignOutlinedComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item">
+          <ComboBox Style="{StaticResource MaterialDesignOutlinedComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item"
+                    materialDesign:ComboBoxAssist.CustomPopupPlacementCallback="{x:Static materialDesignDemo:ComboBoxes.Rotate90DegreesClockWiseCallback}">
             <ComboBox.LayoutTransform>
               <RotateTransform Angle="90"/>
             </ComboBox.LayoutTransform>
@@ -420,7 +424,8 @@
       <StackPanel Margin="16,15,0,0" Orientation="Horizontal">
 
         <smtx:XamlDisplay UniqueKey="counter_clockwise_1" Margin="0">
-          <ComboBox Style="{StaticResource MaterialDesignFloatingHintComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item">
+          <ComboBox Style="{StaticResource MaterialDesignFloatingHintComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item"
+                    materialDesign:ComboBoxAssist.CustomPopupPlacementCallback="{x:Static materialDesignDemo:ComboBoxes.Rotate90DegreesCounterClockWiseCallback}">
             <ComboBox.LayoutTransform>
               <RotateTransform Angle="-90"/>
             </ComboBox.LayoutTransform>
@@ -441,7 +446,8 @@
         </smtx:XamlDisplay>
 
         <smtx:XamlDisplay UniqueKey="counter_clockwise_2" Margin="150,0">
-          <ComboBox Style="{StaticResource MaterialDesignFilledComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item">
+          <ComboBox Style="{StaticResource MaterialDesignFilledComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item"
+                    materialDesign:ComboBoxAssist.CustomPopupPlacementCallback="{x:Static materialDesignDemo:ComboBoxes.Rotate90DegreesCounterClockWiseCallback}">
             <ComboBox.LayoutTransform>
               <RotateTransform Angle="-90"/>
             </ComboBox.LayoutTransform>
@@ -462,7 +468,8 @@
         </smtx:XamlDisplay>
 
         <smtx:XamlDisplay UniqueKey="counter_clockwise_3" Margin="0">
-          <ComboBox Style="{StaticResource MaterialDesignOutlinedComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item">
+          <ComboBox Style="{StaticResource MaterialDesignOutlinedComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item"
+                    materialDesign:ComboBoxAssist.CustomPopupPlacementCallback="{x:Static materialDesignDemo:ComboBoxes.Rotate90DegreesCounterClockWiseCallback}">
             <ComboBox.LayoutTransform>
               <RotateTransform Angle="-90"/>
             </ComboBox.LayoutTransform>

--- a/MainDemo.Wpf/ComboBoxes.xaml
+++ b/MainDemo.Wpf/ComboBoxes.xaml
@@ -7,6 +7,7 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
+             xmlns:converters="clr-namespace:MaterialDesignDemo.Converters"
              d:DataContext="{d:DesignInstance colorsDomain:ComboBoxesViewModel,
                                               IsDesignTimeCreatable=False}"
              d:DesignHeight="300"
@@ -339,5 +340,150 @@
         </ComboBox>
       </smtx:XamlDisplay>
     </StackPanel>
+
+    <TextBlock Style="{StaticResource SectionTitle}" Text="Rotation Clockwise" />
+
+    <StackPanel Margin="0,8,0,0">
+      <CheckBox x:Name="CheckBoxClockwiseRotateContent" IsChecked="False" Content="Rotate drop-down content" Margin="16,0" />
+      <StackPanel Margin="16,15,0,0" Orientation="Horizontal">
+
+        <smtx:XamlDisplay UniqueKey="clockwise_1" Margin="0">
+          <ComboBox Style="{StaticResource MaterialDesignFloatingHintComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item">
+            <ComboBox.LayoutTransform>
+              <RotateTransform Angle="90"/>
+            </ComboBox.LayoutTransform>
+            <ComboBox.ItemsPanel>
+              <ItemsPanelTemplate>
+                <StackPanel Orientation="Vertical">
+                  <StackPanel.LayoutTransform>
+                    <RotateTransform Angle="{Binding ElementName=CheckBoxClockwiseRotateContent, Path=IsChecked, Converter={converters:BooleanToDoubleConverter TrueValue=-90, FalseValue=0}}"/>
+                  </StackPanel.LayoutTransform>
+                </StackPanel>
+              </ItemsPanelTemplate>
+            </ComboBox.ItemsPanel>
+            <ComboBoxItem Content="Item 1" />
+            <ComboBoxItem Content="Item 2" />
+            <ComboBoxItem Content="Item 3" />
+            <ComboBoxItem Content="Item 4" />
+          </ComboBox>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay UniqueKey="clockwise_2" Margin="150,0">
+          <ComboBox Style="{StaticResource MaterialDesignFilledComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item">
+            <ComboBox.LayoutTransform>
+              <RotateTransform Angle="90"/>
+            </ComboBox.LayoutTransform>
+            <ComboBox.ItemsPanel>
+              <ItemsPanelTemplate>
+                <StackPanel Orientation="Vertical">
+                  <StackPanel.LayoutTransform>
+                    <RotateTransform Angle="{Binding ElementName=CheckBoxClockwiseRotateContent, Path=IsChecked, Converter={converters:BooleanToDoubleConverter TrueValue=-90, FalseValue=0}}"/>
+                  </StackPanel.LayoutTransform>
+                </StackPanel>
+              </ItemsPanelTemplate>
+            </ComboBox.ItemsPanel>
+            <ComboBoxItem Content="Item 1" />
+            <ComboBoxItem Content="Item 2" />
+            <ComboBoxItem Content="Item 3" />
+            <ComboBoxItem Content="Item 4" />
+          </ComboBox>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay UniqueKey="clockwise_3" Margin="0">
+          <ComboBox Style="{StaticResource MaterialDesignOutlinedComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item">
+            <ComboBox.LayoutTransform>
+              <RotateTransform Angle="90"/>
+            </ComboBox.LayoutTransform>
+            <ComboBox.ItemsPanel>
+              <ItemsPanelTemplate>
+                <StackPanel Orientation="Vertical">
+                  <StackPanel.LayoutTransform>
+                    <RotateTransform Angle="{Binding ElementName=CheckBoxClockwiseRotateContent, Path=IsChecked, Converter={converters:BooleanToDoubleConverter TrueValue=-90, FalseValue=0}}"/>
+                  </StackPanel.LayoutTransform>
+                </StackPanel>
+              </ItemsPanelTemplate>
+            </ComboBox.ItemsPanel>
+            <ComboBoxItem Content="Item 1" />
+            <ComboBoxItem Content="Item 2" />
+            <ComboBoxItem Content="Item 3" />
+            <ComboBoxItem Content="Item 4" />
+          </ComboBox>
+        </smtx:XamlDisplay>
+
+      </StackPanel>
+    </StackPanel>
+
+    <TextBlock Style="{StaticResource SectionTitle}" Text="Rotation Counter-Clockwise" />
+
+    <StackPanel Margin="0,8,0,0">
+      <CheckBox x:Name="CheckBoxCounterClockwiseRotateContent" IsChecked="False" Content="Rotate drop-down content" Margin="16,0" />
+      <StackPanel Margin="16,15,0,0" Orientation="Horizontal">
+
+        <smtx:XamlDisplay UniqueKey="counter_clockwise_1" Margin="0">
+          <ComboBox Style="{StaticResource MaterialDesignFloatingHintComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item">
+            <ComboBox.LayoutTransform>
+              <RotateTransform Angle="-90"/>
+            </ComboBox.LayoutTransform>
+            <ComboBox.ItemsPanel>
+              <ItemsPanelTemplate>
+                <StackPanel Orientation="Vertical">
+                  <StackPanel.LayoutTransform>
+                    <RotateTransform Angle="{Binding ElementName=CheckBoxCounterClockwiseRotateContent, Path=IsChecked, Converter={converters:BooleanToDoubleConverter TrueValue=90, FalseValue=0}}"/>
+                  </StackPanel.LayoutTransform>
+                </StackPanel>
+              </ItemsPanelTemplate>
+            </ComboBox.ItemsPanel>
+            <ComboBoxItem Content="Item 1" />
+            <ComboBoxItem Content="Item 2" />
+            <ComboBoxItem Content="Item 3" />
+            <ComboBoxItem Content="Item 4" />
+          </ComboBox>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay UniqueKey="counter_clockwise_2" Margin="150,0">
+          <ComboBox Style="{StaticResource MaterialDesignFilledComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item">
+            <ComboBox.LayoutTransform>
+              <RotateTransform Angle="-90"/>
+            </ComboBox.LayoutTransform>
+            <ComboBox.ItemsPanel>
+              <ItemsPanelTemplate>
+                <StackPanel Orientation="Vertical">
+                  <StackPanel.LayoutTransform>
+                    <RotateTransform Angle="{Binding ElementName=CheckBoxCounterClockwiseRotateContent, Path=IsChecked, Converter={converters:BooleanToDoubleConverter TrueValue=90, FalseValue=0}}"/>
+                  </StackPanel.LayoutTransform>
+                </StackPanel>
+              </ItemsPanelTemplate>
+            </ComboBox.ItemsPanel>
+            <ComboBoxItem Content="Item 1" />
+            <ComboBoxItem Content="Item 2" />
+            <ComboBoxItem Content="Item 3" />
+            <ComboBoxItem Content="Item 4" />
+          </ComboBox>
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay UniqueKey="counter_clockwise_3" Margin="0">
+          <ComboBox Style="{StaticResource MaterialDesignOutlinedComboBox}" Width="150" materialDesign:HintAssist.Hint="Selected Item">
+            <ComboBox.LayoutTransform>
+              <RotateTransform Angle="-90"/>
+            </ComboBox.LayoutTransform>
+            <ComboBox.ItemsPanel>
+              <ItemsPanelTemplate>
+                <StackPanel Orientation="Vertical">
+                  <StackPanel.LayoutTransform>
+                    <RotateTransform Angle="{Binding ElementName=CheckBoxCounterClockwiseRotateContent, Path=IsChecked, Converter={converters:BooleanToDoubleConverter TrueValue=90, FalseValue=0}}"/>
+                  </StackPanel.LayoutTransform>
+                </StackPanel>
+              </ItemsPanelTemplate>
+            </ComboBox.ItemsPanel>
+            <ComboBoxItem Content="Item 1" />
+            <ComboBoxItem Content="Item 2" />
+            <ComboBoxItem Content="Item 3" />
+            <ComboBoxItem Content="Item 4" />
+          </ComboBox>
+        </smtx:XamlDisplay>
+
+      </StackPanel>
+    </StackPanel>
+    
   </StackPanel>
 </UserControl>

--- a/MainDemo.Wpf/ComboBoxes.xaml.cs
+++ b/MainDemo.Wpf/ComboBoxes.xaml.cs
@@ -1,19 +1,60 @@
 ﻿using MaterialDesignDemo.Domain;
+using Screen = System.Windows.Forms.Screen;
+using DrawingPoint = System.Drawing.Point;
 
-namespace MaterialDesignDemo
+namespace MaterialDesignDemo;
+
+public partial class ComboBoxes
 {
-    public partial class ComboBoxes
+    private const double DropShadowHeight = 6;    // This does not account for DPI scaling!
+
+    public static CustomPopupPlacementCallback Rotate90DegreesClockWiseCallback { get; } = (popupSize, targetSize, offset) =>
     {
-        public ComboBoxes()
+        // ComboBox is rotated 90 degrees clockwise (ie. Left=Up, Right=Down)
+        var comboBox = VisualTreeUtil.GetElementUnderMouse<ComboBox>();
+        var comboBoxLocation = comboBox.PointToScreen(new Point(0, 0));
+        Screen screen = Screen.FromPoint(new DrawingPoint((int)comboBoxLocation.X, (int)comboBoxLocation.Y));
+        int comboBoxOffsetX = (int)(comboBoxLocation.X - screen.Bounds.X) % screen.Bounds.Width;
+        double y = offset.Y - DropShadowHeight;
+        double x = offset.X;
+        double rotatedComboBoxHeight = targetSize.Width;
+        if (comboBoxOffsetX + x > popupSize.Width + rotatedComboBoxHeight)
         {
-            InitializeComponent();
-            DataContext = new ComboBoxesViewModel();
+            x -= popupSize.Width + rotatedComboBoxHeight;
         }
+        return new[] { new CustomPopupPlacement(new Point(x, y), PopupPrimaryAxis.Horizontal) };
+    };
 
-        private void ClearFilledComboBox_Click(object sender, System.Windows.RoutedEventArgs e)
-            => FilledComboBox.SelectedItem = null;
+    public static CustomPopupPlacementCallback Rotate90DegreesCounterClockWiseCallback { get; } = (popupSize, targetSize, offset) =>
+    {
+        // ComboBox is rotated 90 degrees counter-clockwise (ie. Left=Down, Right=Up)
+        var comboBox = VisualTreeUtil.GetElementUnderMouse<ComboBox>();
+        var comboBoxLocation = comboBox.PointToScreen(new Point(0, 0));
+        Screen screen = Screen.FromPoint(new DrawingPoint((int)comboBoxLocation.X, (int)comboBoxLocation.Y));
+        int comboBoxOffsetX = (int)(comboBoxLocation.X - screen.Bounds.X) % screen.Bounds.Width;
+        double y = offset.Y - popupSize.Height + DropShadowHeight;
+        double x = offset.X;
+        double rotatedComboBoxHeight = targetSize.Width;
+        if (comboBoxOffsetX + x + rotatedComboBoxHeight + popupSize.Width > screen.Bounds.Width)
+        {
+            x -= popupSize.Width;
+        }
+        else
+        {
+            x += rotatedComboBoxHeight;
+        }
+        return new[] { new CustomPopupPlacement(new Point(x, y), PopupPrimaryAxis.Horizontal) };
+    };
 
-        private void ClearOutlinedComboBox_Click(object sender, System.Windows.RoutedEventArgs e)
-            => OutlinedComboBox.SelectedItem = null;
+    public ComboBoxes()
+    {
+        InitializeComponent();
+        DataContext = new ComboBoxesViewModel();
     }
+
+    private void ClearFilledComboBox_Click(object sender, System.Windows.RoutedEventArgs e)
+        => FilledComboBox.SelectedItem = null;
+
+    private void ClearOutlinedComboBox_Click(object sender, System.Windows.RoutedEventArgs e)
+        => OutlinedComboBox.SelectedItem = null;
 }

--- a/MainDemo.Wpf/Converters/BooleanToDoubleConverter.cs
+++ b/MainDemo.Wpf/Converters/BooleanToDoubleConverter.cs
@@ -1,0 +1,17 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+
+namespace MaterialDesignDemo.Converters;
+
+public class BooleanToDoubleConverter : MarkupExtension, IValueConverter
+{
+    public double TrueValue { get; set; }
+    public double FalseValue { get; set; }
+
+    public override object ProvideValue(IServiceProvider serviceProvider) => this;
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => value is true ? TrueValue : FalseValue;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    
+}

--- a/MainDemo.Wpf/VisualTreeUtil.cs
+++ b/MainDemo.Wpf/VisualTreeUtil.cs
@@ -1,0 +1,22 @@
+﻿using System.Windows.Media;
+
+namespace MaterialDesignDemo;
+
+internal static class VisualTreeUtil
+{
+    private static T FindVisualParent<T>(UIElement element) where T : UIElement?
+    {
+        UIElement? parent = element;
+        while (parent != null)
+        {
+            if (parent is T correctlyTyped)
+            {
+                return correctlyTyped;
+            }
+            parent = VisualTreeHelper.GetParent(parent) as UIElement;
+        }
+        return default!;
+    }
+
+    internal static T GetElementUnderMouse<T>() where T : UIElement? => FindVisualParent<T>((Mouse.DirectlyOver as UIElement)!);
+}

--- a/MaterialDesignThemes.Wpf/ComboBoxAssist.cs
+++ b/MaterialDesignThemes.Wpf/ComboBoxAssist.cs
@@ -59,4 +59,17 @@ public static class ComboBoxAssist
     public static int GetMaxLength(DependencyObject element) => (int)element.GetValue(MaxLengthProperty);
     public static void SetMaxLength(DependencyObject element, int value) => element.SetValue(MaxLengthProperty, value);
     #endregion
+
+    #region AttachedProperty : CustomPopupPlacementCallback
+    public static readonly DependencyProperty CustomPopupPlacementCallbackProperty =
+        DependencyProperty.RegisterAttached(
+            "CustomPopupPlacementCallback",
+            typeof(CustomPopupPlacementCallback),
+            typeof(ComboBoxAssist),
+            new FrameworkPropertyMetadata(default(CustomPopupPlacementCallback),
+                FrameworkPropertyMetadataOptions.AffectsRender));
+
+    public static void SetCustomPopupPlacementCallback(DependencyObject element, CustomPopupPlacementCallback value) => element.SetValue(CustomPopupPlacementCallbackProperty, value);
+    public static CustomPopupPlacementCallback GetCustomPopupPlacementCallback(DependencyObject element) => (CustomPopupPlacementCallback) element.GetValue(CustomPopupPlacementCallbackProperty);
+    #endregion
 }

--- a/MaterialDesignThemes.Wpf/ComboBoxPopup.cs
+++ b/MaterialDesignThemes.Wpf/ComboBoxPopup.cs
@@ -256,8 +256,8 @@ namespace MaterialDesignThemes.Wpf
 
         public CustomPopupPlacementCallback? CustomPopupPlacementCallbackOverride
         {
-            get { return (CustomPopupPlacementCallback?) GetValue(CustomPopupPlacementCallbackOverrideProperty); }
-            set { SetValue(CustomPopupPlacementCallbackOverrideProperty, value); }
+            get => return (CustomPopupPlacementCallback?) GetValue(CustomPopupPlacementCallbackOverrideProperty); 
+            set => SetValue(CustomPopupPlacementCallbackOverrideProperty, value);
         }
 
         public ComboBoxPopup()

--- a/MaterialDesignThemes.Wpf/ComboBoxPopup.cs
+++ b/MaterialDesignThemes.Wpf/ComboBoxPopup.cs
@@ -256,7 +256,7 @@ namespace MaterialDesignThemes.Wpf
 
         public CustomPopupPlacementCallback? CustomPopupPlacementCallbackOverride
         {
-            get => return (CustomPopupPlacementCallback?) GetValue(CustomPopupPlacementCallbackOverrideProperty); 
+            get => (CustomPopupPlacementCallback?) GetValue(CustomPopupPlacementCallbackOverrideProperty); 
             set => SetValue(CustomPopupPlacementCallbackOverrideProperty, value);
         }
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -427,7 +427,8 @@
                            Tag="{DynamicResource MaterialDesignPaper}"
                            UpVerticalOffset="15"
                            UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
-                           VerticalOffset="0">
+                           VerticalOffset="0"
+                           CustomPopupPlacementCallbackOverride="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ComboBoxAssist.CustomPopupPlacementCallback)}">
           <wpf:ComboBoxPopup.Background>
             <MultiBinding Converter="{StaticResource FallbackBrushConverter}">
               <Binding Path="Background" RelativeSource="{RelativeSource TemplatedParent}" />


### PR DESCRIPTION
Fixes #3004 
Originates from discussion #2934

This PR exposes a `ComboBoxAssist.CustomPopupPlacementCallback` attached property which can be applied in cases where the user wants to handle the placement of the `Popup` shown by the `ComboBox` in a special way (e.g. when rotating the `ComboBox` +/- 90 degrees).

I extended the `ComboBoxes` page in the demo app as seen below. The code-behind includes 2 specialized callbacks: one for rotating 90 degrees clockwise, and one for rotating 90 degrees counter-clockwise.

![RotatedDropDowns](https://user-images.githubusercontent.com/19572699/209147255-49c5289e-2e34-4507-897b-fc1fb26eb6d3.gif)
