### PR TITLE
Add DialogHost.DialogContentUniformCornerRadius

### DIFF
--- a/MainDemo.Wpf/Dialogs.xaml
+++ b/MainDemo.Wpf/Dialogs.xaml
@@ -62,7 +62,8 @@
                         UniqueKey="dialogs_sample1">
         <materialDesign:DialogHost DialogClosed="Sample1_DialogHost_OnDialogClosed"
                                    DialogClosing="Sample1_DialogHost_OnDialogClosing"
-                                   DialogTheme="Inherit">
+                                   DialogTheme="Inherit"
+                                   DialogContentUniformCornerRadius="20">
           <materialDesign:DialogHost.DialogContent>
             <StackPanel Margin="16">
               <TextBlock Text="Add a new fruit." />

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -432,6 +432,15 @@ namespace MaterialDesignThemes.Wpf
             set => SetValue(DialogContentProperty, value);
         }
 
+        public static readonly DependencyProperty DialogContentUniformCornerRadiusProperty = DependencyProperty.Register(
+            nameof(DialogContentUniformCornerRadius), typeof(double), typeof(DialogHost), new PropertyMetadata(4d));
+
+        public double DialogContentUniformCornerRadius
+        {
+            get { return (double)GetValue(DialogContentUniformCornerRadiusProperty); }
+            set { SetValue(DialogContentUniformCornerRadiusProperty, value); }
+        }
+
         public static readonly DependencyProperty DialogContentTemplateProperty = DependencyProperty.Register(
             nameof(DialogContentTemplate), typeof(DataTemplate), typeof(DialogHost), new PropertyMetadata(default(DataTemplate)));
 

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -437,8 +437,8 @@ namespace MaterialDesignThemes.Wpf
 
         public double DialogContentUniformCornerRadius
         {
-            get { return (double)GetValue(DialogContentUniformCornerRadiusProperty); }
-            set { SetValue(DialogContentUniformCornerRadiusProperty, value); }
+            get => (double)GetValue(DialogContentUniformCornerRadiusProperty);
+            set => SetValue(DialogContentUniformCornerRadiusProperty, value);
         }
 
         public static readonly DependencyProperty DialogContentTemplateProperty = DependencyProperty.Register(

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -173,7 +173,7 @@
                           RenderTransformOrigin=".5,.5"
                           Tag="{TemplateBinding DialogBackground}"
                           TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-                          UniformCornerRadius="4">
+                          UniformCornerRadius="{TemplateBinding DialogContentUniformCornerRadius}">
                   <wpf:Card.Style>
                     <Style TargetType="wpf:Card" BasedOn="{StaticResource {x:Type wpf:Card}}">
                       <Setter Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}}" />
@@ -418,7 +418,7 @@
                         RenderTransformOrigin=".5,.5"
                         Tag="{TemplateBinding DialogBackground}"
                         TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-                        UniformCornerRadius="4">
+                        UniformCornerRadius="{TemplateBinding DialogContentUniformCornerRadius}">
                 <wpf:Card.RenderTransform>
                   <TransformGroup>
                     <ScaleTransform x:Name="CardScaleTransform" ScaleX="0" ScaleY="0" />


### PR DESCRIPTION
Addresses #3088 

Allows users of `DialogHost` to specify a custom (uniform) corner radius for the nested `Card`.

An alternative approach could be to introduce a `CardAssist.UniformCornerRadius` attached property; although it would clash a little with the already defined `Card.UniformCornerRadius` normal dependency property.

![image](https://user-images.githubusercontent.com/19572699/221290434-8f80bb87-b32c-4de8-a315-5167e72c026e.png)
