### PR TITLE
Cleanup: Aligning hint, helper text and validation error based on padding

### DIFF
--- a/MainDemo.Wpf/Domain/SmartHintViewModel.cs
+++ b/MainDemo.Wpf/Domain/SmartHintViewModel.cs
@@ -10,14 +10,16 @@ internal class SmartHintViewModel : ViewModelBase
     private bool _showClearButton = true;
     private bool _showLeadingIcon = true;
     private string _hintText = "Hint text";
-    private Point _selectedFloatingOffset = new (0, -16);
+    private string _helperText = "Helper text";
+    private Point _selectedFloatingOffset = new(0, -16);
+    private bool _applyCustomPadding;
+    private Thickness _selectedCustomPadding = new(5);
 
     public IEnumerable<FloatingHintHorizontalAlignment> HorizontalAlignmentOptions { get; } = Enum.GetValues(typeof(FloatingHintHorizontalAlignment)).OfType<FloatingHintHorizontalAlignment>();
     public IEnumerable<double> FloatingScaleOptions { get; } = new[] {0.25, 0.5, 0.75, 1.0};
-
     public IEnumerable<Point> FloatingOffsetOptions { get; } = new[] { new Point(0, -16), new Point(0, 16), new Point(16, 16), new Point(-16, -16) };
-
     public IEnumerable<string> ComboBoxOptions { get; } = new[] {"Option 1", "Option 2", "Option 3"};
+    public IEnumerable<Thickness> CustomPaddingOptions { get; } = new [] { new Thickness(0), new Thickness(5), new Thickness(10), new Thickness(15) };
 
     public bool FloatHint
     {
@@ -85,6 +87,36 @@ internal class SmartHintViewModel : ViewModelBase
         set
         {
             _hintText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string HelperText
+    {
+        get => _helperText;
+        set
+        {
+            _helperText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool ApplyCustomPadding
+    {
+        get => _applyCustomPadding;
+        set
+        {
+            _applyCustomPadding = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public Thickness SelectedCustomPadding
+    {
+        get => _selectedCustomPadding;
+        set
+        {
+            _selectedCustomPadding = value;
             OnPropertyChanged();
         }
     }

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -100,6 +100,12 @@
       <ComboBox x:Name="MaterialDesignFloatingHintComboBoxDefaults" Style="{StaticResource MaterialDesignFloatingHintComboBox}" />
       <ComboBox x:Name="MaterialDesignFilledComboBoxDefaults" Style="{StaticResource MaterialDesignFilledComboBox}" />
       <ComboBox x:Name="MaterialDesignOutlinedComboBoxDefaults" Style="{StaticResource MaterialDesignOutlinedComboBox}" />
+      <DatePicker x:Name="MaterialDesignFloatingHintDatePickerDefaults" Style="{StaticResource MaterialDesignFloatingHintDatePicker}" />
+      <DatePicker x:Name="MaterialDesignFilledDatePickerDefaults" Style="{StaticResource MaterialDesignFilledDatePicker}" />
+      <DatePicker x:Name="MaterialDesignOutlinedDatePickerDefaults" Style="{StaticResource MaterialDesignOutlinedDatePicker}" />
+      <materialDesign:TimePicker x:Name="MaterialDesignFloatingHintTimePickerDefaults" Style="{StaticResource MaterialDesignFloatingHintTimePicker}" />
+      <materialDesign:TimePicker x:Name="MaterialDesignFilledTimePickerDefaults" Style="{StaticResource MaterialDesignFilledTimePicker}" />
+      <materialDesign:TimePicker x:Name="MaterialDesignOutlinedTimePickerDefaults" Style="{StaticResource MaterialDesignOutlinedTimePicker}" />
     </StackPanel>
 
     <ScrollViewer Grid.Row="2" VerticalAlignment="Top" materialDesign:ScrollViewerAssist.BubbleVerticalScroll="False" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Hidden" Margin="0,20,0,0"
@@ -656,6 +662,252 @@
           </smtx:XamlDisplay>
           <smtx:XamlDisplay Grid.Column="4" UniqueKey="combobox_outlined_stretch">
             <ComboBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+
+        <!-- DatePicker variants -->
+        <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="DatePicker styles" Margin="0,40,0,0" />
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type DatePicker}" BasedOn="{StaticResource MaterialDesignFloatingHintDatePicker}">
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFloatingHintDatePickerDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFloatingHintDatePicker</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="datepicker_floating_left">
+            <DatePicker HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="datepicker_floating_center">
+            <DatePicker HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="datepicker_floating_right">
+            <DatePicker HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="datepicker_floating_stretch">
+            <DatePicker HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type DatePicker}" BasedOn="{StaticResource MaterialDesignFilledDatePicker}">
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFilledDatePickerDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFilledDatePicker</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="datepicker_filled_left">
+            <DatePicker HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="datepicker_filled_center">
+            <DatePicker HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="datepicker_filled_right">
+            <DatePicker HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="datepicker_filled_stretch">
+            <DatePicker HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type DatePicker}" BasedOn="{StaticResource MaterialDesignOutlinedDatePicker}">
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignOutlinedDatePickerDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignOutlinedDatePicker</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="datepicker_outlined_left">
+            <DatePicker HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="datepicker_outlined_center">
+            <DatePicker HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="datepicker_outlined_right">
+            <DatePicker HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="datepicker_outlined_stretch">
+            <DatePicker HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+
+        <!-- TimePicker variants -->
+        <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="TimePicker styles" Margin="0,40,0,0" />
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type materialDesign:TimePicker}" BasedOn="{StaticResource MaterialDesignFloatingHintTimePicker}">
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFloatingHintTimePickerDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFloatingHintTimePicker</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="timepicker_floating_left">
+            <materialDesign:TimePicker HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="timepicker_floating_center">
+            <materialDesign:TimePicker HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="timepicker_floating_right">
+            <materialDesign:TimePicker HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="timepicker_floating_stretch">
+            <materialDesign:TimePicker HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type materialDesign:TimePicker}" BasedOn="{StaticResource MaterialDesignFilledTimePicker}">
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFilledTimePickerDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFilledTimePicker</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="timepicker_filled_left">
+            <materialDesign:TimePicker HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="timepicker_filled_center">
+            <materialDesign:TimePicker HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="timepicker_filled_right">
+            <materialDesign:TimePicker HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="timepicker_filled_stretch">
+            <materialDesign:TimePicker HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type materialDesign:TimePicker}" BasedOn="{StaticResource MaterialDesignOutlinedTimePicker}">
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignOutlinedTimePickerDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
+            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignOutlinedTimePicker</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="timepicker_outlined_left">
+            <materialDesign:TimePicker HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="timepicker_outlined_center">
+            <materialDesign:TimePicker HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="timepicker_outlined_right">
+            <materialDesign:TimePicker HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="timepicker_outlined_stretch">
+            <materialDesign:TimePicker HorizontalContentAlignment="Stretch" />
           </smtx:XamlDisplay>
         </Grid>
       </StackPanel>

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -6,6 +6,7 @@
              xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:domain="clr-namespace:MaterialDesignDemo.Domain"
+             xmlns:local="clr-namespace:MaterialDesignDemo"
              mc:Ignorable="d"
              x:Name="_root"
              d:DataContext="{d:DesignInstance domain:SmartHintViewModel, IsDesignTimeCreatable=False}"
@@ -13,8 +14,9 @@
   <Grid Grid.IsSharedSizeScope="True">
     <Grid.Resources>
       <materialDesign:MathConverter x:Key="SubtractConverter" Operation="Subtract" />
+      <local:CustomPaddingConverter x:Key="CustomPaddingConverter" />
       <Style TargetType="{x:Type smtx:XamlDisplay}" BasedOn="{StaticResource {x:Type smtx:XamlDisplay}}">
-        <Setter Property="Margin" Value="0,10,16,0" />
+        <Setter Property="Margin" Value="0,10,16,16" />
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="Width" Value="186" />
@@ -22,6 +24,7 @@
         <Setter Property="materialDesign:HintAssist.FloatingScale" Value="{Binding SelectedFloatingScale}" />
         <Setter Property="materialDesign:HintAssist.FloatingOffset" Value="{Binding SelectedFloatingOffset}" />
         <Setter Property="materialDesign:HintAssist.Hint" Value="{Binding HintText}" />
+        <Setter Property="materialDesign:HintAssist.HelperText" Value="{Binding HelperText}" />
       </Style>
       <Style x:Key="StyleNameIndicator" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource MaterialDesignCaptionTextBlock}">
         <Setter Property="Margin" Value="0,10,16,0" />
@@ -39,18 +42,26 @@
     </Grid.RowDefinitions>
 
     <GroupBox Grid.Row="0" Margin="8,0,16,16" Header="Hint Settings" Style="{StaticResource MaterialDesignCardGroupBox}">
-      <StackPanel Orientation="Horizontal" Margin="10">
-        <CheckBox Content="IsFloating" IsChecked="{Binding FloatHint}" />
-        <TextBlock Text="Alignment:" VerticalAlignment="Center" Margin="20,0,0,0" />
-        <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding HorizontalAlignmentOptions}" SelectedItem="{Binding SelectedAlignment, Mode=TwoWay}" />
-        <TextBlock Text="FloatingScale:" VerticalAlignment="Center" Margin="20,0,0,0" />
-        <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FloatingScaleOptions}" SelectedItem="{Binding SelectedFloatingScale, Mode=TwoWay}" ItemStringFormat="F2" />
-        <TextBlock Text="FloatingOffset:" VerticalAlignment="Center" Margin="20,0,0,0" />
-        <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FloatingOffsetOptions}" SelectedItem="{Binding SelectedFloatingOffset, Mode=TwoWay}" />
-        <CheckBox Content="HasClearButton" IsChecked="{Binding ShowClearButton}" Margin="20,0,0,0" />
-        <CheckBox Content="HasLeadingIcon" IsChecked="{Binding ShowLeadingIcon}" Margin="20,0,0,0" />
-        <TextBox Text="{Binding HintText, UpdateSourceTrigger=PropertyChanged}" Margin="20,0,0,0" Width="180" />
-      </StackPanel>
+      <StackPanel Orientation="Vertical">
+        <StackPanel Orientation="Horizontal" Margin="10">
+          <CheckBox Content="IsFloating" IsChecked="{Binding FloatHint}" />
+          <TextBlock Text="Alignment:" VerticalAlignment="Center" Margin="20,0,0,0" />
+          <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding HorizontalAlignmentOptions}" SelectedItem="{Binding SelectedAlignment, Mode=TwoWay}" />
+          <TextBlock Text="FloatingScale:" VerticalAlignment="Center" Margin="20,0,0,0" />
+          <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FloatingScaleOptions}" SelectedItem="{Binding SelectedFloatingScale, Mode=TwoWay}" ItemStringFormat="F2" />
+          <TextBlock Text="FloatingOffset:" VerticalAlignment="Center" Margin="20,0,0,0" />
+          <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FloatingOffsetOptions}" SelectedItem="{Binding SelectedFloatingOffset, Mode=TwoWay}" />
+          <CheckBox Content="HasClearButton" IsChecked="{Binding ShowClearButton}" Margin="20,0,0,0" />
+          <CheckBox Content="HasLeadingIcon" IsChecked="{Binding ShowLeadingIcon}" Margin="20,0,0,0" />
+        </StackPanel>
+
+        <StackPanel Orientation="Horizontal" Margin="10">
+          <TextBox Text="{Binding HintText, UpdateSourceTrigger=PropertyChanged}"  Width="200" />
+          <TextBox Text="{Binding HelperText, UpdateSourceTrigger=PropertyChanged}" Margin="20,0,0,0" Width="200" />
+          <CheckBox x:Name="CustomPaddingCheckBox" Content="Custom Padding" IsChecked="{Binding ApplyCustomPadding}" Margin="20,0,0,0" />
+          <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding CustomPaddingOptions}" SelectedItem="{Binding SelectedCustomPadding, Mode=TwoWay}" IsEnabled="{Binding ElementName=CustomPaddingCheckBox, Path=IsChecked}" />
+        </StackPanel>
+        </StackPanel>
     </GroupBox>
 
     <Grid Grid.Row="1" Margin="0,16,0,0">
@@ -73,8 +84,25 @@
       <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Stretch" Grid.Column="4" Grid.Row="1" HorizontalAlignment="Center" />
     </Grid>
 
+    <!-- Invisible controls only used to be able to fallback to default style values -->
+    <StackPanel Grid.Row="2" Visibility="Collapsed">
+      <TextBox x:Name="MaterialDesignFloatingHintTextBoxDefaults" Style="{StaticResource MaterialDesignFloatingHintTextBox}" />
+      <TextBox x:Name="MaterialDesignFilledTextBoxDefaults" Style="{StaticResource MaterialDesignFilledTextBox}" />
+      <TextBox x:Name="MaterialDesignOutlinedTextBoxDefaults" Style="{StaticResource MaterialDesignOutlinedTextBox}" />
+      <RichTextBox x:Name="MaterialDesignRichTextBoxDefaults" Style="{StaticResource MaterialDesignRichTextBox}" />
+      <PasswordBox x:Name="MaterialDesignFloatingHintPasswordBoxDefaults" Style="{StaticResource MaterialDesignFloatingHintPasswordBox}" />
+      <PasswordBox x:Name="MaterialDesignFilledPasswordBoxDefaults" Style="{StaticResource MaterialDesignFilledPasswordBox}" />
+      <PasswordBox x:Name="MaterialDesignOutlinedPasswordBoxDefaults" Style="{StaticResource MaterialDesignOutlinedPasswordBox}" />
+      <PasswordBox x:Name="MaterialDesignFloatingHintRevealPasswordBoxDefaults" Style="{StaticResource MaterialDesignFloatingHintRevealPasswordBox}" />
+      <PasswordBox x:Name="MaterialDesignFilledRevealPasswordBoxDefaults" Style="{StaticResource MaterialDesignFilledRevealPasswordBox}" />
+      <PasswordBox x:Name="MaterialDesignOutlinedRevealPasswordBoxDefaults" Style="{StaticResource MaterialDesignOutlinedRevealPasswordBox}" />
+      <ComboBox x:Name="MaterialDesignFloatingHintComboBoxDefaults" Style="{StaticResource MaterialDesignFloatingHintComboBox}" />
+      <ComboBox x:Name="MaterialDesignFilledComboBoxDefaults" Style="{StaticResource MaterialDesignFilledComboBox}" />
+      <ComboBox x:Name="MaterialDesignOutlinedComboBoxDefaults" Style="{StaticResource MaterialDesignOutlinedComboBox}" />
+    </StackPanel>
+
     <ScrollViewer Grid.Row="2" VerticalAlignment="Top" materialDesign:ScrollViewerAssist.BubbleVerticalScroll="False" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Hidden" Margin="0,20,0,0"
-                  Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ScrollViewer}}, Path=ViewportHeight, Converter={StaticResource SubtractConverter}, ConverterParameter=250}">
+                  Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ScrollViewer}}, Path=ViewportHeight, Converter={StaticResource SubtractConverter}, ConverterParameter=290}">
       <StackPanel Margin="8,0,16,0" VerticalAlignment="Top" HorizontalAlignment="Left">
 
         <!-- TextBox variants -->
@@ -86,6 +114,15 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFloatingHintTextBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -117,6 +154,15 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFilledTextBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -148,6 +194,15 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignOutlinedTextBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -181,6 +236,15 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignRichTextBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -215,6 +279,15 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFloatingHintPasswordDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -246,6 +319,15 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFilledPasswordBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -277,6 +359,15 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignOutlinedPasswordBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -311,6 +402,15 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFloatingHintRevealPasswordBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -342,6 +442,15 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFilledRevealPasswordBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -373,6 +482,15 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignOutlinedRevealPasswordBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -409,6 +527,15 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="True" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFloatingHintComboBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -442,6 +569,15 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="True" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFilledComboBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -475,6 +611,15 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="True" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignOutlinedComboBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -60,8 +60,9 @@
           <TextBox Text="{Binding HelperText, UpdateSourceTrigger=PropertyChanged}" Margin="20,0,0,0" Width="200" />
           <CheckBox x:Name="CustomPaddingCheckBox" Content="Custom Padding" IsChecked="{Binding ApplyCustomPadding}" Margin="20,0,0,0" />
           <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding CustomPaddingOptions}" SelectedItem="{Binding SelectedCustomPadding, Mode=TwoWay}" IsEnabled="{Binding ElementName=CustomPaddingCheckBox, Path=IsChecked}" />
+          <CheckBox Content="HasErrors" IsChecked="False" Checked="HasErrors_OnToggled" Unchecked="HasErrors_OnToggled" Margin="20,0,0,0" />
         </StackPanel>
-        </StackPanel>
+      </StackPanel>
     </GroupBox>
 
     <Grid Grid.Row="1" Margin="0,16,0,0">
@@ -103,7 +104,7 @@
 
     <ScrollViewer Grid.Row="2" VerticalAlignment="Top" materialDesign:ScrollViewerAssist.BubbleVerticalScroll="False" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Hidden" Margin="0,20,0,0"
                   Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ScrollViewer}}, Path=ViewportHeight, Converter={StaticResource SubtractConverter}, ConverterParameter=290}">
-      <StackPanel Margin="8,0,16,0" VerticalAlignment="Top" HorizontalAlignment="Left">
+      <StackPanel x:Name="ControlsPanel" Margin="8,0,16,0" VerticalAlignment="Top" HorizontalAlignment="Left">
 
         <!-- TextBox variants -->
         <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="TextBox styles" />
@@ -114,6 +115,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -154,6 +156,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -194,6 +197,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -236,6 +240,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="local:SmartHint.RichTextBoxText" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -279,6 +284,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -319,6 +325,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -359,6 +366,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -402,6 +410,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -442,6 +451,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -482,6 +492,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -525,6 +536,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="True" />
               <Setter Property="Padding">
@@ -567,6 +579,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="True" />
               <Setter Property="Padding">
@@ -609,6 +622,7 @@
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="True" />
               <Setter Property="Padding">

--- a/MainDemo.Wpf/SmartHint.xaml.cs
+++ b/MainDemo.Wpf/SmartHint.xaml.cs
@@ -58,6 +58,10 @@ public partial class SmartHint : UserControl
             return passwordBox.GetBindingExpression(PasswordBoxAssist.PasswordProperty);
         if (element is ComboBox comboBox)
             return comboBox.GetBindingExpression(ComboBox.TextProperty);
+        if (element is DatePicker datePicker)
+            return datePicker.GetBindingExpression(DatePicker.TextProperty);
+        if (element is TimePicker timePicker)
+            return timePicker.GetBindingExpression(TimePicker.TextProperty);
         return default;
     }
 

--- a/MainDemo.Wpf/SmartHint.xaml.cs
+++ b/MainDemo.Wpf/SmartHint.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using System.Globalization;
 using System.Windows.Data;
+using System.Windows.Media;
 using MaterialDesignDemo.Domain;
+using MaterialDesignThemes.Wpf;
 
 namespace MaterialDesignDemo;
 
@@ -9,10 +11,72 @@ namespace MaterialDesignDemo;
 /// </summary>
 public partial class SmartHint : UserControl
 {
+    // Attached property used for binding in the RichTextBox to enable triggering of validation errors.
+    internal static readonly DependencyProperty RichTextBoxTextProperty = DependencyProperty.RegisterAttached(
+        "RichTextBoxText", typeof(object), typeof(SmartHint), new PropertyMetadata(null));
+    internal static void SetRichTextBoxText(DependencyObject element, object value) => element.SetValue(RichTextBoxTextProperty, value);
+    internal static object GetRichTextBoxText(DependencyObject element) => element.GetValue(RichTextBoxTextProperty);
+
     public SmartHint()
     {
         DataContext = new SmartHintViewModel();
         InitializeComponent();
+    }
+
+    private void HasErrors_OnToggled(object sender, RoutedEventArgs e)
+    {
+        CheckBox c = (CheckBox) sender;
+
+        foreach (FrameworkElement element in FindVisualChildren<FrameworkElement>(ControlsPanel))
+        {
+            var binding = GetBinding(element);
+            if (binding is null)
+                continue;
+
+            if (c.IsChecked.GetValueOrDefault(false))
+            {
+                var error = new ValidationError(new ExceptionValidationRule(), binding)
+                {
+                    ErrorContent = "Invalid input, please fix it!"
+                };
+                Validation.MarkInvalid(binding, error);
+            }
+            else
+            {
+                Validation.ClearInvalid(binding);
+            }
+        }
+    }
+
+    private static BindingExpression? GetBinding(FrameworkElement element)
+    {
+        if (element is TextBox textBox)
+            return textBox.GetBindingExpression(TextBox.TextProperty);
+        if (element is RichTextBox richTextBox)
+            return richTextBox.GetBindingExpression(RichTextBoxTextProperty);
+        if (element is PasswordBox passwordBox)
+            return passwordBox.GetBindingExpression(PasswordBoxAssist.PasswordProperty);
+        if (element is ComboBox comboBox)
+            return comboBox.GetBindingExpression(ComboBox.TextProperty);
+        return default;
+    }
+
+    private static IEnumerable<T> FindVisualChildren<T>(DependencyObject? dependencyObject) where T : DependencyObject
+    {
+        if (dependencyObject is null)
+            yield break;
+
+        if (dependencyObject is T obj)
+            yield return obj;
+
+        for (int i = 0; i < VisualTreeHelper.GetChildrenCount(dependencyObject); i++)
+        {
+            DependencyObject child = VisualTreeHelper.GetChild(dependencyObject, i);
+            foreach (T childOfChild in FindVisualChildren<T>(child))
+            {
+                yield return childOfChild;
+            }
+        }
     }
 }
 

--- a/MainDemo.Wpf/SmartHint.xaml.cs
+++ b/MainDemo.Wpf/SmartHint.xaml.cs
@@ -1,4 +1,6 @@
-﻿using MaterialDesignDemo.Domain;
+﻿using System.Globalization;
+using System.Windows.Data;
+using MaterialDesignDemo.Domain;
 
 namespace MaterialDesignDemo;
 
@@ -12,4 +14,18 @@ public partial class SmartHint : UserControl
         DataContext = new SmartHintViewModel();
         InitializeComponent();
     }
+}
+
+internal class CustomPaddingConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        Thickness? defaultPadding = values[0] as Thickness?;
+        bool applyCustomPadding = (bool) values[1];
+        Thickness customPadding = (Thickness) values[2];
+        return applyCustomPadding ? customPadding : defaultPadding ?? DependencyProperty.UnsetValue;
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }

--- a/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
@@ -183,7 +183,7 @@ public class ComboBoxTests : TestBase
         await using var recorder = new TestRecorder(App);
 
         // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
-        double tolerance = 1.5;
+        const double tolerance = 1.5;
 
         string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
         string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;
@@ -224,7 +224,7 @@ public class ComboBoxTests : TestBase
         await using var recorder = new TestRecorder(App);
 
         // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
-        double tolerance = 1.5;
+        const double tolerance = 1.5;
 
         string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
         string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;

--- a/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using MaterialDesignThemes.UITests.WPF.TextBoxes;
 
 namespace MaterialDesignThemes.UITests.WPF.ComboBoxes;
 
@@ -163,6 +164,96 @@ public class ComboBoxTests : TestBase
         Assert.False(wasOpenAfterClickOnEditableTextBox, "ComboBox should not have opened drop down when clicking the editable TextBox");
         Assert.True(textBoxHasFocus, "Editable TextBox should have focus");
         Assert.True(textBoxHasKeyboardFocus, "Editable TextBox should have keyboard focus");
+
+        recorder.Success();
+    }
+
+    [Theory]
+    [InlineData("MaterialDesignFloatingHintComboBox", null)]
+    [InlineData("MaterialDesignFloatingHintComboBox", 5)]
+    [InlineData("MaterialDesignFloatingHintComboBox", 20)]
+    [InlineData("MaterialDesignFilledComboBox", null)]
+    [InlineData("MaterialDesignFilledComboBox", 5)]
+    [InlineData("MaterialDesignFilledComboBox", 20)]
+    [InlineData("MaterialDesignOutlinedComboBox", null)]
+    [InlineData("MaterialDesignOutlinedComboBox", 5)]
+    [InlineData("MaterialDesignOutlinedComboBox", 20)]
+    public async Task ComboBox_WithHintAndHelperText_RespectsPadding(string styleName, int? padding)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
+        double tolerance = 1.5;
+
+        string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
+        string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;
+
+        var comboBox = await LoadXaml<ComboBox>($@"
+<ComboBox {styleAttribute} {paddingAttribute}
+  materialDesign:HintAssist.Hint=""Hint text""
+  materialDesign:HintAssist.HelperText=""Helper text""
+  Width=""200"" VerticalAlignment=""Center"" HorizontalAlignment=""Center"" />
+");
+
+        var contentHost = await comboBox.GetElement<ScrollViewer>("PART_ContentHost");
+        var hint = await comboBox.GetElement<SmartHint>("Hint");
+        var helperText = await comboBox.GetElement<TextBlock>("HelperTextTextBlock");
+
+        Rect? contentHostCoordinates = await contentHost.GetCoordinates();
+        Rect? hintCoordinates = await hint.GetCoordinates();
+        Rect? helperTextCoordinates = await helperText.GetCoordinates();
+
+        Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - hintCoordinates.Value.Left), 0, tolerance);
+        Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - helperTextCoordinates.Value.Left), 0, tolerance);
+
+        recorder.Success();
+    }
+
+    [Theory]
+    [InlineData("MaterialDesignFloatingHintComboBox", null)]
+    [InlineData("MaterialDesignFloatingHintComboBox", 5)]
+    [InlineData("MaterialDesignFloatingHintComboBox", 20)]
+    [InlineData("MaterialDesignFilledComboBox", null)]
+    [InlineData("MaterialDesignFilledComboBox", 5)]
+    [InlineData("MaterialDesignFilledComboBox", 20)]
+    [InlineData("MaterialDesignOutlinedComboBox", null)]
+    [InlineData("MaterialDesignOutlinedComboBox", 5)]
+    [InlineData("MaterialDesignOutlinedComboBox", 20)]
+    public async Task ComboBox_WithHintAndValidationError_RespectsPadding(string styleName, int? padding)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
+        double tolerance = 1.5;
+
+        string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
+        string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;
+
+        var comboBox = await LoadXaml<ComboBox>($@"
+<ComboBox {styleAttribute} {paddingAttribute}
+  materialDesign:HintAssist.Hint=""Hint text""
+  materialDesign:HintAssist.HelperText=""Helper text""
+  Width=""200"" VerticalAlignment=""Center"" HorizontalAlignment=""Center"">
+  <ComboBox.Text>
+    <Binding RelativeSource=""{{RelativeSource Self}}"" Path=""Tag"" UpdateSourceTrigger=""PropertyChanged"">
+      <Binding.ValidationRules>
+        <local:NotEmptyValidationRule ValidatesOnTargetUpdated=""True""/>
+      </Binding.ValidationRules>
+    </Binding>
+  </ComboBox.Text>
+</ComboBox>
+", ("local", typeof(NotEmptyValidationRule)));
+
+        var contentHost = await comboBox.GetElement<ScrollViewer>("PART_ContentHost");
+        var hint = await comboBox.GetElement<SmartHint>("Hint");
+        var errorViewer = await comboBox.GetElement<Border>("DefaultErrorViewer");
+
+        Rect? contentHostCoordinates = await contentHost.GetCoordinates();
+        Rect? hintCoordinates = await hint.GetCoordinates();
+        Rect? errorViewerCoordinates = await errorViewer.GetCoordinates();
+
+        Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - hintCoordinates.Value.Left), 0, tolerance);
+        Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - errorViewerCoordinates.Value.Left), 0, tolerance);
 
         recorder.Success();
     }

--- a/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
@@ -129,7 +129,7 @@ public class DatePickerTests : TestBase
         await using var recorder = new TestRecorder(App);
 
         // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
-        double tolerance = 1.5;
+        const double tolerance = 1.5;
 
         string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
         string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;
@@ -170,7 +170,7 @@ public class DatePickerTests : TestBase
         await using var recorder = new TestRecorder(App);
 
         // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
-        double tolerance = 1.5;
+        const double tolerance = 1.5;
 
         string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
         string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;

--- a/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Globalization;
+using MaterialDesignThemes.UITests.WPF.TextBoxes;
 
 namespace MaterialDesignThemes.UITests.WPF.DatePickers;
 
@@ -109,6 +110,96 @@ public class DatePickerTests : TestBase
         Assert.Equal(expectedActiveBorderThickness, hoverBorderThickness);
         Assert.Equal(expectedActiveBorderThickness, focusedBorderThickness);
         Assert.Equal(expectedActiveBorderThickness, withErrorBorderThickness);
+
+        recorder.Success();
+    }
+
+    [Theory]
+    [InlineData("MaterialDesignFloatingHintDatePicker", null)]
+    [InlineData("MaterialDesignFloatingHintDatePicker", 5)]
+    [InlineData("MaterialDesignFloatingHintDatePicker", 20)]
+    [InlineData("MaterialDesignFilledDatePicker", null)]
+    [InlineData("MaterialDesignFilledDatePicker", 5)]
+    [InlineData("MaterialDesignFilledDatePicker", 20)]
+    [InlineData("MaterialDesignOutlinedDatePicker", null)]
+    [InlineData("MaterialDesignOutlinedDatePicker", 5)]
+    [InlineData("MaterialDesignOutlinedDatePicker", 20)]
+    public async Task DatePicker_WithHintAndHelperText_RespectsPadding(string styleName, int? padding)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
+        double tolerance = 1.5;
+
+        string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
+        string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;
+
+        var datePicker = await LoadXaml<DatePicker>($@"
+<DatePicker {styleAttribute} {paddingAttribute}
+  materialDesign:HintAssist.Hint=""Hint text""
+  materialDesign:HintAssist.HelperText=""Helper text""
+  Width=""200"" VerticalAlignment=""Center"" HorizontalAlignment=""Center"" />
+");
+
+        var contentHost = await datePicker.GetElement<ScrollViewer>("PART_ContentHost");
+        var hint = await datePicker.GetElement<SmartHint>("Hint");
+        var helperText = await datePicker.GetElement<TextBlock>("HelperTextTextBlock");
+
+        Rect? contentHostCoordinates = await contentHost.GetCoordinates();
+        Rect? hintCoordinates = await hint.GetCoordinates();
+        Rect? helperTextCoordinates = await helperText.GetCoordinates();
+
+        Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - hintCoordinates.Value.Left), 0, tolerance);
+        Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - helperTextCoordinates.Value.Left), 0, tolerance);
+
+        recorder.Success();
+    }
+
+    [Theory]
+    [InlineData("MaterialDesignFloatingHintDatePicker", null)]
+    [InlineData("MaterialDesignFloatingHintDatePicker", 5)]
+    [InlineData("MaterialDesignFloatingHintDatePicker", 20)]
+    [InlineData("MaterialDesignFilledDatePicker", null)]
+    [InlineData("MaterialDesignFilledDatePicker", 5)]
+    [InlineData("MaterialDesignFilledDatePicker", 20)]
+    [InlineData("MaterialDesignOutlinedDatePicker", null)]
+    [InlineData("MaterialDesignOutlinedDatePicker", 5)]
+    [InlineData("MaterialDesignOutlinedDatePicker", 20)]
+    public async Task DatePicker_WithHintAndValidationError_RespectsPadding(string styleName, int? padding)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
+        double tolerance = 1.5;
+
+        string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
+        string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;
+
+        var datePicker = await LoadXaml<DatePicker>($@"
+<DatePicker {styleAttribute} {paddingAttribute}
+  materialDesign:HintAssist.Hint=""Hint text""
+  materialDesign:HintAssist.HelperText=""Helper text""
+  Width=""200"" VerticalAlignment=""Center"" HorizontalAlignment=""Center"">
+  <DatePicker.Text>
+    <Binding RelativeSource=""{{RelativeSource Self}}"" Path=""Tag"" UpdateSourceTrigger=""PropertyChanged"">
+      <Binding.ValidationRules>
+        <local:NotEmptyValidationRule ValidatesOnTargetUpdated=""True""/>
+      </Binding.ValidationRules>
+    </Binding>
+  </DatePicker.Text>
+</DatePicker>
+", ("local", typeof(NotEmptyValidationRule)));
+
+        var contentHost = await datePicker.GetElement<ScrollViewer>("PART_ContentHost");
+        var hint = await datePicker.GetElement<SmartHint>("Hint");
+        var errorViewer = await datePicker.GetElement<Border>("DefaultErrorViewer");
+
+        Rect? contentHostCoordinates = await contentHost.GetCoordinates();
+        Rect? hintCoordinates = await hint.GetCoordinates();
+        Rect? errorViewerCoordinates = await errorViewer.GetCoordinates();
+
+        Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - hintCoordinates.Value.Left), 0, tolerance);
+        Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - errorViewerCoordinates.Value.Left), 0, tolerance);
 
         recorder.Success();
     }

--- a/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using MaterialDesignThemes.UITests.Samples.PasswordBox;
+using MaterialDesignThemes.UITests.WPF.TextBoxes;
 
 namespace MaterialDesignThemes.UITests.WPF.PasswordBoxes;
 
@@ -183,6 +184,114 @@ public class PasswordBoxTests : TestBase
 
         // Assert
         Assert.Equal(maxLength1, maxLength2);
+
+        recorder.Success();
+    }
+
+    [Theory]
+    [InlineData("MaterialDesignFloatingHintPasswordBox", null)]
+    [InlineData("MaterialDesignFloatingHintPasswordBox", 5)]
+    [InlineData("MaterialDesignFloatingHintPasswordBox", 20)]
+    [InlineData("MaterialDesignFloatingHintRevealPasswordBox", null)]
+    [InlineData("MaterialDesignFloatingHintRevealPasswordBox", 5)]
+    [InlineData("MaterialDesignFloatingHintRevealPasswordBox", 20)]
+    [InlineData("MaterialDesignFilledPasswordBox", null)]
+    [InlineData("MaterialDesignFilledPasswordBox", 5)]
+    [InlineData("MaterialDesignFilledPasswordBox", 20)]
+    [InlineData("MaterialDesignFilledRevealPasswordBox", null)]
+    [InlineData("MaterialDesignFilledRevealPasswordBox", 5)]
+    [InlineData("MaterialDesignFilledRevealPasswordBox", 20)]
+    [InlineData("MaterialDesignOutlinedPasswordBox", null)]
+    [InlineData("MaterialDesignOutlinedPasswordBox", 5)]
+    [InlineData("MaterialDesignOutlinedPasswordBox", 20)]
+    [InlineData("MaterialDesignOutlinedRevealPasswordBox", null)]
+    [InlineData("MaterialDesignOutlinedRevealPasswordBox", 5)]
+    [InlineData("MaterialDesignOutlinedRevealPasswordBox", 20)]
+    public async Task PasswordBox_WithHintAndHelperText_RespectsPadding(string styleName, int? padding)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
+        double tolerance = 1.5;
+
+        string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
+        string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;
+
+        var passwordBox = await LoadXaml<PasswordBox>($@"
+<PasswordBox {styleAttribute} {paddingAttribute}
+  materialDesign:HintAssist.Hint=""Hint text""
+  materialDesign:HintAssist.HelperText=""Helper text""
+  Width=""200"" VerticalAlignment=""Center"" HorizontalAlignment=""Center"" />
+");
+
+        var contentHost = await passwordBox.GetElement<ScrollViewer>("PART_ContentHost");
+        var hint = await passwordBox.GetElement<SmartHint>("Hint");
+        var helperText = await passwordBox.GetElement<TextBlock>("HelperTextTextBlock");
+
+        Rect? contentHostCoordinates = await contentHost.GetCoordinates();
+        Rect? hintCoordinates = await hint.GetCoordinates();
+        Rect? helperTextCoordinates = await helperText.GetCoordinates();
+
+        Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - hintCoordinates.Value.Left), 0, tolerance);
+        Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - helperTextCoordinates.Value.Left), 0, tolerance);
+
+        recorder.Success();
+    }
+
+    [Theory]
+    [InlineData("MaterialDesignFloatingHintPasswordBox", null)]
+    [InlineData("MaterialDesignFloatingHintPasswordBox", 5)]
+    [InlineData("MaterialDesignFloatingHintPasswordBox", 20)]
+    [InlineData("MaterialDesignFloatingHintRevealPasswordBox", null)]
+    [InlineData("MaterialDesignFloatingHintRevealPasswordBox", 5)]
+    [InlineData("MaterialDesignFloatingHintRevealPasswordBox", 20)]
+    [InlineData("MaterialDesignFilledPasswordBox", null)]
+    [InlineData("MaterialDesignFilledPasswordBox", 5)]
+    [InlineData("MaterialDesignFilledPasswordBox", 20)]
+    [InlineData("MaterialDesignFilledRevealPasswordBox", null)]
+    [InlineData("MaterialDesignFilledRevealPasswordBox", 5)]
+    [InlineData("MaterialDesignFilledRevealPasswordBox", 20)]
+    [InlineData("MaterialDesignOutlinedPasswordBox", null)]
+    [InlineData("MaterialDesignOutlinedPasswordBox", 5)]
+    [InlineData("MaterialDesignOutlinedPasswordBox", 20)]
+    [InlineData("MaterialDesignOutlinedRevealPasswordBox", null)]
+    [InlineData("MaterialDesignOutlinedRevealPasswordBox", 5)]
+    [InlineData("MaterialDesignOutlinedRevealPasswordBox", 20)]
+    public async Task PasswordBox_WithHintAndValidationError_RespectsPadding(string styleName, int? padding)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
+        double tolerance = 1.5;
+
+        string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
+        string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;
+
+        var passwordBox = await LoadXaml<PasswordBox>($@"
+<PasswordBox {styleAttribute} {paddingAttribute}
+  materialDesign:HintAssist.Hint=""Hint text""
+  materialDesign:HintAssist.HelperText=""Helper text""
+  Width=""200"" VerticalAlignment=""Center"" HorizontalAlignment=""Center"">
+  <materialDesign:PasswordBoxAssist.Password>
+    <Binding RelativeSource=""{{RelativeSource Self}}"" Path=""Tag"" UpdateSourceTrigger=""PropertyChanged"">
+      <Binding.ValidationRules>
+        <local:NotEmptyValidationRule ValidatesOnTargetUpdated=""True""/>
+      </Binding.ValidationRules>
+    </Binding>
+  </materialDesign:PasswordBoxAssist.Password>
+</PasswordBox>
+", ("local", typeof(NotEmptyValidationRule)));
+
+        var contentHost = await passwordBox.GetElement<ScrollViewer>("PART_ContentHost");
+        var hint = await passwordBox.GetElement<SmartHint>("Hint");
+        var errorViewer = await passwordBox.GetElement<Border>("DefaultErrorViewer");
+
+        Rect? contentHostCoordinates = await contentHost.GetCoordinates();
+        Rect? hintCoordinates = await hint.GetCoordinates();
+        Rect? errorViewerCoordinates = await errorViewer.GetCoordinates();
+
+        Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - hintCoordinates.Value.Left), 0, tolerance);
+        Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - errorViewerCoordinates.Value.Left), 0, tolerance);
 
         recorder.Success();
     }

--- a/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
@@ -212,7 +212,7 @@ public class PasswordBoxTests : TestBase
         await using var recorder = new TestRecorder(App);
 
         // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
-        double tolerance = 1.5;
+        const double tolerance = 1.5;
 
         string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
         string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;
@@ -262,7 +262,7 @@ public class PasswordBoxTests : TestBase
         await using var recorder = new TestRecorder(App);
 
         // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
-        double tolerance = 1.5;
+        const double tolerance = 1.5;
 
         string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
         string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;

--- a/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
@@ -488,7 +488,7 @@ public class TextBoxTests : TestBase
         await using var recorder = new TestRecorder(App);
 
         // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
-        double tolerance = 1.5;
+        const double tolerance = 1.5;
 
         string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
         string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;
@@ -529,7 +529,7 @@ public class TextBoxTests : TestBase
         await using var recorder = new TestRecorder(App);
 
         // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
-        double tolerance = 1.5;
+        const double tolerance = 1.5;
 
         string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
         string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;

--- a/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Globalization;
 using System.Windows.Media;
 
@@ -510,6 +510,55 @@ public class TextBoxTests : TestBase
 
         Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - hintCoordinates.Value.Left), 0, tolerance);
         Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - helperTextCoordinates.Value.Left), 0, tolerance);
+
+        recorder.Success();
+    }
+
+    [Theory]
+    [InlineData("MaterialDesignFloatingHintTextBox", null)]
+    [InlineData("MaterialDesignFloatingHintTextBox", 5)]
+    [InlineData("MaterialDesignFloatingHintTextBox", 20)]
+    [InlineData("MaterialDesignFilledTextBox", null)]
+    [InlineData("MaterialDesignFilledTextBox", 5)]
+    [InlineData("MaterialDesignFilledTextBox", 20)]
+    [InlineData("MaterialDesignOutlinedTextBox", null)]
+    [InlineData("MaterialDesignOutlinedTextBox", 5)]
+    [InlineData("MaterialDesignOutlinedTextBox", 20)]
+    public async Task TextBox_WithHintAndValidationError_RespectsPadding(string styleName, int? padding)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // FIXME: Tolerance needed because TextFieldAssist.TextBoxViewMargin is in play and slightly modifies the hint text placement in certain cases.
+        double tolerance = 1.5;
+
+        string styleAttribute = $"Style=\"{{StaticResource {styleName}}}\"";
+        string paddingAttribute = padding.HasValue ? $"Padding=\"{padding.Value}\"" : string.Empty;
+
+        var textBox = await LoadXaml<TextBox>($@"
+<TextBox {styleAttribute} {paddingAttribute}
+  materialDesign:HintAssist.Hint=""Hint text""
+  materialDesign:HintAssist.HelperText=""Helper text""
+  Width=""200"" VerticalAlignment=""Center"" HorizontalAlignment=""Center"">
+  <TextBox.Text>
+    <Binding RelativeSource=""{{RelativeSource Self}}"" Path=""Tag"" UpdateSourceTrigger=""PropertyChanged"">
+      <Binding.ValidationRules>
+        <local:NotEmptyValidationRule ValidatesOnTargetUpdated=""True""/>
+      </Binding.ValidationRules>
+    </Binding>
+  </TextBox.Text>
+</TextBox>
+", ("local", typeof(NotEmptyValidationRule)));
+
+        var contentHost = await textBox.GetElement<ScrollViewer>("PART_ContentHost");
+        var hint = await textBox.GetElement<SmartHint>("Hint");
+        var errorViewer = await textBox.GetElement<Border>("DefaultErrorViewer");
+
+        Rect? contentHostCoordinates = await contentHost.GetCoordinates();
+        Rect? hintCoordinates = await hint.GetCoordinates();
+        Rect? errorViewerCoordinates = await errorViewer.GetCoordinates();
+
+        Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - hintCoordinates.Value.Left), 0, tolerance);
+        Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - errorViewerCoordinates.Value.Left), 0, tolerance);
 
         recorder.Success();
     }

--- a/MaterialDesignThemes.Wpf/Converters/ThicknessCloneConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/ThicknessCloneConverter.cs
@@ -7,7 +7,7 @@ public class ThicknessCloneConverter : IValueConverter
 {
     public ThicknessEdges CloneEdges { get; set; } = ThicknessEdges.All;
 
-    public double NonClonedEdgeValue { get; set; } = 0;
+    public double NonClonedEdgeValue { get; set; }
 
     public double? FixedLeft { get; set; }
     public double? FixedTop { get; set; }

--- a/MaterialDesignThemes.Wpf/Converters/ThicknessCloneConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/ThicknessCloneConverter.cs
@@ -1,0 +1,43 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+
+namespace MaterialDesignThemes.Wpf.Converters;
+
+public class ThicknessCloneConverter : IValueConverter
+{
+    public ThicknessEdges CloneEdges { get; set; } = ThicknessEdges.All;
+
+    public double NonClonedEdgeValue { get; set; } = 0;
+
+    public double? FixedLeft { get; set; }
+    public double? FixedTop { get; set; }
+    public double? FixedRight { get; set; }
+    public double? FixedBottom { get; set; }
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is Thickness thickness)
+        {
+            double left = FixedLeft ?? (CloneEdges.HasFlag(ThicknessEdges.Left) ? thickness.Left : NonClonedEdgeValue);
+            double top = FixedTop ?? (CloneEdges.HasFlag(ThicknessEdges.Top) ? thickness.Top : NonClonedEdgeValue);
+            double right = FixedRight ?? (CloneEdges.HasFlag(ThicknessEdges.Right) ? thickness.Right : NonClonedEdgeValue);
+            double bottom = FixedBottom ?? (CloneEdges.HasFlag(ThicknessEdges.Bottom) ? thickness.Bottom : NonClonedEdgeValue);
+            return new Thickness(left, top, right, bottom);
+        }
+        return DependencyProperty.UnsetValue;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}
+
+[Flags]
+public enum ThicknessEdges
+{
+    None = 0,
+    Left = 1,
+    Top = 2,
+    Right = 4,
+    Bottom = 8,
+    All = Left | Top | Right | Bottom
+}

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -26,6 +26,7 @@
   <converters:FloatingHintOffsetCalculationConverter x:Key="FloatingHintOffsetCalculationConverter" />
   <converters:ComboBoxClearButtonMarginConverter x:Key="ComboBoxClearButtonMarginConverter" />
   <converters:DoubleToThicknessConverter x:Key="DoubleToThicknessConverter" />
+  <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left" />
 
   <system:Double x:Key="PopupContentPresenterExtend">4</system:Double>
   <system:Double x:Key="PopupTopBottomMargin">8</system:Double>
@@ -363,7 +364,6 @@
 
                 <wpf:SmartHint x:Name="Hint"
                                Grid.Column="1"
-                               Margin="{TemplateBinding wpf:TextFieldAssist.TextBoxViewMargin}"
                                FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
                                FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
                                FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
@@ -400,8 +400,8 @@
                        CornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
                        IsActive="{Binding ElementName=PART_EditableTextBox, Path=IsKeyboardFocused}"
                        Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}" />
-        <Canvas x:Name="HelperTextWrapper" VerticalAlignment="Bottom">
-          <TextBlock Canvas.Top="2"
+        <Canvas x:Name="HelperTextWrapper" VerticalAlignment="Bottom" Margin="{TemplateBinding Padding, Converter={StaticResource HelperTextMarginConverter}}">
+          <TextBlock x:Name="HelperTextTextBlock" Canvas.Top="2"
                      MaxWidth="{Binding ActualWidth, ElementName=toggleButton}"
                      FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                      Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
@@ -480,11 +480,7 @@
       </Grid>
     </AdornerDecorator>
     <ControlTemplate.Triggers>
-      <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
-        <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
-      </Trigger>
       <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
-        <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
         <Setter TargetName="Hint" Property="FloatingOffset">
           <Setter.Value>
             <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -212,7 +212,7 @@
                            CornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
                            Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}" />
             <Canvas x:Name="HelperTextWrapper" VerticalAlignment="Bottom">
-              <TextBlock Canvas.Top="2"
+              <TextBlock x:Name="HelperTextTextBlock" Canvas.Top="2"
                          MaxWidth="{Binding ActualWidth, ElementName=border}"
                          FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                          Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -19,6 +19,7 @@
   <converters:FloatingHintOffsetCalculationConverter x:Key="FloatingHintOffsetCalculationConverter" />
   <converters:PickerInnerPaddingConverter x:Key="PickerInnerPaddingConverter" />
   <converters:OutlinedDateTimePickerActiveBorderThicknessConverter x:Key="OutlinedDateTimePickerActiveBorderThicknessConverter" />
+  <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left" />
 
   <Style x:Key="MaterialDesignDatePickerTextBox" TargetType="{x:Type DatePickerTextBox}">
     <Setter Property="AllowDrop" Value="true" />
@@ -211,7 +212,7 @@
                            Background="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
                            CornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
                            Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}" />
-            <Canvas x:Name="HelperTextWrapper" VerticalAlignment="Bottom">
+            <Canvas x:Name="HelperTextWrapper" VerticalAlignment="Bottom" Margin="{TemplateBinding Padding, Converter={StaticResource HelperTextMarginConverter}}">
               <TextBlock x:Name="HelperTextTextBlock" Canvas.Top="2"
                          MaxWidth="{Binding ActualWidth, ElementName=border}"
                          FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
@@ -256,13 +257,11 @@
             </MultiTrigger>
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-              <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:DatePickerAssist.OutlinedBorderInactiveThickness)}" />
               <Setter Property="VerticalContentAlignment" Value="Top" />
-              <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -123,14 +123,15 @@
                       BorderThickness="{TemplateBinding BorderThickness}"
                       CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                       SnapsToDevicePixels="True">
-                <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                <Grid HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition />
                     <ColumnDefinition Width="Auto" />
                   </Grid.ColumnDefinitions>
                   <Grid x:Name="grid"
                         MinWidth="1"
-                        VerticalAlignment="Center">
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition Width="Auto" />
                       <ColumnDefinition Width="*" />
@@ -165,7 +166,8 @@
                                    FontSize="{TemplateBinding FontSize}"
                                    HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                    HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
-                                   UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}">
+                                   UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
                       <wpf:SmartHint.Hint>
                         <Border x:Name="HintBackgroundBorder"
                                 Background="{TemplateBinding wpf:HintAssist.Background}"
@@ -255,13 +257,11 @@
             </MultiTrigger>
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-              <Setter Property="Padding" Value="16,8,12,8" />
               <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:DatePickerAssist.OutlinedBorderInactiveThickness)}" />
-              <Setter Property="Padding" Value="16,16,12,16" />
               <Setter Property="VerticalContentAlignment" Value="Top" />
               <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
               <Setter TargetName="Hint" Property="FloatingOffset">
@@ -271,7 +271,7 @@
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
-                    <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="Padding" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
                 </Setter.Value>
               </Setter>
@@ -530,12 +530,10 @@
           <ControlTemplate.Triggers>
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-              <Setter Property="Padding" Value="16,8" />
               <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
-              <Setter Property="Padding" Value="16" />
               <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
             </Trigger>
             <MultiTrigger>
@@ -616,6 +614,7 @@
     <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />
     <Setter Property="wpf:TextFieldAssist.UnderlineCornerRadius" Value="0" />
+    <Setter Property="Padding" Value="16,8" />
   </Style>
 
   <Style x:Key="MaterialDesignOutlinedDatePicker"
@@ -623,6 +622,7 @@
          BasedOn="{StaticResource MaterialDesignFloatingHintDatePicker}">
     <Setter Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />
+    <Setter Property="Padding" Value="16" />
   </Style>
 
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -159,7 +159,6 @@
                                   VerticalScrollBarVisibility="Hidden" />
                     <wpf:SmartHint x:Name="Hint"
                                    Grid.Column="1"
-                                   Margin="{TemplateBinding wpf:TextFieldAssist.TextBoxViewMargin}"
                                    FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
                                    FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
                                    FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
@@ -530,11 +529,9 @@
           <ControlTemplate.Triggers>
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-              <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
-              <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
             </Trigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -165,7 +165,6 @@
                                   VerticalScrollBarVisibility="Hidden" />
                     <wpf:SmartHint x:Name="Hint"
                                    Grid.Column="1"
-                                   Margin="{TemplateBinding wpf:TextFieldAssist.TextBoxViewMargin}"
                                    FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
                                    FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
                                    FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
@@ -270,13 +269,11 @@
             </MultiTrigger>
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-              <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="1" />
               <Setter Property="VerticalContentAlignment" Value="Top" />
-              <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
@@ -657,7 +654,6 @@
 
                     <wpf:SmartHint x:Name="Hint"
                                    Grid.Column="1"
-                                   Margin="{TemplateBinding wpf:TextFieldAssist.TextBoxViewMargin}"
                                    FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
                                    FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
                                    FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
@@ -772,13 +768,11 @@
             </MultiTrigger>
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-              <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="1" />
               <Setter Property="VerticalContentAlignment" Value="Top" />
-              <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -21,6 +21,7 @@
   <converters:FloatingHintOffsetCalculationConverter x:Key="FloatingHintOffsetCalculationConverter" />
   <converters:CursorConverter x:Key="ArrowCursorConverter" FallbackCursor="Arrow" />
   <converters:CursorConverter x:Key="IBeamCursorConverter" FallbackCursor="IBeam" />
+  <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left" />
 
   <Style x:Key="MaterialDesignPasswordCharacterCounterTextBlock"
          TargetType="TextBlock"
@@ -46,6 +47,7 @@
     <Setter Property="FontSize" Value="{Binding Path=(wpf:HintAssist.HelperTextFontSize), RelativeSource={RelativeSource Mode=TemplatedParent}}" />
     <Setter Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource Mode=TemplatedParent}}" />
     <Setter Property="Text" Value="{Binding Path=(wpf:HintAssist.HelperText), RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+    <Setter Property="Margin" Value="{Binding Path=Padding, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource HelperTextMarginConverter}}" />
   </Style>
 
   <Style x:Key="MaterialDesignPasswordBox" TargetType="{x:Type PasswordBox}">
@@ -269,14 +271,12 @@
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
               <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
-              <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="1" />
               <Setter Property="VerticalContentAlignment" Value="Top" />
               <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
-              <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
@@ -773,14 +773,12 @@
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
               <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
-              <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="1" />
               <Setter Property="VerticalContentAlignment" Value="Top" />
               <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
-              <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -18,6 +18,7 @@
   <converters:CursorConverter x:Key="ArrowCursorConverter" FallbackCursor="Arrow" />
   <converters:CursorConverter x:Key="IBeamCursorConverter" FallbackCursor="IBeam" />
   <converters:StringLengthValueConverter x:Key="StringLengthValueConverter" />
+  <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left" />
 
   <Style x:Key="MaterialDesignCharacterCounterTextBlock"
          TargetType="TextBlock"
@@ -259,7 +260,8 @@
                   <ColumnDefinition />
                   <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-                <TextBlock x:Name="HelperTextTextBlock" Style="{Binding Path=(wpf:HintAssist.HelperTextStyle), RelativeSource={RelativeSource TemplatedParent}}" />
+                <TextBlock x:Name="HelperTextTextBlock" Style="{Binding Path=(wpf:HintAssist.HelperTextStyle), RelativeSource={RelativeSource TemplatedParent}}"
+                           Margin="{TemplateBinding Padding, Converter={StaticResource HelperTextMarginConverter}}"/>
                 <Border x:Name="CharacterCounterContainer" Grid.Column="1">
                   <TextBlock x:Name="CharacterCounterTextBlock" Style="{Binding Path=(wpf:TextFieldAssist.CharacterCounterStyle), RelativeSource={RelativeSource TemplatedParent}}" />
                 </Border>
@@ -304,13 +306,11 @@
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
               <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
-              <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="1" />
               <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
-              <Setter TargetName="HelperTextTextBlock" Property="Margin" Value="16,0,0,0" />
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -192,7 +192,6 @@
 
                     <wpf:SmartHint x:Name="Hint"
                                    Grid.Column="0"
-                                   Margin="{TemplateBinding wpf:TextFieldAssist.TextBoxViewMargin}"
                                    FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
                                    FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
                                    FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
@@ -305,12 +304,10 @@
             </MultiTrigger>
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-              <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="1" />
-              <Setter TargetName="Hint" Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -156,7 +156,6 @@
                                   VerticalScrollBarVisibility="Hidden" />
                     <wpf:SmartHint x:Name="Hint"
                                    Grid.Column="1"
-                                   Margin="{TemplateBinding wpf:TextFieldAssist.TextBoxViewMargin}"
                                    FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
                                    FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
                                    FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
@@ -539,11 +538,9 @@
           <ControlTemplate.Triggers>
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-              <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
-              <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
             </Trigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -120,14 +120,15 @@
                       BorderThickness="{TemplateBinding BorderThickness}"
                       CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                       SnapsToDevicePixels="True">
-                <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                <Grid HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition />
                     <ColumnDefinition Width="Auto" />
                   </Grid.ColumnDefinitions>
                   <Grid x:Name="grid"
                         MinWidth="1"
-                        VerticalAlignment="Center">
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition Width="Auto" />
                       <ColumnDefinition Width="*" />
@@ -162,7 +163,8 @@
                                    FontSize="{TemplateBinding FontSize}"
                                    HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                    HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
-                                   UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}">
+                                   UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
                       <wpf:SmartHint.Hint>
                         <Border x:Name="HintBackgroundBorder"
                                 Background="{TemplateBinding wpf:HintAssist.Background}"
@@ -251,13 +253,11 @@
             </MultiTrigger>
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-              <Setter Property="Padding" Value="16,8,12,8" />
               <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TimePickerAssist.OutlinedBorderInactiveThickness)}" />
-              <Setter Property="Padding" Value="16,16,12,16" />
               <Setter Property="VerticalContentAlignment" Value="Top" />
               <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
               <Setter TargetName="Hint" Property="FloatingOffset">
@@ -267,7 +267,7 @@
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
-                    <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="Padding" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
                 </Setter.Value>
               </Setter>
@@ -539,12 +539,10 @@
           <ControlTemplate.Triggers>
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-              <Setter Property="Padding" Value="16,8" />
               <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
-              <Setter Property="Padding" Value="16" />
               <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMarginEmbedded}" />
             </Trigger>
             <MultiTrigger>
@@ -615,6 +613,7 @@
     <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />
     <Setter Property="wpf:TextFieldAssist.UnderlineCornerRadius" Value="0" />
+    <Setter Property="Padding" Value="16,8" />
   </Style>
 
   <Style x:Key="MaterialDesignOutlinedTimePicker"
@@ -622,6 +621,7 @@
          BasedOn="{StaticResource MaterialDesignFloatingHintTimePicker}">
     <Setter Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />
+    <Setter Property="Padding" Value="16" />
   </Style>
 
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -16,6 +16,7 @@
   <converters:FloatingHintOffsetCalculationConverter x:Key="FloatingHintOffsetCalculationConverter" />
   <converters:PickerInnerPaddingConverter x:Key="PickerInnerPaddingConverter" />
   <converters:OutlinedDateTimePickerActiveBorderThicknessConverter x:Key="OutlinedDateTimePickerActiveBorderThicknessConverter" />
+  <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left" />
 
   <Style x:Key="MaterialDesignTimePickerTextBox" TargetType="{x:Type wpf:TimePickerTextBox}">
     <Setter Property="AllowDrop" Value="true" />
@@ -207,7 +208,7 @@
                            Background="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
                            CornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
                            Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}" />
-            <Canvas x:Name="HelperTextWrapper" VerticalAlignment="Bottom">
+            <Canvas x:Name="HelperTextWrapper" VerticalAlignment="Bottom" Margin="{TemplateBinding Padding, Converter={StaticResource HelperTextMarginConverter}}">
               <TextBlock x:Name="HelperTextTextBlock" Canvas.Top="2"
                          MaxWidth="{Binding ActualWidth, ElementName=border}"
                          FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
@@ -252,13 +253,11 @@
             </MultiTrigger>
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
-              <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
             </Trigger>
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TimePickerAssist.OutlinedBorderInactiveThickness)}" />
               <Setter Property="VerticalContentAlignment" Value="Top" />
-              <Setter TargetName="HelperTextWrapper" Property="Margin" Value="16,0,0,0" />
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -208,7 +208,7 @@
                            CornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
                            Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}" />
             <Canvas x:Name="HelperTextWrapper" VerticalAlignment="Bottom">
-              <TextBlock Canvas.Top="2"
+              <TextBlock x:Name="HelperTextTextBlock" Canvas.Top="2"
                          MaxWidth="{Binding ActualWidth, ElementName=border}"
                          FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                          Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
@@ -1,10 +1,15 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
+                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
   <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
   <ControlTemplate x:Key="MaterialDesignValidationErrorTemplate">
     <ControlTemplate.Resources>
+      <converters:ThicknessCloneConverter x:Key="FloatingHintValidationErrorTextMarginConverter" CloneEdges="Left" />
+      <converters:ThicknessCloneConverter x:Key="FilledValidationErrorTextMarginConverter" CloneEdges="Left" FixedTop="2" FixedBottom="2" />
+      <converters:ThicknessCloneConverter x:Key="OutlinedValidationErrorTextMarginConverter" CloneEdges="Left" FixedTop="2" />
+
       <DataTemplate DataType="{x:Type ValidationError}">
         <TextBlock MaxWidth="{Binding ElementName=Placeholder, Path=ActualWidth}"
                    Margin="2"
@@ -20,6 +25,7 @@
       <AdornedElementPlaceholder Name="Placeholder" />
       <Border x:Name="DefaultErrorViewer"
               Background="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.Background)}"
+              Margin="{Binding ElementName=Placeholder, Path=AdornedElement.Padding, Converter={StaticResource FloatingHintValidationErrorTextMarginConverter}}"
               Visibility="Collapsed">
         <TextBlock MaxWidth="{Binding ElementName=Placeholder, Path=ActualWidth}"
                    Margin="0,2"
@@ -95,12 +101,12 @@
       </DataTrigger>
 
       <DataTrigger Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:TextFieldAssist.HasOutlinedTextField)}" Value="True">
-        <Setter TargetName="DefaultErrorViewer" Property="Margin" Value="16,2,0,0" />
+        <Setter TargetName="DefaultErrorViewer" Property="Margin" Value="{Binding ElementName=Placeholder, Path=AdornedElement.Padding, Converter={StaticResource OutlinedValidationErrorTextMarginConverter}}" />
         <Setter TargetName="ValidationPopup" Property="VerticalOffset" Value="2" />
       </DataTrigger>
 
       <DataTrigger Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:TextFieldAssist.HasFilledTextField)}" Value="True">
-        <Setter TargetName="DefaultErrorViewer" Property="Margin" Value="16,2,0,2" />
+        <Setter TargetName="DefaultErrorViewer" Property="Margin" Value="{Binding ElementName=Placeholder, Path=AdornedElement.Padding, Converter={StaticResource OutlinedValidationErrorTextMarginConverter}}" />
       </DataTrigger>
     </ControlTemplate.Triggers>
   </ControlTemplate>


### PR DESCRIPTION
This PR cleans up the styles utilizing the `SmartHint` because there are several scenarios where the helper text and validation error do not align properly when a non-default `TextBox.Padding` is set. 

I updated the SmartHint demo app page to enable applying custom padding and toggling `Validation.HasError` on/off. This is a quick way to visually see if things are as you'd expect.

I wrote some UI tests to ensure the alignments are correct. Well almost, currently within accepted tolerance. Follow up PRs (see below) should hopefully remove this tolerance.

Fixed for the following controls:
- TextBox
- PasswordBox
- RichTextBox
- ComboBox
- DatePicker
- TimePicker

Removed the wrong usages of `TextFieldAssist.TextBoxViewMargin` in the templates above.

There are still some minor misalignments between the hint, helper text, validation text and the actual control text content that should be taken care of; this will come in other PRs.

![SmartHintDemo](https://user-images.githubusercontent.com/19572699/218757645-eb32b79e-27fc-49ff-918b-9f99cd5ff4b1.gif)
