### PR TITLE
Fixed issue with contents of MaterialDesignElevatedCard not being rounded

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -31,10 +31,8 @@
                 <Border x:Name="PART_ClipBorder"
                         Padding="{TemplateBinding Padding}"
                         Background="{TemplateBinding Background}"
-                        Clip="{TemplateBinding ContentClip}" />
-              </Border>
-            </AdornerDecorator>
-            <ContentPresenter x:Name="ContentPresenter"
+                        Clip="{TemplateBinding ContentClip}">
+                  <ContentPresenter x:Name="ContentPresenter"
                               Margin="{TemplateBinding Padding}"
                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -42,6 +40,9 @@
                               ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}"
                               ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}"
                               ContentTemplateSelector="{TemplateBinding ContentControl.ContentTemplateSelector}" />
+                </Border>
+              </Border>
+            </AdornerDecorator>
           </Grid>
           <ControlTemplate.Triggers>
             <Trigger Property="ClipContent" Value="True">


### PR DESCRIPTION
The corners of contents in a Card (Style: MaterialDesignElevatedCard) were not rounded anymore.
See the screenshot below for a visual result of the change.
This also fixes the MaterialDesignCardGroupBox style to have rounded corners again.

![Fix-Card-Corner-Rounding](https://user-images.githubusercontent.com/7225673/222449169-4c7bc08b-ce3e-49be-a649-0fe7e7f3adf8.png)
