### PR TITLE
Refactor SmartHint alignment

### DIFF
--- a/MainDemo.Wpf/Domain/MainWindowViewModel.cs
+++ b/MainDemo.Wpf/Domain/MainWindowViewModel.cs
@@ -419,6 +419,15 @@ public class MainWindowViewModel : ViewModelBase
                 DocumentationLink.StyleLink("Shadows"),
                 DocumentationLink.SpecsLink("https://material.io/design/environment/elevation.html", "Elevation")
             });
+
+        yield return new DemoItem(
+            "Smart Hint",
+            typeof(SmartHint),
+            new[]
+            {
+                DocumentationLink.DemoPageLink<SmartHint>(),
+                DocumentationLink.StyleLink("SmartHint"),
+            });
     }
 
     private bool DemoItemsFilter(object obj)

--- a/MainDemo.Wpf/Domain/SmartHintViewModel.cs
+++ b/MainDemo.Wpf/Domain/SmartHintViewModel.cs
@@ -1,0 +1,80 @@
+﻿using MaterialDesignThemes.Wpf;
+
+namespace MaterialDesignDemo.Domain;
+
+internal class SmartHintViewModel : ViewModelBase
+{
+    private FloatingHintHorizontalAlignment _selectedAlignment = FloatingHintHorizontalAlignment.Inherit;
+    private double _selectedFloatingScale = 0.75;
+    private bool _showClearButton = true;
+    private bool _showLeadingIcon = true;
+    private string _hintText = "Hint text";
+    private Point _selectedFloatingOffset = new (0, -16);
+
+    public IEnumerable<FloatingHintHorizontalAlignment> HorizontalAlignmentOptions { get; } = Enum.GetValues(typeof(FloatingHintHorizontalAlignment)).OfType<FloatingHintHorizontalAlignment>();
+    public IEnumerable<double> FloatingScaleOptions { get; } = new[] {0.25, 0.5, 0.75, 1.0};
+
+    public IEnumerable<Point> FloatingOffsetOptions { get; } = new[] { new Point(0, -16), new Point(0, 16), new Point(16, 16), new Point(-16, -16) };
+
+    public IEnumerable<string> ComboBoxOptions { get; } = new[] {"Option 1", "Option 2", "Option 3"};
+
+    public FloatingHintHorizontalAlignment SelectedAlignment
+    {
+        get => _selectedAlignment;
+        set
+        {
+            _selectedAlignment = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public double SelectedFloatingScale
+    {
+        get => _selectedFloatingScale;
+        set
+        {
+            _selectedFloatingScale = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public Point SelectedFloatingOffset
+    {
+        get => _selectedFloatingOffset;
+        set
+        {
+            _selectedFloatingOffset = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool ShowClearButton
+    {
+        get => _showClearButton;
+        set
+        {
+            _showClearButton = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool ShowLeadingIcon
+    {
+        get => _showLeadingIcon;
+        set
+        {
+            _showLeadingIcon = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string HintText
+    {
+        get => _hintText;
+        set
+        {
+            _hintText = value;
+            OnPropertyChanged();
+        }
+    }
+}

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -1,0 +1,491 @@
+﻿<UserControl x:Class="MaterialDesignDemo.SmartHint"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:domain="clr-namespace:MaterialDesignDemo.Domain"
+             mc:Ignorable="d"
+             x:Name="_root"
+             d:DataContext="{d:DesignInstance domain:SmartHintViewModel, IsDesignTimeCreatable=False}"
+             d:DesignHeight="450" d:DesignWidth="800" Margin="-16,0,-16,0">
+  <Grid Grid.IsSharedSizeScope="True">
+    <Grid.Resources>
+      <materialDesign:MathConverter x:Key="SubtractConverter" Operation="Subtract" />
+      <Style TargetType="{x:Type smtx:XamlDisplay}" BasedOn="{StaticResource {x:Type smtx:XamlDisplay}}">
+        <Setter Property="Margin" Value="0,10,16,0" />
+        <Setter Property="VerticalAlignment" Value="Top" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="Width" Value="186" />
+        <Setter Property="materialDesign:HintAssist.FloatingHintHorizontalAlignment" Value="{Binding SelectedAlignment}" />
+        <Setter Property="materialDesign:HintAssist.FloatingScale" Value="{Binding SelectedFloatingScale}" />
+        <Setter Property="materialDesign:HintAssist.FloatingOffset" Value="{Binding SelectedFloatingOffset}" />
+        <Setter Property="materialDesign:HintAssist.Hint" Value="{Binding HintText}" />
+      </Style>
+      <Style x:Key="StyleNameIndicator" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource MaterialDesignCaptionTextBlock}">
+        <Setter Property="Margin" Value="0,10,16,0" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="TextWrapping" Value="Wrap" />
+      </Style>
+      <materialDesign:PackIconKind x:Key="LeadingIcon">Github</materialDesign:PackIconKind>
+    </Grid.Resources>
+
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+    </Grid.RowDefinitions>
+
+    <GroupBox Grid.Row="0" Margin="8,0,16,16" Header="Hint Settings" Style="{StaticResource MaterialDesignCardGroupBox}">
+      <StackPanel Orientation="Horizontal" Margin="10">
+        <TextBlock Text="FloatingHintHorizontalAlignment:" VerticalAlignment="Center" />
+        <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding HorizontalAlignmentOptions}" SelectedItem="{Binding SelectedAlignment, Mode=TwoWay}" />
+        <TextBlock Text="FloatingScale:" VerticalAlignment="Center" Margin="20,0,0,0" />
+        <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FloatingScaleOptions}" SelectedItem="{Binding SelectedFloatingScale, Mode=TwoWay}" ItemStringFormat="F2" />
+        <TextBlock Text="FloatingOffset:" VerticalAlignment="Center" Margin="20,0,0,0" />
+        <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FloatingOffsetOptions}" SelectedItem="{Binding SelectedFloatingOffset, Mode=TwoWay}" />
+        <CheckBox Content="HasClearButton" IsChecked="{Binding ShowClearButton}" Margin="20,0,0,0" />
+        <CheckBox Content="HasLeadingIcon" IsChecked="{Binding ShowLeadingIcon}" Margin="20,0,0,0" />
+        <TextBox Text="{Binding HintText, UpdateSourceTrigger=PropertyChanged}" Margin="20,0,0,0" Width="180" />
+      </StackPanel>
+    </GroupBox>
+
+    <Grid Grid.Row="1" Margin="0,16,0,0">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" Width="200" />
+        <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+        <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+        <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+        <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+      </Grid.ColumnDefinitions>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+      </Grid.RowDefinitions>
+
+      <TextBlock Style="{StaticResource MaterialDesignHeadline5TextBlock}" Text="--- Alignments ---" Grid.Column="1" Grid.Row="0" Grid.ColumnSpan="4" HorizontalAlignment="Center" Margin="0,0,0,10" />
+      <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Left" Grid.Column="1" Grid.Row="1" HorizontalAlignment="Center" />
+      <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Center" Grid.Column="2" Grid.Row="1" HorizontalAlignment="Center" />
+      <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Right" Grid.Column="3" Grid.Row="1" HorizontalAlignment="Center" />
+      <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Stretch" Grid.Column="4" Grid.Row="1" HorizontalAlignment="Center" />
+    </Grid>
+
+    <ScrollViewer Grid.Row="2" VerticalAlignment="Top" materialDesign:ScrollViewerAssist.BubbleVerticalScroll="False" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Hidden" Margin="0,20,0,0"
+                  Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ScrollViewer}}, Path=ViewportHeight, Converter={StaticResource SubtractConverter}, ConverterParameter=250}">
+      <StackPanel Margin="8,0,16,0" VerticalAlignment="Top" HorizontalAlignment="Left">
+
+        <!-- TextBox variants -->
+        <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="TextBox styles" />
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}">
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFloatingHintTextBox</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="textbox_floating_left">
+            <TextBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="textbox_floating_center">
+            <TextBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="textbox_floating_right">
+            <TextBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="textbox_floating_stretch">
+            <TextBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFilledTextBox}">
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFilledTextBox</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="textbox_filled_left">
+            <TextBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="textbox_filled_center">
+            <TextBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="textbox_filled_right">
+            <TextBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="textbox_filled_stretch">
+            <TextBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignOutlinedTextBox}">
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignOutlinedTextBox</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="textbox_outlined_left">
+            <TextBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="textbox_outlined_center">
+            <TextBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="textbox_outlined_right">
+            <TextBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="textbox_outlined_stretch">
+            <TextBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+
+        <!-- RichTextBox variants -->
+        <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="RichTextBox styles" Margin="0,40,0,0" />
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type RichTextBox}" BasedOn="{StaticResource MaterialDesignRichTextBox}">
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignRichTextBox</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="richtextbox_left">
+            <RichTextBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="richtextbox_center">
+            <RichTextBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="richtextbox_right">
+            <RichTextBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="richtextbox_stretch">
+            <RichTextBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+
+        <!-- PasswordBox variants -->
+        <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="PasswordBox styles" Margin="0,40,0,0" />
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type PasswordBox}" BasedOn="{StaticResource MaterialDesignFloatingHintPasswordBox}">
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFloatingHintPasswordBox</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="passwordbox_floating_left">
+            <PasswordBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="passwordbox_floating_center">
+            <PasswordBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="passwordbox_floating_right">
+            <PasswordBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="passwordbox_floating_stretch">
+            <PasswordBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type PasswordBox}" BasedOn="{StaticResource MaterialDesignFilledPasswordBox}">
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFilledPasswordBox</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="passwordbox_filled_left">
+            <PasswordBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="passwordbox_filled_center">
+            <PasswordBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="passwordbox_filled_right">
+            <PasswordBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="passwordbox_filled_stretch">
+            <PasswordBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type PasswordBox}" BasedOn="{StaticResource MaterialDesignOutlinedPasswordBox}">
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignOutlinedPasswordBox</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="passwordbox_outlined_left">
+            <PasswordBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="passwordbox_outlined_center">
+            <PasswordBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="passwordbox_outlined_right">
+            <PasswordBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="passwordbox_outlined_stretch">
+            <PasswordBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+
+        <!-- Reveal style PasswordBox variants -->
+        <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="PasswordBox 'reveal' styles" Margin="0,40,0,0" />
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type PasswordBox}" BasedOn="{StaticResource MaterialDesignFloatingHintRevealPasswordBox}">
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFloatingHintRevealPasswordBox</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="passwordbox_reveal_floating_left">
+            <PasswordBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="passwordbox_reveal_floating_center">
+            <PasswordBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="passwordbox_reveal_floating_right">
+            <PasswordBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="passwordbox_reveal_floating_stretch">
+            <PasswordBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type PasswordBox}" BasedOn="{StaticResource MaterialDesignFilledRevealPasswordBox}">
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFilledRevealPasswordBox</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="passwordbox_reveal_filled_left">
+            <PasswordBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="passwordbox_reveal_filled_center">
+            <PasswordBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="passwordbox_reveal_filled_right">
+            <PasswordBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="passwordbox_reveal_filled_stretch">
+            <PasswordBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type PasswordBox}" BasedOn="{StaticResource MaterialDesignOutlinedRevealPasswordBox}">
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignOutlinedRevealPasswordBox</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="passwordbox_reveal_outlined_left">
+            <PasswordBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="passwordbox_reveal_outlined_center">
+            <PasswordBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="passwordbox_reveal_outlined_right">
+            <PasswordBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="passwordbox_reveal_outlined_stretch">
+            <PasswordBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+
+        <!-- ComboBox variants -->
+        <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="ComboBox styles" Margin="0,40,0,0" />
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource MaterialDesignFloatingHintComboBox}">
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
+              <Setter Property="IsEditable" Value="True" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFloatingHintComboBox</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="combobox_floating_left">
+            <ComboBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="combobox_floating_center">
+            <ComboBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="combobox_floating_right">
+            <ComboBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="combobox_floating_stretch">
+            <ComboBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource MaterialDesignFilledComboBox}">
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
+              <Setter Property="IsEditable" Value="True" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFilledComboBox</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="combobox_filled_left">
+            <ComboBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="combobox_filled_center">
+            <ComboBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="combobox_filled_right">
+            <ComboBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="combobox_filled_stretch">
+            <ComboBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource MaterialDesignOutlinedComboBox}">
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
+              <Setter Property="IsEditable" Value="True" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignOutlinedComboBox</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="combobox_outlined_left">
+            <ComboBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="combobox_outlined_center">
+            <ComboBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="combobox_outlined_right">
+            <ComboBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="combobox_outlined_stretch">
+            <ComboBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+      </StackPanel>
+    </ScrollViewer>
+  </Grid>
+</UserControl>

--- a/MainDemo.Wpf/SmartHint.xaml.cs
+++ b/MainDemo.Wpf/SmartHint.xaml.cs
@@ -1,0 +1,15 @@
+﻿using MaterialDesignDemo.Domain;
+
+namespace MaterialDesignDemo;
+
+/// <summary>
+/// Interaction logic for SmartHint.xaml
+/// </summary>
+public partial class SmartHint : UserControl
+{
+    public SmartHint()
+    {
+        DataContext = new SmartHintViewModel();
+        InitializeComponent();
+    }
+}

--- a/MaterialDesignThemes.Wpf/Converters/FloatingHintTextBlockMarginConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/FloatingHintTextBlockMarginConverter.cs
@@ -1,0 +1,116 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace MaterialDesignThemes.Wpf.Converters;
+
+internal class FloatingHintTextBlockMarginConverter : IMultiValueConverter
+{
+    public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values == null || values.Length != 7 || values.Any(v => v == null)
+            || values[0] is not FloatingHintHorizontalAlignment floatingAlignment
+            || values[1] is not HorizontalAlignment restingAlignment
+            || !double.TryParse(values[2]!.ToString(), out double desiredWidth)
+            || !double.TryParse(values[3]!.ToString(), out double availableWidth)
+            || !double.TryParse(values[4]!.ToString(), out double scale)
+            || !double.TryParse(values[5]!.ToString(), out double lower)
+            || !double.TryParse(values[6]!.ToString(), out double upper))
+        {
+            return Transform.Identity;
+        }
+
+        double scaleMultiplier = upper + (lower - upper) * scale;
+
+        HorizontalAlignment alignment = restingAlignment;
+        if (scale != 0)
+        {
+            switch (floatingAlignment)
+            {
+                case FloatingHintHorizontalAlignment.Inherit:
+                    alignment = restingAlignment;
+                    break;
+                case FloatingHintHorizontalAlignment.Left:
+                    alignment = HorizontalAlignment.Left;
+                    break;
+                case FloatingHintHorizontalAlignment.Center:
+                    alignment = HorizontalAlignment.Center;
+                    break;
+                case FloatingHintHorizontalAlignment.Right:
+                    alignment = HorizontalAlignment.Right;
+                    break;
+                case FloatingHintHorizontalAlignment.Stretch:
+                    alignment = HorizontalAlignment.Stretch;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+        switch (alignment)
+        {
+            case HorizontalAlignment.Right:
+                return FloatRight();
+            case HorizontalAlignment.Center:
+                return FloatCenter();
+            default:
+                return FloatLeft();
+        }
+
+        Thickness FloatLeft()
+        {
+            if (restingAlignment == HorizontalAlignment.Center)
+            {
+                // Animate from center to left
+                double offset = Math.Max(0, (availableWidth - desiredWidth) / 2);
+                return new Thickness(offset - offset * scale, 0, 0, 0);
+            }
+            if (restingAlignment == HorizontalAlignment.Right)
+            {
+                // Animate from right to left
+                double offset = Math.Max(0, availableWidth - desiredWidth);
+                return new Thickness(offset - offset * scale, 0, 0, 0);
+            }
+            return new Thickness(0);
+        }
+
+        Thickness FloatCenter()
+        {
+            if (restingAlignment == HorizontalAlignment.Left || restingAlignment == HorizontalAlignment.Stretch)
+            {
+                // Animate from left to center
+                double offset = Math.Max(0, (availableWidth - desiredWidth * scaleMultiplier) / 2);
+                return new Thickness(offset * scale, 0, 0, 0);
+            }
+            if (restingAlignment == HorizontalAlignment.Right)
+            {
+                // Animate from right to center
+                double startOffset = Math.Max(0, availableWidth - desiredWidth);
+                double endOffset = Math.Max(0, (availableWidth - desiredWidth) / 2);
+                double endOffsetDelta = startOffset - endOffset;
+                return new Thickness(endOffset + endOffsetDelta * (1 - scale), 0, 0, 0);
+            }
+            return new Thickness(Math.Max(0, availableWidth - desiredWidth * scaleMultiplier) / 2, 0, 0, 0);
+        }
+
+        Thickness FloatRight()
+        {
+            if (restingAlignment == HorizontalAlignment.Left || restingAlignment == HorizontalAlignment.Stretch)
+            {
+                // Animate from left to right
+                double offset = Math.Max(0, availableWidth - desiredWidth * scaleMultiplier);
+                return new Thickness(offset * scale, 0, 0, 0);
+            }
+            if (restingAlignment == HorizontalAlignment.Center)
+            {
+                // Animate from center to right
+                double startOffset = Math.Max(0, (availableWidth - desiredWidth) / 2);
+                double endOffsetDelta = Math.Max(0, availableWidth - desiredWidth * scaleMultiplier) - startOffset;
+                return new Thickness(startOffset + endOffsetDelta * scale, 0, 0, 0);
+            }
+            return new Thickness(Math.Max(0, availableWidth - desiredWidth * scaleMultiplier), 0, 0, 0);
+        }
+    }
+
+    public object?[]? ConvertBack(object? value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/MaterialDesignThemes.Wpf/Converters/FloatingHintTextBlockMarginConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/FloatingHintTextBlockMarginConverter.cs
@@ -8,7 +8,7 @@ internal class FloatingHintTextBlockMarginConverter : IMultiValueConverter
 {
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (values == null || values.Length != 7 || values.Any(v => v == null)
+        if (values?.Length != 7 || values.Any(v => v == null)
             || values[0] is not FloatingHintHorizontalAlignment floatingAlignment
             || values[1] is not HorizontalAlignment restingAlignment
             || !double.TryParse(values[2]!.ToString(), out double desiredWidth)

--- a/MaterialDesignThemes.Wpf/FloatingHintHorizontalAlignment.cs
+++ b/MaterialDesignThemes.Wpf/FloatingHintHorizontalAlignment.cs
@@ -1,0 +1,10 @@
+﻿namespace MaterialDesignThemes.Wpf;
+
+public enum FloatingHintHorizontalAlignment
+{
+    Inherit,
+    Left,
+    Center,
+    Right,
+    Stretch
+}

--- a/MaterialDesignThemes.Wpf/HintAssist.cs
+++ b/MaterialDesignThemes.Wpf/HintAssist.cs
@@ -66,6 +66,17 @@ namespace MaterialDesignThemes.Wpf
             => element.SetValue(HintOpacityProperty, value);
         #endregion
 
+        #region AttachedProperty : FloatingHintHorizontalAlignment
+        public static readonly DependencyProperty FloatingHintHorizontalAlignmentProperty
+            = DependencyProperty.RegisterAttached("FloatingHintHorizontalAlignment", typeof(FloatingHintHorizontalAlignment), typeof(HintAssist),
+                new FrameworkPropertyMetadata(FloatingHintHorizontalAlignment.Inherit, FrameworkPropertyMetadataOptions.Inherits));
+
+        public static void SetFloatingHintHorizontalAlignment(DependencyObject element, FloatingHintHorizontalAlignment value)
+            => element.SetValue(FloatingHintHorizontalAlignmentProperty, value);
+        public static FloatingHintHorizontalAlignment GetFloatingHintHorizontalAlignment(DependencyObject element)
+            => (FloatingHintHorizontalAlignment) element.GetValue(FloatingHintHorizontalAlignmentProperty);
+        #endregion
+
         #region AttachedProperty : HintFontFamilyProperty
         public static readonly DependencyProperty FontFamilyProperty
             = DependencyProperty.RegisterAttached("FontFamily", typeof(FontFamily), typeof(HintAssist),

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -326,7 +326,7 @@
                     Grid.Column="0"
                     Padding="{TemplateBinding Padding}">
               <Grid x:Name="InnerRoot"
-                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                    HorizontalAlignment="Stretch"
                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                     UseLayoutRounding="{TemplateBinding UseLayoutRounding}">
@@ -353,7 +353,7 @@
                 <TextBox x:Name="PART_EditableTextBox"
                          Grid.Column="1"
                          MinWidth="10"
-                         HorizontalAlignment="Stretch"
+                         HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                          HorizontalContentAlignment="Stretch"
                          CaretBrush="{TemplateBinding Foreground}"
                          IsReadOnly="{TemplateBinding IsReadOnly}"
@@ -372,7 +372,8 @@
                                HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
-                               UseLayoutRounding="{TemplateBinding UseLayoutRounding}">
+                               UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
+                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
                   <wpf:SmartHint.Hint>
                     <Border x:Name="HintBackgroundBorder"
                             Background="{TemplateBinding wpf:HintAssist.Background}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -131,14 +131,15 @@
                       BorderThickness="{TemplateBinding BorderThickness}"
                       CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                       SnapsToDevicePixels="True">
-                <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                <Grid HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition />
                     <ColumnDefinition Width="Auto" />
                   </Grid.ColumnDefinitions>
                   <Grid x:Name="grid"
                         MinWidth="1"
-                        VerticalAlignment="Center">
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition Width="Auto" />
                       <ColumnDefinition Width="*" />
@@ -155,6 +156,7 @@
                                   wpf:ScrollViewerAssist.IgnorePadding="True"
                                   Cursor="{TemplateBinding Cursor, Converter={StaticResource IBeamCursorConverter}}"
                                   Focusable="false"
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   HorizontalScrollBarVisibility="Hidden"
                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                   UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
@@ -168,7 +170,8 @@
                                    FontSize="{TemplateBinding FontSize}"
                                    HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                    HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
-                                   UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}">
+                                   UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
                       <wpf:SmartHint.Hint>
                         <Border x:Name="HintBackgroundBorder"
                                 Background="{TemplateBinding wpf:HintAssist.Background}"
@@ -595,15 +598,16 @@
                       BorderThickness="{TemplateBinding BorderThickness}"
                       CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                       SnapsToDevicePixels="True">
-                <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                <Grid HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                   <Grid.ColumnDefinitions>
-                    <ColumnDefinition />
+                    <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
                   </Grid.ColumnDefinitions>
                   <Grid x:Name="grid"
                         MinWidth="1"
-                        VerticalAlignment="Center">
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition Width="Auto" />
                       <ColumnDefinition Width="*" />
@@ -618,6 +622,7 @@
                     <Grid x:Name="ContentGrid"
                           Grid.Column="1"
                           Panel.ZIndex="1"
+                          HorizontalAlignment="Stretch"
                           wpf:PasswordBoxAssist.IsPasswordRevealed="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed)}">
 
                       <ScrollViewer x:Name="PART_ContentHost"
@@ -628,6 +633,7 @@
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                     UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
                                     VerticalScrollBarVisibility="Hidden"
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                     Visibility="{Binding ElementName=ContentGrid, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed), Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
                       <TextBox x:Name="RevealPasswordTextBox"
                                Grid.Column="0"
@@ -639,6 +645,7 @@
                                SelectionBrush="{TemplateBinding SelectionBrush}"
                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                Style="{StaticResource MaterialDesignRawTextBox}"
+                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:PasswordBoxAssist.Password), UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                                UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
                                Visibility="{Binding ElementName=ContentGrid, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed), Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -657,7 +664,8 @@
                                    FontSize="{TemplateBinding FontSize}"
                                    HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                    HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
-                                   UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}">
+                                   UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
                       <wpf:SmartHint.Hint>
                         <Border x:Name="HintBackgroundBorder"
                                 Background="{TemplateBinding wpf:HintAssist.Background}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -10,6 +10,7 @@
                                            TrueValue="Collapsed" />
   <converters:FloatingHintTransformConverter x:Key="FloatingHintCanvasTransformConverter" ApplyScaleTransform="False" />
   <converters:FloatingHintTransformConverter x:Key="FloatingHintTransformConverter" ApplyTranslateTransform="False" />
+  <converters:FloatingHintTextBlockMarginConverter x:Key="FloatingHintTextBlockMarginConverter" />
   <system:Double x:Key="NoContentFloatingScale">1.0</system:Double>
   <CubicEase x:Key="AnimationEasingFunction" EasingMode="EaseInOut" />
 
@@ -159,6 +160,17 @@
                                   Opacity="{TemplateBinding HintOpacity}"
                                   RenderTransformOrigin="0,0"
                                   Visibility="{TemplateBinding UseFloating, Converter={StaticResource BoolToVisConverter}}">
+                    <ContentControl.Margin>
+                      <MultiBinding Converter="{StaticResource FloatingHintTextBlockMarginConverter}">
+                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.FloatingHintHorizontalAlignment)" />
+                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="HorizontalContentAlignment" />
+                        <Binding RelativeSource="{RelativeSource Self}" Path="ActualWidth" />
+                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualWidth" />
+                        <Binding ElementName="ScaleHost" Path="Scale" />
+                        <Binding Path="FloatingScale" RelativeSource="{RelativeSource TemplatedParent}" />
+                        <Binding Source="{StaticResource NoContentFloatingScale}" />
+                      </MultiBinding>
+                    </ContentControl.Margin>
                     <ContentControl.Tag>
                       <system:Double>0.0</system:Double>
                     </ContentControl.Tag>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -127,7 +127,7 @@
                       BorderThickness="{TemplateBinding BorderThickness}"
                       CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                       SnapsToDevicePixels="True">
-                <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                <Grid HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition />
@@ -145,7 +145,9 @@
 
                   <Grid x:Name="grid"
                         Grid.Column="1"
-                        MinWidth="1">
+                        MinWidth="1"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Stretch">
                     <Grid Grid.Column="0">
                       <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -170,6 +172,7 @@
                       <ScrollViewer x:Name="PART_ContentHost"
                                     Grid.Column="1"
                                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                     Panel.ZIndex="1"
                                     wpf:ScrollViewerAssist.IgnorePadding="True"
                                     Cursor="{TemplateBinding Cursor, Converter={StaticResource IBeamCursorConverter}}"
@@ -195,7 +198,8 @@
                                    FontSize="{TemplateBinding FontSize}"
                                    HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                    HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
-                                   UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}">
+                                   UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
                       <wpf:SmartHint.Hint>
                         <Border x:Name="HintBackgroundBorder"
                                 Background="{TemplateBinding wpf:HintAssist.Background}"


### PR DESCRIPTION
Fixes #3055

As mentioned in #3055 my recent PR (#3041) caused a regression for input elements with `HorizontalContentAlignment=Right`. I had not considered this scenario when coding the fix.

This PR refactors the `SmartHint` alignment quite extensively, and could potentially be considered a breaking change (I added the label; remove it if you disagree).

Essentials of the PR:
- Changes the MDIX `Style` of the controls that currently use the `SmartHint` such that the `SmartHint` is "stretched" to fill the available space, thus allowing it to infer the location of the hint text.
- Expands the usages of the `SmartHint` to also provide the `HorizontalContentAlignment` allowing the hint to float accordingly.
- Changes the `SmartHint` implementation to use a converter to handle the horizontal alignment of the hint text.
- Adds a `HintAssist.FloatingHintHorizontalAlignment` attached property which allows the user to have a different floating/resting alignments which are not the same. I think this may be useful in a "user form" scenario where you stack elements and would like the floating hints to align, but may want to enter values with `HorizontalContentAlignment=Right` for example for currencies.
- Extends the demo app with a dedicated page which allows extensive manual testing of all the floating hint options. This page may be **too exhaustive** for a demo application and we may want to trim down to some fewer samples, but it was very useful for manual testing and ensuring this work as expected.

Ideally I would like to eventually write some XAMLTest UI tests that assert these floating alignments are respected, I think I would like your input on how to best go about doing that.

There are still a few minor alignment issues which can be spotted, but most of these are also present in the previous implementations.

Preview of the page in the demo app:
![SmartHint](https://user-images.githubusercontent.com/19572699/215066664-40ebf2c2-3861-4726-b16e-fc392a0d38b3.gif)
