### PR TITLE
Make ClearText work with ControlTemplate

### DIFF
--- a/MaterialDesignThemes.Wpf/Internal/ClearText.cs
+++ b/MaterialDesignThemes.Wpf/Internal/ClearText.cs
@@ -35,7 +35,7 @@
 
             static void OnClearCommand(object sender, ExecutedRoutedEventArgs e)
             {
-                switch (e.Source)
+                switch (sender)
                 {
                     case DatePicker datePicker:
                         datePicker.SetCurrentValue(DatePicker.SelectedDateProperty, null);


### PR DESCRIPTION
When upgrading to .NET 7 I also ran into the issue described in: https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2510

**Issue description:**
When using md:TextFieldAssist.HasClearButton="True" within the ControlTemplate of a custom control the ClearText.OnClearCommand e.Source is set to the Button instead of the TextBox.

**Resolution:**
To resolve this I validated that we can succesfully use the Sender instead. In all cases this is the targeted control. I also validated this for the other control types in the ClearText class: DatePicker, ComboBox and PasswordBox.