### PR TITLE
Add initial "dry run" action for stale issues/PRs

### DIFF
--- a/.github/workflows/stale_issues_and_prs.yml
+++ b/.github/workflows/stale_issues_and_prs.yml
@@ -1,0 +1,24 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'This issue is marked stale because it has been open 30 days with no activity. Remove stale label or update the issue, otherwise it will be closed in 14 days.'
+          stale-pr-message: 'This PR is marked stale because it has been open 60 days with no activity. Remove stale label or update the PR, otherwise it will be closed in 14 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 14 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 14 days with no activity.'
+          only-issue-labels: Waiting on feedback            # Only consider issues with 'Waiting on feedback' labels
+          exempt-draft-pr: true                             # Do not consider a draft PR stale
+          exempt-all-pr-milestones: true                    # Do not consider a PR associated with a Milestone stale
+          days-before-stale: 30
+          days-before-pr-stale: 60
+          days-before-close: 14
+          ascending: true                                   # Start with the oldest issues/PRs first
+          debug-only: true                                  # Currently only doing "dry runs" until we're satisfied with the configuration
+          operations-per-run: 1000                          # GitHub API calls are rate limited. When debug-only is "false", this value should be approx. 30 (default) or less


### PR DESCRIPTION
Adding a first-draft of the "stale" GitHub action configuration which is supposed to perform the actions below.

Note that it is currently configured with `debug-only=true` which means it is effectively performing dry runs, and we can inspect the actions it "would have performed" in the logs. Once we're satisfied, we can disable debugging (and adjust the `operations-per-run` to avoid rate limiting!)

* Mark issues stale after 30 days if they are marked with the `Waiting on feedback` label.
* Mark PRs stale after 60 days if they are NOT drafts and NOT associated with a milestone.
* Close issues/PRs 14 days after marking them stale. Any activity after marking an issue/PR stale will remove the stale label and effectively "reset" for the given issue/PR.
* Consider issues/PRs from oldest to newest. This should probably be changed eventually, but I think it is probably good to start at the bottom of the backlog.