### PR TITLE
Refactor SmartHint to allow taking up available space when floated

### DIFF
--- a/MainDemo.Wpf/ComboBoxes.xaml
+++ b/MainDemo.Wpf/ComboBoxes.xaml
@@ -237,7 +237,7 @@
 
           <ComboBox x:Name="FilledComboBox"
                     Width="256"
-                    materialDesign:HintAssist.Hint="Some item"
+                    materialDesign:HintAssist.Hint="Some item with a very long hint text that will cut off when floating"
                     IsEnabled="{Binding Path=IsChecked, ElementName=FilledComboBoxEnabledCheckBox}"
                     Style="{StaticResource MaterialDesignFilledComboBox}">
             <ComboBoxItem Content="Item 1" />

--- a/MainDemo.Wpf/Fields.xaml
+++ b/MainDemo.Wpf/Fields.xaml
@@ -299,7 +299,7 @@
 
           <TextBox MaxWidth="400"
                    VerticalAlignment="Top"
-                   materialDesign:HintAssist.Hint="Floating hint in a box"
+                   materialDesign:HintAssist.Hint="Floating hint in a box that will cut off"
                    AcceptsReturn="True"
                    IsEnabled="{Binding Path=IsChecked, ElementName=MaterialDesignFilledTextBoxEnabledComboBox}"
                    Style="{StaticResource MaterialDesignFilledTextBox}"

--- a/MaterialDesignThemes.Wpf.Tests/Converters/FloatingHintTransformConverterTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/Converters/FloatingHintTransformConverterTests.cs
@@ -3,84 +3,81 @@ using System.Windows.Media;
 using MaterialDesignThemes.Wpf.Converters;
 using Xunit;
 
-namespace MaterialDesignThemes.Wpf.Tests.Converters
+namespace MaterialDesignThemes.Wpf.Tests.Converters;
+
+public class FloatingHintTransformConverterTests
 {
-    public class FloatingHintTransformConverterTests
+    public static IEnumerable<object?[]> InvalidParameters =>
+        new[]
+        {
+            new object?[] {null, null, null, null},
+            new object?[] {1.0, null, null, null},
+            new object?[] {null, 1.0, null, null},
+            new object?[] {null, null, 1.0, null},
+            new object?[] {null, null, null, new Point()},
+            new object?[] {1.0, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue},
+            new object?[] {DependencyProperty.UnsetValue, 1.0, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue},
+            new object?[] {DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, 1.0, DependencyProperty.UnsetValue},
+            new object?[] {DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, new Point() },
+        };
+
+    [Theory]
+    [MemberData(nameof(InvalidParameters))]
+    public void WhenParametersAreNotSetItReturnsIdentity(object? scale, object? lower, object? upper, object? offset)
     {
-        public static IEnumerable<object?[]> InvalidParameters =>
-            new[]
-            {
-                new object?[] {null, null, null, null},
-                new object?[] {1.0, null, null, null},
-                new object?[] {null, 1.0, null, null},
-                new object?[] {null, null, 1.0, null},
-                new object?[] {null, null, null, new Point()},
-                new object?[] {1.0, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue},
-                new object?[] {DependencyProperty.UnsetValue, 1.0, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue},
-                new object?[] {DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, 1.0, DependencyProperty.UnsetValue},
-                new object?[] {DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, new Point() },
-            };
+        var converter = new FloatingHintTransformConverter();
 
-        [StaTheory]
-        [MemberData(nameof(InvalidParameters))]
-        public void WhenParametersAreNotSetItReturnsIdentity(object? scale, object? lower, object? upper, object? offset)
-        {
-            var converter = new FloatingHintTransformConverter();
+        var result = converter.Convert(new[] { scale, lower, upper, offset },
+            typeof(Transform), null, CultureInfo.CurrentUICulture);
 
-            var result = converter.Convert(new[] { scale, lower, upper, offset },
-                typeof(Transform), null, CultureInfo.CurrentUICulture);
-
-            Assert.Equal(Transform.Identity, result);
-        }
-
-        [StaTheory]
-        [InlineData(2.0, 1.5, 3.0, 3.0, 4.0)]
-        [InlineData(1.5, 2.0, 3.0, 2.0, 3.0)]
-        public void WhenParametersAreSpecifiedItReturnsTransforms(double scale, double lower, double upper, double x, double y)
-        {
-            var converter = new FloatingHintTransformConverter();
-
-            var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y) }, typeof(Transform), null, CultureInfo.CurrentUICulture);
-
-            Assert.NotNull(result);
-            var scaleTransform = (ScaleTransform)result!.Children[0];
-            var translateTransform = (TranslateTransform)result.Children[1];
-
-            Assert.Equal(upper + (lower - upper) * scale, scaleTransform.ScaleX);
-            Assert.Equal(upper + (lower - upper) * scale, scaleTransform.ScaleY);
-
-            Assert.Equal(scale * x, translateTransform.X);
-            Assert.Equal(scale * y, translateTransform.Y);
-        }
-
-        [StaTheory]
-        [InlineData(2.0, 1.5, 3.0, 3.0, 4.0)]
-        [InlineData(1.5, 2.0, 3.0, 2.0, 3.0)]
-        public void WhenParametersAreSpecifiedAndScaleTransformDisabledItReturnsTransforms(double scale, double lower, double upper, double x, double y)
-        {
-            var converter = new FloatingHintTransformConverter { ApplyScaleTransform = false };
-
-            var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y) }, typeof(Transform), null, CultureInfo.CurrentUICulture);
-
-            Assert.NotNull(result);
-            Assert.Single(result.Children);
-            Assert.IsType<TranslateTransform>(result.Children[0]);
-        }
-
-        [StaTheory]
-        [InlineData(2.0, 1.5, 3.0, 3.0, 4.0)]
-        [InlineData(1.5, 2.0, 3.0, 2.0, 3.0)]
-        public void WhenParametersAreSpecifiedAndTranslateTransformDisabledItReturnsTransforms(double scale, double lower, double upper, double x, double y)
-        {
-            var converter = new FloatingHintTransformConverter { ApplyTranslateTransform = false };
-
-            var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y) }, typeof(Transform), null, CultureInfo.CurrentUICulture);
-
-            Assert.NotNull(result);
-            Assert.Single(result.Children);
-            Assert.IsType<ScaleTransform>(result.Children[0]);
-        }
+        Assert.Equal(Transform.Identity, result);
     }
 
+    [Theory]
+    [InlineData(2.0, 1.5, 3.0, 3.0, 4.0)]
+    [InlineData(1.5, 2.0, 3.0, 2.0, 3.0)]
+    public void WhenParametersAreSpecifiedItReturnsTransforms(double scale, double lower, double upper, double x, double y)
+    {
+        var converter = new FloatingHintTransformConverter();
 
+        var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y) }, typeof(Transform), null, CultureInfo.CurrentUICulture);
+
+        Assert.NotNull(result);
+        var scaleTransform = (ScaleTransform)result!.Children[0];
+        var translateTransform = (TranslateTransform)result.Children[1];
+
+        Assert.Equal(upper + (lower - upper) * scale, scaleTransform.ScaleX);
+        Assert.Equal(upper + (lower - upper) * scale, scaleTransform.ScaleY);
+
+        Assert.Equal(scale * x, translateTransform.X);
+        Assert.Equal(scale * y, translateTransform.Y);
+    }
+
+    [Theory]
+    [InlineData(2.0, 1.5, 3.0, 3.0, 4.0)]
+    [InlineData(1.5, 2.0, 3.0, 2.0, 3.0)]
+    public void WhenParametersAreSpecifiedAndScaleTransformDisabledItReturnsTransforms(double scale, double lower, double upper, double x, double y)
+    {
+        var converter = new FloatingHintTransformConverter { ApplyScaleTransform = false };
+
+        var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y) }, typeof(Transform), null, CultureInfo.CurrentUICulture);
+
+        Assert.NotNull(result);
+        Assert.Single(result.Children);
+        Assert.IsType<TranslateTransform>(result.Children[0]);
+    }
+
+    [Theory]
+    [InlineData(2.0, 1.5, 3.0, 3.0, 4.0)]
+    [InlineData(1.5, 2.0, 3.0, 2.0, 3.0)]
+    public void WhenParametersAreSpecifiedAndTranslateTransformDisabledItReturnsTransforms(double scale, double lower, double upper, double x, double y)
+    {
+        var converter = new FloatingHintTransformConverter { ApplyTranslateTransform = false };
+
+        var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y) }, typeof(Transform), null, CultureInfo.CurrentUICulture);
+
+        Assert.NotNull(result);
+        Assert.Single(result.Children);
+        Assert.IsType<ScaleTransform>(result.Children[0]);
+    }
 }

--- a/MaterialDesignThemes.Wpf.Tests/Converters/FloatingHintTransformConverterTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/Converters/FloatingHintTransformConverterTests.cs
@@ -63,7 +63,7 @@ namespace MaterialDesignThemes.Wpf.Tests.Converters
             var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y) }, typeof(Transform), null, CultureInfo.CurrentUICulture);
 
             Assert.NotNull(result);
-            Assert.Equal(1, result.Children.Count);
+            Assert.Single(result.Children);
             Assert.IsType<TranslateTransform>(result.Children[0]);
         }
 
@@ -77,7 +77,7 @@ namespace MaterialDesignThemes.Wpf.Tests.Converters
             var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y) }, typeof(Transform), null, CultureInfo.CurrentUICulture);
 
             Assert.NotNull(result);
-            Assert.Equal(1, result.Children.Count);
+            Assert.Single(result.Children);
             Assert.IsType<ScaleTransform>(result.Children[0]);
         }
     }

--- a/MaterialDesignThemes.Wpf.Tests/Converters/FloatingHintTransformConverterTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/Converters/FloatingHintTransformConverterTests.cs
@@ -52,6 +52,34 @@ namespace MaterialDesignThemes.Wpf.Tests.Converters
             Assert.Equal(scale * x, translateTransform.X);
             Assert.Equal(scale * y, translateTransform.Y);
         }
+
+        [StaTheory]
+        [InlineData(2.0, 1.5, 3.0, 3.0, 4.0)]
+        [InlineData(1.5, 2.0, 3.0, 2.0, 3.0)]
+        public void WhenParametersAreSpecifiedAndScaleTransformDisabledItReturnsTransforms(double scale, double lower, double upper, double x, double y)
+        {
+            var converter = new FloatingHintTransformConverter { ApplyScaleTransform = false };
+
+            var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y) }, typeof(Transform), null, CultureInfo.CurrentUICulture);
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result.Children.Count);
+            Assert.IsType<TranslateTransform>(result.Children[0]);
+        }
+
+        [StaTheory]
+        [InlineData(2.0, 1.5, 3.0, 3.0, 4.0)]
+        [InlineData(1.5, 2.0, 3.0, 2.0, 3.0)]
+        public void WhenParametersAreSpecifiedAndTranslateTransformDisabledItReturnsTransforms(double scale, double lower, double upper, double x, double y)
+        {
+            var converter = new FloatingHintTransformConverter { ApplyTranslateTransform = false };
+
+            var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y) }, typeof(Transform), null, CultureInfo.CurrentUICulture);
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result.Children.Count);
+            Assert.IsType<ScaleTransform>(result.Children[0]);
+        }
     }
 
 

--- a/MaterialDesignThemes.Wpf/Converters/FloatingHintTransformConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/FloatingHintTransformConverter.cs
@@ -6,6 +6,9 @@ namespace MaterialDesignThemes.Wpf.Converters
 {
     internal class FloatingHintTransformConverter : IMultiValueConverter
     {
+        public bool ApplyScaleTransform { get; set; } = true;
+        public bool ApplyTranslateTransform { get; set; } = true;
+
         public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
         {
             if (values == null
@@ -22,16 +25,22 @@ namespace MaterialDesignThemes.Wpf.Converters
             double result = upper + (lower - upper) * scale;
 
             var transformGroup = new TransformGroup();
-            transformGroup.Children.Add(new ScaleTransform
+            if (ApplyScaleTransform)
             {
-                ScaleX = result,
-                ScaleY = result
-            });
-            transformGroup.Children.Add(new TranslateTransform
+                transformGroup.Children.Add(new ScaleTransform
+                {
+                    ScaleX = result,
+                    ScaleY = result
+                });
+            }
+            if (ApplyTranslateTransform)
             {
-                X = scale * floatingOffset.X,
-                Y = scale * floatingOffset.Y
-            });
+                transformGroup.Children.Add(new TranslateTransform
+                {
+                    X = scale * floatingOffset.X,
+                    Y = scale * floatingOffset.Y
+                });
+            }
             return transformGroup;
         }
 

--- a/MaterialDesignThemes.Wpf/Converters/FloatingHintTransformConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/FloatingHintTransformConverter.cs
@@ -2,49 +2,47 @@
 using System.Windows.Data;
 using System.Windows.Media;
 
-namespace MaterialDesignThemes.Wpf.Converters
+namespace MaterialDesignThemes.Wpf.Converters;
+
+internal class FloatingHintTransformConverter : IMultiValueConverter
 {
-    internal class FloatingHintTransformConverter : IMultiValueConverter
+    public bool ApplyScaleTransform { get; set; } = true;
+    public bool ApplyTranslateTransform { get; set; } = true;
+
+    public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
-        public bool ApplyScaleTransform { get; set; } = true;
-        public bool ApplyTranslateTransform { get; set; } = true;
-
-        public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
+        if (values?.Length != 4
+            || values.Any(v => v == null)
+            || !double.TryParse(values[0]!.ToString(), out double scale)
+            || !double.TryParse(values[1]!.ToString(), out double lower)
+            || !double.TryParse(values[2]!.ToString(), out double upper)
+            || values[3] is not Point floatingOffset)
         {
-            if (values == null
-                || values.Length != 4
-                || values.Any(v => v == null)
-                || !double.TryParse(values[0]?.ToString(), out double scale)
-                || !double.TryParse(values[1]?.ToString(), out double lower)
-                || !double.TryParse(values[2]?.ToString(), out double upper)
-                || !(values[3] is Point floatingOffset))
-            {
-                return Transform.Identity;
-            }
-
-            double result = upper + (lower - upper) * scale;
-
-            var transformGroup = new TransformGroup();
-            if (ApplyScaleTransform)
-            {
-                transformGroup.Children.Add(new ScaleTransform
-                {
-                    ScaleX = result,
-                    ScaleY = result
-                });
-            }
-            if (ApplyTranslateTransform)
-            {
-                transformGroup.Children.Add(new TranslateTransform
-                {
-                    X = scale * floatingOffset.X,
-                    Y = scale * floatingOffset.Y
-                });
-            }
-            return transformGroup;
+            return Transform.Identity;
         }
 
-        public object?[]? ConvertBack(object? value, Type[] targetTypes, object? parameter, CultureInfo culture)
-            => throw new NotImplementedException();
+        double result = upper + (lower - upper) * scale;
+
+        var transformGroup = new TransformGroup();
+        if (ApplyScaleTransform)
+        {
+            transformGroup.Children.Add(new ScaleTransform
+            {
+                ScaleX = result,
+                ScaleY = result
+            });
+        }
+        if (ApplyTranslateTransform)
+        {
+            transformGroup.Children.Add(new TranslateTransform
+            {
+                X = scale * floatingOffset.X,
+                Y = scale * floatingOffset.Y
+            });
+        }
+        return transformGroup;
     }
+
+    public object?[]? ConvertBack(object? value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:system="clr-namespace:System;assembly=mscorlib"
@@ -8,12 +8,13 @@
   <converters:BooleanToVisibilityConverter x:Key="InverseBoolToVisConverter"
                                            FalseValue="Visible"
                                            TrueValue="Collapsed" />
-  <converters:FloatingHintTransformConverter x:Key="FloatingHintTransformConverter" />
+  <converters:FloatingHintTransformConverter x:Key="FloatingHintCanvasTransformConverter" ApplyScaleTransform="False" />
+  <converters:FloatingHintTransformConverter x:Key="FloatingHintTransformConverter" ApplyTranslateTransform="False" />
   <system:Double x:Key="NoContentFloatingScale">1.0</system:Double>
   <CubicEase x:Key="AnimationEasingFunction" EasingMode="EaseInOut" />
 
   <Style TargetType="{x:Type wpf:SmartHint}">
-    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="IsHitTestVisible" Value="False" />
     <Setter Property="IsTabStop" Value="False" />
@@ -138,29 +139,39 @@
                   </VisualStateGroup>
                 </VisualStateManager.VisualStateGroups>
                 <wpf:ScaleHost x:Name="ScaleHost" />
-                <ContentControl x:Name="FloatingHintTextBlock"
-                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                Content="{TemplateBinding Hint}"
-                                FontFamily="{TemplateBinding FontFamily}"
-                                FontSize="{TemplateBinding FontSize}"
-                                IsHitTestVisible="False"
-                                IsTabStop="False"
-                                Opacity="{TemplateBinding HintOpacity}"
-                                RenderTransformOrigin="0,0"
-                                Visibility="{TemplateBinding UseFloating, Converter={StaticResource BoolToVisConverter}}">
-                  <ContentControl.Tag>
-                    <system:Double>0.0</system:Double>
-                  </ContentControl.Tag>
-                  <ContentControl.RenderTransform>
-                    <MultiBinding Converter="{StaticResource FloatingHintTransformConverter}">
+                <Canvas ClipToBounds="True" HorizontalAlignment="Stretch" Height="{Binding ElementName=FloatingHintTextBlock, Path=ActualHeight}">
+                  <Canvas.RenderTransform>
+                    <MultiBinding Converter="{StaticResource FloatingHintCanvasTransformConverter}">
                       <Binding ElementName="ScaleHost" Path="Scale" />
                       <Binding Path="FloatingScale" RelativeSource="{RelativeSource TemplatedParent}" />
                       <Binding Source="{StaticResource NoContentFloatingScale}" />
                       <Binding Path="FloatingOffset" RelativeSource="{RelativeSource TemplatedParent}" />
                     </MultiBinding>
-                  </ContentControl.RenderTransform>
-                </ContentControl>
+                  </Canvas.RenderTransform>
+                  <ContentControl x:Name="FloatingHintTextBlock"
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  Content="{TemplateBinding Hint}"
+                                  FontFamily="{TemplateBinding FontFamily}"
+                                  FontSize="{TemplateBinding FontSize}"
+                                  IsHitTestVisible="False"
+                                  IsTabStop="False"
+                                  Opacity="{TemplateBinding HintOpacity}"
+                                  RenderTransformOrigin="0,0"
+                                  Visibility="{TemplateBinding UseFloating, Converter={StaticResource BoolToVisConverter}}">
+                    <ContentControl.Tag>
+                      <system:Double>0.0</system:Double>
+                    </ContentControl.Tag>
+                    <ContentControl.RenderTransform>
+                      <MultiBinding Converter="{StaticResource FloatingHintTransformConverter}">
+                        <Binding ElementName="ScaleHost" Path="Scale" />
+                        <Binding Path="FloatingScale" RelativeSource="{RelativeSource TemplatedParent}" />
+                        <Binding Source="{StaticResource NoContentFloatingScale}" />
+                        <Binding Path="FloatingOffset" RelativeSource="{RelativeSource TemplatedParent}" />
+                      </MultiBinding>
+                    </ContentControl.RenderTransform>
+                  </ContentControl>
+                </Canvas>
               </Grid>
             </ControlTemplate>
           </Setter.Value>


### PR DESCRIPTION
Fixes #2686 

Refactors the SmartHint such that it is allowed to take up the available width of the "container" when the hint is floated. Previously, when the hint was floated, it was the `FloatingHintTextBlock` which was both moved and scaled down which effectively meant that the "available space" was scaled down with it.

This PR changes that "animation" such that the scaling is still applied to the `FloatingHintTextBlock` but the moving of it is done on a `Canvas` which is not scaled down, but simply moved. This allows it to retain its full (available) width.

Before the changes, the floating hints that exceeded the available width looked like this when floated (animations slowed down for better overview):

![FieldHintBefore](https://user-images.githubusercontent.com/19572699/212428874-fce8350b-f544-4a47-b6c6-7a07da9527bf.gif)
![ComboBoxHintBefore](https://user-images.githubusercontent.com/19572699/212428884-415a098f-30c9-4c80-b740-08be4ba6ec94.gif)

In both of these cases, the hint text is actually longer than what is displayed, but even when space becomes available it does not show.

After the changes, they now look like this:

![FieldHintAfter](https://user-images.githubusercontent.com/19572699/212429111-89df477e-173b-4441-a5d3-52a170b27139.gif)
![ComboBoxHintAfter](https://user-images.githubusercontent.com/19572699/212429126-432fc3c9-94e8-4941-95cd-bb49a542e29c.gif)

As can be seen, the text is actually **still** too long to be fully displayed, but at least it now uses more of the available space. It could be considered to add `TextTrimming="CharacterEllipsis"` and perhaps even a `ToolTip` (when truncated) if that is desirable.
