### PR TITLE
Refactor PopupBox placement to respect configurable elevation

### DIFF
--- a/MainDemo.Wpf/Domain/MainWindowViewModel.cs
+++ b/MainDemo.Wpf/Domain/MainWindowViewModel.cs
@@ -428,6 +428,15 @@ public class MainWindowViewModel : ViewModelBase
                 DocumentationLink.DemoPageLink<SmartHint>(),
                 DocumentationLink.StyleLink("SmartHint"),
             });
+
+        yield return new DemoItem(
+            "PopupBox",
+            typeof(PopupBox),
+            new[]
+            {
+                DocumentationLink.DemoPageLink<PopupBox>(),
+                DocumentationLink.StyleLink("PopupBox"), 
+            });
     }
 
     private bool DemoItemsFilter(object obj)

--- a/MainDemo.Wpf/PopupBox.xaml
+++ b/MainDemo.Wpf/PopupBox.xaml
@@ -1,0 +1,198 @@
+﻿<UserControl x:Class="MaterialDesignDemo.PopupBox"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:MaterialDesignDemo"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:system="clr-namespace:System;assembly=System.Runtime"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <!-- This is needed to avoid runtime exceptions?! Seems like this might be a bug? -->
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.PopupBox.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+
+      <DataTemplate x:Key="ContentTemplateGrid">
+        <Grid Width="200" Height="100">
+          <TextBlock Text="Popup content in grid" HorizontalAlignment="Center" VerticalAlignment="Center">
+            <!-- This explicit style should not be needed; possibly because the MaterialDesignMultiFloatingActionPopupBox style enforces special brushes? Or perhaps an issue with correctly applying theming? -->
+            <TextBlock.Style>
+              <Style TargetType="TextBlock" BasedOn="{StaticResource MaterialDesignTextBlock}">
+                <Setter Property="TextElement.Foreground" Value="{StaticResource MaterialDesignLightForeground}" />
+              </Style>
+            </TextBlock.Style>
+          </TextBlock>
+        </Grid>
+      </DataTemplate>
+
+      <DataTemplate x:Key="ContentTemplateGridWithBackground">
+        <Grid Width="200" Height="100" Background="Fuchsia">
+          <TextBlock Text="Popup content in colored grid" HorizontalAlignment="Center" VerticalAlignment="Center" />
+        </Grid>
+      </DataTemplate>
+
+      <DataTemplate x:Key="ContentTemplateButtonStack">
+        <!-- Margin of 10 here is to "make room" for the elevation drop shadows of the buttons. Must be compensated for in some (left/right) alignment scenarios using PopupBox.PopupHorizontalOffset -->
+        <StackPanel Margin="10">
+          <Button Content="1"
+                  Opacity="0.5"
+                  ToolTip="One with custom opacity" />
+          <Button Content="2" ToolTip="Two" />
+          <Button Content="3" ToolTip="Three" />
+        </StackPanel>
+      </DataTemplate>
+
+      <local:ComboBoxItemToDataTemplateConverter x:Key="ComboBoxItemToDataTemplateConverter" />
+      <local:ComboBoxItemToStyleConverter x:Key="ComboBoxItemToStyleConverter" />
+      <local:ComboBoxItemToHelperTextConverter x:Key="ComboBoxItemToHelperTextConverter" />
+
+      <Thickness x:Key="Spacer">0,30,0,0</Thickness>
+    </ResourceDictionary>
+  </UserControl.Resources>
+  <Grid>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="250" />
+    </Grid.ColumnDefinitions>
+
+    <Grid Grid.Column="0">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="*" />
+      </Grid.RowDefinitions>
+
+      <TextBlock Grid.Row="0" HorizontalAlignment="Center" Style="{StaticResource MaterialDesignSubtitle2TextBlock}"
+                 Text="{Binding ElementName=ContentComboBox, Path=SelectedItem, Converter={StaticResource ComboBoxItemToHelperTextConverter}}" />
+
+      <materialDesign:PopupBox Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Center" SnapsToDevicePixels="True" Padding="0"
+                               Style="{Binding ElementName=StyleComboBox, Path=SelectedItem, Converter={StaticResource ComboBoxItemToStyleConverter}}"
+                               materialDesign:ElevationAssist.Elevation="{Binding ElementName=ElevationComboBox, Path=SelectedItem}"
+                               PopupUniformCornerRadius="{Binding ElementName=UniformCornerRadiusComboBox, Path=SelectedItem}"
+                               PopupHorizontalOffset="{Binding ElementName=HorizontalOffsetComboBox, Path=SelectedItem}"
+                               PopupVerticalOffset="{Binding ElementName=VerticalOffsetComboBox, Path=SelectedItem}"
+                               PlacementMode="{Binding ElementName=PopupBoxPlacementModeComboBox, Path=SelectedItem}">
+        <ContentControl ContentTemplate="{Binding ElementName=ContentComboBox, Path=SelectedItem, Converter={StaticResource ComboBoxItemToDataTemplateConverter}}" />
+      </materialDesign:PopupBox>
+    </Grid>
+    
+    <StackPanel Grid.Column="1" Orientation="Vertical">
+      <GroupBox Header="Properties" Padding="10">
+        <StackPanel Orientation="Vertical">
+          <TextBlock Text="Style:" Style="{StaticResource MaterialDesignSubtitle2TextBlock}" />
+          <ComboBox x:Name="StyleComboBox" SelectedIndex="0">
+            <ComboBoxItem Tag="{StaticResource MaterialDesignPopupBox}">MaterialDesignPopupBox</ComboBoxItem>
+            <ComboBoxItem Tag="{StaticResource MaterialDesignMultiFloatingActionPopupBox}">MaterialDesignMultiFloatingActionPopupBox</ComboBoxItem>
+          </ComboBox>
+
+          <TextBlock Text="Elevation:" Margin="{StaticResource Spacer}" Style="{StaticResource MaterialDesignSubtitle2TextBlock}" />
+          <ComboBox x:Name="ElevationComboBox" SelectedIndex="6">
+            <materialDesign:Elevation>Dp0</materialDesign:Elevation>
+            <materialDesign:Elevation>Dp1</materialDesign:Elevation>
+            <materialDesign:Elevation>Dp2</materialDesign:Elevation>
+            <materialDesign:Elevation>Dp3</materialDesign:Elevation>
+            <materialDesign:Elevation>Dp4</materialDesign:Elevation>
+            <materialDesign:Elevation>Dp5</materialDesign:Elevation>
+            <materialDesign:Elevation>Dp6</materialDesign:Elevation>
+            <materialDesign:Elevation>Dp7</materialDesign:Elevation>
+            <materialDesign:Elevation>Dp8</materialDesign:Elevation>
+            <materialDesign:Elevation>Dp12</materialDesign:Elevation>
+            <materialDesign:Elevation>Dp16</materialDesign:Elevation>
+            <materialDesign:Elevation>Dp24</materialDesign:Elevation>
+          </ComboBox>
+
+          <TextBlock Text="PopupUniformCornerRadius:" Margin="{StaticResource Spacer}" Style="{StaticResource MaterialDesignSubtitle2TextBlock}" />
+          <ComboBox x:Name="UniformCornerRadiusComboBox" SelectedIndex="2">
+            <system:Double>0</system:Double>
+            <system:Double>2</system:Double>
+            <system:Double>4</system:Double>
+            <system:Double>6</system:Double>
+            <system:Double>8</system:Double>
+            <system:Double>10</system:Double>
+            <system:Double>20</system:Double>
+          </ComboBox>
+
+          <TextBlock Text="PopupHorizontalOffset:" Margin="{StaticResource Spacer}" Style="{StaticResource MaterialDesignSubtitle2TextBlock}" />
+          <ComboBox x:Name="HorizontalOffsetComboBox" SelectedIndex="10">
+            <system:Double>-100</system:Double>
+            <system:Double>-50</system:Double>
+            <system:Double>-20</system:Double>
+            <system:Double>-15</system:Double>
+            <system:Double>-10</system:Double>
+            <system:Double>-5</system:Double>
+            <system:Double>-4</system:Double>
+            <system:Double>-3</system:Double>
+            <system:Double>-2</system:Double>
+            <system:Double>-1</system:Double>
+            <system:Double>0</system:Double>
+            <system:Double>1</system:Double>
+            <system:Double>2</system:Double>
+            <system:Double>3</system:Double>
+            <system:Double>4</system:Double>
+            <system:Double>5</system:Double>
+            <system:Double>10</system:Double>
+            <system:Double>15</system:Double>
+            <system:Double>20</system:Double>
+            <system:Double>50</system:Double>
+            <system:Double>100</system:Double>
+          </ComboBox>
+
+          <TextBlock Text="PopupVerticalOffset:" Margin="{StaticResource Spacer}" Style="{StaticResource MaterialDesignSubtitle2TextBlock}" />
+          <ComboBox x:Name="VerticalOffsetComboBox" SelectedIndex="10">
+            <system:Double>-100</system:Double>
+            <system:Double>-50</system:Double>
+            <system:Double>-20</system:Double>
+            <system:Double>-15</system:Double>
+            <system:Double>-10</system:Double>
+            <system:Double>-5</system:Double>
+            <system:Double>-4</system:Double>
+            <system:Double>-3</system:Double>
+            <system:Double>-2</system:Double>
+            <system:Double>-1</system:Double>
+            <system:Double>0</system:Double>
+            <system:Double>1</system:Double>
+            <system:Double>2</system:Double>
+            <system:Double>3</system:Double>
+            <system:Double>4</system:Double>
+            <system:Double>5</system:Double>
+            <system:Double>10</system:Double>
+            <system:Double>15</system:Double>
+            <system:Double>20</system:Double>
+            <system:Double>50</system:Double>
+            <system:Double>100</system:Double>
+          </ComboBox>
+
+          <TextBlock Text="PopupBoxPlacementMode:" Margin="{StaticResource Spacer}" Style="{StaticResource MaterialDesignSubtitle2TextBlock}" />
+          <ComboBox x:Name="PopupBoxPlacementModeComboBox" SelectedIndex="1">
+            <materialDesign:PopupBoxPlacementMode>BottomAndAlignCentres</materialDesign:PopupBoxPlacementMode>
+            <materialDesign:PopupBoxPlacementMode>BottomAndAlignLeftEdges</materialDesign:PopupBoxPlacementMode>
+            <materialDesign:PopupBoxPlacementMode>BottomAndAlignRightEdges</materialDesign:PopupBoxPlacementMode>
+            <materialDesign:PopupBoxPlacementMode>LeftAndAlignBottomEdges</materialDesign:PopupBoxPlacementMode>
+            <materialDesign:PopupBoxPlacementMode>LeftAndAlignMiddles</materialDesign:PopupBoxPlacementMode>
+            <materialDesign:PopupBoxPlacementMode>LeftAndAlignTopEdges</materialDesign:PopupBoxPlacementMode>
+            <materialDesign:PopupBoxPlacementMode>RightAndAlignBottomEdges</materialDesign:PopupBoxPlacementMode>
+            <materialDesign:PopupBoxPlacementMode>RightAndAlignMiddles</materialDesign:PopupBoxPlacementMode>
+            <materialDesign:PopupBoxPlacementMode>RightAndAlignTopEdges</materialDesign:PopupBoxPlacementMode>
+            <materialDesign:PopupBoxPlacementMode>TopAndAlignCentres</materialDesign:PopupBoxPlacementMode>
+            <materialDesign:PopupBoxPlacementMode>TopAndAlignLeftEdges</materialDesign:PopupBoxPlacementMode>
+            <materialDesign:PopupBoxPlacementMode>TopAndAlignRightEdges</materialDesign:PopupBoxPlacementMode>
+          </ComboBox>
+        </StackPanel>
+      </GroupBox>
+
+      <GroupBox Header="Popup" Margin="{StaticResource Spacer}" Padding="10">
+        <StackPanel Orientation="Vertical">
+          <TextBlock Text="Popup Content:" Style="{StaticResource MaterialDesignSubtitle2TextBlock}" />
+          <ComboBox x:Name="ContentComboBox" SelectedIndex="0">
+            <ComboBoxItem Tag="{StaticResource ContentTemplateGrid}" materialDesign:HintAssist.HelperText="Selected content works best when used with the MaterialDesignPopupBox style">Grid</ComboBoxItem>
+            <ComboBoxItem Tag="{StaticResource ContentTemplateGridWithBackground}">Colored grid</ComboBoxItem>
+            <ComboBoxItem Tag="{StaticResource ContentTemplateButtonStack}" materialDesign:HintAssist.HelperText="Margin in the selected content (stack of buttons) needs to be compensated for in certain alignments (left/right)">Stack of buttons</ComboBoxItem>
+          </ComboBox>
+
+        </StackPanel>
+      </GroupBox>
+    </StackPanel>
+  </Grid>
+</UserControl>

--- a/MainDemo.Wpf/PopupBox.xaml
+++ b/MainDemo.Wpf/PopupBox.xaml
@@ -16,15 +16,8 @@
       </ResourceDictionary.MergedDictionaries>
 
       <DataTemplate x:Key="ContentTemplateGrid">
-        <Grid Width="200" Height="100">
-          <TextBlock Text="Popup content in grid" HorizontalAlignment="Center" VerticalAlignment="Center">
-            <!-- This explicit style should not be needed; possibly because the MaterialDesignMultiFloatingActionPopupBox style enforces special brushes? Or perhaps an issue with correctly applying theming? -->
-            <TextBlock.Style>
-              <Style TargetType="TextBlock" BasedOn="{StaticResource MaterialDesignTextBlock}">
-                <Setter Property="TextElement.Foreground" Value="{StaticResource MaterialDesignLightForeground}" />
-              </Style>
-            </TextBlock.Style>
-          </TextBlock>
+        <Grid Width="200" Height="100" TextElement.Foreground="{DynamicResource MaterialDesignLightForeground}">
+          <TextBlock Text="Popup content in grid" HorizontalAlignment="Center" VerticalAlignment="Center" />
         </Grid>
       </DataTemplate>
 

--- a/MainDemo.Wpf/PopupBox.xaml
+++ b/MainDemo.Wpf/PopupBox.xaml
@@ -38,6 +38,28 @@
         </StackPanel>
       </DataTemplate>
 
+      <DataTemplate x:Key="ContentTemplateButtonStackWithBackground">
+        <Grid Background="Fuchsia">
+          <StackPanel Margin="10">
+            <Button Content="1"
+                    Opacity="0.5"
+                    ToolTip="One with custom opacity" />
+            <Button Content="2" ToolTip="Two" />
+            <Button Content="3" ToolTip="Three" />
+          </StackPanel>
+        </Grid>
+      </DataTemplate>
+
+      <x:Array x:Key="{x:Static local:PopupBox.DefaultStyleContentKey}" Type="ComboBoxItem">
+        <ComboBoxItem Tag="{StaticResource ContentTemplateGrid}" materialDesign:HintAssist.HelperText="Selected content works best when used with the MaterialDesignPopupBox style">Grid</ComboBoxItem>
+        <ComboBoxItem Tag="{StaticResource ContentTemplateGridWithBackground}">Colored grid</ComboBoxItem>
+      </x:Array>
+
+      <x:Array x:Key="{x:Static local:PopupBox.MultiFloatingActionStyleContentKey}" Type="ComboBoxItem">
+        <ComboBoxItem Tag="{StaticResource ContentTemplateButtonStack}" materialDesign:HintAssist.HelperText="Margin in the selected content (stack of buttons) needs to be compensated for in certain alignments (left/right)">Stack of buttons</ComboBoxItem>
+        <ComboBoxItem Tag="{StaticResource ContentTemplateButtonStackWithBackground}">Stack of buttons in colored grid</ComboBoxItem>
+      </x:Array>
+
       <local:ComboBoxItemToDataTemplateConverter x:Key="ComboBoxItemToDataTemplateConverter" />
       <local:ComboBoxItemToStyleConverter x:Key="ComboBoxItemToStyleConverter" />
       <local:ComboBoxItemToHelperTextConverter x:Key="ComboBoxItemToHelperTextConverter" />
@@ -56,13 +78,13 @@
         <RowDefinition Height="Auto" />
         <RowDefinition Height="*" />
       </Grid.RowDefinitions>
-
+  
       <TextBlock Grid.Row="0" HorizontalAlignment="Center" Style="{StaticResource MaterialDesignSubtitle2TextBlock}"
                  Text="{Binding ElementName=ContentComboBox, Path=SelectedItem, Converter={StaticResource ComboBoxItemToHelperTextConverter}}" />
 
       <materialDesign:PopupBox Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Center" SnapsToDevicePixels="True" Padding="0"
                                Style="{Binding ElementName=StyleComboBox, Path=SelectedItem, Converter={StaticResource ComboBoxItemToStyleConverter}}"
-                               materialDesign:ElevationAssist.Elevation="{Binding ElementName=ElevationComboBox, Path=SelectedItem}"
+                               PopupElevation="{Binding ElementName=ElevationComboBox, Path=SelectedItem}"
                                PopupUniformCornerRadius="{Binding ElementName=UniformCornerRadiusComboBox, Path=SelectedItem}"
                                PopupHorizontalOffset="{Binding ElementName=HorizontalOffsetComboBox, Path=SelectedItem}"
                                PopupVerticalOffset="{Binding ElementName=VerticalOffsetComboBox, Path=SelectedItem}"
@@ -75,7 +97,7 @@
       <GroupBox Header="Properties" Padding="10">
         <StackPanel Orientation="Vertical">
           <TextBlock Text="Style:" Style="{StaticResource MaterialDesignSubtitle2TextBlock}" />
-          <ComboBox x:Name="StyleComboBox" SelectedIndex="0">
+          <ComboBox x:Name="StyleComboBox" SelectionChanged="StyleComboBox_OnSelectionChanged">
             <ComboBoxItem Tag="{StaticResource MaterialDesignPopupBox}">MaterialDesignPopupBox</ComboBoxItem>
             <ComboBoxItem Tag="{StaticResource MaterialDesignMultiFloatingActionPopupBox}">MaterialDesignMultiFloatingActionPopupBox</ComboBoxItem>
           </ComboBox>
@@ -178,12 +200,7 @@
       <GroupBox Header="Popup" Margin="{StaticResource Spacer}" Padding="10">
         <StackPanel Orientation="Vertical">
           <TextBlock Text="Popup Content:" Style="{StaticResource MaterialDesignSubtitle2TextBlock}" />
-          <ComboBox x:Name="ContentComboBox" SelectedIndex="0">
-            <ComboBoxItem Tag="{StaticResource ContentTemplateGrid}" materialDesign:HintAssist.HelperText="Selected content works best when used with the MaterialDesignPopupBox style">Grid</ComboBoxItem>
-            <ComboBoxItem Tag="{StaticResource ContentTemplateGridWithBackground}">Colored grid</ComboBoxItem>
-            <ComboBoxItem Tag="{StaticResource ContentTemplateButtonStack}" materialDesign:HintAssist.HelperText="Margin in the selected content (stack of buttons) needs to be compensated for in certain alignments (left/right)">Stack of buttons</ComboBoxItem>
-          </ComboBox>
-
+          <ComboBox x:Name="ContentComboBox" />
         </StackPanel>
       </GroupBox>
     </StackPanel>

--- a/MainDemo.Wpf/PopupBox.xaml.cs
+++ b/MainDemo.Wpf/PopupBox.xaml.cs
@@ -17,27 +17,27 @@ public partial class PopupBox : UserControl
 
 internal class ComboBoxItemToDataTemplateConverter : IValueConverter
 {
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        => value is ComboBoxItem {Tag: DataTemplate template} ? template : null!;
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is ComboBoxItem { Tag: DataTemplate template} ? template : null;
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotImplementedException();
 }
 
 internal class ComboBoxItemToStyleConverter : IValueConverter
 {
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        => value is ComboBoxItem { Tag: Style style } ? style : null!;
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is ComboBoxItem { Tag: Style style } ? style : null;
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotImplementedException();
 }
 
 internal class ComboBoxItemToHelperTextConverter : IValueConverter
 {
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         => value is ComboBoxItem item  ? HintAssist.GetHelperText(item) : null!;
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotImplementedException();
 }

--- a/MainDemo.Wpf/PopupBox.xaml.cs
+++ b/MainDemo.Wpf/PopupBox.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+using MaterialDesignThemes.Wpf;
+
+namespace MaterialDesignDemo;
+
+/// <summary>
+/// Interaction logic for PopupBox.xaml
+/// </summary>
+public partial class PopupBox : UserControl
+{
+    public PopupBox()
+    {
+        InitializeComponent();
+    }
+}
+
+internal class ComboBoxItemToDataTemplateConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is ComboBoxItem {Tag: DataTemplate template} ? template : null!;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}
+
+internal class ComboBoxItemToStyleConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is ComboBoxItem { Tag: Style style } ? style : null!;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}
+
+internal class ComboBoxItemToHelperTextConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is ComboBoxItem item  ? HintAssist.GetHelperText(item) : null!;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/MainDemo.Wpf/PopupBox.xaml.cs
+++ b/MainDemo.Wpf/PopupBox.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Collections;
+using System.Globalization;
 using System.Windows.Data;
 using MaterialDesignThemes.Wpf;
 
@@ -9,9 +10,34 @@ namespace MaterialDesignDemo;
 /// </summary>
 public partial class PopupBox : UserControl
 {
+    public const string DefaultStyleContentKey = nameof(DefaultStyleContentKey);
+    public const string MultiFloatingActionStyleContentKey = nameof(MultiFloatingActionStyleContentKey);
+
+    private readonly IEnumerable _defaultStyleContent;
+    private readonly IEnumerable _multiFloatingActionStyleContentKey;
+
     public PopupBox()
     {
         InitializeComponent();
+
+        _defaultStyleContent = (IEnumerable)FindResource(DefaultStyleContentKey);
+        _multiFloatingActionStyleContentKey = (IEnumerable)FindResource(MultiFloatingActionStyleContentKey);
+
+        Loaded += (sender, args) => StyleComboBox.SelectedIndex = 0;
+    }
+
+    private void StyleComboBox_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        ComboBoxItem selectedItem = (ComboBoxItem) StyleComboBox.SelectedItem;
+        if (Equals(selectedItem.Content, "MaterialDesignPopupBox"))
+        {
+            ContentComboBox.ItemsSource = _defaultStyleContent;
+        }
+        else
+        {
+            ContentComboBox.ItemsSource = _multiFloatingActionStyleContentKey;
+        }
+        ContentComboBox.SelectedIndex = 0;
     }
 }
 

--- a/MaterialDesignThemes.UITests/WPF/PopupBox/PopupBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/PopupBox/PopupBoxTests.cs
@@ -1,0 +1,37 @@
+﻿using System.ComponentModel;
+
+namespace MaterialDesignThemes.UITests.WPF.PopupBox;
+
+public class PopupBoxTests : TestBase
+{
+    public PopupBoxTests(ITestOutputHelper output)
+        : base(output)
+    { }
+
+    [Theory]
+    [InlineData(Elevation.Dp0)]
+    [InlineData(Elevation.Dp16)]
+    [InlineData(Elevation.Dp24)]
+    [Description("Issue 3129")]
+    public async Task PopupBox_WithElevation_AppliesElevationToNestedCard(Elevation elevation)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        //Arrange
+        IVisualElement<Wpf.PopupBox> popupBox = await LoadXaml<Wpf.PopupBox>($@"
+<materialDesign:PopupBox VerticalAlignment=""Top""
+                         materialDesign:ElevationAssist.Elevation=""{elevation}"">
+  <StackPanel>
+    <Button Content=""More"" />
+    <Button Content=""Options"" />
+  </StackPanel>
+</materialDesign:PopupBox>");
+
+        IVisualElement<Card> card = await popupBox.GetElement<Card>("/Card");
+
+        // Assert
+        Assert.Equal(elevation, await card.GetProperty<Elevation?>(ElevationAssist.ElevationProperty));
+
+        recorder.Success();
+    }
+}

--- a/MaterialDesignThemes.UITests/WPF/PopupBox/PopupBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/PopupBox/PopupBoxTests.cs
@@ -20,7 +20,7 @@ public class PopupBoxTests : TestBase
         //Arrange
         IVisualElement<Wpf.PopupBox> popupBox = await LoadXaml<Wpf.PopupBox>($@"
 <materialDesign:PopupBox VerticalAlignment=""Top""
-                         materialDesign:ElevationAssist.Elevation=""{elevation}"">
+                         PopupElevation=""{elevation}"">
   <StackPanel>
     <Button Content=""More"" />
     <Button Content=""Options"" />

--- a/MaterialDesignThemes.Wpf/Card.cs
+++ b/MaterialDesignThemes.Wpf/Card.cs
@@ -17,7 +17,14 @@ namespace MaterialDesignThemes.Wpf
         }
         public static readonly DependencyProperty UniformCornerRadiusProperty
             = DependencyProperty.Register(nameof(UniformCornerRadius), typeof(double), typeof(Card),
-                new FrameworkPropertyMetadata(DefaultUniformCornerRadius, FrameworkPropertyMetadataOptions.AffectsMeasure));
+                new FrameworkPropertyMetadata(DefaultUniformCornerRadius, FrameworkPropertyMetadataOptions.AffectsMeasure, UniformCornerRadiusChangedCallback));
+
+        private static void UniformCornerRadiusChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            Card card = (Card) d;
+            card.UpdateContentClip();
+        }
+
         #endregion
 
         #region DependencyProperty : ContentClipProperty
@@ -59,7 +66,11 @@ namespace MaterialDesignThemes.Wpf
         protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
         {
             base.OnRenderSizeChanged(sizeInfo);
+            UpdateContentClip();
+        }
 
+        private void UpdateContentClip()
+        {
             if (_clipBorder is null)
             {
                 return;

--- a/MaterialDesignThemes.Wpf/DpiHelper.cs
+++ b/MaterialDesignThemes.Wpf/DpiHelper.cs
@@ -31,6 +31,14 @@ namespace MaterialDesignThemes.Wpf
             return TransformToDeviceY(y);
         }
 
+        public static double TransformFromDeviceY(Visual visual, double y)
+        {
+            var source = PresentationSource.FromVisual(visual);
+            if (source?.CompositionTarget != null) return y / source.CompositionTarget.TransformToDevice.M22;
+
+            return TransformFromDeviceY(y);
+        }
+
         public static double TransformToDeviceX(Visual visual, double x)
         {
             var source = PresentationSource.FromVisual(visual);
@@ -39,8 +47,20 @@ namespace MaterialDesignThemes.Wpf
             return TransformToDeviceX(x);
         }
 
+        public static double TransformFromDeviceX(Visual visual, double x)
+        {
+            var source = PresentationSource.FromVisual(visual);
+            if (source?.CompositionTarget != null) return x / source.CompositionTarget.TransformToDevice.M11;
+
+            return TransformFromDeviceX(x);
+        }
+
         public static double TransformToDeviceY(double y) => y * DpiY / StandardDpiY;
 
+        public static double TransformFromDeviceY(double y) => y / DpiY * StandardDpiY;
+
         public static double TransformToDeviceX(double x) => x * DpiX / StandardDpiX;
+
+        public static double TransformFromDeviceX(double x) => x / DpiX * StandardDpiX;
     }
 }

--- a/MaterialDesignThemes.Wpf/ElevationAssist.cs
+++ b/MaterialDesignThemes.Wpf/ElevationAssist.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Media.Effects;
+﻿using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media.Effects;
 
 namespace MaterialDesignThemes.Wpf;
 
@@ -60,4 +62,36 @@ public static class ElevationAssist
     public static Elevation GetElevation(DependencyObject element) => (Elevation)element.GetValue(ElevationProperty);
 
     public static DropShadowEffect? GetDropShadow(Elevation elevation) => ElevationInfo.GetDropShadow(elevation);
+}
+
+public class ElevationMarginConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is Elevation elevation && elevation != Elevation.Dp0)
+        {
+            return new Thickness(ElevationInfo.GetDropShadow(elevation)!.BlurRadius);
+        }
+        return new Thickness(0);
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}
+
+public class ElevationRadiusConverter : IValueConverter
+{
+    public double Multiplier { get; set; } = 1.0;
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is Elevation elevation && elevation != Elevation.Dp0)
+        {
+            return ElevationInfo.GetDropShadow(elevation)!.BlurRadius * Multiplier;
+        }
+        return 0;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }

--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -518,69 +518,79 @@ namespace MaterialDesignThemes.Wpf
                 SetCurrentValue(IsPopupOpenProperty, false);
         }
 
-        private CustomPopupPlacement[] GetPopupPlacement(Size popupSize, Size targetSize, Point offset)
+        private CustomPopupPlacement[] GetPopupPlacement(Size popupSize, Size targetSize, Point _)
         {
             double x, y;
+            double offsetX = PopupHorizontalOffset;
+            double offsetY = PopupVerticalOffset;
 
-            if (FlowDirection == FlowDirection.RightToLeft)
-                offset.X += targetSize.Width / 2;
+            Size popupSizeTransformed = new Size(DpiHelper.TransformFromDeviceX(this, popupSize.Width), DpiHelper.TransformFromDeviceY(this, popupSize.Height));
+            Size targetSizeTransformed = new Size(DpiHelper.TransformFromDeviceX(this, targetSize.Width), DpiHelper.TransformFromDeviceY(this, targetSize.Height));
 
             switch (PlacementMode)
             {
                 case PopupBoxPlacementMode.BottomAndAlignLeftEdges:
-                    x = 0 - Math.Abs(offset.X * 3);
-                    y = targetSize.Height - Math.Abs(offset.Y);
+                    x = 0 + offsetX - UseOffsetIfRtl(popupSizeTransformed.Width);
+                    y = targetSizeTransformed.Height + offsetY;
                     break;
                 case PopupBoxPlacementMode.BottomAndAlignRightEdges:
-                    x = 0 - popupSize.Width + targetSize.Width - offset.X;
-                    y = targetSize.Height - Math.Abs(offset.Y);
+                    x = 0 - popupSizeTransformed.Width + targetSizeTransformed.Width + offsetX + UseOffsetIfRtl(popupSizeTransformed.Width - targetSizeTransformed.Width * 2);
+                    y = targetSizeTransformed.Height + offsetY;
                     break;
                 case PopupBoxPlacementMode.BottomAndAlignCentres:
-                    x = targetSize.Width / 2 - popupSize.Width / 2 - Math.Abs(offset.X * 2);
-                    y = targetSize.Height - Math.Abs(offset.Y);
+                    x = (targetSizeTransformed.Width - popupSizeTransformed.Width) / 2 + offsetX - UseOffsetIfRtl(targetSizeTransformed.Width);
+                    y = targetSizeTransformed.Height + offsetY;
                     break;
                 case PopupBoxPlacementMode.TopAndAlignLeftEdges:
-                    x = 0 - Math.Abs(offset.X * 3);
-                    y = 0 - popupSize.Height - Math.Abs(offset.Y * 2);
+                    x = 0 + offsetX - UseOffsetIfRtl(popupSizeTransformed.Width);
+                    y = 0 - popupSizeTransformed.Height + offsetY;
                     break;
                 case PopupBoxPlacementMode.TopAndAlignRightEdges:
-                    x = 0 - popupSize.Width + targetSize.Width - offset.X;
-                    y = 0 - popupSize.Height - Math.Abs(offset.Y * 2);
+                    x = 0 - popupSizeTransformed.Width + targetSizeTransformed.Width + offsetX + UseOffsetIfRtl(popupSizeTransformed.Width - targetSizeTransformed.Width * 2);
+                    y = 0 - popupSizeTransformed.Height + offsetY;
                     break;
                 case PopupBoxPlacementMode.TopAndAlignCentres:
-                    x = targetSize.Width / 2 - popupSize.Width / 2 - Math.Abs(offset.X * 2);
-                    y = 0 - popupSize.Height - Math.Abs(offset.Y * 2);
+                    x = (targetSizeTransformed.Width - popupSizeTransformed.Width) / 2 + offsetX - UseOffsetIfRtl(targetSizeTransformed.Width);
+                    y = 0 - popupSizeTransformed.Height + offsetY;
                     break;
                 case PopupBoxPlacementMode.LeftAndAlignTopEdges:
-                    x = 0 - popupSize.Width - Math.Abs(offset.X * 2);
-                    y = 0 - Math.Abs(offset.Y * 3);
+                    x = 0 - popupSizeTransformed.Width + offsetX + UseOffsetIfRtl(popupSizeTransformed.Width);
+                    y = 0 + offsetY;
                     break;
                 case PopupBoxPlacementMode.LeftAndAlignBottomEdges:
-                    x = 0 - popupSize.Width - Math.Abs(offset.X * 2);
-                    y = 0 - (popupSize.Height - targetSize.Height);
+                    x = 0 - popupSizeTransformed.Width + offsetX + UseOffsetIfRtl(popupSizeTransformed.Width);
+                    y = 0 - (popupSizeTransformed.Height - targetSizeTransformed.Height) + offsetY;
                     break;
                 case PopupBoxPlacementMode.LeftAndAlignMiddles:
-                    x = 0 - popupSize.Width - Math.Abs(offset.X * 2);
-                    y = targetSize.Height / 2 - popupSize.Height / 2 - Math.Abs(offset.Y * 2);
+                    x = 0 - popupSizeTransformed.Width + offsetX + UseOffsetIfRtl(popupSizeTransformed.Width);
+                    y = 0 - (popupSizeTransformed.Height - targetSizeTransformed.Height) / 2 + offsetY;
                     break;
                 case PopupBoxPlacementMode.RightAndAlignTopEdges:
-                    x = targetSize.Width;
-                    y = 0 - Math.Abs(offset.X * 3);
+                    x = targetSizeTransformed.Width + offsetX - UseOffsetIfRtl(popupSizeTransformed.Width + targetSizeTransformed.Width * 2);
+                    y = 0 + offsetY;
                     break;
                 case PopupBoxPlacementMode.RightAndAlignBottomEdges:
-                    x = targetSize.Width;
-                    y = 0 - (popupSize.Height - targetSize.Height);
+                    x = targetSizeTransformed.Width + offsetX - UseOffsetIfRtl(popupSizeTransformed.Width + targetSizeTransformed.Width * 2);
+                    y = 0 - (popupSizeTransformed.Height - targetSizeTransformed.Height) + offsetY;
                     break;
                 case PopupBoxPlacementMode.RightAndAlignMiddles:
-                    x = targetSize.Width;
-                    y = targetSize.Height / 2 - popupSize.Height / 2 - Math.Abs(offset.Y * 2);
+                    x = targetSizeTransformed.Width + offsetX - UseOffsetIfRtl(popupSizeTransformed.Width + targetSizeTransformed.Width * 2);
+                    y = 0 - (popupSizeTransformed.Height - targetSizeTransformed.Height) / 2 + offsetY;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
 
-            _popupPointFromLastRequest = new Point(x, y);
+            double xTransformed = DpiHelper.TransformToDeviceX(x);
+            double yTransformed = DpiHelper.TransformToDeviceY(y);
+
+            _popupPointFromLastRequest = new Point(xTransformed, yTransformed);
             return new[] { new CustomPopupPlacement(_popupPointFromLastRequest, PopupPrimaryAxis.Horizontal) };
+
+            double UseOffsetIfRtl(double rtlOffset)
+            {
+                return FlowDirection == FlowDirection.LeftToRight ? 0 : rtlOffset;
+            }
         }
 
         private void AnimateChildrenIn(bool reverse)

--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -353,6 +353,21 @@ namespace MaterialDesignThemes.Wpf
         }
 
         /// <summary>
+        /// Gets or sets the elevation of the popup card.
+        /// </summary>
+        public static readonly DependencyProperty PopupElevationProperty = DependencyProperty.Register(
+            nameof(PopupElevation), typeof(Elevation), typeof(PopupBox), new PropertyMetadata(Elevation.Dp0));
+
+        /// <summary>
+        /// Gets or sets the elevation of the popup card.
+        /// </summary>
+        public Elevation PopupElevation
+        {
+            get { return (Elevation) GetValue(PopupElevationProperty); }
+            set { SetValue(PopupElevationProperty, value); }
+        }
+
+        /// <summary>
         /// Framework use. Provides the method used to position the popup.
         /// </summary>
         public CustomPopupPlacementCallback PopupPlacementMethod => GetPopupPlacement;

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -9,6 +9,10 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ToolTip.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
+  <wpf:ElevationMarginConverter x:Key="ElevationMarginConverter" />
+  <wpf:ElevationRadiusConverter x:Key="ElevationRadiusConverter" Multiplier="-1" />
+  <wpf:ElevationRadiusConverter x:Key="RtlElevationRadiusConverter" Multiplier="1" />
+
   <Style x:Key="MaterialDesignPopupBoxButton" TargetType="{x:Type Button}">
     <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -84,9 +88,9 @@
     <Setter Property="Focusable" Value="True" />
     <Setter Property="HorizontalAlignment" Value="Left" />
     <Setter Property="Padding" Value="0,8,0,8" />
-    <Setter Property="PopupHorizontalOffset" Value="5" />
+    <Setter Property="PopupHorizontalOffset" Value="0" />
     <Setter Property="PopupUniformCornerRadius" Value="2" />
-    <Setter Property="PopupVerticalOffset" Value="5" />
+    <Setter Property="PopupVerticalOffset" Value="0" />
     <Setter Property="ToolTipService.IsEnabled" Value="{Binding IsPopupOpen, RelativeSource={RelativeSource Self}, Converter={StaticResource NotConverter}}"/>
     <Setter Property="Template">
       <Setter.Value>
@@ -126,19 +130,20 @@
             <wpf:PopupEx x:Name="PART_Popup"
                          AllowsTransparency="True"
                          CustomPopupPlacementCallback="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PopupPlacementMethod}"
-                         HorizontalOffset="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PopupHorizontalOffset}"
+                         HorizontalOffset="{TemplateBinding wpf:ElevationAssist.Elevation, Converter={StaticResource ElevationRadiusConverter}}"
+                         VerticalOffset="{TemplateBinding wpf:ElevationAssist.Elevation, Converter={StaticResource ElevationRadiusConverter}}"
                          IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPopupOpen, Mode=TwoWay}"
                          Placement="Custom"
                          PlacementTarget="{Binding ElementName=PART_Toggle}"
-                         PopupAnimation="Fade"
-                         VerticalOffset="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PopupVerticalOffset}">
-              <wpf:Card Margin="5"
+                         PopupAnimation="Fade">
+              <wpf:Card Margin="{TemplateBinding wpf:ElevationAssist.Elevation, Converter={StaticResource ElevationMarginConverter}}"
                         Padding="{TemplateBinding Padding}"
                         Content="{TemplateBinding PopupContent}"
                         ContentTemplate="{TemplateBinding PopupContentTemplate}"
                         Foreground="{DynamicResource MaterialDesignBody}"
                         RenderOptions.ClearTypeHint="Enabled"
-                        UniformCornerRadius="{TemplateBinding PopupUniformCornerRadius}">
+                        UniformCornerRadius="{TemplateBinding PopupUniformCornerRadius}"
+                        wpf:ElevationAssist.Elevation="{TemplateBinding wpf:ElevationAssist.Elevation}">
                 <wpf:Card.Resources>
                   <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignPopupBoxButton}" />
                 </wpf:Card.Resources>
@@ -148,6 +153,9 @@
           <ControlTemplate.Triggers>
             <Trigger Property="IsEnabled" Value="false">
               <Setter Property="Opacity" Value="0.38" />
+            </Trigger>
+            <Trigger Property="FlowDirection" Value="RightToLeft">
+              <Setter TargetName="PART_Popup" Property="HorizontalOffset" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation), Converter={StaticResource RtlElevationRadiusConverter}}" />
             </Trigger>
           </ControlTemplate.Triggers>
         </ControlTemplate>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -9,10 +9,6 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ToolTip.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
-  <wpf:ElevationMarginConverter x:Key="ElevationMarginConverter" />
-  <wpf:ElevationRadiusConverter x:Key="ElevationRadiusConverter" Multiplier="-1" />
-  <wpf:ElevationRadiusConverter x:Key="RtlElevationRadiusConverter" Multiplier="1" />
-
   <Style x:Key="MaterialDesignPopupBoxButton" TargetType="{x:Type Button}">
     <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -97,6 +93,10 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type wpf:PopupBox}">
           <ControlTemplate.Resources>
+            <wpf:ElevationMarginConverter x:Key="ElevationMarginConverter" />
+            <wpf:ElevationRadiusConverter x:Key="ElevationRadiusConverter" Multiplier="-1" />
+            <wpf:ElevationRadiusConverter x:Key="RtlElevationRadiusConverter" Multiplier="1" />
+
             <Style TargetType="Separator" BasedOn="{StaticResource MaterialDesignSeparator}" />
             <Style x:Key="ToggleButtonStyle" TargetType="ToggleButton">
               <Setter Property="Template">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -90,6 +90,7 @@
     <Setter Property="Padding" Value="0,8,0,8" />
     <Setter Property="PopupHorizontalOffset" Value="0" />
     <Setter Property="PopupUniformCornerRadius" Value="2" />
+    <Setter Property="PopupElevation" Value="Dp6" />
     <Setter Property="PopupVerticalOffset" Value="0" />
     <Setter Property="ToolTipService.IsEnabled" Value="{Binding IsPopupOpen, RelativeSource={RelativeSource Self}, Converter={StaticResource NotConverter}}"/>
     <Setter Property="Template">
@@ -130,20 +131,20 @@
             <wpf:PopupEx x:Name="PART_Popup"
                          AllowsTransparency="True"
                          CustomPopupPlacementCallback="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PopupPlacementMethod}"
-                         HorizontalOffset="{TemplateBinding wpf:ElevationAssist.Elevation, Converter={StaticResource ElevationRadiusConverter}}"
-                         VerticalOffset="{TemplateBinding wpf:ElevationAssist.Elevation, Converter={StaticResource ElevationRadiusConverter}}"
+                         HorizontalOffset="{TemplateBinding PopupElevation, Converter={StaticResource ElevationRadiusConverter}}"
+                         VerticalOffset="{TemplateBinding PopupElevation, Converter={StaticResource ElevationRadiusConverter}}"
                          IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPopupOpen, Mode=TwoWay}"
                          Placement="Custom"
                          PlacementTarget="{Binding ElementName=PART_Toggle}"
                          PopupAnimation="Fade">
-              <wpf:Card Margin="{TemplateBinding wpf:ElevationAssist.Elevation, Converter={StaticResource ElevationMarginConverter}}"
+              <wpf:Card Margin="{TemplateBinding PopupElevation, Converter={StaticResource ElevationMarginConverter}}"
                         Padding="{TemplateBinding Padding}"
                         Content="{TemplateBinding PopupContent}"
                         ContentTemplate="{TemplateBinding PopupContentTemplate}"
                         Foreground="{DynamicResource MaterialDesignBody}"
                         RenderOptions.ClearTypeHint="Enabled"
                         UniformCornerRadius="{TemplateBinding PopupUniformCornerRadius}"
-                        wpf:ElevationAssist.Elevation="{TemplateBinding wpf:ElevationAssist.Elevation}">
+                        wpf:ElevationAssist.Elevation="{TemplateBinding PopupElevation}">
                 <wpf:Card.Resources>
                   <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignPopupBoxButton}" />
                 </wpf:Card.Resources>
@@ -163,7 +164,6 @@
     </Setter>
     <Setter Property="TextElement.FontWeight" Value="Normal" />
     <Setter Property="ToggleContent" Value="{StaticResource MaterialDesignPopupBoxToggleContent}" />
-    <Setter Property="wpf:ElevationAssist.Elevation" Value="Dp6" />
     <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesignFlatButtonRipple}" />
   </Style>
 
@@ -411,8 +411,6 @@
                 -->
                 <Border Background="White" Opacity="0.002" />
                 <ContentControl x:Name="PART_PopupContentControl"
-                                Margin="5"
-                                Padding="8"
                                 Content="{TemplateBinding PopupContent}"
                                 ContentTemplate="{TemplateBinding PopupContentTemplate}"
                                 Opacity="0"


### PR DESCRIPTION
Fixes #3129

I set out to simply add `ElevationAssist.Elevation` support for the `PopupBox`, but I ended up opening "a can of worms".

**UPDATE**: After discussing this, we agreed not to use `ElevationAssist.Elevation`, but rather create a dedicated `PopupBox.Elevation`.

When applying a drop shadow to the `Card` contained in the `PopupBox`, the `Popup` that is displayed, needs to reserve space for said drop shadow; it cannot draw outside its bounds. To solve this problem, a `Margin` matching the drop shadow size is applied to the `Card` and this is then compensated for in the placement of the `Popup`.

The `PopupBox` also supports custom offsets of the `Popup` set by the calling code. Previously these were directly applied to the `Popup.HorizontalOffset`/`Popup.VerticalOffset` properties, and were then needed to be taken into consideration when calculating the custom popup placement. This made the calculations a bit funky; in fact I don't believe they were correct in all cases. It definitely did not support DPI scaling correctly, and I also believe it had issues with some alignments in `FlowDirection=RightToLeft`.

This PR refactors this such that the `Popup.HorizontalOffset`/`Popup.VerticalOffset` are **only** used to compensate for the drop shadow size. The custom offsets that can be applied (`PopupBox.PopupHorizontalOffset` and `PopupBox.PopupVerticalOffset`) are now included in the calculations in the `PopupBox.GetPopupPlacement()` callback instead. This callback is also refactored to adjust for DPI scaling and respect `FlowDirection` for all alignment cases.

I added a dedicated page in the demo app for the `PopupBox` to allow for manual testing of the various scenarios.

![PopupBoxDemo](https://user-images.githubusercontent.com/19572699/224542553-f6d55281-1eb2-4aa8-ad17-4f6900d0b39f.gif)
