### PR TITLE
TextBox: Removed not needed VerticalAlignment and it now respects VerticalContentAlignment

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
@@ -562,6 +562,34 @@ public class TextBoxTests : TestBase
 
         recorder.Success();
     }
+
+    [Theory]
+    [InlineData(VerticalAlignment.Stretch, VerticalAlignment.Top)]
+    [InlineData(VerticalAlignment.Top, VerticalAlignment.Top)]
+    [InlineData(VerticalAlignment.Bottom, VerticalAlignment.Bottom)]
+    [InlineData(VerticalAlignment.Center, VerticalAlignment.Center)]
+    [Description("Issue 3161")]
+    public async Task TextBox_MultiLineAndFixedHeight_RespectsVerticalContentAlignment(VerticalAlignment alignment, VerticalAlignment expectedFloatingHintAlignment)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        var stackPanel = await LoadXaml<StackPanel>($$"""
+            <StackPanel>
+              <TextBox Style="{StaticResource MaterialDesignFilledTextBox}"
+                materialDesign:HintAssist.Hint="Hint text"
+                VerticalContentAlignment="{{alignment}}"
+                AcceptsReturn="True"
+                Height="200" />
+            </StackPanel>
+            """);
+
+        IVisualElement<TextBox> textBox = await stackPanel.GetElement<TextBox>("/TextBox");
+        IVisualElement<Grid> hintClippingGrid = await textBox.GetElement<Grid>("HintClippingGrid");
+
+        Assert.Equal(expectedFloatingHintAlignment, await hintClippingGrid.GetVerticalAlignment());
+
+        recorder.Success();
+    }
 }
 
 public class NotEmptyValidationRule : ValidationRule

--- a/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
@@ -391,7 +391,7 @@ public class TextBoxTests : TestBase
         foreach (var alignment in Enum.GetValues<VerticalAlignment>())
         {
             await textBox.SetVerticalContentAlignment(alignment);
-            Assert.Equal(alignment, await scrollViewer.GetVerticalAlignment());
+            Assert.Equal(alignment, await scrollViewer.GetVerticalContentAlignment());
         }
 
         recorder.Success();

--- a/MaterialDesignThemes.Wpf/SmartHint.cs
+++ b/MaterialDesignThemes.Wpf/SmartHint.cs
@@ -1,230 +1,240 @@
 ﻿using System.ComponentModel;
+using System.Globalization;
+using System.Windows.Data;
 using MaterialDesignThemes.Wpf.Converters;
 
-namespace MaterialDesignThemes.Wpf
+namespace MaterialDesignThemes.Wpf;
+
+/// <summary>
+/// A control that implement placeholder behavior. Can work as a simple placeholder either as a floating hint, see <see cref="UseFloating"/> property.
+/// <para/>
+/// To set a target control you should set the HintProxy property. Use the <see cref="HintProxyFabricConverter.Instance"/> converter which converts a control into the IHintProxy interface.
+/// </summary>
+[TemplateVisualState(GroupName = ContentStatesGroupName, Name = HintRestingPositionName)]
+[TemplateVisualState(GroupName = ContentStatesGroupName, Name = HintFloatingPositionName)]
+public class SmartHint : Control
 {
+    public const string ContentStatesGroupName = "ContentStates";
 
-    /// <summary>
-    /// A control that implement placeholder behavior. Can work as a simple placeholder either as a floating hint, see <see cref="UseFloating"/> property.
-    /// <para/>
-    /// To set a target control you should set the HintProxy property. Use the <see cref="HintProxyFabricConverter.Instance"/> converter which converts a control into the IHintProxy interface.
-    /// </summary>
-    [TemplateVisualState(GroupName = ContentStatesGroupName, Name = HintRestingPositionName)]
-    [TemplateVisualState(GroupName = ContentStatesGroupName, Name = HintFloatingPositionName)]
-    public class SmartHint : Control
+    public const string HintRestingPositionName = "HintRestingPosition";
+    public const string HintFloatingPositionName = "HintFloatingPosition";
+
+    #region ManagedProperty
+
+    public static readonly DependencyProperty HintProxyProperty = DependencyProperty.Register(
+        nameof(HintProxy), typeof(IHintProxy), typeof(SmartHint), new PropertyMetadata(default(IHintProxy?), HintProxyPropertyChangedCallback));
+
+    public IHintProxy? HintProxy
     {
-        public const string ContentStatesGroupName = "ContentStates";
+        get => (IHintProxy)GetValue(HintProxyProperty);
+        set => SetValue(HintProxyProperty, value);
+    }
 
-        public const string HintRestingPositionName = "HintRestingPosition";
-        public const string HintFloatingPositionName = "HintFloatingPosition";
+    #endregion
 
-        #region ManagedProperty
+    #region HintProperty
 
-        public static readonly DependencyProperty HintProxyProperty = DependencyProperty.Register(
-            nameof(HintProxy), typeof(IHintProxy), typeof(SmartHint), new PropertyMetadata(default(IHintProxy?), HintProxyPropertyChangedCallback));
+    public static readonly DependencyProperty HintProperty = DependencyProperty.Register(
+        nameof(Hint), typeof(object), typeof(SmartHint), new PropertyMetadata(null));
 
-        public IHintProxy? HintProxy
+    public object? Hint
+    {
+        get => GetValue(HintProperty);
+        set => SetValue(HintProperty, value);
+    }
+
+    #endregion
+
+    #region IsContentNullOrEmpty
+
+    private static readonly DependencyPropertyKey IsContentNullOrEmptyPropertyKey =
+        DependencyProperty.RegisterReadOnly(
+            "IsContentNullOrEmpty", typeof(bool), typeof(SmartHint),
+            new PropertyMetadata(default(bool)));
+
+    public static readonly DependencyProperty IsContentNullOrEmptyProperty =
+        IsContentNullOrEmptyPropertyKey.DependencyProperty;
+
+    public bool IsContentNullOrEmpty
+    {
+        get => (bool)GetValue(IsContentNullOrEmptyProperty);
+        private set => SetValue(IsContentNullOrEmptyPropertyKey, value);
+    }
+
+    #endregion
+
+    #region IsHintInFloatingPosition
+
+    private static readonly DependencyPropertyKey IsHintInFloatingPositionPropertyKey =
+        DependencyProperty.RegisterReadOnly(
+            "IsHintInFloatingPosition", typeof(bool), typeof(SmartHint),
+            new PropertyMetadata(default(bool)));
+
+    public static readonly DependencyProperty IsHintInFloatingPositionProperty =
+        IsHintInFloatingPositionPropertyKey.DependencyProperty;
+
+    public bool IsHintInFloatingPosition
+    {
+        get => (bool)GetValue(IsHintInFloatingPositionProperty);
+        private set => SetValue(IsHintInFloatingPositionPropertyKey, value);
+    }
+
+    #endregion
+
+    #region UseFloating
+
+    public static readonly DependencyProperty UseFloatingProperty = DependencyProperty.Register(
+        nameof(UseFloating), typeof(bool), typeof(SmartHint), new PropertyMetadata(false));
+
+    public bool UseFloating
+    {
+        get => (bool)GetValue(UseFloatingProperty);
+        set => SetValue(UseFloatingProperty, value);
+    }
+
+    #endregion
+
+    #region FloatingScale & FloatingOffset
+
+    public static readonly DependencyProperty FloatingScaleProperty = DependencyProperty.Register(
+        nameof(FloatingScale), typeof(double), typeof(SmartHint), new PropertyMetadata(.74));
+
+    public double FloatingScale
+    {
+        get => (double)GetValue(FloatingScaleProperty);
+        set => SetValue(FloatingScaleProperty, value);
+    }
+
+    public static readonly DependencyProperty FloatingOffsetProperty = DependencyProperty.Register(
+        nameof(FloatingOffset), typeof(Point), typeof(SmartHint), new PropertyMetadata(new Point(1, -16)));
+
+    public Point FloatingOffset
+    {
+        get => (Point)GetValue(FloatingOffsetProperty);
+        set => SetValue(FloatingOffsetProperty, value);
+    }
+
+    #endregion
+
+    #region HintOpacity
+
+    public static readonly DependencyProperty HintOpacityProperty = DependencyProperty.Register(
+        nameof(HintOpacity), typeof(double), typeof(SmartHint), new PropertyMetadata(.46));
+
+    public double HintOpacity
+    {
+        get => (double)GetValue(HintOpacityProperty);
+        set => SetValue(HintOpacityProperty, value);
+    }
+
+    #endregion
+
+    static SmartHint()
+    {
+        DefaultStyleKeyProperty.OverrideMetadata(typeof(SmartHint), new FrameworkPropertyMetadata(typeof(SmartHint)));
+    }
+
+    private static void HintProxyPropertyChangedCallback(DependencyObject? dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+    {
+        var smartHint = dependencyObject as SmartHint;
+        if (smartHint is null) return;
+
+        if (dependencyPropertyChangedEventArgs.OldValue is IHintProxy oldHintProxy)
         {
-            get => (IHintProxy)GetValue(HintProxyProperty);
-            set => SetValue(HintProxyProperty, value);
+            oldHintProxy.IsVisibleChanged -= smartHint.OnHintProxyIsVisibleChanged;
+            oldHintProxy.ContentChanged -= smartHint.OnHintProxyContentChanged;
+            oldHintProxy.Loaded -= smartHint.OnHintProxyContentChanged;
+            oldHintProxy.FocusedChanged -= smartHint.OnHintProxyFocusedChanged;
+            oldHintProxy.Dispose();
         }
 
-        #endregion
-
-        #region HintProperty
-
-        public static readonly DependencyProperty HintProperty = DependencyProperty.Register(
-            nameof(Hint), typeof(object), typeof(SmartHint), new PropertyMetadata(null));
-
-        public object? Hint
+        if (dependencyPropertyChangedEventArgs.NewValue is IHintProxy newHintProxy)
         {
-            get => GetValue(HintProperty);
-            set => SetValue(HintProperty, value);
-        }
-
-        #endregion
-
-        #region IsContentNullOrEmpty
-
-        private static readonly DependencyPropertyKey IsContentNullOrEmptyPropertyKey =
-            DependencyProperty.RegisterReadOnly(
-                "IsContentNullOrEmpty", typeof(bool), typeof(SmartHint),
-                new PropertyMetadata(default(bool)));
-
-        public static readonly DependencyProperty IsContentNullOrEmptyProperty =
-            IsContentNullOrEmptyPropertyKey.DependencyProperty;
-
-        public bool IsContentNullOrEmpty
-        {
-            get => (bool)GetValue(IsContentNullOrEmptyProperty);
-            private set => SetValue(IsContentNullOrEmptyPropertyKey, value);
-        }
-
-        #endregion
-
-        #region IsHintInFloatingPosition
-
-        private static readonly DependencyPropertyKey IsHintInFloatingPositionPropertyKey =
-            DependencyProperty.RegisterReadOnly(
-                "IsHintInFloatingPosition", typeof(bool), typeof(SmartHint),
-                new PropertyMetadata(default(bool)));
-
-        public static readonly DependencyProperty IsHintInFloatingPositionProperty =
-            IsHintInFloatingPositionPropertyKey.DependencyProperty;
-
-        public bool IsHintInFloatingPosition
-        {
-            get => (bool)GetValue(IsHintInFloatingPositionProperty);
-            private set => SetValue(IsHintInFloatingPositionPropertyKey, value);
-        }
-
-        #endregion
-
-        #region UseFloating
-
-        public static readonly DependencyProperty UseFloatingProperty = DependencyProperty.Register(
-            nameof(UseFloating), typeof(bool), typeof(SmartHint), new PropertyMetadata(false));
-
-        public bool UseFloating
-        {
-            get => (bool)GetValue(UseFloatingProperty);
-            set => SetValue(UseFloatingProperty, value);
-        }
-
-        #endregion
-
-        #region FloatingScale & FloatingOffset
-
-        public static readonly DependencyProperty FloatingScaleProperty = DependencyProperty.Register(
-            nameof(FloatingScale), typeof(double), typeof(SmartHint), new PropertyMetadata(.74));
-
-        public double FloatingScale
-        {
-            get => (double)GetValue(FloatingScaleProperty);
-            set => SetValue(FloatingScaleProperty, value);
-        }
-
-        public static readonly DependencyProperty FloatingOffsetProperty = DependencyProperty.Register(
-            nameof(FloatingOffset), typeof(Point), typeof(SmartHint), new PropertyMetadata(new Point(1, -16)));
-
-        public Point FloatingOffset
-        {
-            get => (Point)GetValue(FloatingOffsetProperty);
-            set => SetValue(FloatingOffsetProperty, value);
-        }
-
-        #endregion
-
-        #region HintOpacity
-
-        public static readonly DependencyProperty HintOpacityProperty = DependencyProperty.Register(
-            nameof(HintOpacity), typeof(double), typeof(SmartHint), new PropertyMetadata(.46));
-
-        public double HintOpacity
-        {
-            get => (double)GetValue(HintOpacityProperty);
-            set => SetValue(HintOpacityProperty, value);
-        }
-
-        #endregion
-
-        static SmartHint()
-        {
-            DefaultStyleKeyProperty.OverrideMetadata(typeof(SmartHint), new FrameworkPropertyMetadata(typeof(SmartHint)));
-        }
-
-        private static void HintProxyPropertyChangedCallback(DependencyObject? dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
-        {
-            var smartHint = dependencyObject as SmartHint;
-            if (smartHint is null) return;
-
-            if (dependencyPropertyChangedEventArgs.OldValue is IHintProxy oldHintProxy)
-            {
-                oldHintProxy.IsVisibleChanged -= smartHint.OnHintProxyIsVisibleChanged;
-                oldHintProxy.ContentChanged -= smartHint.OnHintProxyContentChanged;
-                oldHintProxy.Loaded -= smartHint.OnHintProxyContentChanged;
-                oldHintProxy.FocusedChanged -= smartHint.OnHintProxyFocusedChanged;
-                oldHintProxy.Dispose();
-            }
-
-            if (dependencyPropertyChangedEventArgs.NewValue is IHintProxy newHintProxy)
-            {
-                newHintProxy.IsVisibleChanged += smartHint.OnHintProxyIsVisibleChanged;
-                newHintProxy.ContentChanged += smartHint.OnHintProxyContentChanged;
-                newHintProxy.Loaded += smartHint.OnHintProxyContentChanged;
-                newHintProxy.FocusedChanged += smartHint.OnHintProxyFocusedChanged;
-                smartHint.RefreshState(false);
-            }
-        }
-
-        protected virtual void OnHintProxyFocusedChanged(object? sender, EventArgs e)
-        {
-            if (HintProxy is { } hintProxy)
-            {
-                if (hintProxy.IsLoaded)
-                    RefreshState(true);
-                else
-                    hintProxy.Loaded += HintProxySetStateOnLoaded;
-            }
-        }
-
-        protected virtual void OnHintProxyContentChanged(object? sender, EventArgs e)
-        {
-            IsContentNullOrEmpty = HintProxy?.IsEmpty() == true;
-
-            if (HintProxy is { } hintProxy)
-            {
-                if (hintProxy.IsLoaded)
-                    RefreshState(true);
-                else
-                    hintProxy.Loaded += HintProxySetStateOnLoaded;
-            }
-        }
-
-        private void HintProxySetStateOnLoaded(object? sender, EventArgs e)
-        {
-            RefreshState(false);
-            if (HintProxy is { } hintProxy)
-            {
-                hintProxy.Loaded -= HintProxySetStateOnLoaded;
-            }
-        }
-
-        protected virtual void OnHintProxyIsVisibleChanged(object? sender, EventArgs e)
-            => RefreshState(false);
-
-        private void RefreshState(bool useTransitions)
-        {
-            IHintProxy? proxy = HintProxy;
-
-            if (proxy is null) return;
-            if (!proxy.IsVisible) return;
-
-            var action = new Action(() =>
-            {
-                string state = string.Empty;
-
-                bool isEmpty = proxy.IsEmpty();
-                bool isFocused = proxy.IsFocused();
-
-                if (UseFloating)
-                    state = !isEmpty || isFocused ? HintFloatingPositionName : HintRestingPositionName;
-                else
-                    state = !isEmpty ? HintFloatingPositionName : HintRestingPositionName;
-
-                IsHintInFloatingPosition = state == HintFloatingPositionName;
-
-                VisualStateManager.GoToState(this, state, useTransitions);
-            });
-
-            if (DesignerProperties.GetIsInDesignMode(this))
-            {
-                action();
-            }
-            else
-            {
-                Dispatcher.BeginInvoke(action);
-            }
+            newHintProxy.IsVisibleChanged += smartHint.OnHintProxyIsVisibleChanged;
+            newHintProxy.ContentChanged += smartHint.OnHintProxyContentChanged;
+            newHintProxy.Loaded += smartHint.OnHintProxyContentChanged;
+            newHintProxy.FocusedChanged += smartHint.OnHintProxyFocusedChanged;
+            smartHint.RefreshState(false);
         }
     }
+
+    protected virtual void OnHintProxyFocusedChanged(object? sender, EventArgs e)
+    {
+        if (HintProxy is { } hintProxy)
+        {
+            if (hintProxy.IsLoaded)
+                RefreshState(true);
+            else
+                hintProxy.Loaded += HintProxySetStateOnLoaded;
+        }
+    }
+
+    protected virtual void OnHintProxyContentChanged(object? sender, EventArgs e)
+    {
+        IsContentNullOrEmpty = HintProxy?.IsEmpty() == true;
+
+        if (HintProxy is { } hintProxy)
+        {
+            if (hintProxy.IsLoaded)
+                RefreshState(true);
+            else
+                hintProxy.Loaded += HintProxySetStateOnLoaded;
+        }
+    }
+
+    private void HintProxySetStateOnLoaded(object? sender, EventArgs e)
+    {
+        RefreshState(false);
+        if (HintProxy is { } hintProxy)
+        {
+            hintProxy.Loaded -= HintProxySetStateOnLoaded;
+        }
+    }
+
+    protected virtual void OnHintProxyIsVisibleChanged(object? sender, EventArgs e)
+        => RefreshState(false);
+
+    private void RefreshState(bool useTransitions)
+    {
+        IHintProxy? proxy = HintProxy;
+
+        if (proxy is null) return;
+        if (!proxy.IsVisible) return;
+
+        var action = new Action(() =>
+        {
+            string state = string.Empty;
+
+            bool isEmpty = proxy.IsEmpty();
+            bool isFocused = proxy.IsFocused();
+
+            if (UseFloating)
+                state = !isEmpty || isFocused ? HintFloatingPositionName : HintRestingPositionName;
+            else
+                state = !isEmpty ? HintFloatingPositionName : HintRestingPositionName;
+
+            IsHintInFloatingPosition = state == HintFloatingPositionName;
+
+            VisualStateManager.GoToState(this, state, useTransitions);
+        });
+
+        if (DesignerProperties.GetIsInDesignMode(this))
+        {
+            action();
+        }
+        else
+        {
+            Dispatcher.BeginInvoke(action);
+        }
+    }
+}
+
+public class VerticalAlignmentConverter : IValueConverter
+{
+    public VerticalAlignment StretchReplacement { get; set; } = VerticalAlignment.Top;
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is VerticalAlignment.Stretch ? StretchReplacement : value;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -140,7 +140,6 @@
                   </Grid.ColumnDefinitions>
                   <Grid x:Name="grid"
                         MinWidth="1"
-                        VerticalAlignment="Center"
                         HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition Width="Auto" />
@@ -604,7 +603,6 @@
                   </Grid.ColumnDefinitions>
                   <Grid x:Name="grid"
                         MinWidth="1"
-                        VerticalAlignment="Center"
                         HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition Width="Auto" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -141,7 +141,7 @@
                   </VisualStateGroup>
                 </VisualStateManager.VisualStateGroups>
                 <wpf:ScaleHost x:Name="ScaleHost" />
-                <Grid ClipToBounds="True" VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}">
+                <Grid x:Name="HintClippingGrid" ClipToBounds="True" VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}">
                   <Grid.RenderTransform>
                     <MultiBinding Converter="{StaticResource FloatingHintClippingGridTransformConverter}">
                       <Binding ElementName="ScaleHost" Path="Scale" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -11,6 +11,7 @@
   <converters:FloatingHintTransformConverter x:Key="FloatingHintClippingGridTransformConverter" ApplyScaleTransform="False" />
   <converters:FloatingHintTransformConverter x:Key="FloatingHintTransformConverter" ApplyTranslateTransform="False" />
   <converters:FloatingHintTextBlockMarginConverter x:Key="FloatingHintTextBlockMarginConverter" />
+  <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
   <system:Double x:Key="NoContentFloatingScale">1.0</system:Double>
   <CubicEase x:Key="AnimationEasingFunction" EasingMode="EaseInOut" />
 
@@ -140,7 +141,7 @@
                   </VisualStateGroup>
                 </VisualStateManager.VisualStateGroups>
                 <wpf:ScaleHost x:Name="ScaleHost" />
-                <Grid ClipToBounds="True">
+                <Grid ClipToBounds="True" VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}">
                   <Grid.RenderTransform>
                     <MultiBinding Converter="{StaticResource FloatingHintClippingGridTransformConverter}">
                       <Binding ElementName="ScaleHost" Path="Scale" />
@@ -149,7 +150,7 @@
                       <Binding Path="FloatingOffset" RelativeSource="{RelativeSource TemplatedParent}" />
                     </MultiBinding>
                   </Grid.RenderTransform>
-                  <Canvas HorizontalAlignment="Left" VerticalAlignment="Bottom" Width="{Binding ElementName=FloatingHintTextBlock, Path= ActualWidth}" Height="{Binding ElementName=FloatingHintTextBlock, Path=ActualHeight}">
+                  <Canvas HorizontalAlignment="Left" Width="{Binding ElementName=FloatingHintTextBlock, Path= ActualWidth}" Height="{Binding ElementName=FloatingHintTextBlock, Path=ActualHeight}">
                     <ContentControl x:Name="FloatingHintTextBlock"
                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -147,7 +147,6 @@
                   <Grid x:Name="grid"
                         Grid.Column="1"
                         MinWidth="1"
-                        VerticalAlignment="Center"
                         HorizontalAlignment="Stretch">
                     <Grid Grid.Column="0">
                       <Grid.ColumnDefinitions>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -128,7 +128,7 @@
                       BorderThickness="{TemplateBinding BorderThickness}"
                       CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                       SnapsToDevicePixels="True">
-                <Grid HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition />
@@ -147,6 +147,7 @@
                   <Grid x:Name="grid"
                         Grid.Column="1"
                         MinWidth="1"
+                        VerticalAlignment="Stretch"
                         HorizontalAlignment="Stretch">
                     <Grid Grid.Column="0">
                       <Grid.ColumnDefinitions>
@@ -171,7 +172,8 @@
 
                       <ScrollViewer x:Name="PART_ContentHost"
                                     Grid.Column="1"
-                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    VerticalAlignment="Stretch"
+                                    VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                     HorizontalAlignment="Stretch"
                                     HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                     Panel.ZIndex="1"
@@ -199,6 +201,8 @@
                                    HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                    HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                    UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                                   VerticalAlignment="Stretch"
+                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
                       <wpf:SmartHint.Hint>
                         <Border x:Name="HintBackgroundBorder"


### PR DESCRIPTION
Fixes #3161 

Apparently I had missed this when doing the refactoring, and I must admit I cannot recall exactly why that `VerticalAlignment` was introduced in the `TextBox` style. My guess is one of two things happened:
* Either it is a left over change I forgot to revert when trying various approaches to get the `SmartHint` to align correctly, or
* An attempt to align across the `PasswordBox` and `TextBox` styles; because `The PasswordBox` had this alignment already in its 2 styles.

~~Anyways, this PR removes it as it does not seem needed. I think there may still be an issue though (should probably be created as a separate issue): I would assume that the hint as well as the "text box content" would respect the `TextBox.VerticalContentAlignment` which I don't think it currently does.~~

~~Another thing is, as mentioned in #3161, we should put some UI tests in place to catch regressions in these horizontal/vertical alignment scenarios.~~

I managed to find a little free time after all. I updated the PR to consider `TextBox.VerticalContentAlignment` as well, and added UI tests for all `VerticalAlignment` enum values. For the "non-top-aligned" scenarios, the user will need to manually adjust the `HintAssist.FloatingOffset` to get correct floating placement of the hint (I have done this for the GIFs below).

@Keboo The UI test is probably not the best test in the world, as it simply asserts the `VerticalAlignment` value is correctly propagated down to the hint. I guess ideally it should also assert that the absolute position of the hint is "correct" (i.e. top/center/bottom of the `TextBox`).

`VerticalAlignment.Top` or `VerticalAlignment.Stretch`
![AlignmentTopOrStretch](https://user-images.githubusercontent.com/19572699/230738624-a7883ea3-8630-4172-a44c-91634b4ea6e7.gif)

`VerticalAlignment.Center`
![AlignmentMiddle](https://user-images.githubusercontent.com/19572699/230738650-0ac37d16-7ad4-4c7a-afd0-50cc6d2d746b.gif)

`VerticalAlignment.Bottom`
![AlignmentBottom](https://user-images.githubusercontent.com/19572699/230738665-6ee238cd-d1c2-4203-8562-983092beb10d.gif)
