### PR TITLE
DatePicker ContextMenu fix - Partial revert of #2502

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -501,7 +501,7 @@
                                Background="{TemplateBinding Background}"
                                BorderBrush="{TemplateBinding BorderBrush}"
                                Focusable="{TemplateBinding Focusable}"
-                               Style="{StaticResource MaterialDesignDatePickerTextBox}">
+                               Style="{DynamicResource MaterialDesignDatePickerTextBox}">
               <DatePickerTextBox.Padding>
                 <MultiBinding Converter="{StaticResource PickerInnerPaddingConverter}">
                   <Binding Path="Padding" RelativeSource="{RelativeSource TemplatedParent}" />


### PR DESCRIPTION
Fixes #3007 

As we discussed, I am rolling back a small part of a previous PR to fix the issue.

The PR #2502 included a seemingly non-related change from DynamicResource to StaticResource which effectively broke the ability to override the style. Only reverting this particular part of the PR:

https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/pull/2502/files#diff-9223925c6d6052ba159059666e83a002034f38005382dd8684c025dbba4f985bL460