### PR TITLE
TabControl: Update IsItemsHost on changes to Visibility rather than IsVisible

### DIFF
--- a/MaterialDesignThemes.Wpf/TabAssist.cs
+++ b/MaterialDesignThemes.Wpf/TabAssist.cs
@@ -16,20 +16,20 @@ public static class TabAssist
 
     public static bool GetHasUniformTabWidth(DependencyObject element) => (bool)element.GetValue(HasUniformTabWidthProperty);
 
-    internal static bool GetBindableIsItemsHost(DependencyObject obj)
-        => (bool)obj.GetValue(BindableIsItemsHostProperty);
+    internal static Visibility GetBindableIsItemsHost(DependencyObject obj)
+        => (Visibility)obj.GetValue(BindableIsItemsHostProperty);
 
-    internal static void SetBindableIsItemsHost(DependencyObject obj, bool value)
+    internal static void SetBindableIsItemsHost(DependencyObject obj, Visibility value)
         => obj.SetValue(BindableIsItemsHostProperty, value);
 
     internal static readonly DependencyProperty BindableIsItemsHostProperty =
-        DependencyProperty.RegisterAttached("BindableIsItemsHost", typeof(bool), typeof(TabAssist), new PropertyMetadata(false, OnBindableIsItemsHostChanged));
+        DependencyProperty.RegisterAttached("BindableIsItemsHost", typeof(Visibility), typeof(TabAssist), new PropertyMetadata(Visibility.Collapsed, OnBindableIsItemsHostChanged));
 
     private static void OnBindableIsItemsHostChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is Panel panel)
         {
-            panel.IsItemsHost = (bool)e.NewValue;
+            panel.IsItemsHost = (Visibility)e.NewValue == Visibility.Visible;
         }
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -50,14 +50,14 @@
                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                Focusable="False"
-                               wpf:TabAssist.BindableIsItemsHost="{Binding IsVisible, RelativeSource={RelativeSource Self}}"
+                               wpf:TabAssist.BindableIsItemsHost="{Binding Visibility, RelativeSource={RelativeSource Self}}"
                                KeyboardNavigation.TabIndex="1"
                                Rows="1" />
                   <VirtualizingStackPanel x:Name="HeaderPanel"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                           Focusable="False"
-                                          wpf:TabAssist.BindableIsItemsHost="{Binding IsVisible, RelativeSource={RelativeSource Self}}"
+                                          wpf:TabAssist.BindableIsItemsHost="{Binding Visibility, RelativeSource={RelativeSource Self}}"
                                           KeyboardNavigation.TabIndex="1"
                                           Orientation="Horizontal" />
                 </StackPanel>


### PR DESCRIPTION
Fixes #3063 

Regression introduced in 6be496b24b70c4a2b247a80d45e9f65ba6eb2be5.

The original change updated the `Panel.IsItemsHost` when the `bool` value was changed. This was bound to `IsVisible`. This PR changes that behavior to bind to `Visibility` instead (which is being set by the triggers).

The DP callback did actually fire correctly, but the UI was not appropriately updated. Moving the mouse around and doing "various stuff" could then suddenly make the content appear again. By changing the binding to use `Visibility` instead, this problem seems to disappear and the control works as expected.