### PR TITLE
Added SliderAssist.HideActiveTrack

### DIFF
--- a/MainDemo.Wpf/Sliders.xaml
+++ b/MainDemo.Wpf/Sliders.xaml
@@ -72,7 +72,7 @@
           <Slider Maximum="50"
                   Minimum="0"
                   Value="35"
-                  materialDesign:SliderAssist.ShowActiveTrack="False" />
+                  materialDesign:SliderAssist.HideActiveTrack="True" />
         </smtx:XamlDisplay>
 
       </StackPanel>
@@ -123,7 +123,7 @@
                   Minimum="0"
                   Orientation="Vertical"
                   Value="25"
-                  materialDesign:SliderAssist.ShowActiveTrack="False" />
+                  materialDesign:SliderAssist.HideActiveTrack="True" />
         </smtx:XamlDisplay>
 
       </StackPanel>
@@ -195,7 +195,7 @@
                     TickFrequency="{Binding DiscreteHorizontal.TickFrequency}"
                     TickPlacement="BottomRight"
                     Value="40"
-                    materialDesign:SliderAssist.ShowActiveTrack="False" />
+                    materialDesign:SliderAssist.HideActiveTrack="True" />
           </smtx:XamlDisplay>
 
           
@@ -304,7 +304,7 @@
                     TickFrequency="{Binding DiscreteVertical.TickFrequency}"
                     TickPlacement="BottomRight"
                     Value="70000"
-                    materialDesign:SliderAssist.ShowActiveTrack="False" />
+                    materialDesign:SliderAssist.HideActiveTrack="True" />
           </smtx:XamlDisplay>
         </StackPanel>
       </Grid>

--- a/MainDemo.Wpf/Sliders.xaml
+++ b/MainDemo.Wpf/Sliders.xaml
@@ -68,6 +68,13 @@
                   Value="10" />
         </smtx:XamlDisplay>
 
+        <smtx:XamlDisplay Margin="0,16,0,0" UniqueKey="continuous_slider_h_5">
+          <Slider Maximum="50"
+                  Minimum="0"
+                  Value="35"
+                  materialDesign:SliderAssist.ShowActiveTrack="False" />
+        </smtx:XamlDisplay>
+
       </StackPanel>
     </GroupBox>
 
@@ -109,6 +116,14 @@
                   TickFrequency="10"
                   TickPlacement="TopLeft"
                   Value="30" />
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay Margin="16,0,0,0" UniqueKey="continuous_slider_v_5">
+          <Slider Maximum="50"
+                  Minimum="0"
+                  Orientation="Vertical"
+                  Value="25"
+                  materialDesign:SliderAssist.ShowActiveTrack="False" />
         </smtx:XamlDisplay>
 
       </StackPanel>
@@ -173,6 +188,17 @@
                     Value="50" />
           </smtx:XamlDisplay>
 
+          <smtx:XamlDisplay Margin="0,24,0,0" UniqueKey="discrete_slider_h_5">
+            <Slider Maximum="{Binding DiscreteHorizontal.Maximum}"
+                    Minimum="0"
+                    Style="{StaticResource MaterialDesignDiscreteSlider}"
+                    TickFrequency="{Binding DiscreteHorizontal.TickFrequency}"
+                    TickPlacement="BottomRight"
+                    Value="40"
+                    materialDesign:SliderAssist.ShowActiveTrack="False" />
+          </smtx:XamlDisplay>
+
+          
         </StackPanel>
 
       </StackPanel>
@@ -259,7 +285,7 @@
                     Value="70000" />
           </smtx:XamlDisplay>
 
-          <smtx:XamlDisplay UniqueKey="discrete_slider_v_6">
+          <smtx:XamlDisplay Margin="20,0,0,0" UniqueKey="discrete_slider_v_6">
             <Slider materialDesign:SliderAssist.OnlyShowFocusVisualWhileDragging="True"
                     Maximum="{Binding DiscreteVertical.Maximum}"
                     Minimum="0"
@@ -270,6 +296,16 @@
                     Value="70000" />
           </smtx:XamlDisplay>
 
+          <smtx:XamlDisplay Margin="20,0,0,0" UniqueKey="discrete_slider_v_7">
+            <Slider Maximum="{Binding DiscreteVertical.Maximum}"
+                    Minimum="0"
+                    Orientation="Vertical"
+                    Style="{StaticResource MaterialDesignDiscreteSlider}"
+                    TickFrequency="{Binding DiscreteVertical.TickFrequency}"
+                    TickPlacement="BottomRight"
+                    Value="70000"
+                    materialDesign:SliderAssist.ShowActiveTrack="False" />
+          </smtx:XamlDisplay>
         </StackPanel>
       </Grid>
     </GroupBox>

--- a/MaterialDesignThemes.Wpf/SliderAssist.cs
+++ b/MaterialDesignThemes.Wpf/SliderAssist.cs
@@ -2,17 +2,17 @@
 {
     public static class SliderAssist
     {
-        public static readonly DependencyProperty ShowActiveTrackProperty
+        public static readonly DependencyProperty HideActiveTrackProperty
             = DependencyProperty.RegisterAttached(
-                "ShowActiveTrack",
+                "HideActiveTrack",
                 typeof(bool),
                 typeof(SliderAssist),
-                new PropertyMetadata(true));
+                new PropertyMetadata(false));
 
-        public static bool GetShowActiveTrack(DependencyObject element)
-            => (bool)element.GetValue(ShowActiveTrackProperty);
-        public static void SetShowActiveTrack(DependencyObject element, bool value)
-            => element.SetValue(ShowActiveTrackProperty, value);
+        public static bool GetHideActiveTrack(DependencyObject element)
+            => (bool)element.GetValue(HideActiveTrackProperty);
+        public static void SetHideActiveTrack(DependencyObject element, bool value)
+            => element.SetValue(HideActiveTrackProperty, value);
 
         public static readonly DependencyProperty OnlyShowFocusVisualWhileDraggingProperty
             = DependencyProperty.RegisterAttached(

--- a/MaterialDesignThemes.Wpf/SliderAssist.cs
+++ b/MaterialDesignThemes.Wpf/SliderAssist.cs
@@ -2,6 +2,18 @@
 {
     public static class SliderAssist
     {
+        public static readonly DependencyProperty ShowActiveTrackProperty
+            = DependencyProperty.RegisterAttached(
+                "ShowActiveTrack",
+                typeof(bool),
+                typeof(SliderAssist),
+                new PropertyMetadata(true));
+
+        public static bool GetShowActiveTrack(DependencyObject element)
+            => (bool)element.GetValue(ShowActiveTrackProperty);
+        public static void SetShowActiveTrack(DependencyObject element, bool value)
+            => element.SetValue(ShowActiveTrackProperty, value);
+
         public static readonly DependencyProperty OnlyShowFocusVisualWhileDraggingProperty
             = DependencyProperty.RegisterAttached(
                 "OnlyShowFocusVisualWhileDragging",

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
@@ -687,6 +687,9 @@
         <Setter TargetName="activeTrack" Property="CornerRadius" Value="0,3,3,0" />
         <Setter TargetName="activeTrack" Property="HorizontalAlignment" Value="Right" />
       </Trigger>
+      <Trigger Property="wpf:SliderAssist.ShowActiveTrack" Value="False">
+        <Setter TargetName="activeTrack" Property="Visibility" Value="Hidden" />
+      </Trigger>
     </ControlTemplate.Triggers>
   </ControlTemplate>
 
@@ -777,6 +780,9 @@
       <Trigger Property="IsDirectionReversed" Value="True">
         <Setter TargetName="activeTrack" Property="CornerRadius" Value="3,3,0,0" />
         <Setter TargetName="activeTrack" Property="VerticalAlignment" Value="Top" />
+      </Trigger>
+      <Trigger Property="wpf:SliderAssist.ShowActiveTrack" Value="False">
+        <Setter TargetName="activeTrack" Property="Visibility" Value="Hidden" />
       </Trigger>
     </ControlTemplate.Triggers>
   </ControlTemplate>
@@ -869,6 +875,9 @@
         <Setter TargetName="activeTrack" Property="CornerRadius" Value="0,3,3,0" />
         <Setter TargetName="activeTrack" Property="HorizontalAlignment" Value="Right" />
       </Trigger>
+      <Trigger Property="wpf:SliderAssist.ShowActiveTrack" Value="False">
+        <Setter TargetName="activeTrack" Property="Visibility" Value="Hidden" />
+      </Trigger>
     </ControlTemplate.Triggers>
   </ControlTemplate>
 
@@ -959,6 +968,9 @@
       <Trigger Property="IsDirectionReversed" Value="True">
         <Setter TargetName="activeTrack" Property="CornerRadius" Value="3,3,0,0" />
         <Setter TargetName="activeTrack" Property="VerticalAlignment" Value="Top" />
+      </Trigger>
+      <Trigger Property="wpf:SliderAssist.ShowActiveTrack" Value="False">
+        <Setter TargetName="activeTrack" Property="Visibility" Value="Hidden" />
       </Trigger>
     </ControlTemplate.Triggers>
   </ControlTemplate>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
@@ -687,7 +687,7 @@
         <Setter TargetName="activeTrack" Property="CornerRadius" Value="0,3,3,0" />
         <Setter TargetName="activeTrack" Property="HorizontalAlignment" Value="Right" />
       </Trigger>
-      <Trigger Property="wpf:SliderAssist.ShowActiveTrack" Value="False">
+      <Trigger Property="wpf:SliderAssist.HideActiveTrack" Value="True">
         <Setter TargetName="activeTrack" Property="Visibility" Value="Hidden" />
       </Trigger>
     </ControlTemplate.Triggers>
@@ -781,7 +781,7 @@
         <Setter TargetName="activeTrack" Property="CornerRadius" Value="3,3,0,0" />
         <Setter TargetName="activeTrack" Property="VerticalAlignment" Value="Top" />
       </Trigger>
-      <Trigger Property="wpf:SliderAssist.ShowActiveTrack" Value="False">
+      <Trigger Property="wpf:SliderAssist.HideActiveTrack" Value="True">
         <Setter TargetName="activeTrack" Property="Visibility" Value="Hidden" />
       </Trigger>
     </ControlTemplate.Triggers>
@@ -875,7 +875,7 @@
         <Setter TargetName="activeTrack" Property="CornerRadius" Value="0,3,3,0" />
         <Setter TargetName="activeTrack" Property="HorizontalAlignment" Value="Right" />
       </Trigger>
-      <Trigger Property="wpf:SliderAssist.ShowActiveTrack" Value="False">
+      <Trigger Property="wpf:SliderAssist.HideActiveTrack" Value="True">
         <Setter TargetName="activeTrack" Property="Visibility" Value="Hidden" />
       </Trigger>
     </ControlTemplate.Triggers>
@@ -969,7 +969,7 @@
         <Setter TargetName="activeTrack" Property="CornerRadius" Value="3,3,0,0" />
         <Setter TargetName="activeTrack" Property="VerticalAlignment" Value="Top" />
       </Trigger>
-      <Trigger Property="wpf:SliderAssist.ShowActiveTrack" Value="False">
+      <Trigger Property="wpf:SliderAssist.HideActiveTrack" Value="True">
         <Setter TargetName="activeTrack" Property="Visibility" Value="Hidden" />
       </Trigger>
     </ControlTemplate.Triggers>


### PR DESCRIPTION
Added SliderAssist.ShowActiveTrack to support the ability to hide the active track of a slider.

In the screenshot of the demo the last slider of each GroupBox shows the result.

![image](https://user-images.githubusercontent.com/7225673/223686050-b7c4a137-1f87-49b0-9aae-e81bfc8f76fd.png)
