### PR TITLE
Added RatingBar.InvertDirection to support inverting "fill" direction

### DIFF
--- a/MainDemo.Wpf/RatingBar.xaml
+++ b/MainDemo.Wpf/RatingBar.xaml
@@ -197,6 +197,55 @@
                  VerticalAlignment="Top"
                  Text="{Binding ElementName=CustomRatingBarFractionalPreview, Path=Value, StringFormat=Rating: {0}}" />
     </StackPanel>
+
+    <TextBlock Style="{StaticResource MaterialDesignHeadline5TextBlock}" Text="Rating bar with preview, fractional values, and InvertDirection=true" />
+
+    <StackPanel Margin="0,16,0,0" Orientation="Horizontal">
+      <smtx:XamlDisplay Margin="5,0,0,5"
+                        VerticalContentAlignment="Top"
+                        UniqueKey="fractionalPreviewRatingBar_3">
+        <materialDesign:RatingBar x:Name="BasicRatingBarFractionalPreview2"
+                                  IsPreviewValueEnabled="True"
+                                  Max="5"
+                                  Min="0"
+                                  InvertDirection="True"
+                                  ValueIncrements="0.25"
+                                  Value="0" />
+      </smtx:XamlDisplay>
+
+      <TextBlock Margin="10,2,0,0"
+                 VerticalAlignment="Top"
+                 Text="{Binding ElementName=BasicRatingBarFractionalPreview2, Path=Value, StringFormat=Rating: {0}}" />
+
+      <smtx:XamlDisplay Margin="24,0,0,5" UniqueKey="fractionalPreviewRatingBar_4">
+        <materialDesign:RatingBar x:Name="CustomRatingBarFractionalPreview2"
+                                  IsPreviewValueEnabled="True"
+                                  Max="3"
+                                  Min="0"
+                                  Orientation="Vertical"
+                                  InvertDirection="True"
+                                  ValueIncrements="0.25"
+                                  Value="2">
+          <materialDesign:RatingBar.ValueItemTemplate>
+            <DataTemplate DataType="system:Int32">
+              <Grid>
+                <materialDesign:PackIcon Width="24"
+                                         Height="24"
+                                         Kind="Heart" />
+                <TextBlock HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           FontSize="8"
+                           Foreground="{DynamicResource PrimaryHueMidForegroundBrush}"
+                           Text="{Binding}" />
+              </Grid>
+            </DataTemplate>
+          </materialDesign:RatingBar.ValueItemTemplate>
+        </materialDesign:RatingBar>
+      </smtx:XamlDisplay>
+      <TextBlock Margin="10,2,0,0"
+                 VerticalAlignment="Top"
+                 Text="{Binding ElementName=CustomRatingBarFractionalPreview2, Path=Value, StringFormat=Rating: {0}}" />
+    </StackPanel>
   </StackPanel>
 </UserControl>
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RatingBar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RatingBar.xaml
@@ -49,6 +49,7 @@
                         <MultiBinding Converter="{x:Static wpf:RatingBar+TextBlockForegroundConverter.Instance}">
                           <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
                           <Binding Path="Orientation" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
+                          <Binding Path="InvertDirection" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                           <Binding Path="Value" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                           <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                         </MultiBinding>
@@ -70,6 +71,7 @@
                                   <Binding Path="ActualWidth" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding ElementName="previewValueHorizontal" Path="ActualWidth" />
                                   <Binding Path="Orientation" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
+                                  <Binding Path="InvertDirection" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                                   <Binding Path="IsFractionalValueEnabled" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                                   <Binding Path="PreviewValue" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                                   <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -81,6 +83,7 @@
                                   <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding ElementName="previewValueHorizontal" Path="ActualHeight" />
                                   <Binding Path="Orientation" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
+                                  <Binding Path="InvertDirection" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                                   <Binding Path="IsFractionalValueEnabled" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                                   <Binding Path="PreviewValue" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                                   <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -124,6 +127,7 @@
                                   <Binding Path="ActualWidth" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding ElementName="previewValueVertical" Path="ActualWidth" />
                                   <Binding Path="Orientation" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
+                                  <Binding Path="InvertDirection" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                                   <Binding Path="IsFractionalValueEnabled" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                                   <Binding Path="PreviewValue" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                                   <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -135,6 +139,7 @@
                                   <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding ElementName="previewValueVertical" Path="ActualHeight" />
                                   <Binding Path="Orientation" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
+                                  <Binding Path="InvertDirection" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                                   <Binding Path="IsFractionalValueEnabled" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                                   <Binding Path="PreviewValue" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                                   <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -245,6 +250,7 @@
                         <MultiBinding Converter="{x:Static wpf:RatingBar+TextBlockForegroundConverter.Instance}">
                           <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
                           <Binding Path="Orientation" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
+                          <Binding Path="InvertDirection" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                           <Binding Path="Value" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
                           <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                         </MultiBinding>


### PR DESCRIPTION
Fixes #3113

Adds `RatingBar.InvertDirection` dependency property which can be used to "invert" the fill direction. This is probably most useful when you want to fill from bottom and up, but the implementation also supports horizontal orientation where it then fills from right to left (probably not something anyone needs as "the same" can be achieved with `FlowDirection="RightToLeft"`).

![RatingBarInvertDirection](https://user-images.githubusercontent.com/19572699/222242551-ca73e16b-99e9-44bc-93c0-2fc5a7551cb5.gif)
