### PR TITLE
Fix clear button in TimePicker

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
@@ -502,6 +502,7 @@ public class TimePickerTests : TestBase
 
         // Act
         await clearButton.LeftClick();
+        await Task.Delay(50);
 
         // Assert
         Assert.Null(await timePicker.GetSelectedTime());

--- a/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
@@ -482,6 +482,32 @@ public class TimePickerTests : TestBase
 
         recorder.Success();
     }
+
+    [Fact]
+    [Description("Issue 3119")]
+    public async Task TimePicker_WithClearButton_ClearButtonClearsSelectedTime()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // Arrange
+        var stackPanel = await LoadXaml<StackPanel>($@"
+<StackPanel>
+  <materialDesign:TimePicker
+    SelectedTime=""08:30""
+    materialDesign:TextFieldAssist.HasClearButton=""True"" />
+</StackPanel>");
+        var timePicker = await stackPanel.GetElement<TimePicker>("/TimePicker");
+        var clearButton = await timePicker.GetElement<Button>("PART_ClearButton");
+        Assert.NotNull(await timePicker.GetSelectedTime());
+
+        // Act
+        await clearButton.LeftClick();
+
+        // Assert
+        Assert.Null(await timePicker.GetSelectedTime());
+
+        recorder.Success();
+    }
 }
 
 public class OnlyTenOClockValidationRule : ValidationRule

--- a/MaterialDesignThemes.Wpf/Internal/ClearText.cs
+++ b/MaterialDesignThemes.Wpf/Internal/ClearText.cs
@@ -40,6 +40,9 @@ public static class ClearText
                 case DatePicker datePicker:
                     datePicker.SetCurrentValue(DatePicker.SelectedDateProperty, null);
                     break;
+                case TimePicker timePicker:
+                    timePicker.SetCurrentValue(TimePicker.SelectedTimeProperty, null);
+                    break;
                 case TextBox textBox:
                     textBox.SetCurrentValue(TextBox.TextProperty, null);
                     break;

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -1,8 +1,9 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
-                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
+                    xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal">
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Menu.xaml" />
@@ -183,6 +184,7 @@
                           Grid.Column="1"
                           Height="Auto"
                           Padding="2,0,0,0"
+                          Command="{x:Static internal:ClearText.ClearCommand}"
                           Focusable="False"
                           Style="{DynamicResource MaterialDesignToolButton}">
                     <Button.Visibility>
@@ -595,6 +597,7 @@
     <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
     <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMargin}" />
     <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource PrimaryHueMidBrush}" />
+    <Setter Property="internal:ClearText.HandlesClearCommand" Value="True" />
   </Style>
 
   <Style x:Key="MaterialDesignFloatingHintTimePicker"


### PR DESCRIPTION
Fixes #3119

`TextFieldAssist.HasClearButton` was not completely implemented on the `TimePicker`. This PR fixes that.

Added UI test reproducing the issue and then fixed the problem.