### PR TITLE
Unregister hooks in ScrollViewerAssist when the ScrollViewer is unloaded

### DIFF
--- a/MaterialDesignThemes.Wpf/ScrollViewerAssist.cs
+++ b/MaterialDesignThemes.Wpf/ScrollViewerAssist.cs
@@ -71,6 +71,9 @@ public static class ScrollViewerAssist
     private static readonly DependencyProperty HorizontalScrollHookProperty = DependencyProperty.RegisterAttached(
         "HorizontalScrollHook", typeof(HwndSourceHook), typeof(ScrollViewerAssist), new PropertyMetadata(null));
 
+    private static readonly DependencyProperty HorizontalScrollSourceProperty = DependencyProperty.RegisterAttached(
+        "HorizontalScrollSource", typeof(HwndSource), typeof(ScrollViewerAssist), new PropertyMetadata(null));
+
     public static readonly DependencyProperty SupportHorizontalScrollProperty = DependencyProperty.RegisterAttached(
         "SupportHorizontalScroll", typeof(bool), typeof(ScrollViewerAssist), new PropertyMetadata(false, OnSupportHorizontalScrollChanged));
 
@@ -88,6 +91,8 @@ public static class ScrollViewerAssist
                         RegisterHook(sv);
                     }
                 });
+
+                OnUnloaded(scrollViewer, RemoveHook);
             }
             else
             {
@@ -119,10 +124,24 @@ public static class ScrollViewerAssist
             }
         }
 
+        static void OnUnloaded(ScrollViewer scrollViewer, Action<ScrollViewer> doOnUnloaded)
+        {
+            if (!scrollViewer.IsLoaded)
+            {
+                RoutedEventHandler? onUnloaded = null;
+                onUnloaded = (_, _) =>
+                {
+                    scrollViewer.Unloaded -= onUnloaded;
+                    doOnUnloaded(scrollViewer);
+                };
+                scrollViewer.Unloaded += onUnloaded;
+            }
+        }
+
         static void RemoveHook(ScrollViewer scrollViewer)
         {
             if (scrollViewer.GetValue(HorizontalScrollHookProperty) is HwndSourceHook hook &&
-                PresentationSource.FromVisual(scrollViewer) is HwndSource source)
+                scrollViewer.GetValue(HorizontalScrollSourceProperty) is HwndSource source)
             {
                 source.RemoveHook(hook);
                 scrollViewer.SetValue(HorizontalScrollHookProperty, null);
@@ -135,6 +154,7 @@ public static class ScrollViewerAssist
             if (PresentationSource.FromVisual(scrollViewer) is HwndSource source)
             {
                 HwndSourceHook hook = Hook;
+                scrollViewer.SetValue(HorizontalScrollSourceProperty, source);
                 scrollViewer.SetValue(HorizontalScrollHookProperty, hook);
                 source.AddHook(hook);
             }
@@ -175,6 +195,8 @@ public static class ScrollViewerAssist
                         RegisterHook(sv);
                     }
                 });
+
+                OnUnloaded(scrollViewer, RemoveHook);
             }
             else
             {
@@ -203,6 +225,20 @@ public static class ScrollViewerAssist
                     doOnLoaded(scrollViewer);
                 };
                 scrollViewer.Loaded += onLoaded;
+            }
+        }
+
+        static void OnUnloaded(ScrollViewer scrollViewer, Action<ScrollViewer> doOnUnloaded)
+        {
+            if (!scrollViewer.IsLoaded)
+            {
+                RoutedEventHandler? onUnloaded = null;
+                onUnloaded = (_, _) =>
+                {
+                    scrollViewer.Unloaded -= onUnloaded;
+                    doOnUnloaded(scrollViewer);
+                };
+                scrollViewer.Unloaded += onUnloaded;
             }
         }
 

--- a/MaterialDesignThemes.Wpf/ScrollViewerAssist.cs
+++ b/MaterialDesignThemes.Wpf/ScrollViewerAssist.cs
@@ -82,59 +82,42 @@ public static class ScrollViewerAssist
         //Based on: https://blog.walterlv.com/post/handle-horizontal-scrolling-of-touchpad-en.html
         if (d is ScrollViewer scrollViewer)
         {
-            if ((bool)e.NewValue)
-            {
-                OnLoaded(scrollViewer, sv =>
-                {
-                    if (GetSupportHorizontalScroll(sv))
-                    {
-                        RegisterHook(sv);
-                    }
-                });
-
-                OnUnloaded(scrollViewer, RemoveHook);
-            }
-            else
-            {
-                OnLoaded(scrollViewer, sv =>
-                {
-                    if (!GetSupportHorizontalScroll(sv))
-                    {
-                        RemoveHook(sv);
-                    }
-                });
-            }
-        }
-
-        static void OnLoaded(ScrollViewer scrollViewer, Action<ScrollViewer> doOnLoaded)
-        {
             if (scrollViewer.IsLoaded)
             {
-                doOnLoaded(scrollViewer);
+                DoOnLoaded(scrollViewer);
             }
             else
             {
-                RoutedEventHandler? onLoaded = null;
-                onLoaded = (_, _) =>
-                {
-                    scrollViewer.Loaded -= onLoaded;
-                    doOnLoaded(scrollViewer);
-                };
-                scrollViewer.Loaded += onLoaded;
+                WeakEventManager<ScrollViewer, RoutedEventArgs>.AddHandler(scrollViewer, nameof(ScrollViewer.Loaded), OnLoaded);
+                WeakEventManager<ScrollViewer, RoutedEventArgs>.AddHandler(scrollViewer, nameof(ScrollViewer.Unloaded), OnUnloaded);
             }
         }
 
-        static void OnUnloaded(ScrollViewer scrollViewer, Action<ScrollViewer> doOnUnloaded)
+        static void OnLoaded(object? sender, RoutedEventArgs e)
         {
-            if (!scrollViewer.IsLoaded)
+            if (sender is ScrollViewer sv)
             {
-                RoutedEventHandler? onUnloaded = null;
-                onUnloaded = (_, _) =>
-                {
-                    scrollViewer.Unloaded -= onUnloaded;
-                    doOnUnloaded(scrollViewer);
-                };
-                scrollViewer.Unloaded += onUnloaded;
+                DoOnLoaded(sv);
+            }
+        }
+
+        static void DoOnLoaded(ScrollViewer sv)
+        {
+            if (GetSupportHorizontalScroll(sv))
+            {
+                RegisterHook(sv);
+            }
+            else
+            {
+                RemoveHook(sv);
+            }
+        }
+
+        static void OnUnloaded(object? sender, RoutedEventArgs e)
+        {
+            if (sender is ScrollViewer sv)
+            {
+                RemoveHook(sv);
             }
         }
 
@@ -186,59 +169,42 @@ public static class ScrollViewerAssist
     {
         if (d is ScrollViewer scrollViewer)
         {
-            if ((bool)e.NewValue)
-            {
-                OnLoaded(scrollViewer, sv =>
-                {
-                    if (GetBubbleVerticalScroll(sv))
-                    {
-                        RegisterHook(sv);
-                    }
-                });
-
-                OnUnloaded(scrollViewer, RemoveHook);
-            }
-            else
-            {
-                OnLoaded(scrollViewer, sv =>
-                {
-                    if (!GetBubbleVerticalScroll(sv))
-                    {
-                        RemoveHook(sv);
-                    }
-                });
-            }
-        }
-
-        static void OnLoaded(ScrollViewer scrollViewer, Action<ScrollViewer> doOnLoaded)
-        {
             if (scrollViewer.IsLoaded)
             {
-                doOnLoaded(scrollViewer);
+                DoOnLoaded(scrollViewer);
             }
             else
             {
-                RoutedEventHandler? onLoaded = null;
-                onLoaded = (_, _) =>
-                {
-                    scrollViewer.Loaded -= onLoaded;
-                    doOnLoaded(scrollViewer);
-                };
-                scrollViewer.Loaded += onLoaded;
+                WeakEventManager<ScrollViewer, RoutedEventArgs>.AddHandler(scrollViewer, nameof(ScrollViewer.Loaded), OnLoaded);
+                WeakEventManager<ScrollViewer, RoutedEventArgs>.AddHandler(scrollViewer, nameof(ScrollViewer.Unloaded), OnUnloaded);
             }
         }
 
-        static void OnUnloaded(ScrollViewer scrollViewer, Action<ScrollViewer> doOnUnloaded)
+        static void OnLoaded(object? sender, RoutedEventArgs e)
         {
-            if (!scrollViewer.IsLoaded)
+            if (sender is ScrollViewer sv)
             {
-                RoutedEventHandler? onUnloaded = null;
-                onUnloaded = (_, _) =>
-                {
-                    scrollViewer.Unloaded -= onUnloaded;
-                    doOnUnloaded(scrollViewer);
-                };
-                scrollViewer.Unloaded += onUnloaded;
+                DoOnLoaded(sv);
+            }
+        }
+
+        static void DoOnLoaded(ScrollViewer sv)
+        {
+            if (GetBubbleVerticalScroll(sv))
+            {
+                RegisterHook(sv);
+            }
+            else
+            {
+                RemoveHook(sv);
+            }
+        }
+
+        static void OnUnloaded(object? sender, RoutedEventArgs e)
+        {
+            if (sender is ScrollViewer sv)
+            {
+                RemoveHook(sv);
             }
         }
 


### PR DESCRIPTION
Fixes #3130.

This covers the necessary clean-up of registered Win32 hooks and event handlers for the `SupportHorizontalScroll` and `BubbleVerticalScroll` attached properties.

To unregister the `HwndSourceHook` we have to capture the `HwndSource` in the Loaded event. I'm happy to consider an alternative approach.

I was tempted to promote the duplicated `OnLoaded` and `OnUnloaded` local methods to instance level methods as they are not property-specific.