### PR TITLE
TextBox: Respect externally set TextBox.Padding in triggers

### DIFF
--- a/MainDemo.Wpf/Domain/SmartHintViewModel.cs
+++ b/MainDemo.Wpf/Domain/SmartHintViewModel.cs
@@ -4,6 +4,7 @@ namespace MaterialDesignDemo.Domain;
 
 internal class SmartHintViewModel : ViewModelBase
 {
+    private bool _floatHint = true;
     private FloatingHintHorizontalAlignment _selectedAlignment = FloatingHintHorizontalAlignment.Inherit;
     private double _selectedFloatingScale = 0.75;
     private bool _showClearButton = true;
@@ -17,6 +18,16 @@ internal class SmartHintViewModel : ViewModelBase
     public IEnumerable<Point> FloatingOffsetOptions { get; } = new[] { new Point(0, -16), new Point(0, 16), new Point(16, 16), new Point(-16, -16) };
 
     public IEnumerable<string> ComboBoxOptions { get; } = new[] {"Option 1", "Option 2", "Option 3"};
+
+    public bool FloatHint
+    {
+        get => _floatHint;
+        set
+        {
+            _floatHint = value;
+            OnPropertyChanged();
+        }
+    }
 
     public FloatingHintHorizontalAlignment SelectedAlignment
     {

--- a/MainDemo.Wpf/MainWindow.xaml
+++ b/MainDemo.Wpf/MainWindow.xaml
@@ -60,13 +60,11 @@
                    Width="200"
                    Margin="16,4"
                    materialDesign:HintAssist.Hint="Search"
-                   materialDesign:HintAssist.IsFloating="True"
                    materialDesign:TextFieldAssist.DecorationVisibility="Collapsed"
                    materialDesign:TextFieldAssist.HasClearButton="True"
-                   materialDesign:TextFieldAssist.HasOutlinedTextField="True"
-                   materialDesign:TextFieldAssist.TextFieldCornerRadius="4"
                    DockPanel.Dock="Top"
-                   Text="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}" />
+                   Text="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"
+                   Style="{StaticResource MaterialDesignOutlinedTextBox}"/>
 
           <ListBox x:Name="DemoItemsListBox"
                    Margin="0,16,0,16"

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -40,7 +40,8 @@
 
     <GroupBox Grid.Row="0" Margin="8,0,16,16" Header="Hint Settings" Style="{StaticResource MaterialDesignCardGroupBox}">
       <StackPanel Orientation="Horizontal" Margin="10">
-        <TextBlock Text="FloatingHintHorizontalAlignment:" VerticalAlignment="Center" />
+        <CheckBox Content="IsFloating" IsChecked="{Binding FloatHint}" />
+        <TextBlock Text="Alignment:" VerticalAlignment="Center" Margin="20,0,0,0" />
         <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding HorizontalAlignmentOptions}" SelectedItem="{Binding SelectedAlignment, Mode=TwoWay}" />
         <TextBlock Text="FloatingScale:" VerticalAlignment="Center" Margin="20,0,0,0" />
         <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FloatingScaleOptions}" SelectedItem="{Binding SelectedFloatingScale, Mode=TwoWay}" ItemStringFormat="F2" />
@@ -84,6 +85,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -114,6 +116,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -144,6 +147,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -176,6 +180,7 @@
             <Style TargetType="{x:Type RichTextBox}" BasedOn="{StaticResource MaterialDesignRichTextBox}">
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -209,6 +214,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -239,6 +245,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -269,6 +276,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -302,6 +310,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -332,6 +341,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -362,6 +372,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -395,6 +406,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="True" />
             </Style>
@@ -427,6 +439,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="True" />
             </Style>
@@ -459,6 +472,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="True" />
             </Style>

--- a/MaterialDesign3.Demo.Wpf/MainWindow.xaml
+++ b/MaterialDesign3.Demo.Wpf/MainWindow.xaml
@@ -109,13 +109,12 @@
           <TextBox x:Name="DemoItemsSearchBox"
                    Margin="16,4,16,4"
                    materialDesign:HintAssist.Hint="Search"
-                   materialDesign:HintAssist.IsFloating="True"
                    materialDesign:TextFieldAssist.DecorationVisibility="Collapsed"
                    materialDesign:TextFieldAssist.HasClearButton="True"
-                   materialDesign:TextFieldAssist.HasOutlinedTextField="True"
                    materialDesign:TextFieldAssist.TextFieldCornerRadius="8"
                    DockPanel.Dock="Top"
-                   Text="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}" />
+                   Text="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"
+                   Style="{StaticResource MaterialDesignOutlinedTextBox}"/>
           <ListBox x:Name="DemoItemsListBox"
                    Margin="12,16,12,16"
                    AutomationProperties.Name="DemoPagesListBox"

--- a/MaterialDesignThemes.Wpf/Constants.cs
+++ b/MaterialDesignThemes.Wpf/Constants.cs
@@ -3,6 +3,8 @@ namespace MaterialDesignThemes.Wpf;
 public static class Constants
 {
     public static readonly Thickness TextBoxDefaultPadding = new Thickness(0, 4, 0, 4);
+    public static readonly Thickness FilledTextBoxDefaultPadding = new Thickness(16, 8, 12, 8);
+    public static readonly Thickness OutlinedTextBoxDefaultPadding = new Thickness(16, 16, 12, 16);
     public static readonly Thickness DefaultTextBoxViewMargin = new Thickness(1, 0, 1, 0);
     public static readonly Thickness DefaultTextBoxViewMarginEmbedded = new Thickness(0);
     public const double TextBoxNotEnabledOpacity = 0.56;

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -481,7 +481,6 @@
     </AdornerDecorator>
     <ControlTemplate.Triggers>
       <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
-        <Setter Property="Padding" Value="16,8,12,8" />
         <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
       </Trigger>
       <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
@@ -880,7 +879,7 @@
          TargetType="{x:Type ComboBox}"
          BasedOn="{StaticResource MaterialDesignFloatingHintComboBox}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-    <Setter Property="Padding" Value="12,8,8,8" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.FilledTextBoxDefaultPadding}" />
     <Setter Property="VerticalAlignment" Value="Stretch" />
     <Setter Property="VerticalContentAlignment" Value="Stretch" />
     <Setter Property="wpf:ComboBoxAssist.ShowSelectedItem" Value="True" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -268,14 +268,12 @@
             </MultiTrigger>
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-              <Setter Property="Padding" Value="16,8,12,8" />
               <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
               <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="1" />
-              <Setter Property="Padding" Value="16,16,12,16" />
               <Setter Property="VerticalContentAlignment" Value="Top" />
               <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
               <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
@@ -469,6 +467,7 @@
     <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />
     <Setter Property="wpf:TextFieldAssist.UnderlineCornerRadius" Value="0" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.FilledTextBoxDefaultPadding}" />
   </Style>
 
   <Style x:Key="MaterialDesignOutlinedPasswordBox"
@@ -476,6 +475,7 @@
          BasedOn="{StaticResource MaterialDesignFloatingHintPasswordBox}">
     <Setter Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.OutlinedTextBoxDefaultPadding}" />
   </Style>
 
   <!-- ******************** "Reveal" PasswordBox styles below ***************************** -->
@@ -772,14 +772,12 @@
             </MultiTrigger>
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-              <Setter Property="Padding" Value="16,8,12,8" />
               <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
               <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="1" />
-              <Setter Property="Padding" Value="16,16,12,16" />
               <Setter Property="VerticalContentAlignment" Value="Top" />
               <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
               <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
@@ -986,6 +984,7 @@
     <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />
     <Setter Property="wpf:TextFieldAssist.UnderlineCornerRadius" Value="0" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.FilledTextBoxDefaultPadding}" />
   </Style>
 
   <Style x:Key="MaterialDesignOutlinedRevealPasswordBox"
@@ -993,6 +992,7 @@
          BasedOn="{StaticResource MaterialDesignFloatingHintRevealPasswordBox}">
     <Setter Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.OutlinedTextBoxDefaultPadding}" />
   </Style>
 
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -303,14 +303,12 @@
             </MultiTrigger>
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-              <Setter Property="Padding" Value="16,8,12,8" />
               <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
               <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="1" />
-              <Setter Property="Padding" Value="16,16,12,16" />
               <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
               <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
               <Setter TargetName="Hint" Property="FloatingOffset">
@@ -512,6 +510,7 @@
     <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />
     <Setter Property="wpf:TextFieldAssist.UnderlineCornerRadius" Value="0" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.FilledTextBoxDefaultPadding}" />
   </Style>
 
   <Style x:Key="MaterialDesignOutlinedTextBox"
@@ -519,6 +518,7 @@
          BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}">
     <Setter Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.OutlinedTextBoxDefaultPadding}" />
   </Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
Fixes #3058 
Fixes #3076

This PR extracts the `TextBox.Padding` setters out of the trigger collection and into the overriden `Style` instead. This allows the user to override them.

There is a consequence to this however: you now **have** to set the style, you cannot only set the attached properties. This is a visual breaking change. You can see how I needed to modify the `MainWindow.xaml` to get the correct behavior for the `DemoItemsSearchBox`.

There is also another (internal) consequence, which is that any trigger or similar which previously relied on the "hardcoded" padding for a particular style, now needs to respect any margin because the user can override it.

There is also the fact that this is not limited to the `TextBox` styles. If we decide to go this route, it should be fixed for all filled/outlined styles in a similar manner.

In the example below, I have set `TextBox.Padding="5"` on the `SmartHint` demo page (via a style setter) to illustrate that it is now possible to override in a style.
![image](https://user-images.githubusercontent.com/19572699/216997309-c58edb68-766b-4399-a8fa-2dd46de6b66a.png)

