### PR TITLE
Fix PasswordBox keyboard focus traversal issue

### DIFF
--- a/Directory.packages.props
+++ b/Directory.packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="ShowMeTheXAML.AvalonEdit" Version="2.0.0" />
     <PackageVersion Include="ShowMeTheXAML.MSBuild" Version="2.0.0" />
     <PackageVersion Include="VirtualizingWrapPanel" Version="1.5.7" />
-    <PackageVersion Include="XAMLTest" Version="1.0.0-ci390" />
+    <PackageVersion Include="XAMLTest" Version="1.0.0-ci400" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageVersion Include="Xunit.StaFact" Version="1.1.11" />

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -408,7 +408,11 @@
         </Grid>
 
         <!-- Reveal style PasswordBox variants -->
-        <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="PasswordBox 'reveal' styles" Margin="0,40,0,0" />
+        <StackPanel Orientation="Horizontal" Margin="0,40,0,0">
+          <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="PasswordBox 'reveal' styles" />
+          <CheckBox x:Name="PasswordBoxesRevealedCheckBox" Content="IsPasswordRevealed" Margin="20,0,0,0" />
+        </StackPanel>
+        
         <Grid>
           <Grid.Resources>
             <Style TargetType="{x:Type PasswordBox}" BasedOn="{StaticResource MaterialDesignFloatingHintRevealPasswordBox}">
@@ -417,6 +421,7 @@
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -458,6 +463,7 @@
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -499,6 +505,7 @@
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -534,7 +541,10 @@
         </Grid>
 
         <!-- ComboBox variants -->
-        <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="ComboBox styles" Margin="0,40,0,0" />
+        <StackPanel Orientation="Horizontal" Margin="0,40,0,0">
+          <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="ComboBox styles"  />
+          <CheckBox x:Name="ComboBoxesEditableCheckBox" Content="IsEditable" Margin="20,0,0,0" />
+        </StackPanel>
         <Grid>
           <Grid.Resources>
             <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource MaterialDesignFloatingHintComboBox}">
@@ -544,7 +554,7 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
-              <Setter Property="IsEditable" Value="True" />
+              <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -587,7 +597,7 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
-              <Setter Property="IsEditable" Value="True" />
+              <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -630,7 +640,7 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
-              <Setter Property="IsEditable" Value="True" />
+              <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">

--- a/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
@@ -325,10 +325,10 @@ public class PasswordBoxTests : TestBase
         Assert.True(await textBox2.GetIsKeyboardFocused());
 
         // Assert Tab backwards
-        await textBox2.SendKeyboardInput($"+{Key.Tab}");
-        //Assert.True(await revealPasswordTextBox.GetIsKeyboardFocused());      FIXME: SHIFT key (+) seems to be unsupported by XAMLTest
-        await revealPasswordTextBox.SendKeyboardInput($"+{Key.Tab}");
-        //Assert.True(await textBox1.GetIsKeyboardFocused());                   FIXME: SHIFT key (+) seems to be unsupported by XAMLTest
+        await textBox2.SendKeyboardInput($"{ModifierKeys.Shift}{Key.Tab}");
+        Assert.True(await revealPasswordTextBox.GetIsKeyboardFocused());
+        await revealPasswordTextBox.SendKeyboardInput($"{Key.Tab}{ModifierKeys.None}");
+        Assert.True(await textBox1.GetIsKeyboardFocused());
 
         recorder.Success();
     }

--- a/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
@@ -295,4 +295,41 @@ public class PasswordBoxTests : TestBase
 
         recorder.Success();
     }
+
+    [Fact]
+    [Description("Issue 3095")]
+    public async Task PasswordBox_WithRevealedPassword_RespectsKeyboardTabNavigation()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        var stackPanel = await LoadXaml<StackPanel>(@"
+<StackPanel Orientation=""Vertical"">
+  <TextBox x:Name=""TextBox1"" Width=""200"" />
+  <PasswordBox x:Name=""PasswordBox"" Width=""200""
+               materialDesign:PasswordBoxAssist.IsPasswordRevealed=""True""
+               Style=""{StaticResource MaterialDesignFloatingHintRevealPasswordBox}"" />
+  <TextBox x:Name=""TextBox2"" Width=""200"" />
+</StackPanel>");
+
+        var textBox1 = await stackPanel.GetElement<TextBox>("TextBox1");
+        var passwordBox = await stackPanel.GetElement<PasswordBox>("PasswordBox");
+        var revealPasswordTextBox = await passwordBox.GetElement<TextBox>("RevealPasswordTextBox");
+        var textBox2 = await stackPanel.GetElement<TextBox>("TextBox2");
+
+        // Assert Tab forward
+        await textBox1.MoveKeyboardFocus();
+        Assert.True(await textBox1.GetIsKeyboardFocused());
+        await textBox1.SendKeyboardInput($"{Key.Tab}");
+        Assert.True(await revealPasswordTextBox.GetIsKeyboardFocused());
+        await revealPasswordTextBox.SendKeyboardInput($"{Key.Tab}");
+        Assert.True(await textBox2.GetIsKeyboardFocused());
+
+        // Assert Tab backwards
+        await textBox2.SendKeyboardInput($"+{Key.Tab}");
+        //Assert.True(await revealPasswordTextBox.GetIsKeyboardFocused());      FIXME: SHIFT key (+) seems to be unsupported by XAMLTest
+        await revealPasswordTextBox.SendKeyboardInput($"+{Key.Tab}");
+        //Assert.True(await textBox1.GetIsKeyboardFocused());                   FIXME: SHIFT key (+) seems to be unsupported by XAMLTest
+
+        recorder.Success();
+    }
 }

--- a/MaterialDesignThemes.Wpf/Behaviors/PasswordBoxBehavior.cs
+++ b/MaterialDesignThemes.Wpf/Behaviors/PasswordBoxBehavior.cs
@@ -6,10 +6,33 @@ internal class PasswordBoxBehavior : Behavior<PasswordBox>
 {
     private void PasswordBoxLoaded(object sender, RoutedEventArgs e) => PasswordBoxAssist.SetPassword(AssociatedObject, AssociatedObject.Password);
 
+    private void PasswordBoxPreviewGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+    {
+        if (PasswordBoxAssist.GetIsPasswordRevealed(AssociatedObject) &&
+            AssociatedObject.FindChild<TextBox>("RevealPasswordTextBox") is { } revealPasswordTextBox)
+        {
+            if (ReferenceEquals(e.OldFocus, revealPasswordTextBox))
+            {
+                // When password box receives keyboard focus, but it came from the nested reveal TextBox. We request focus transfer to the previous element from the password box's POV
+                TraversalRequest request = new TraversalRequest(FocusNavigationDirection.Previous);
+                AssociatedObject.MoveFocus(request);
+                e.Handled = true;
+            }
+            else if (!ReferenceEquals(e.OriginalSource, revealPasswordTextBox))
+            {
+                // When password box receives keyboard focus while the password is revealed, we transfer the focus to the nested reveal TextBox.
+                revealPasswordTextBox.Focus();
+                e.Handled = true;
+            }
+        }
+        
+    }
+
     protected override void OnAttached()
     {
         base.OnAttached();
         AssociatedObject.Loaded += PasswordBoxLoaded;
+        AssociatedObject.PreviewGotKeyboardFocus += PasswordBoxPreviewGotKeyboardFocus;
     }
 
     protected override void OnDetaching()
@@ -17,6 +40,7 @@ internal class PasswordBoxBehavior : Behavior<PasswordBox>
         if (AssociatedObject != null)
         {
             AssociatedObject.Loaded -= PasswordBoxLoaded;
+            AssociatedObject.PreviewGotKeyboardFocus -= PasswordBoxPreviewGotKeyboardFocus;
         }
         base.OnDetaching();
     }

--- a/MaterialDesignThemes.Wpf/Behaviors/PasswordBoxBehavior.cs
+++ b/MaterialDesignThemes.Wpf/Behaviors/PasswordBoxBehavior.cs
@@ -11,7 +11,7 @@ internal class PasswordBoxBehavior : Behavior<PasswordBox>
         if (PasswordBoxAssist.GetIsPasswordRevealed(AssociatedObject) &&
             AssociatedObject.FindChild<TextBox>("RevealPasswordTextBox") is { } revealPasswordTextBox)
         {
-            if (ReferenceEquals(e.OldFocus, revealPasswordTextBox))
+            if (ReferenceEquals(e.OldFocus, revealPasswordTextBox) && ReferenceEquals(e.NewFocus, AssociatedObject))
             {
                 // When password box receives keyboard focus, but it came from the nested reveal TextBox. We request focus transfer to the previous element from the password box's POV
                 TraversalRequest request = new TraversalRequest(FocusNavigationDirection.Previous);


### PR DESCRIPTION
Fixes #3095 

This PR fixes the keyboard focus traversal associated with the "reveal style" password box. See the associated issue for details.

I updated the Smart Hint demo page to easily test this out.

I also added a UI test to verify the fix as well, however I was only able to get the "forward tabbing" to work. Either I don't know the correct syntax, or XAMLTest does not behave nicely with the special codes for SHIFT/CTRL/ALT modifiers which are mentioned approximately halfway down on this page:

https://learn.microsoft.com/dotnet/api/system.windows.forms.sendkeys.send
(I know this is Windows Forms link, but I assume XAMLTest is just using the same underlying P/Invoke calls?)

I left the "backwards tabbing" in the test, but commented out the assertions with FIXMEs attached. Perhaps you know the correct syntax to get this working?