### PR TITLE
Additional SmartHint refactoring

### DIFF
--- a/MainDemo.Wpf/Domain/SmartHintViewModel.cs
+++ b/MainDemo.Wpf/Domain/SmartHintViewModel.cs
@@ -9,17 +9,27 @@ internal class SmartHintViewModel : ViewModelBase
     private double _selectedFloatingScale = 0.75;
     private bool _showClearButton = true;
     private bool _showLeadingIcon = true;
+    private bool _showTrailingIcon = true;
     private string _hintText = "Hint text";
     private string _helperText = "Helper text";
     private Point _selectedFloatingOffset = new(0, -16);
     private bool _applyCustomPadding;
     private Thickness _selectedCustomPadding = new(5);
+    private double _selectedCustomHeight = double.NaN;
+    private VerticalAlignment _selectedVerticalAlignment = VerticalAlignment.Center;
+    private double _selectedLeadingIconSize = 20;
+    private double _selectedTrailingIconSize = 20;
+    private string? _prefixText;
+    private string? _suffixText;
 
     public IEnumerable<FloatingHintHorizontalAlignment> HorizontalAlignmentOptions { get; } = Enum.GetValues(typeof(FloatingHintHorizontalAlignment)).OfType<FloatingHintHorizontalAlignment>();
     public IEnumerable<double> FloatingScaleOptions { get; } = new[] {0.25, 0.5, 0.75, 1.0};
-    public IEnumerable<Point> FloatingOffsetOptions { get; } = new[] { new Point(0, -16), new Point(0, 16), new Point(16, 16), new Point(-16, -16) };
+    public IEnumerable<Point> FloatingOffsetOptions { get; } = new[] { new Point(0, -16), new Point(0, 16), new Point(16, 16), new Point(-16, -16), new Point(0, -40) };
     public IEnumerable<string> ComboBoxOptions { get; } = new[] {"Option 1", "Option 2", "Option 3"};
     public IEnumerable<Thickness> CustomPaddingOptions { get; } = new [] { new Thickness(0), new Thickness(5), new Thickness(10), new Thickness(15) };
+    public IEnumerable<double> CustomHeightOptions { get; } = new[] { double.NaN, 50, 75, 100 };
+    public IEnumerable<VerticalAlignment> VerticalAlignmentOptions { get; } = (VerticalAlignment[])Enum.GetValues(typeof(VerticalAlignment));
+    public IEnumerable<double> IconSizeOptions { get; } = new[] { 10.0, 15, 20, 30, 50, 75 };
 
     public bool FloatHint
     {
@@ -81,6 +91,16 @@ internal class SmartHintViewModel : ViewModelBase
         }
     }
 
+    public bool ShowTrailingIcon
+    {
+        get => _showTrailingIcon;
+        set
+        {
+            _showTrailingIcon = value;
+            OnPropertyChanged();
+        }
+    }
+
     public string HintText
     {
         get => _hintText;
@@ -117,6 +137,66 @@ internal class SmartHintViewModel : ViewModelBase
         set
         {
             _selectedCustomPadding = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public double SelectedCustomHeight
+    {
+        get => _selectedCustomHeight;
+        set
+        {
+            _selectedCustomHeight = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public VerticalAlignment SelectedVerticalAlignment
+    {
+        get => _selectedVerticalAlignment;
+        set
+        {
+            _selectedVerticalAlignment = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public double SelectedLeadingIconSize
+    {
+        get => _selectedLeadingIconSize;
+        set
+        {
+            _selectedLeadingIconSize = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public double SelectedTrailingIconSize
+    {
+        get => _selectedTrailingIconSize;
+        set
+        {
+            _selectedTrailingIconSize = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string? PrefixText
+    {
+        get => _prefixText;
+        set
+        {
+            _prefixText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string? SuffixText
+    {
+        get => _suffixText;
+        set
+        {
+            _suffixText = value;
             OnPropertyChanged();
         }
     }

--- a/MainDemo.Wpf/Domain/SmartHintViewModel.cs
+++ b/MainDemo.Wpf/Domain/SmartHintViewModel.cs
@@ -1,10 +1,12 @@
-﻿using MaterialDesignThemes.Wpf;
+﻿using System.Windows.Media;
+using MaterialDesignThemes.Wpf;
 
 namespace MaterialDesignDemo.Domain;
 
 internal class SmartHintViewModel : ViewModelBase
 {
     public static Point DefaultFloatingOffset { get; } = new(0, -16);
+    public static FontFamily DefaultFontFamily = (FontFamily)new MaterialDesignFontExtension().ProvideValue(null!);
 
     private bool _floatHint = true;
     private FloatingHintHorizontalAlignment _selectedAlignment = FloatingHintHorizontalAlignment.Inherit;
@@ -24,6 +26,7 @@ internal class SmartHintViewModel : ViewModelBase
     private string? _prefixText;
     private string? _suffixText;
     private double _selectedFontSize = double.NaN;
+    private FontFamily? _selectedFontFamily = DefaultFontFamily;
 
     public IEnumerable<FloatingHintHorizontalAlignment> HorizontalAlignmentOptions { get; } = Enum.GetValues(typeof(FloatingHintHorizontalAlignment)).OfType<FloatingHintHorizontalAlignment>();
     public IEnumerable<double> FloatingScaleOptions { get; } = new[] {0.25, 0.5, 0.75, 1.0};
@@ -34,6 +37,7 @@ internal class SmartHintViewModel : ViewModelBase
     public IEnumerable<VerticalAlignment> VerticalAlignmentOptions { get; } = (VerticalAlignment[])Enum.GetValues(typeof(VerticalAlignment));
     public IEnumerable<double> IconSizeOptions { get; } = new[] { 10.0, 15, 20, 30, 50, 75 };
     public IEnumerable<double> FontSizeOptions { get; } = new[] { double.NaN, 8, 12, 16, 20, 24, 28 };
+    public IEnumerable<FontFamily> FontFamilyOptions { get; } = new FontFamily[] { DefaultFontFamily }.Concat(Fonts.SystemFontFamilies.OrderBy(f => f.Source));
 
     public bool FloatHint
     {
@@ -211,6 +215,16 @@ internal class SmartHintViewModel : ViewModelBase
         set
         {
             _selectedFontSize = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public FontFamily? SelectedFontFamily
+    {
+        get => _selectedFontFamily;
+        set
+        {
+            _selectedFontFamily = value;
             OnPropertyChanged();
         }
     }

--- a/MainDemo.Wpf/Domain/SmartHintViewModel.cs
+++ b/MainDemo.Wpf/Domain/SmartHintViewModel.cs
@@ -23,6 +23,7 @@ internal class SmartHintViewModel : ViewModelBase
     private double _selectedTrailingIconSize = 20;
     private string? _prefixText;
     private string? _suffixText;
+    private double _selectedFontSize = double.NaN;
 
     public IEnumerable<FloatingHintHorizontalAlignment> HorizontalAlignmentOptions { get; } = Enum.GetValues(typeof(FloatingHintHorizontalAlignment)).OfType<FloatingHintHorizontalAlignment>();
     public IEnumerable<double> FloatingScaleOptions { get; } = new[] {0.25, 0.5, 0.75, 1.0};
@@ -32,6 +33,7 @@ internal class SmartHintViewModel : ViewModelBase
     public IEnumerable<double> CustomHeightOptions { get; } = new[] { double.NaN, 50, 75, 100 };
     public IEnumerable<VerticalAlignment> VerticalAlignmentOptions { get; } = (VerticalAlignment[])Enum.GetValues(typeof(VerticalAlignment));
     public IEnumerable<double> IconSizeOptions { get; } = new[] { 10.0, 15, 20, 30, 50, 75 };
+    public IEnumerable<double> FontSizeOptions { get; } = new[] { double.NaN, 8, 12, 16, 20, 24, 28 };
 
     public bool FloatHint
     {
@@ -199,6 +201,16 @@ internal class SmartHintViewModel : ViewModelBase
         set
         {
             _suffixText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public double SelectedFontSize
+    {
+        get => _selectedFontSize;
+        set
+        {
+            _selectedFontSize = value;
             OnPropertyChanged();
         }
     }

--- a/MainDemo.Wpf/Domain/SmartHintViewModel.cs
+++ b/MainDemo.Wpf/Domain/SmartHintViewModel.cs
@@ -4,6 +4,8 @@ namespace MaterialDesignDemo.Domain;
 
 internal class SmartHintViewModel : ViewModelBase
 {
+    public static Point DefaultFloatingOffset { get; } = new(0, -16);
+
     private bool _floatHint = true;
     private FloatingHintHorizontalAlignment _selectedAlignment = FloatingHintHorizontalAlignment.Inherit;
     private double _selectedFloatingScale = 0.75;
@@ -12,7 +14,7 @@ internal class SmartHintViewModel : ViewModelBase
     private bool _showTrailingIcon = true;
     private string _hintText = "Hint text";
     private string _helperText = "Helper text";
-    private Point _selectedFloatingOffset = new(0, -16);
+    private Point _selectedFloatingOffset = DefaultFloatingOffset;
     private bool _applyCustomPadding;
     private Thickness _selectedCustomPadding = new(5);
     private double _selectedCustomHeight = double.NaN;
@@ -24,7 +26,7 @@ internal class SmartHintViewModel : ViewModelBase
 
     public IEnumerable<FloatingHintHorizontalAlignment> HorizontalAlignmentOptions { get; } = Enum.GetValues(typeof(FloatingHintHorizontalAlignment)).OfType<FloatingHintHorizontalAlignment>();
     public IEnumerable<double> FloatingScaleOptions { get; } = new[] {0.25, 0.5, 0.75, 1.0};
-    public IEnumerable<Point> FloatingOffsetOptions { get; } = new[] { new Point(0, -16), new Point(0, 16), new Point(16, 16), new Point(-16, -16), new Point(0, -40) };
+    public IEnumerable<Point> FloatingOffsetOptions { get; } = new[] { DefaultFloatingOffset, new Point(0, -25), new Point(16, -16), new Point(-16, -16), new Point(0, -50) };
     public IEnumerable<string> ComboBoxOptions { get; } = new[] {"Option 1", "Option 2", "Option 3"};
     public IEnumerable<Thickness> CustomPaddingOptions { get; } = new [] { new Thickness(0), new Thickness(5), new Thickness(10), new Thickness(15) };
     public IEnumerable<double> CustomHeightOptions { get; } = new[] { double.NaN, 50, 75, 100 };

--- a/MainDemo.Wpf/MainWindow.xaml
+++ b/MainDemo.Wpf/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:system="clr-namespace:System;assembly=mscorlib"
         Title="Material Design in XAML"
-        Width="1100"
+        Width="1150"
         MaxHeight="{Binding Source={x:Static SystemParameters.MaximizedPrimaryScreenHeight}}"
         d:DataContext="{d:DesignInstance domain:MainWindowViewModel}"
         AutomationProperties.Name="{Binding Title, RelativeSource={RelativeSource Self}}"

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -16,10 +16,8 @@
       <materialDesign:MathConverter x:Key="SubtractConverter" Operation="Subtract" />
       <local:CustomPaddingConverter x:Key="CustomPaddingConverter" />
       <Style TargetType="{x:Type smtx:XamlDisplay}" BasedOn="{StaticResource {x:Type smtx:XamlDisplay}}">
-        <Setter Property="Margin" Value="0,10,16,16" />
+        <Setter Property="Margin" Value="10,10,10,16" />
         <Setter Property="VerticalAlignment" Value="Top" />
-        <Setter Property="HorizontalAlignment" Value="Left" />
-        <Setter Property="Width" Value="186" />
         <Setter Property="materialDesign:HintAssist.FloatingHintHorizontalAlignment" Value="{Binding SelectedAlignment}" />
         <Setter Property="materialDesign:HintAssist.FloatingScale" Value="{Binding SelectedFloatingScale}" />
         <Setter Property="materialDesign:HintAssist.FloatingOffset" Value="{Binding SelectedFloatingOffset}" />
@@ -27,21 +25,22 @@
         <Setter Property="materialDesign:HintAssist.HelperText" Value="{Binding HelperText}" />
       </Style>
       <Style x:Key="StyleNameIndicator" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource MaterialDesignCaptionTextBlock}">
-        <Setter Property="Margin" Value="0,10,16,0" />
+        <Setter Property="Margin" Value="0,10,0,0" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalAlignment" Value="Left" />
-        <Setter Property="TextWrapping" Value="Wrap" />
       </Style>
       <materialDesign:PackIconKind x:Key="LeadingIcon">Github</materialDesign:PackIconKind>
+      <materialDesign:PackIconKind x:Key="TrailingIcon">Fungus</materialDesign:PackIconKind>
     </Grid.Resources>
 
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto" />
       <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
       <RowDefinition Height="*" />
     </Grid.RowDefinitions>
 
-    <GroupBox Grid.Row="0" Margin="8,0,16,16" Header="Hint Settings" Style="{StaticResource MaterialDesignCardGroupBox}">
+    <GroupBox Grid.Row="0" Margin="8,0,16,4" Header="Hint Settings" Style="{StaticResource MaterialDesignCardGroupBox}">
       <StackPanel Orientation="Vertical">
         <StackPanel Orientation="Horizontal" Margin="10">
           <CheckBox Content="IsFloating" IsChecked="{Binding FloatHint}" />
@@ -52,41 +51,52 @@
           <TextBlock Text="FloatingOffset:" VerticalAlignment="Center" Margin="20,0,0,0" />
           <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FloatingOffsetOptions}" SelectedItem="{Binding SelectedFloatingOffset, Mode=TwoWay}" />
           <CheckBox Content="HasClearButton" IsChecked="{Binding ShowClearButton}" Margin="20,0,0,0" />
-          <CheckBox Content="HasLeadingIcon" IsChecked="{Binding ShowLeadingIcon}" Margin="20,0,0,0" />
+          <CheckBox Content="HasErrors" IsChecked="False" Checked="HasErrors_OnToggled" Unchecked="HasErrors_OnToggled" Margin="20,0,0,0" />
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Margin="10">
-          <TextBox Text="{Binding HintText, UpdateSourceTrigger=PropertyChanged}"  Width="200" />
-          <TextBox Text="{Binding HelperText, UpdateSourceTrigger=PropertyChanged}" Margin="20,0,0,0" Width="200" />
-          <CheckBox x:Name="CustomPaddingCheckBox" Content="Custom Padding" IsChecked="{Binding ApplyCustomPadding}" Margin="20,0,0,0" />
-          <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding CustomPaddingOptions}" SelectedItem="{Binding SelectedCustomPadding, Mode=TwoWay}" IsEnabled="{Binding ElementName=CustomPaddingCheckBox, Path=IsChecked}" />
-          <CheckBox Content="HasErrors" IsChecked="False" Checked="HasErrors_OnToggled" Unchecked="HasErrors_OnToggled" Margin="20,0,0,0" />
+          <TextBox Text="{Binding HintText, UpdateSourceTrigger=PropertyChanged}" materialDesign:HintAssist.Hint="Hint text" materialDesign:TextFieldAssist.HasClearButton="True" Width="200" />
+          <TextBox Text="{Binding HelperText, UpdateSourceTrigger=PropertyChanged}" materialDesign:HintAssist.Hint="Helper text" materialDesign:TextFieldAssist.HasClearButton="True" Margin="20,0,0,0" Width="200" />
+          <CheckBox x:Name="CheckBoxLeadingIcon" Content="HasLeadingIcon" IsChecked="{Binding ShowLeadingIcon}" Margin="20,0,0,0" />
+          <TextBlock Text="Size:" VerticalAlignment="Center" Margin="10,2,0,0" />
+          <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding IconSizeOptions}" SelectedItem="{Binding SelectedLeadingIconSize, Mode=TwoWay}" IsEnabled="{Binding ElementName=CheckBoxLeadingIcon, Path=IsChecked}" />
+          <CheckBox x:Name="CheckBoxTrailingIcon" Content="HasLeadingIcon" IsChecked="{Binding ShowTrailingIcon}" Margin="20,0,0,0" />
+          <TextBlock Text="Size:" VerticalAlignment="Center" Margin="10,2,0,0" />
+          <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding IconSizeOptions}" SelectedItem="{Binding SelectedTrailingIconSize, Mode=TwoWay}" IsEnabled="{Binding ElementName=CheckBoxTrailingIcon, Path=IsChecked}" />
         </StackPanel>
       </StackPanel>
     </GroupBox>
 
-    <Grid Grid.Row="1" Margin="0,16,0,0">
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" Width="200" />
-        <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-        <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-        <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-        <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
-      </Grid.ColumnDefinitions>
-      <Grid.RowDefinitions>
-        <RowDefinition Height="Auto" />
-        <RowDefinition Height="Auto" />
-      </Grid.RowDefinitions>
+    <GroupBox Grid.Row="1" Margin="8,0,16,16" Header="Control Settings" Style="{StaticResource MaterialDesignCardGroupBox}">
+      <StackPanel Orientation="Horizontal" Margin="10">
+        <CheckBox x:Name="CustomPaddingCheckBox" Content="Custom Padding" IsChecked="{Binding ApplyCustomPadding}" />
+        <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding CustomPaddingOptions}" SelectedItem="{Binding SelectedCustomPadding, Mode=TwoWay}" IsEnabled="{Binding ElementName=CustomPaddingCheckBox, Path=IsChecked}" />
+        <TextBlock Text="Custom Height:" VerticalAlignment="Center" Margin="20,0,0,0" />
+        <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding CustomHeightOptions}" SelectedItem="{Binding SelectedCustomHeight, Mode=TwoWay}" />
+        <TextBlock Text="VerticalContentAlignment:" VerticalAlignment="Center" Margin="20,0,0,0" />
+        <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding VerticalAlignmentOptions}" SelectedItem="{Binding SelectedVerticalAlignment, Mode=TwoWay}" />
+        <TextBox Text="{Binding PrefixText, UpdateSourceTrigger=PropertyChanged}" materialDesign:HintAssist.Hint="Prefix text" materialDesign:TextFieldAssist.HasClearButton="True" Margin="20,0,0,0" Width="200" MaxLength="3" />
+        <TextBox Text="{Binding SuffixText, UpdateSourceTrigger=PropertyChanged}" materialDesign:HintAssist.Hint="Suffix text" materialDesign:TextFieldAssist.HasClearButton="True" Margin="20,0,0,0" Width="200" MaxLength="3" />
+      </StackPanel>
+    </GroupBox>
 
-      <TextBlock Style="{StaticResource MaterialDesignHeadline5TextBlock}" Text="--- Alignments ---" Grid.Column="1" Grid.Row="0" Grid.ColumnSpan="4" HorizontalAlignment="Center" Margin="0,0,0,10" />
-      <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Left" Grid.Column="1" Grid.Row="1" HorizontalAlignment="Center" />
-      <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Center" Grid.Column="2" Grid.Row="1" HorizontalAlignment="Center" />
-      <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Right" Grid.Column="3" Grid.Row="1" HorizontalAlignment="Center" />
-      <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Stretch" Grid.Column="4" Grid.Row="1" HorizontalAlignment="Center" />
+    <Grid Grid.Row="2" Margin="8,16,36,0">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="*" />
+      </Grid.ColumnDefinitions>
+
+      <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Left" Grid.Column="1" HorizontalAlignment="Stretch" TextAlignment="Center" Margin="10,0,20,0" />
+      <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Center" Grid.Column="2" HorizontalAlignment="Stretch" TextAlignment="Center" Margin="10,0,20,0" />
+      <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Right" Grid.Column="3" HorizontalAlignment="Stretch" TextAlignment="Center" Margin="10,0,20,0" />
+      <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Stretch" Grid.Column="4" HorizontalAlignment="Stretch" TextAlignment="Center" Margin="10,0,20,0" />
     </Grid>
 
     <!-- Invisible controls only used to be able to fallback to default style values -->
-    <StackPanel Grid.Row="2" Visibility="Collapsed">
+    <StackPanel Grid.Row="3" Visibility="Collapsed">
       <TextBox x:Name="MaterialDesignFloatingHintTextBoxDefaults" Style="{StaticResource MaterialDesignFloatingHintTextBox}" />
       <TextBox x:Name="MaterialDesignFilledTextBoxDefaults" Style="{StaticResource MaterialDesignFilledTextBox}" />
       <TextBox x:Name="MaterialDesignOutlinedTextBoxDefaults" Style="{StaticResource MaterialDesignOutlinedTextBox}" />
@@ -108,20 +118,28 @@
       <materialDesign:TimePicker x:Name="MaterialDesignOutlinedTimePickerDefaults" Style="{StaticResource MaterialDesignOutlinedTimePicker}" />
     </StackPanel>
 
-    <ScrollViewer Grid.Row="2" VerticalAlignment="Top" materialDesign:ScrollViewerAssist.BubbleVerticalScroll="False" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Hidden" Margin="0,20,0,0"
-                  Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ScrollViewer}}, Path=ViewportHeight, Converter={StaticResource SubtractConverter}, ConverterParameter=290}">
-      <StackPanel x:Name="ControlsPanel" Margin="8,0,16,0" VerticalAlignment="Top" HorizontalAlignment="Left">
+    <ScrollViewer Grid.Row="3" VerticalAlignment="Top" materialDesign:ScrollViewerAssist.BubbleVerticalScroll="False" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Hidden" Margin="0,20,0,0"
+                  Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ScrollViewer}}, Path=ViewportHeight, Converter={StaticResource SubtractConverter}, ConverterParameter=350}">
+      <StackPanel x:Name="ControlsPanel" Margin="8,0,16,0" VerticalAlignment="Top" HorizontalAlignment="Stretch">
 
         <!-- TextBox variants -->
         <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="TextBox styles" />
-        <Grid>
+        <Grid HorizontalAlignment="Stretch">
           <Grid.Resources>
             <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}">
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -135,10 +153,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFloatingHintTextBox</TextBlock>
@@ -161,8 +179,16 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -176,10 +202,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFilledTextBox</TextBlock>
@@ -202,8 +228,16 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -217,10 +251,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignOutlinedTextBox</TextBlock>
@@ -245,8 +279,16 @@
             <Style TargetType="{x:Type RichTextBox}" BasedOn="{StaticResource MaterialDesignRichTextBox}">
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="local:SmartHint.RichTextBoxText" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="HorizontalContentAlignment" Value="Stretch" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -256,19 +298,24 @@
                   </MultiBinding>
                 </Setter.Value>
               </Setter>
+
+              <!-- TODO: This is needed in order to avoid the RichTextBox only showing a single character per line?!?! There must be a bug somewhere! Min/MinWidth both "work" -->
+              <!--       Also note that it does not work correctly, it now simply allows characters up to the width defined below before wrapping to the next line. -->
+              <Setter Property="MinWidth" Value="100" />
+
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignRichTextBox</TextBlock>
           <smtx:XamlDisplay Grid.Column="1" UniqueKey="richtextbox_left">
-            <RichTextBox HorizontalContentAlignment="Left" />
+            <RichTextBox />
           </smtx:XamlDisplay>
           <smtx:XamlDisplay Grid.Column="2" UniqueKey="richtextbox_center">
             <RichTextBox HorizontalContentAlignment="Center" />
@@ -289,12 +336,19 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
-                    <Binding ElementName="MaterialDesignFloatingHintPasswordDefaults" Path="Padding" />
+                    <Binding ElementName="MaterialDesignFloatingHintPasswordBoxDefaults" Path="Padding" />
                     <Binding Path="ApplyCustomPadding" />
                     <Binding Path="SelectedCustomPadding" />
                   </MultiBinding>
@@ -304,10 +358,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFloatingHintPasswordBox</TextBlock>
@@ -330,8 +384,15 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -345,10 +406,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFilledPasswordBox</TextBlock>
@@ -371,8 +432,15 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -386,10 +454,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignOutlinedPasswordBox</TextBlock>
@@ -419,9 +487,16 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -435,10 +510,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFloatingHintRevealPasswordBox</TextBlock>
@@ -461,9 +536,16 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -477,10 +559,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFilledRevealPasswordBox</TextBlock>
@@ -503,9 +585,16 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -519,10 +608,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignOutlinedRevealPasswordBox</TextBlock>
@@ -551,10 +640,17 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -568,10 +664,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFloatingHintComboBox</TextBlock>
@@ -594,10 +690,17 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -611,10 +714,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFilledComboBox</TextBlock>
@@ -637,10 +740,17 @@
               <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -654,10 +764,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignOutlinedComboBox</TextBlock>
@@ -682,8 +792,15 @@
             <Style TargetType="{x:Type DatePicker}" BasedOn="{StaticResource MaterialDesignFloatingHintDatePicker}">
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -697,10 +814,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFloatingHintDatePicker</TextBlock>
@@ -722,8 +839,15 @@
             <Style TargetType="{x:Type DatePicker}" BasedOn="{StaticResource MaterialDesignFilledDatePicker}">
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -737,10 +861,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFilledDatePicker</TextBlock>
@@ -762,8 +886,15 @@
             <Style TargetType="{x:Type DatePicker}" BasedOn="{StaticResource MaterialDesignOutlinedDatePicker}">
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -777,10 +908,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignOutlinedDatePicker</TextBlock>
@@ -805,8 +936,15 @@
             <Style TargetType="{x:Type materialDesign:TimePicker}" BasedOn="{StaticResource MaterialDesignFloatingHintTimePicker}">
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -820,10 +958,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFloatingHintTimePicker</TextBlock>
@@ -845,8 +983,15 @@
             <Style TargetType="{x:Type materialDesign:TimePicker}" BasedOn="{StaticResource MaterialDesignFilledTimePicker}">
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -860,10 +1005,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFilledTimePicker</TextBlock>
@@ -885,8 +1030,15 @@
             <Style TargetType="{x:Type materialDesign:TimePicker}" BasedOn="{StaticResource MaterialDesignOutlinedTimePicker}">
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -900,10 +1052,10 @@
           </Grid.Resources>
           <Grid.ColumnDefinitions>
             <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupLeftAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupCenterAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupRightAlignment" Width="Auto" />
-            <ColumnDefinition SharedSizeGroup="SizeGroupStretchAlignment" Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignOutlinedTimePicker</TextBlock>

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -37,6 +37,9 @@
       <DataTemplate x:Key="CustomHeightTemplate" DataType="{x:Type system:Double}">
         <TextBlock Text="{Binding Converter={StaticResource DoubleOptionToStringConverter}}" />
       </DataTemplate>
+      <DataTemplate x:Key="FontSizeTemplate" DataType="{x:Type system:Double}">
+        <TextBlock Text="{Binding Converter={StaticResource DoubleOptionToStringConverter}}" />
+      </DataTemplate>
 
       <local:PointOptionToStringConverter x:Key="FloatingOffsetOptionToStringConverter" DefaultValue="{x:Static domain:SmartHintViewModel.DefaultFloatingOffset}" />
       <DataTemplate x:Key="FloatingOffsetTemplate">
@@ -86,8 +89,10 @@
         <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding CustomHeightOptions}" SelectedItem="{Binding SelectedCustomHeight, Mode=TwoWay}" ItemTemplate="{StaticResource CustomHeightTemplate}"/>
         <TextBlock Text="VerticalContentAlignment:" VerticalAlignment="Center" Margin="20,0,0,0" />
         <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding VerticalAlignmentOptions}" SelectedItem="{Binding SelectedVerticalAlignment, Mode=TwoWay}" />
-        <TextBox Text="{Binding PrefixText, UpdateSourceTrigger=PropertyChanged}" materialDesign:HintAssist.Hint="Prefix text" materialDesign:TextFieldAssist.HasClearButton="True" Margin="20,0,0,0" Width="200" MaxLength="3" />
-        <TextBox Text="{Binding SuffixText, UpdateSourceTrigger=PropertyChanged}" materialDesign:HintAssist.Hint="Suffix text" materialDesign:TextFieldAssist.HasClearButton="True" Margin="20,0,0,0" Width="200" MaxLength="3" />
+        <TextBox Text="{Binding PrefixText, UpdateSourceTrigger=PropertyChanged}" materialDesign:HintAssist.Hint="Prefix text" materialDesign:TextFieldAssist.HasClearButton="True" Margin="20,0,0,0" Width="50" MaxLength="3" />
+        <TextBox Text="{Binding SuffixText, UpdateSourceTrigger=PropertyChanged}" materialDesign:HintAssist.Hint="Suffix text" materialDesign:TextFieldAssist.HasClearButton="True" Margin="20,0,0,0" Width="50" MaxLength="3" />
+        <TextBlock Text="FontSize:" VerticalAlignment="Center" Margin="20,0,0,0" />
+        <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FontSizeOptions}" SelectedItem="{Binding SelectedFontSize, Mode=TwoWay}" ItemTemplate="{StaticResource FontSizeTemplate}" />
       </StackPanel>
     </GroupBox>
 
@@ -151,6 +156,7 @@
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -200,6 +206,7 @@
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -249,6 +256,7 @@
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -300,7 +308,7 @@
               <Setter Property="local:SmartHint.RichTextBoxText" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
-              <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -358,6 +366,7 @@
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -407,6 +416,7 @@
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -456,6 +466,7 @@
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -513,6 +524,7 @@
               <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -563,6 +575,7 @@
               <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -613,6 +626,7 @@
               <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -670,6 +684,7 @@
               <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -721,6 +736,7 @@
               <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -772,6 +788,7 @@
               <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -823,6 +840,7 @@
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -871,6 +889,7 @@
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -919,6 +938,7 @@
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -970,6 +990,7 @@
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -1018,6 +1039,7 @@
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -1066,6 +1088,7 @@
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -42,8 +42,11 @@
         <TextBlock Text="{Binding Converter={StaticResource DoubleOptionToStringConverter}}" />
       </DataTemplate>
       <DataTemplate x:Key="FontSizeTemplate" DataType="{x:Type system:Double}">
-        <TextBlock Text="{Binding Converter={StaticResource DoubleOptionToStringConverter}}" Foreground="DarkRed" />
+        <TextBlock Text="{Binding Converter={StaticResource DoubleOptionToStringConverter}}" />
       </DataTemplate>
+      <Style x:Key="FontSizeHelperTextStyle" TargetType="TextBlock" BasedOn="{StaticResource MaterialDesignHelperTextBlock}">
+        <Setter Property="Foreground" Value="DarkRed" />
+      </Style>
 
       <local:PointOptionToStringConverter x:Key="FloatingOffsetOptionToStringConverter" DefaultValue="{x:Static domain:SmartHintViewModel.DefaultFloatingOffset}" />
       <DataTemplate x:Key="FloatingOffsetTemplate">
@@ -102,8 +105,10 @@
         <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding VerticalAlignmentOptions}" SelectedItem="{Binding SelectedVerticalAlignment, Mode=TwoWay}" />
         <TextBox Text="{Binding PrefixText, UpdateSourceTrigger=PropertyChanged}" materialDesign:HintAssist.Hint="Prefix text" materialDesign:TextFieldAssist.HasClearButton="True" Margin="20,0,0,0" Width="50" MaxLength="3" />
         <TextBox Text="{Binding SuffixText, UpdateSourceTrigger=PropertyChanged}" materialDesign:HintAssist.Hint="Suffix text" materialDesign:TextFieldAssist.HasClearButton="True" Margin="20,0,0,0" Width="50" MaxLength="3" />
-        <TextBlock Text="FontSize:" VerticalAlignment="Center" Margin="20,0,0,0" Foreground="DarkRed"/>
-        <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FontSizeOptions}" SelectedItem="{Binding SelectedFontSize, Mode=TwoWay}" ItemTemplate="{StaticResource FontSizeTemplate}" />
+        <TextBlock Text="FontSize:" VerticalAlignment="Center" Margin="20,0,0,0" />
+        <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FontSizeOptions}" SelectedItem="{Binding SelectedFontSize, Mode=TwoWay}" ItemTemplate="{StaticResource FontSizeTemplate}" Width="160"
+                  materialDesign:HintAssist.HelperText="Currently only 'Default' is supported"
+                  materialDesign:HintAssist.HelperTextStyle="{StaticResource FontSizeHelperTextStyle}"/>
       </StackPanel>
     </GroupBox>
 

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -38,7 +38,7 @@
         <TextBlock Text="{Binding Converter={StaticResource DoubleOptionToStringConverter}}" />
       </DataTemplate>
       <DataTemplate x:Key="FontSizeTemplate" DataType="{x:Type system:Double}">
-        <TextBlock Text="{Binding Converter={StaticResource DoubleOptionToStringConverter}}" />
+        <TextBlock Text="{Binding Converter={StaticResource DoubleOptionToStringConverter}}" Foreground="DarkRed" />
       </DataTemplate>
 
       <local:PointOptionToStringConverter x:Key="FloatingOffsetOptionToStringConverter" DefaultValue="{x:Static domain:SmartHintViewModel.DefaultFloatingOffset}" />
@@ -91,7 +91,7 @@
         <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding VerticalAlignmentOptions}" SelectedItem="{Binding SelectedVerticalAlignment, Mode=TwoWay}" />
         <TextBox Text="{Binding PrefixText, UpdateSourceTrigger=PropertyChanged}" materialDesign:HintAssist.Hint="Prefix text" materialDesign:TextFieldAssist.HasClearButton="True" Margin="20,0,0,0" Width="50" MaxLength="3" />
         <TextBox Text="{Binding SuffixText, UpdateSourceTrigger=PropertyChanged}" materialDesign:HintAssist.Hint="Suffix text" materialDesign:TextFieldAssist.HasClearButton="True" Margin="20,0,0,0" Width="50" MaxLength="3" />
-        <TextBlock Text="FontSize:" VerticalAlignment="Center" Margin="20,0,0,0" />
+        <TextBlock Text="FontSize:" VerticalAlignment="Center" Margin="20,0,0,0" Foreground="DarkRed"/>
         <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FontSizeOptions}" SelectedItem="{Binding SelectedFontSize, Mode=TwoWay}" ItemTemplate="{StaticResource FontSizeTemplate}" />
       </StackPanel>
     </GroupBox>

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -288,6 +288,7 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="local:SmartHint.RichTextBoxText" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="HorizontalContentAlignment" Value="Stretch" />
               <Setter Property="Padding">
                 <Setter.Value>
@@ -345,6 +346,7 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -393,6 +395,7 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -441,6 +444,7 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -497,6 +501,7 @@
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -546,6 +551,7 @@
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -595,6 +601,7 @@
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -651,6 +658,7 @@
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -701,6 +709,7 @@
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -751,6 +760,7 @@
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -801,6 +811,7 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -848,6 +859,7 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -895,6 +907,7 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -945,6 +958,7 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -992,6 +1006,7 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
@@ -1039,6 +1054,7 @@
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -7,6 +7,7 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:domain="clr-namespace:MaterialDesignDemo.Domain"
              xmlns:local="clr-namespace:MaterialDesignDemo"
+             xmlns:system="clr-namespace:System;assembly=System.Runtime"
              mc:Ignorable="d"
              x:Name="_root"
              d:DataContext="{d:DesignInstance domain:SmartHintViewModel, IsDesignTimeCreatable=False}"
@@ -31,6 +32,16 @@
       </Style>
       <materialDesign:PackIconKind x:Key="LeadingIcon">Github</materialDesign:PackIconKind>
       <materialDesign:PackIconKind x:Key="TrailingIcon">Fungus</materialDesign:PackIconKind>
+
+      <local:DoubleOptionToStringConverter x:Key="DoubleOptionToStringConverter" DefaultValue="{x:Static system:Double.NaN}" />
+      <DataTemplate x:Key="CustomHeightTemplate" DataType="{x:Type system:Double}">
+        <TextBlock Text="{Binding Converter={StaticResource DoubleOptionToStringConverter}}" />
+      </DataTemplate>
+
+      <local:PointOptionToStringConverter x:Key="FloatingOffsetOptionToStringConverter" DefaultValue="{x:Static domain:SmartHintViewModel.DefaultFloatingOffset}" />
+      <DataTemplate x:Key="FloatingOffsetTemplate">
+        <TextBlock Text="{Binding Converter={StaticResource FloatingOffsetOptionToStringConverter}}" />
+      </DataTemplate>
     </Grid.Resources>
 
     <Grid.RowDefinitions>
@@ -49,7 +60,7 @@
           <TextBlock Text="FloatingScale:" VerticalAlignment="Center" Margin="20,0,0,0" />
           <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FloatingScaleOptions}" SelectedItem="{Binding SelectedFloatingScale, Mode=TwoWay}" ItemStringFormat="F2" />
           <TextBlock Text="FloatingOffset:" VerticalAlignment="Center" Margin="20,0,0,0" />
-          <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FloatingOffsetOptions}" SelectedItem="{Binding SelectedFloatingOffset, Mode=TwoWay}" />
+          <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FloatingOffsetOptions}" SelectedItem="{Binding SelectedFloatingOffset, Mode=TwoWay}" ItemTemplate="{StaticResource FloatingOffsetTemplate}" />
           <CheckBox Content="HasClearButton" IsChecked="{Binding ShowClearButton}" Margin="20,0,0,0" />
           <CheckBox Content="HasErrors" IsChecked="False" Checked="HasErrors_OnToggled" Unchecked="HasErrors_OnToggled" Margin="20,0,0,0" />
         </StackPanel>
@@ -71,8 +82,8 @@
       <StackPanel Orientation="Horizontal" Margin="10">
         <CheckBox x:Name="CustomPaddingCheckBox" Content="Custom Padding" IsChecked="{Binding ApplyCustomPadding}" />
         <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding CustomPaddingOptions}" SelectedItem="{Binding SelectedCustomPadding, Mode=TwoWay}" IsEnabled="{Binding ElementName=CustomPaddingCheckBox, Path=IsChecked}" />
-        <TextBlock Text="Custom Height:" VerticalAlignment="Center" Margin="20,0,0,0" />
-        <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding CustomHeightOptions}" SelectedItem="{Binding SelectedCustomHeight, Mode=TwoWay}" />
+        <TextBlock Text="Height:" VerticalAlignment="Center" Margin="20,0,0,0" />
+        <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding CustomHeightOptions}" SelectedItem="{Binding SelectedCustomHeight, Mode=TwoWay}" ItemTemplate="{StaticResource CustomHeightTemplate}"/>
         <TextBlock Text="VerticalContentAlignment:" VerticalAlignment="Center" Margin="20,0,0,0" />
         <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding VerticalAlignmentOptions}" SelectedItem="{Binding SelectedVerticalAlignment, Mode=TwoWay}" />
         <TextBox Text="{Binding PrefixText, UpdateSourceTrigger=PropertyChanged}" materialDesign:HintAssist.Hint="Prefix text" materialDesign:TextFieldAssist.HasClearButton="True" Margin="20,0,0,0" Width="200" MaxLength="3" />

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -16,6 +16,10 @@
     <Grid.Resources>
       <materialDesign:MathConverter x:Key="SubtractConverter" Operation="Subtract" />
       <local:CustomPaddingConverter x:Key="CustomPaddingConverter" />
+      <!--
+      Ideally I would like to use ShowMeTheXaml to show the "dynamic" properties being applied to the elements. Currently it only shows
+      the static properties set in the XAML, which in this case is very little; actually only HorizontalContentAlignment. 
+      -->
       <Style TargetType="{x:Type smtx:XamlDisplay}" BasedOn="{StaticResource {x:Type smtx:XamlDisplay}}">
         <Setter Property="Margin" Value="10,10,10,16" />
         <Setter Property="VerticalAlignment" Value="Top" />

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -45,6 +45,11 @@
       <DataTemplate x:Key="FloatingOffsetTemplate">
         <TextBlock Text="{Binding Converter={StaticResource FloatingOffsetOptionToStringConverter}}" />
       </DataTemplate>
+
+      <local:FontFamilyOptionToStringConverter x:Key="FontFamilyOptionToStringConverter" DefaultValue="{x:Static domain:SmartHintViewModel.DefaultFontFamily}" />
+      <DataTemplate x:Key="FontFamilyTemplate">
+        <TextBlock Text="{Binding Converter={StaticResource FontFamilyOptionToStringConverter}}" />
+      </DataTemplate>
     </Grid.Resources>
 
     <Grid.RowDefinitions>
@@ -66,6 +71,8 @@
           <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FloatingOffsetOptions}" SelectedItem="{Binding SelectedFloatingOffset, Mode=TwoWay}" ItemTemplate="{StaticResource FloatingOffsetTemplate}" />
           <CheckBox Content="HasClearButton" IsChecked="{Binding ShowClearButton}" Margin="20,0,0,0" />
           <CheckBox Content="HasErrors" IsChecked="False" Checked="HasErrors_OnToggled" Unchecked="HasErrors_OnToggled" Margin="20,0,0,0" />
+          <TextBlock Text="FontFamily:" VerticalAlignment="Center" Margin="20,0,0,0"/>
+          <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding FontFamilyOptions}" SelectedItem="{Binding SelectedFontFamily, Mode=TwoWay}" ItemTemplate="{StaticResource FontFamilyTemplate}" />
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Margin="10">
@@ -153,6 +160,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
@@ -203,6 +211,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
@@ -253,6 +262,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
@@ -305,6 +315,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="local:SmartHint.RichTextBoxText" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
@@ -363,6 +374,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
@@ -413,6 +425,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
@@ -463,6 +476,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
@@ -520,6 +534,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
@@ -571,6 +586,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
@@ -622,6 +638,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="materialDesign:PasswordBoxAssist.Password" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="materialDesign:PasswordBoxAssist.IsPasswordRevealed" Value="{Binding ElementName=PasswordBoxesRevealedCheckBox, Path=IsChecked}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
@@ -679,6 +696,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
@@ -731,6 +749,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
@@ -783,6 +802,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="ItemsSource" Value="{Binding ComboBoxOptions}" />
               <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
@@ -837,6 +857,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
@@ -886,6 +907,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
@@ -935,6 +957,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
@@ -987,6 +1010,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
@@ -1036,6 +1060,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
@@ -1085,6 +1110,7 @@
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -85,7 +85,7 @@
           <CheckBox x:Name="CheckBoxLeadingIcon" Content="HasLeadingIcon" IsChecked="{Binding ShowLeadingIcon}" Margin="20,0,0,0" />
           <TextBlock Text="Size:" VerticalAlignment="Center" Margin="10,2,0,0" />
           <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding IconSizeOptions}" SelectedItem="{Binding SelectedLeadingIconSize, Mode=TwoWay}" IsEnabled="{Binding ElementName=CheckBoxLeadingIcon, Path=IsChecked}" />
-          <CheckBox x:Name="CheckBoxTrailingIcon" Content="HasLeadingIcon" IsChecked="{Binding ShowTrailingIcon}" Margin="20,0,0,0" />
+          <CheckBox x:Name="CheckBoxTrailingIcon" Content="HasTrailingIcon" IsChecked="{Binding ShowTrailingIcon}" Margin="20,0,0,0" />
           <TextBlock Text="Size:" VerticalAlignment="Center" Margin="10,2,0,0" />
           <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" ItemsSource="{Binding IconSizeOptions}" SelectedItem="{Binding SelectedTrailingIconSize, Mode=TwoWay}" IsEnabled="{Binding ElementName=CheckBoxTrailingIcon, Path=IsChecked}" />
         </StackPanel>

--- a/MainDemo.Wpf/SmartHint.xaml.cs
+++ b/MainDemo.Wpf/SmartHint.xaml.cs
@@ -97,3 +97,26 @@ internal class CustomPaddingConverter : IMultiValueConverter
     public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         => throw new NotImplementedException();
 }
+
+internal abstract class OptionToStringConverter<TOptionType> : IValueConverter where TOptionType : notnull 
+{
+    public TOptionType? DefaultValue { get; set; }
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => Equals(value, DefaultValue) ? "Default" : ToString((TOptionType)value!, culture);
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+
+    protected abstract string ToString(TOptionType? value, CultureInfo culture);
+}
+
+internal class DoubleOptionToStringConverter : OptionToStringConverter<double>
+{
+    protected override string ToString(double value, CultureInfo culture) => value.ToString(culture);
+}
+
+internal class PointOptionToStringConverter : OptionToStringConverter<Point>
+{
+    protected override string ToString(Point value, CultureInfo culture) => value.ToString(culture);
+}

--- a/MainDemo.Wpf/SmartHint.xaml.cs
+++ b/MainDemo.Wpf/SmartHint.xaml.cs
@@ -108,7 +108,7 @@ internal abstract class OptionToStringConverter<TOptionType> : IValueConverter w
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotImplementedException();
 
-    protected abstract string ToString(TOptionType? value, CultureInfo culture);
+    protected abstract string ToString(TOptionType value, CultureInfo culture);
 }
 
 internal class DoubleOptionToStringConverter : OptionToStringConverter<double>
@@ -119,4 +119,9 @@ internal class DoubleOptionToStringConverter : OptionToStringConverter<double>
 internal class PointOptionToStringConverter : OptionToStringConverter<Point>
 {
     protected override string ToString(Point value, CultureInfo culture) => value.ToString(culture);
+}
+
+internal class FontFamilyOptionToStringConverter : OptionToStringConverter<FontFamily>
+{
+    protected override string ToString(FontFamily value, CultureInfo culture) => value.Source.ToString(culture);
 }

--- a/MaterialDesignThemes.Wpf.Tests/Converters/FloatingHintTransformConverterTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/Converters/FloatingHintTransformConverterTests.cs
@@ -34,13 +34,13 @@ public class FloatingHintTransformConverterTests
     }
 
     [Theory]
-    [InlineData(2.0, 1.5, 3.0, 3.0, 4.0)]
-    [InlineData(1.5, 2.0, 3.0, 2.0, 3.0)]
+    [InlineData(2.0, 1.5, 3.0, 3.0, -4.0)]
+    [InlineData(1.5, 2.0, 3.0, 2.0, -3.0)]
     public void WhenParametersAreSpecifiedItReturnsTransforms(double scale, double lower, double upper, double x, double y)
     {
         var converter = new FloatingHintTransformConverter();
 
-        var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y) }, typeof(Transform), null, CultureInfo.CurrentUICulture);
+        var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y), 0 }, typeof(Transform), null, CultureInfo.CurrentUICulture);
 
         Assert.NotNull(result);
         var scaleTransform = (ScaleTransform)result!.Children[0];
@@ -60,7 +60,7 @@ public class FloatingHintTransformConverterTests
     {
         var converter = new FloatingHintTransformConverter { ApplyScaleTransform = false };
 
-        var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y) }, typeof(Transform), null, CultureInfo.CurrentUICulture);
+        var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y), 0 }, typeof(Transform), null, CultureInfo.CurrentUICulture);
 
         Assert.NotNull(result);
         Assert.Single(result.Children);
@@ -74,7 +74,7 @@ public class FloatingHintTransformConverterTests
     {
         var converter = new FloatingHintTransformConverter { ApplyTranslateTransform = false };
 
-        var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y) }, typeof(Transform), null, CultureInfo.CurrentUICulture);
+        var result = (TransformGroup?)converter.Convert(new object?[] { scale, lower, upper, new Point(x, y), 0 }, typeof(Transform), null, CultureInfo.CurrentUICulture);
 
         Assert.NotNull(result);
         Assert.Single(result.Children);

--- a/MaterialDesignThemes.Wpf/Converters/FloatingHintOffsetCalculationConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/FloatingHintOffsetCalculationConverter.cs
@@ -22,13 +22,28 @@ namespace MaterialDesignThemes.Wpf.Converters
 
             double hintHeight = fontFamily.LineSpacing * fontSize;
             double floatingHintHeight = hintHeight * floatingScale;
+            double offset = floatingHintHeight;
 
-            double offset = (values.Length > 4 ? values[4] : null) switch
+            // For the "outlined" styles, the hint should (by default) float to the outline; this needs a bit of calculation using additional input.
+            if (values.Length == 7
+                && values[4] is double parentActualHeight
+                && values[5] is Thickness padding
+                && values[6] is VerticalAlignment verticalContentAlignment)
             {
-                Thickness padding => (floatingHintHeight / 2) + padding.Top,
-                double parentHeight => (parentHeight - hintHeight + floatingHintHeight) / 2,
-                _ => floatingHintHeight
-            };
+                switch (verticalContentAlignment)
+                {
+                    case VerticalAlignment.Top:
+                    case VerticalAlignment.Stretch:
+                        offset = (floatingHintHeight / 2) + padding.Top;
+                        break;
+                    case VerticalAlignment.Center:
+                        offset = (floatingHintHeight / 2) + (parentActualHeight - padding.Top) / 2;
+                        break;
+                    case VerticalAlignment.Bottom:
+                        offset = (floatingHintHeight / 2) + parentActualHeight - padding.Top - padding.Bottom;
+                        break;
+                }
+            }
 
             if (IsType<Point>(targetType))
             {

--- a/MaterialDesignThemes.Wpf/Converters/FloatingHintTransformConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/FloatingHintTransformConverter.cs
@@ -11,12 +11,13 @@ internal class FloatingHintTransformConverter : IMultiValueConverter
 
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (values?.Length != 4
+        if (values?.Length != 5
             || values.Any(v => v == null)
             || !double.TryParse(values[0]!.ToString(), out double scale)
             || !double.TryParse(values[1]!.ToString(), out double lower)
             || !double.TryParse(values[2]!.ToString(), out double upper)
-            || values[3] is not Point floatingOffset)
+            || values[3] is not Point floatingOffset
+            || !double.TryParse(values[4]!.ToString(), out double initialVerticalOffset))
         {
             return Transform.Identity;
         }
@@ -34,10 +35,13 @@ internal class FloatingHintTransformConverter : IMultiValueConverter
         }
         if (ApplyTranslateTransform)
         {
+            /* As a consequence of Math.Min() which is used below to ensure the initial offset is respected (in filled style)
+               the SmartHint will not be able to "float downwards". I believe this is acceptable though.
+             */
             transformGroup.Children.Add(new TranslateTransform
             {
                 X = scale * floatingOffset.X,
-                Y = scale * floatingOffset.Y
+                Y = Math.Min(initialVerticalOffset, scale * floatingOffset.Y)
             });
         }
         return transformGroup;

--- a/MaterialDesignThemes.Wpf/Converters/PickerInnerPaddingConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/PickerInnerPaddingConverter.cs
@@ -3,6 +3,7 @@ using System.Windows.Data;
 
 namespace MaterialDesignThemes.Wpf.Converters
 {
+    [Obsolete("No longer used internally by MDIX, but since it is public I have chosen to keep it here. Will be removed in the 5.0 release")]
     public class PickerInnerPaddingConverter : IValueConverter, IMultiValueConverter
     {
         private readonly FloatingHintOffsetCalculationConverter _offsetCalculation = new FloatingHintOffsetCalculationConverter();

--- a/MaterialDesignThemes.Wpf/Converters/ThicknessCloneConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/ThicknessCloneConverter.cs
@@ -14,14 +14,19 @@ public class ThicknessCloneConverter : IValueConverter
     public double? FixedRight { get; set; }
     public double? FixedBottom { get; set; }
 
+    public double AdditionalOffsetLeft { get; set; }
+    public double AdditionalOffsetTop { get; set; }
+    public double AdditionalOffsetRight { get; set; }
+    public double AdditionalOffsetBottom { get; set; }
+
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         if (value is Thickness thickness)
         {
-            double left = FixedLeft ?? (CloneEdges.HasFlag(ThicknessEdges.Left) ? thickness.Left : NonClonedEdgeValue);
-            double top = FixedTop ?? (CloneEdges.HasFlag(ThicknessEdges.Top) ? thickness.Top : NonClonedEdgeValue);
-            double right = FixedRight ?? (CloneEdges.HasFlag(ThicknessEdges.Right) ? thickness.Right : NonClonedEdgeValue);
-            double bottom = FixedBottom ?? (CloneEdges.HasFlag(ThicknessEdges.Bottom) ? thickness.Bottom : NonClonedEdgeValue);
+            double left = (FixedLeft ?? (CloneEdges.HasFlag(ThicknessEdges.Left) ? thickness.Left : NonClonedEdgeValue)) + AdditionalOffsetLeft;
+            double top = (FixedTop ?? (CloneEdges.HasFlag(ThicknessEdges.Top) ? thickness.Top : NonClonedEdgeValue)) + AdditionalOffsetTop;
+            double right = (FixedRight ?? (CloneEdges.HasFlag(ThicknessEdges.Right) ? thickness.Right : NonClonedEdgeValue)) + AdditionalOffsetRight;
+            double bottom = (FixedBottom ?? (CloneEdges.HasFlag(ThicknessEdges.Bottom) ? thickness.Bottom : NonClonedEdgeValue)) + AdditionalOffsetBottom;
             return new Thickness(left, top, right, bottom);
         }
         return DependencyProperty.UnsetValue;

--- a/MaterialDesignThemes.Wpf/SmartHint.cs
+++ b/MaterialDesignThemes.Wpf/SmartHint.cs
@@ -129,6 +129,15 @@ public class SmartHint : Control
 
     #endregion
 
+    public static readonly DependencyProperty InitialVerticalOffsetProperty = DependencyProperty.Register(
+        nameof(InitialVerticalOffset), typeof(double), typeof(SmartHint), new PropertyMetadata(default(double)));
+
+    public double InitialVerticalOffset
+    {
+        get { return (double) GetValue(InitialVerticalOffsetProperty); }
+        set { SetValue(InitialVerticalOffsetProperty, value); }
+    }
+
     static SmartHint()
     {
         DefaultStyleKeyProperty.OverrideMetadata(typeof(SmartHint), new FrameworkPropertyMetadata(typeof(SmartHint)));

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -488,7 +488,7 @@
         <Setter TargetName="Hint" Property="FloatingOffset">
           <Setter.Value>
             <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-              <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+              <Binding Path="FontFamily" ElementName="Hint" />
               <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
               <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
               <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -532,7 +532,7 @@
         <Setter TargetName="Hint" Property="FloatingOffset">
           <Setter.Value>
             <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-              <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+              <Binding Path="FontFamily" ElementName="Hint" />
               <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
               <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
               <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -542,7 +542,7 @@
         <Setter TargetName="InnerRoot" Property="Margin">
           <Setter.Value>
             <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-              <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+              <Binding Path="FontFamily" ElementName="Hint" />
               <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
               <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
               <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -414,7 +414,8 @@
                      MaxWidth="{Binding ActualWidth, ElementName=toggleButton}"
                      FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                      Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                     Text="{TemplateBinding wpf:HintAssist.HelperText}" />
+                     Text="{TemplateBinding wpf:HintAssist.HelperText}"
+                     Style="{Binding Path=(wpf:HintAssist.HelperTextStyle), RelativeSource={RelativeSource TemplatedParent}}"/>
         </Canvas>
         <wpf:ComboBoxPopup x:Name="PART_Popup"
                            Grid.Column="0"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal"
@@ -27,6 +27,9 @@
   <converters:ComboBoxClearButtonMarginConverter x:Key="ComboBoxClearButtonMarginConverter" />
   <converters:DoubleToThicknessConverter x:Key="DoubleToThicknessConverter" />
   <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left" />
+  <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleTrailingIconPaddingConverterTop" CloneEdges="All" AdditionalOffsetTop="2" />
+  <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleTrailingIconPaddingConverterBottom" CloneEdges="All" AdditionalOffsetBottom="4" />
+  <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
 
   <system:Double x:Key="PopupContentPresenterExtend">4</system:Double>
   <system:Double x:Key="PopupTopBottomMargin">8</system:Double>
@@ -238,7 +241,7 @@
               <Border x:Name="splitBorder"
                       Margin="0"
                       HorizontalAlignment="Right"
-                      VerticalAlignment="Center"
+                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                       BorderBrush="Transparent"
                       BorderThickness="0">
                 <Path x:Name="arrow"
@@ -321,6 +324,7 @@
                           Grid.ColumnSpan="2"
                           Margin="{Binding ElementName=InnerRoot, Path=Margin}"
                           Padding="{TemplateBinding Padding}"
+                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
                           BorderBrush="{TemplateBinding BorderBrush}"
                           IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                           Style="{StaticResource MaterialDesignComboBoxToggleButton}" />
@@ -329,7 +333,7 @@
                     Padding="{TemplateBinding Padding}">
               <Grid x:Name="InnerRoot"
                     HorizontalAlignment="Stretch"
-                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                    VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                     UseLayoutRounding="{TemplateBinding UseLayoutRounding}">
                 <Grid.ColumnDefinitions>
@@ -564,13 +568,20 @@
         <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
       </MultiTrigger>
 
+      <!-- toggleButton padding adhering to VerticalContentAlignment -->
       <MultiTrigger>
         <MultiTrigger.Conditions>
           <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-          <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
-          <Condition Property="VerticalContentAlignment" Value="Center" />
+          <Condition SourceName="InnerRoot" Property="VerticalAlignment" Value="Top" />
         </MultiTrigger.Conditions>
-        <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="-6" />
+        <Setter TargetName="toggleButton" Property="Padding" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource DefaultOrFilledStyleTrailingIconPaddingConverterTop}}" />
+      </MultiTrigger>
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+          <Condition SourceName="InnerRoot" Property="VerticalAlignment" Value="Bottom" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="toggleButton" Property="Padding" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource DefaultOrFilledStyleTrailingIconPaddingConverterBottom}}" />
       </MultiTrigger>
 
       <!-- IsEnabled -->

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -30,6 +30,7 @@
   <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleTrailingIconPaddingConverterTop" CloneEdges="All" AdditionalOffsetTop="2" />
   <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleTrailingIconPaddingConverterBottom" CloneEdges="All" AdditionalOffsetBottom="4" />
   <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
+  <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
 
   <system:Double x:Key="PopupContentPresenterExtend">4</system:Double>
   <system:Double x:Key="PopupTopBottomMargin">8</system:Double>
@@ -343,10 +344,12 @@
                 </Grid.ColumnDefinitions>
                 <TextBlock x:Name="PrefixTextBlock"
                            Grid.Column="0"
+                           Margin="0,0,2,0"
                            FontSize="{TemplateBinding FontSize}"
                            IsHitTestVisible="False"
                            Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                           Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}" />
+                           Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}"
+                           Visibility="{TemplateBinding wpf:TextFieldAssist.PrefixText, Converter={StaticResource NullableToVisibilityConverter}}"/>
 
                 <ContentPresenter x:Name="contentPresenter"
                                   Grid.Column="1"
@@ -394,7 +397,8 @@
                            FontSize="{TemplateBinding FontSize}"
                            IsHitTestVisible="False"
                            Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                           Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />
+                           Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}"
+                           Visibility="{TemplateBinding wpf:TextFieldAssist.SuffixText, Converter={StaticResource NullableToVisibilityConverter}}" />
               </Grid>
             </Border>
           </Grid>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -489,6 +489,8 @@
               <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
               <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
               <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
+              <Binding Path="Padding" RelativeSource="{RelativeSource TemplatedParent}" />
+              <Binding Path="VerticalContentAlignment" RelativeSource="{RelativeSource TemplatedParent}" />
             </MultiBinding>
           </Setter.Value>
         </Setter>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -458,7 +458,7 @@
                 Height="Auto"
                 Padding="0"
                 HorizontalAlignment="Right"
-                VerticalAlignment="Stretch"
+                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                 Command="{x:Static internal:ClearText.ClearCommand}"
                 Focusable="False"
                 Style="{DynamicResource MaterialDesignToolButton}">
@@ -562,6 +562,15 @@
         </MultiTrigger.Conditions>
         <Setter TargetName="Hint" Property="Foreground" Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
         <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
+      </MultiTrigger>
+
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+          <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+          <Condition Property="VerticalContentAlignment" Value="Center" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="-6" />
       </MultiTrigger>
 
       <!-- IsEnabled -->

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -866,7 +866,7 @@
     <Setter Property="Template" Value="{StaticResource MaterialDesignFloatingHintComboBoxTemplate}" />
     <Setter Property="Validation.ErrorTemplate" Value="{StaticResource MaterialDesignValidationErrorTemplate}" />
     <Setter Property="VerticalAlignment" Value="Center" />
-    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="internal:ClearText.HandlesClearCommand" Value="True" />
     <Setter Property="wpf:ColorZoneAssist.Mode" Value="Standard" />
     <Setter Property="wpf:ComboBoxAssist.ShowSelectedItem" Value="True" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -484,6 +484,7 @@
     <Setter Property="CalendarStyle" Value="{StaticResource MaterialDesignDatePickerCalendarPortrait}" />
     <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="IsTodayHighlighted" Value="True" />
     <Setter Property="Padding" Value="{x:Static wpf:Constants.TextBoxDefaultPadding}" />
     <Setter Property="SelectedDateFormat" Value="Short" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -233,7 +233,8 @@
                          MaxWidth="{Binding ActualWidth, ElementName=border}"
                          FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                          Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                         Text="{TemplateBinding wpf:HintAssist.HelperText}" />
+                         Text="{TemplateBinding wpf:HintAssist.HelperText}"
+                         Style="{Binding Path=(wpf:HintAssist.HelperTextStyle), RelativeSource={RelativeSource TemplatedParent}}"/>
             </Canvas>
           </Grid>
           <ControlTemplate.Triggers>
@@ -509,6 +510,7 @@
                                wpf:HintAssist.Foreground="{TemplateBinding wpf:HintAssist.Foreground}"
                                wpf:HintAssist.HelperText="{TemplateBinding wpf:HintAssist.HelperText}"
                                wpf:HintAssist.HelperTextFontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
+                               wpf:HintAssist.HelperTextStyle="{TemplateBinding wpf:HintAssist.HelperTextStyle}"
                                wpf:HintAssist.Hint="{TemplateBinding wpf:HintAssist.Hint}"
                                wpf:HintAssist.HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                wpf:HintAssist.IsFloating="{TemplateBinding wpf:HintAssist.IsFloating}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -22,7 +22,7 @@
   <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverter" CloneEdges="Top,Right,Bottom" FixedLeft="0" />
   <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverterTop" CloneEdges="Top,Right,Bottom" FixedLeft="0" AdditionalOffsetTop="12" />
   <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
-
+  <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
 
   <Style x:Key="MaterialDesignDatePickerTextBox" TargetType="{x:Type DatePickerTextBox}">
     <Setter Property="AllowDrop" Value="true" />
@@ -147,7 +147,8 @@
                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                               Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}" />
+                               Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}"
+                               Visibility="{TemplateBinding wpf:TextFieldAssist.PrefixText, Converter={StaticResource NullableToVisibilityConverter}}" />
                     <ContentControl x:Name="PART_Watermark"
                                     Grid.Column="1"
                                     Focusable="False"
@@ -193,7 +194,8 @@
                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                               Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />
+                               Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}"
+                               Visibility="{TemplateBinding wpf:TextFieldAssist.SuffixText, Converter={StaticResource NullableToVisibilityConverter}}" />
                   </Grid>
                   <Button x:Name="PART_ClearButton"
                           Grid.Column="1"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -269,7 +269,9 @@
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="Padding" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="VerticalContentAlignment" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
                 </Setter.Value>
               </Setter>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -510,6 +510,7 @@
                                wpf:HintAssist.Hint="{TemplateBinding wpf:HintAssist.Hint}"
                                wpf:HintAssist.HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                wpf:HintAssist.IsFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                               wpf:HintAssist.FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
                                wpf:TextFieldAssist.DecorationVisibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}"
                                wpf:TextFieldAssist.HasClearButton="{TemplateBinding wpf:TextFieldAssist.HasClearButton}"
                                wpf:TextFieldAssist.HasFilledTextField="{TemplateBinding wpf:TextFieldAssist.HasFilledTextField}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -1,5 +1,4 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal"
@@ -17,9 +16,13 @@
   <converters:NotConverter x:Key="NotConverter" />
   <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
   <converters:FloatingHintOffsetCalculationConverter x:Key="FloatingHintOffsetCalculationConverter" />
-  <converters:PickerInnerPaddingConverter x:Key="PickerInnerPaddingConverter" />
   <converters:OutlinedDateTimePickerActiveBorderThicknessConverter x:Key="OutlinedDateTimePickerActiveBorderThicknessConverter" />
   <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left" />
+  <converters:ThicknessCloneConverter x:Key="DatePickerTextBoxPaddingConverter" CloneEdges="All" AdditionalOffsetRight="18" />
+  <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverter" CloneEdges="Top,Right,Bottom" FixedLeft="0" />
+  <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverterTop" CloneEdges="Top,Right,Bottom" FixedLeft="0" AdditionalOffsetTop="12" />
+  <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
+
 
   <Style x:Key="MaterialDesignDatePickerTextBox" TargetType="{x:Type DatePickerTextBox}">
     <Setter Property="AllowDrop" Value="true" />
@@ -124,14 +127,14 @@
                       BorderThickness="{TemplateBinding BorderThickness}"
                       CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                       SnapsToDevicePixels="True">
-                <Grid HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition />
                     <ColumnDefinition Width="Auto" />
                   </Grid.ColumnDefinitions>
                   <Grid x:Name="grid"
                         MinWidth="1"
-                        VerticalAlignment="Center"
+                        VerticalAlignment="Stretch"
                         HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition Width="Auto" />
@@ -140,6 +143,8 @@
                     </Grid.ColumnDefinitions>
                     <TextBlock x:Name="PrefixTextBlock"
                                Grid.Column="0"
+                               Margin="0,0,2,0"
+                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}" />
@@ -152,6 +157,10 @@
                     <ScrollViewer x:Name="PART_ContentHost"
                                   Grid.Column="1"
                                   Panel.ZIndex="1"
+                                  VerticalAlignment="Stretch"
+                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  HorizontalAlignment="Stretch"
+                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   wpf:ScrollViewerAssist.IgnorePadding="True"
                                   Focusable="false"
                                   HorizontalScrollBarVisibility="Hidden"
@@ -167,6 +176,8 @@
                                    HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                    HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                    UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                                   VerticalAlignment="Stretch"
+                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
                       <wpf:SmartHint.Hint>
                         <Border x:Name="HintBackgroundBorder"
@@ -178,6 +189,8 @@
                     </wpf:SmartHint>
                     <TextBlock x:Name="SuffixTextBlock"
                                Grid.Column="2"
+                               Margin="0,0,2,0"
+                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />
@@ -186,6 +199,7 @@
                           Grid.Column="1"
                           Height="Auto"
                           Padding="2,0,0,0"
+                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                           Command="{x:Static internal:ClearText.ClearCommand}"
                           Focusable="False"
                           Style="{DynamicResource MaterialDesignToolButton}">
@@ -255,6 +269,16 @@
                 </Setter.Value>
               </Setter>
             </MultiTrigger>
+
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                <Condition Property="VerticalContentAlignment" Value="Center" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="-6" />
+            </MultiTrigger>
+
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
             </Trigger>
@@ -473,11 +497,11 @@
           </ControlTemplate.Resources>
           <Grid x:Name="PART_Root">
             <DatePickerTextBox x:Name="PART_TextBox"
-                               Grid.Row="0"
-                               Grid.Column="0"
+                               Padding="{TemplateBinding Padding, Converter={StaticResource DatePickerTextBoxPaddingConverter}}"
                                HorizontalAlignment="Stretch"
+                               VerticalAlignment="Stretch"
                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                               VerticalContentAlignment="Center"
+                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                wpf:HintAssist.FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
                                wpf:HintAssist.FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
                                wpf:HintAssist.Foreground="{TemplateBinding wpf:HintAssist.Foreground}"
@@ -501,21 +525,12 @@
                                Background="{TemplateBinding Background}"
                                BorderBrush="{TemplateBinding BorderBrush}"
                                Focusable="{TemplateBinding Focusable}"
-                               Style="{DynamicResource MaterialDesignDatePickerTextBox}">
-              <DatePickerTextBox.Padding>
-                <MultiBinding Converter="{StaticResource PickerInnerPaddingConverter}">
-                  <Binding Path="Padding" RelativeSource="{RelativeSource TemplatedParent}" />
-                  <Binding ElementName="PART_Button"
-                           Mode="OneWay"
-                           Path="ActualWidth" />
-                </MultiBinding>
-              </DatePickerTextBox.Padding>
-            </DatePickerTextBox>
+                               Style="{DynamicResource MaterialDesignDatePickerTextBox}" />
             <Button x:Name="PART_Button"
                     Height="16"
-                    Margin="{TemplateBinding Padding, Converter={StaticResource PickerInnerPaddingConverter}}"
+                    Margin="{TemplateBinding Padding, Converter={StaticResource PartButtonMarginConverter}}"
                     HorizontalAlignment="Right"
-                    VerticalAlignment="Center"
+                    VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
                     Focusable="False"
                     Foreground="{TemplateBinding BorderBrush}"
                     Template="{StaticResource CalendarButtonTemplate}" />
@@ -528,6 +543,16 @@
                    StaysOpen="False" />
           </Grid>
           <ControlTemplate.Triggers>
+
+            <!-- PART_Button margins adhering to VerticalContentAlignment for default/filled style when VerticalContentAlignment=Top (other cases handled by default value) -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition SourceName="PART_Button" Property="VerticalAlignment" Value="Top" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_Button" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource PartButtonMarginConverterTop}}" />
+            </MultiTrigger>
+
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
             </Trigger>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -251,7 +251,7 @@
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -261,7 +261,7 @@
               <Setter TargetName="grid" Property="Margin">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -289,7 +289,7 @@
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -290,6 +290,8 @@
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="Padding" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="VerticalContentAlignment" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
                 </Setter.Value>
               </Setter>
@@ -800,6 +802,8 @@
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="Padding" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="VerticalContentAlignment" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
                 </Setter.Value>
               </Setter>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -133,13 +133,14 @@
                       BorderThickness="{TemplateBinding BorderThickness}"
                       CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                       SnapsToDevicePixels="True">
-                <Grid HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition />
                     <ColumnDefinition Width="Auto" />
                   </Grid.ColumnDefinitions>
                   <Grid x:Name="grid"
                         MinWidth="1"
+                        VerticalAlignment="Stretch"
                         HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition Width="Auto" />
@@ -148,6 +149,8 @@
                     </Grid.ColumnDefinitions>
                     <TextBlock x:Name="PrefixTextBlock"
                                Grid.Column="0"
+                               Margin="0,0,2,0"
+                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}" />
@@ -157,6 +160,8 @@
                                   wpf:ScrollViewerAssist.IgnorePadding="True"
                                   Cursor="{TemplateBinding Cursor, Converter={StaticResource IBeamCursorConverter}}"
                                   Focusable="false"
+                                  VerticalAlignment="Stretch"
+                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                   HorizontalAlignment="Stretch"
                                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   HorizontalScrollBarVisibility="Hidden"
@@ -172,6 +177,8 @@
                                    HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                    HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                    UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                                   VerticalAlignment="Stretch"
+                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
                       <wpf:SmartHint.Hint>
                         <Border x:Name="HintBackgroundBorder"
@@ -183,6 +190,8 @@
                     </wpf:SmartHint>
                     <TextBlock x:Name="SuffixTextBlock"
                                Grid.Column="2"
+                               Margin="2,0,0,0"
+                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />
@@ -273,7 +282,6 @@
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="1" />
-              <Setter Property="VerticalContentAlignment" Value="Top" />
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
@@ -595,7 +603,7 @@
                       BorderThickness="{TemplateBinding BorderThickness}"
                       CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                       SnapsToDevicePixels="True">
-                <Grid HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
@@ -603,6 +611,7 @@
                   </Grid.ColumnDefinitions>
                   <Grid x:Name="grid"
                         MinWidth="1"
+                        VerticalAlignment="Stretch"
                         HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition Width="Auto" />
@@ -611,6 +620,8 @@
                     </Grid.ColumnDefinitions>
                     <TextBlock x:Name="PrefixTextBlock"
                                Grid.Column="0"
+                               Margin="0,0,2,0"
+                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}" />
@@ -625,12 +636,14 @@
                                     wpf:ScrollViewerAssist.IgnorePadding="True"
                                     Cursor="{TemplateBinding Cursor, Converter={StaticResource IBeamCursorConverter}}"
                                     Focusable="false"
+                                    VerticalAlignment="Stretch"
+                                    VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    HorizontalAlignment="Stretch"
+                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                     HorizontalScrollBarVisibility="Hidden"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                     UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
                                     VerticalScrollBarVisibility="Hidden"
-                                    HorizontalAlignment="Stretch"
-                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                     Visibility="{Binding ElementName=ContentGrid, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed), Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
                       <TextBox x:Name="RevealPasswordTextBox"
                                Grid.Column="0"
@@ -642,6 +655,8 @@
                                SelectionBrush="{TemplateBinding SelectionBrush}"
                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                Style="{StaticResource MaterialDesignRawTextBox}"
+                               VerticalAlignment="Stretch"
+                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                HorizontalAlignment="Stretch"
                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:PasswordBoxAssist.Password), UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
@@ -662,6 +677,8 @@
                                    HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                    HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                    UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                                   VerticalAlignment="Stretch"
+                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
                       <wpf:SmartHint.Hint>
                         <Border x:Name="HintBackgroundBorder"
@@ -673,6 +690,8 @@
                     </wpf:SmartHint>
                     <TextBlock x:Name="SuffixTextBlock"
                                Grid.Column="2"
+                               Margin="2,0,0,0"
+                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />
@@ -773,7 +792,6 @@
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextAreaBorder}" />
               <Setter Property="BorderThickness" Value="1" />
-              <Setter Property="VerticalContentAlignment" Value="Top" />
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -22,6 +22,13 @@
   <converters:CursorConverter x:Key="ArrowCursorConverter" FallbackCursor="Arrow" />
   <converters:CursorConverter x:Key="IBeamCursorConverter" FallbackCursor="IBeam" />
   <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left" />
+  <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleTrailingIconMarginConverterTop" CloneEdges="Top" AdditionalOffsetTop="-2" />
+  <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleTrailingIconMarginConverterCenter" CloneEdges="Top" AdditionalOffsetTop="-12" />
+  <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleTrailingIconMarginConverterBottom" CloneEdges="Top" FixedBottom="-2" />
+  <converters:ThicknessCloneConverter x:Key="OutlinedStyleTrailingIconMarginConverterTop" CloneEdges="Top" AdditionalOffsetTop="-2" />
+  <converters:ThicknessCloneConverter x:Key="OutlinedStyleTrailingIconMarginConverterCenter" CloneEdges="Top" AdditionalOffsetTop="0" />
+  <converters:ThicknessCloneConverter x:Key="OutlinedStyleTrailingIconMarginConverterBottom" CloneEdges="Top" FixedBottom="-2" AdditionalOffsetTop="0" />
+  <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
 
   <Style x:Key="MaterialDesignPasswordCharacterCounterTextBlock"
          TargetType="TextBlock"
@@ -200,6 +207,7 @@
                           Grid.Column="1"
                           Height="Auto"
                           Padding="2,0,0,0"
+                          VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
                           Command="{x:Static internal:ClearText.ClearCommand}"
                           Focusable="False"
                           Style="{StaticResource MaterialDesignToolButton}">
@@ -276,6 +284,55 @@
                 </Setter.Value>
               </Setter>
             </MultiTrigger>
+
+            <!-- Icon margins adhering to VerticalContentAlignment for default/filled style -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Center" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="-6" />
+              <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterCenter}}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Top" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterTop}}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Bottom" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterBottom}}" />
+            </MultiTrigger>
+
+            <!-- Icon margins adhering to VerticalContentAlignment for outlined style -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Center" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterCenter}}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Top" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterTop}}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Bottom" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterBottom}}" />
+            </MultiTrigger>
+
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
             </Trigger>
@@ -702,6 +759,7 @@
                                 Grid.Column="1"
                                 Height="Auto"
                                 Padding="2,0,0,0"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
                                 IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed), Mode=TwoWay}"
                                 Style="{StaticResource MaterialDesignRawToggleButton}">
                     <wpf:PackIcon x:Name="RevealPasswordIcon"
@@ -712,6 +770,7 @@
                           Grid.Column="2"
                           Height="Auto"
                           Padding="2,0,0,0"
+                          VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
                           Command="{x:Static internal:ClearText.ClearCommand}"
                           Focusable="False"
                           Style="{StaticResource MaterialDesignToolButton}">
@@ -788,6 +847,61 @@
                 </Setter.Value>
               </Setter>
             </MultiTrigger>
+
+            <!-- Icon margins adhering to VerticalContentAlignment for default/filled style -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Center" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="-6" />
+              <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterCenter}}" />
+              <Setter TargetName="RevealPasswordButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterCenter}}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Top" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterTop}}" />
+              <Setter TargetName="RevealPasswordButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterTop}}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Bottom" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterBottom}}" />
+              <Setter TargetName="RevealPasswordButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterBottom}}" />
+            </MultiTrigger>
+
+            <!-- Icon margins adhering to VerticalContentAlignment for outlined style -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Center" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterCenter}}" />
+              <Setter TargetName="RevealPasswordButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterCenter}}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Top" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterTop}}" />
+              <Setter TargetName="RevealPasswordButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterTop}}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Bottom" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterBottom}}" />
+              <Setter TargetName="RevealPasswordButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterBottom}}" />
+            </MultiTrigger>
+
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
             </Trigger>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -162,7 +162,7 @@
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}"
-                               Visibility="{TemplateBinding wpf:TextFieldAssist.PrefixText, Converter={StaticResource NullableToVisibilityConverter}}"/>
+                               Visibility="{TemplateBinding wpf:TextFieldAssist.PrefixText, Converter={StaticResource NullableToVisibilityConverter}}" />
                     <ScrollViewer x:Name="PART_ContentHost"
                                   Grid.Column="1"
                                   Panel.ZIndex="1"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -29,6 +29,7 @@
   <converters:ThicknessCloneConverter x:Key="OutlinedStyleTrailingIconMarginConverterCenter" CloneEdges="Top" AdditionalOffsetTop="0" />
   <converters:ThicknessCloneConverter x:Key="OutlinedStyleTrailingIconMarginConverterBottom" CloneEdges="Top" FixedBottom="-2" AdditionalOffsetTop="0" />
   <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
+  <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
 
   <Style x:Key="MaterialDesignPasswordCharacterCounterTextBlock"
          TargetType="TextBlock"
@@ -160,7 +161,8 @@
                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                               Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}" />
+                               Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}"
+                               Visibility="{TemplateBinding wpf:TextFieldAssist.PrefixText, Converter={StaticResource NullableToVisibilityConverter}}"/>
                     <ScrollViewer x:Name="PART_ContentHost"
                                   Grid.Column="1"
                                   Panel.ZIndex="1"
@@ -201,7 +203,8 @@
                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                               Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />
+                               Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}"
+                               Visibility="{TemplateBinding wpf:TextFieldAssist.SuffixText, Converter={StaticResource NullableToVisibilityConverter}}" />
                   </Grid>
                   <Button x:Name="PART_ClearButton"
                           Grid.Column="1"
@@ -683,7 +686,8 @@
                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                               Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}" />
+                               Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}"
+                               Visibility="{TemplateBinding wpf:TextFieldAssist.PrefixText, Converter={StaticResource NullableToVisibilityConverter}}"/>
 
                     <Grid x:Name="ContentGrid"
                           Grid.Column="1"
@@ -753,7 +757,8 @@
                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                               Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />
+                               Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}"
+                               Visibility="{TemplateBinding wpf:TextFieldAssist.SuffixText, Converter={StaticResource NullableToVisibilityConverter}}"/>
                   </Grid>
                   <ToggleButton x:Name="RevealPasswordButton"
                                 Grid.Column="1"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -266,7 +266,7 @@
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -276,7 +276,7 @@
               <Setter TargetName="grid" Property="Margin">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -342,7 +342,7 @@
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -829,7 +829,7 @@
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -839,7 +839,7 @@
               <Setter TargetName="grid" Property="Margin">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -911,7 +911,7 @@
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -148,6 +148,7 @@
                       <Binding Path="FloatingScale" RelativeSource="{RelativeSource TemplatedParent}" />
                       <Binding Source="{StaticResource NoContentFloatingScale}" />
                       <Binding Path="FloatingOffset" RelativeSource="{RelativeSource TemplatedParent}" />
+                      <Binding Path="InitialVerticalOffset" RelativeSource="{RelativeSource TemplatedParent}" />
                     </MultiBinding>
                   </Grid.RenderTransform>
                   <Canvas HorizontalAlignment="Left" Width="{Binding ElementName=FloatingHintTextBlock, Path= ActualWidth}" Height="{Binding ElementName=FloatingHintTextBlock, Path=ActualHeight}">
@@ -182,6 +183,7 @@
                           <Binding Path="FloatingScale" RelativeSource="{RelativeSource TemplatedParent}" />
                           <Binding Source="{StaticResource NoContentFloatingScale}" />
                           <Binding Path="FloatingOffset" RelativeSource="{RelativeSource TemplatedParent}" />
+                          <Binding Path="InitialVerticalOffset" RelativeSource="{RelativeSource TemplatedParent}" />
                         </MultiBinding>
                       </ContentControl.RenderTransform>
                     </ContentControl>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -32,6 +32,7 @@
   <converters:ThicknessCloneConverter x:Key="OutlinedStyleTrailingIconMarginConverterCenter" CloneEdges="Top" AdditionalOffsetTop="0" />
   <converters:ThicknessCloneConverter x:Key="OutlinedStyleTrailingIconMarginConverterBottom" CloneEdges="Top" FixedBottom="-2" AdditionalOffsetTop="0" />
   <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
+  <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
 
   <Style x:Key="MaterialDesignCharacterCounterTextBlock"
          TargetType="TextBlock"
@@ -205,7 +206,8 @@
                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                  FontSize="{TemplateBinding FontSize}"
                                  Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                                 Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />
+                                 Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}"
+                                 Visibility="{TemplateBinding wpf:TextFieldAssist.SuffixText, Converter={StaticResource NullableToVisibilityConverter}}" />
                     </Grid>
 
                     <wpf:SmartHint x:Name="Hint"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -390,7 +390,9 @@
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="Padding" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="VerticalContentAlignment" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
                 </Setter.Value>
               </Setter>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -172,6 +172,7 @@
                       <TextBlock x:Name="PrefixTextBlock"
                                  Grid.Column="0"
                                  Margin="0,0,2,0"
+                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                  FontSize="{TemplateBinding FontSize}"
                                  Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                  Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}">
@@ -200,6 +201,7 @@
 
                       <TextBlock x:Name="SuffixTextBlock"
                                  Grid.Column="2"
+                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                  FontSize="{TemplateBinding FontSize}"
                                  Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                  Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -231,7 +231,7 @@
 
                   </Grid>
 
-                  <StackPanel x:Name="TrailingGrid" Orientation="Horizontal" Grid.Column="2" VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}">
+                  <StackPanel x:Name="TrailingPanel" Orientation="Horizontal" Grid.Column="2" VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}">
                     <wpf:PackIcon x:Name="TrailingPackIcon"
                                   Width="{TemplateBinding wpf:TextFieldAssist.TrailingIconSize}"
                                   Height="{TemplateBinding wpf:TextFieldAssist.TrailingIconSize}"
@@ -332,7 +332,7 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="-6" />
               <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleLeadingIconMarginConverterCenter}}" />
-              <Setter TargetName="TrailingGrid" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterCenter}}" />
+              <Setter TargetName="TrailingPanel" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterCenter}}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -340,7 +340,7 @@
                 <Condition SourceName="LeadingPackIcon" Property="VerticalAlignment" Value="Top" />
               </MultiTrigger.Conditions>
               <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleLeadingIconMarginConverterTop}}" />
-              <Setter TargetName="TrailingGrid" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterTop}}" />
+              <Setter TargetName="TrailingPanel" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterTop}}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -348,7 +348,7 @@
                 <Condition SourceName="LeadingPackIcon" Property="VerticalAlignment" Value="Bottom" />
               </MultiTrigger.Conditions>
               <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleLeadingIconMarginConverterBottom}}" />
-              <Setter TargetName="TrailingGrid" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterBottom}}" />
+              <Setter TargetName="TrailingPanel" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterBottom}}" />
             </MultiTrigger>
 
             <!-- Icon margins adhering to VerticalContentAlignment for outlined style -->
@@ -358,7 +358,7 @@
                 <Condition SourceName="LeadingPackIcon" Property="VerticalAlignment" Value="Center" />
               </MultiTrigger.Conditions>
               <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleLeadingIconMarginConverterCenter}}" />
-              <Setter TargetName="TrailingGrid" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterCenter}}" />
+              <Setter TargetName="TrailingPanel" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterCenter}}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -366,7 +366,7 @@
                 <Condition SourceName="LeadingPackIcon" Property="VerticalAlignment" Value="Top" />
               </MultiTrigger.Conditions>
               <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleLeadingIconMarginConverterTop}}" />
-              <Setter TargetName="TrailingGrid" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterTop}}" />
+              <Setter TargetName="TrailingPanel" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterTop}}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -374,7 +374,7 @@
                 <Condition SourceName="LeadingPackIcon" Property="VerticalAlignment" Value="Bottom" />
               </MultiTrigger.Conditions>
               <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleLeadingIconMarginConverterBottom}}" />
-              <Setter TargetName="TrailingGrid" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterBottom}}" />
+              <Setter TargetName="TrailingPanel" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterBottom}}" />
             </MultiTrigger>
 
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -304,7 +304,7 @@
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -314,7 +314,7 @@
               <Setter TargetName="grid" Property="Margin">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -386,7 +386,7 @@
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -19,6 +19,19 @@
   <converters:CursorConverter x:Key="IBeamCursorConverter" FallbackCursor="IBeam" />
   <converters:StringLengthValueConverter x:Key="StringLengthValueConverter" />
   <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left" />
+  <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleLeadingIconMarginConverterTop" CloneEdges="Top" FixedRight="6" AdditionalOffsetTop="-2" />
+  <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleLeadingIconMarginConverterCenter" CloneEdges="Top" FixedRight="6" AdditionalOffsetTop="-12" />
+  <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleLeadingIconMarginConverterBottom" CloneEdges="Top" FixedRight="6" FixedBottom="-2" />
+  <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleTrailingIconMarginConverterTop" CloneEdges="Top" AdditionalOffsetTop="-2" />
+  <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleTrailingIconMarginConverterCenter" CloneEdges="Top" AdditionalOffsetTop="-12" />
+  <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleTrailingIconMarginConverterBottom" CloneEdges="Top" FixedBottom="-2" />
+  <converters:ThicknessCloneConverter x:Key="OutlinedStyleLeadingIconMarginConverterTop" CloneEdges="Top" FixedRight="6" AdditionalOffsetTop="-2" />
+  <converters:ThicknessCloneConverter x:Key="OutlinedStyleLeadingIconMarginConverterCenter" CloneEdges="Top" FixedRight="6" AdditionalOffsetTop="0" />
+  <converters:ThicknessCloneConverter x:Key="OutlinedStyleLeadingIconMarginConverterBottom" CloneEdges="Top" FixedRight="6" FixedBottom="-2" AdditionalOffsetTop="0" />
+  <converters:ThicknessCloneConverter x:Key="OutlinedStyleTrailingIconMarginConverterTop" CloneEdges="Top" AdditionalOffsetTop="-2" />
+  <converters:ThicknessCloneConverter x:Key="OutlinedStyleTrailingIconMarginConverterCenter" CloneEdges="Top" AdditionalOffsetTop="0" />
+  <converters:ThicknessCloneConverter x:Key="OutlinedStyleTrailingIconMarginConverterBottom" CloneEdges="Top" FixedBottom="-2" AdditionalOffsetTop="0" />
+  <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
 
   <Style x:Key="MaterialDesignCharacterCounterTextBlock"
          TargetType="TextBlock"
@@ -139,7 +152,7 @@
                                 Width="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
                                 Height="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
                                 Margin="0,0,6,0"
-                                VerticalAlignment="Center"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
                                 Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                 Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
@@ -215,31 +228,31 @@
 
                   </Grid>
 
-                  <wpf:PackIcon x:Name="TrailingPackIcon"
-                                Grid.Column="2"
-                                Width="{TemplateBinding wpf:TextFieldAssist.TrailingIconSize}"
-                                Height="{TemplateBinding wpf:TextFieldAssist.TrailingIconSize}"
-                                Margin="4,0,0,0"
-                                VerticalAlignment="Center"
-                                Kind="{TemplateBinding wpf:TextFieldAssist.TrailingIcon}"
-                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                  <StackPanel x:Name="TrailingGrid" Orientation="Horizontal" Grid.Column="2" VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}">
+                    <wpf:PackIcon x:Name="TrailingPackIcon"
+                                  Width="{TemplateBinding wpf:TextFieldAssist.TrailingIconSize}"
+                                  Height="{TemplateBinding wpf:TextFieldAssist.TrailingIconSize}"
+                                  Margin="4,0,0,0"
+                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  Kind="{TemplateBinding wpf:TextFieldAssist.TrailingIcon}"
+                                  Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                                  Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-                  <Button x:Name="PART_ClearButton"
-                          Grid.Column="2"
-                          Height="Auto"
-                          Padding="2,0,0,0"
-                          Command="{x:Static internal:ClearText.ClearCommand}"
-                          Focusable="False"
-                          Style="{StaticResource MaterialDesignToolButton}">
-                    <Button.Visibility>
-                      <MultiBinding Converter="{StaticResource ClearButtonVisibilityConverter}">
-                        <Binding Path="(wpf:TextFieldAssist.HasClearButton)" RelativeSource="{RelativeSource TemplatedParent}" />
-                        <Binding ElementName="Hint" Path="IsContentNullOrEmpty" />
-                      </MultiBinding>
-                    </Button.Visibility>
-                    <wpf:PackIcon Margin="0" Kind="CloseCircle" />
-                  </Button>
+                    <Button x:Name="PART_ClearButton"
+                            Height="Auto"
+                            Padding="2,0,0,0"
+                            Command="{x:Static internal:ClearText.ClearCommand}"
+                            Focusable="False"
+                            Style="{StaticResource MaterialDesignToolButton}">
+                      <Button.Visibility>
+                        <MultiBinding Converter="{StaticResource ClearButtonVisibilityConverter}">
+                          <Binding Path="(wpf:TextFieldAssist.HasClearButton)" RelativeSource="{RelativeSource TemplatedParent}" />
+                          <Binding ElementName="Hint" Path="IsContentNullOrEmpty" />
+                        </MultiBinding>
+                      </Button.Visibility>
+                      <wpf:PackIcon Margin="0" Kind="CloseCircle" />
+                    </Button>
+                  </StackPanel>
                 </Grid>
               </Border>
             </AdornerDecorator>
@@ -306,6 +319,61 @@
                 </Setter.Value>
               </Setter>
             </MultiTrigger>
+
+            <!-- Icon margins adhering to VerticalContentAlignment for default/filled style -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                <Condition SourceName="LeadingPackIcon" Property="VerticalAlignment" Value="Center" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="-6" />
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleLeadingIconMarginConverterCenter}}" />
+              <Setter TargetName="TrailingGrid" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterCenter}}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                <Condition SourceName="LeadingPackIcon" Property="VerticalAlignment" Value="Top" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleLeadingIconMarginConverterTop}}" />
+              <Setter TargetName="TrailingGrid" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterTop}}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                <Condition SourceName="LeadingPackIcon" Property="VerticalAlignment" Value="Bottom" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleLeadingIconMarginConverterBottom}}" />
+              <Setter TargetName="TrailingGrid" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterBottom}}" />
+            </MultiTrigger>
+
+            <!-- Icon margins adhering to VerticalContentAlignment for outlined style -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                <Condition SourceName="LeadingPackIcon" Property="VerticalAlignment" Value="Center" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleLeadingIconMarginConverterCenter}}" />
+              <Setter TargetName="TrailingGrid" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterCenter}}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                <Condition SourceName="LeadingPackIcon" Property="VerticalAlignment" Value="Top" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleLeadingIconMarginConverterTop}}" />
+              <Setter TargetName="TrailingGrid" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterTop}}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                <Condition SourceName="LeadingPackIcon" Property="VerticalAlignment" Value="Bottom" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleLeadingIconMarginConverterBottom}}" />
+              <Setter TargetName="TrailingGrid" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterBottom}}" />
+            </MultiTrigger>
+
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
             </Trigger>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -201,6 +201,7 @@
 
                       <TextBlock x:Name="SuffixTextBlock"
                                  Grid.Column="2"
+                                 Margin="0,0,2,0"
                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                  FontSize="{TemplateBinding FontSize}"
                                  Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -248,7 +248,7 @@
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -258,7 +258,7 @@
               <Setter TargetName="grid" Property="Margin">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -286,7 +286,7 @@
               <Setter TargetName="Hint" Property="FloatingOffset">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding Path="FontFamily" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="FontFamily" ElementName="Hint" />
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -20,6 +20,7 @@
   <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverter" CloneEdges="Top,Right,Bottom" FixedLeft="0" />
   <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverterTop" CloneEdges="Top,Right,Bottom" FixedLeft="0" AdditionalOffsetTop="12" />
   <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
+  <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
 
   <Style x:Key="MaterialDesignTimePickerTextBox" TargetType="{x:Type wpf:TimePickerTextBox}">
     <Setter Property="AllowDrop" Value="true" />
@@ -144,7 +145,8 @@
                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                               Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}" />
+                               Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}"
+                               Visibility="{TemplateBinding wpf:TextFieldAssist.PrefixText, Converter={StaticResource NullableToVisibilityConverter}}" />
                     <ContentControl x:Name="PART_Watermark"
                                     Grid.Column="1"
                                     Focusable="False"
@@ -190,7 +192,8 @@
                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                               Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />
+                               Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}"
+                               Visibility="{TemplateBinding wpf:TextFieldAssist.SuffixText, Converter={StaticResource NullableToVisibilityConverter}}" />
                   </Grid>
                   <Button x:Name="PART_ClearButton"
                           Grid.Column="1"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -267,7 +267,9 @@
                     <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="Padding" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="VerticalContentAlignment" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
                 </Setter.Value>
               </Setter>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -521,6 +521,7 @@
                                    wpf:HintAssist.Hint="{TemplateBinding wpf:HintAssist.Hint}"
                                    wpf:HintAssist.HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                    wpf:HintAssist.IsFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                                   wpf:HintAssist.FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
                                    wpf:TextFieldAssist.DecorationVisibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}"
                                    wpf:TextFieldAssist.HasClearButton="{TemplateBinding wpf:TextFieldAssist.HasClearButton}"
                                    wpf:TextFieldAssist.HasFilledTextField="{TemplateBinding wpf:TextFieldAssist.HasFilledTextField}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -1,5 +1,4 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
@@ -15,9 +14,12 @@
   <converters:NotConverter x:Key="NotConverter" />
   <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
   <converters:FloatingHintOffsetCalculationConverter x:Key="FloatingHintOffsetCalculationConverter" />
-  <converters:PickerInnerPaddingConverter x:Key="PickerInnerPaddingConverter" />
   <converters:OutlinedDateTimePickerActiveBorderThicknessConverter x:Key="OutlinedDateTimePickerActiveBorderThicknessConverter" />
   <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left" />
+  <converters:ThicknessCloneConverter x:Key="TimePickerTextBoxPaddingConverter" CloneEdges="All" AdditionalOffsetRight="18" />
+  <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverter" CloneEdges="Top,Right,Bottom" FixedLeft="0" />
+  <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverterTop" CloneEdges="Top,Right,Bottom" FixedLeft="0" AdditionalOffsetTop="12" />
+  <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
 
   <Style x:Key="MaterialDesignTimePickerTextBox" TargetType="{x:Type wpf:TimePickerTextBox}">
     <Setter Property="AllowDrop" Value="true" />
@@ -122,14 +124,14 @@
                       BorderThickness="{TemplateBinding BorderThickness}"
                       CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                       SnapsToDevicePixels="True">
-                <Grid HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition />
                     <ColumnDefinition Width="Auto" />
                   </Grid.ColumnDefinitions>
                   <Grid x:Name="grid"
                         MinWidth="1"
-                        VerticalAlignment="Center"
+                        VerticalAlignment="Stretch"
                         HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition Width="Auto" />
@@ -138,6 +140,8 @@
                     </Grid.ColumnDefinitions>
                     <TextBlock x:Name="PrefixTextBlock"
                                Grid.Column="0"
+                               Margin="0,0,2,0"
+                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}" />
@@ -150,6 +154,10 @@
                     <ScrollViewer x:Name="PART_ContentHost"
                                   Grid.Column="1"
                                   Panel.ZIndex="1"
+                                  VerticalAlignment="Stretch"
+                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  HorizontalAlignment="Stretch"
+                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   wpf:ScrollViewerAssist.IgnorePadding="True"
                                   Focusable="false"
                                   HorizontalScrollBarVisibility="Hidden"
@@ -165,6 +173,8 @@
                                    HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                    HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                    UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                                   VerticalAlignment="Stretch"
+                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}">
                       <wpf:SmartHint.Hint>
                         <Border x:Name="HintBackgroundBorder"
@@ -176,6 +186,8 @@
                     </wpf:SmartHint>
                     <TextBlock x:Name="SuffixTextBlock"
                                Grid.Column="2"
+                               Margin="0,0,2,0"
+                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                FontSize="{TemplateBinding FontSize}"
                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}" />
@@ -184,6 +196,7 @@
                           Grid.Column="1"
                           Height="Auto"
                           Padding="2,0,0,0"
+                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                           Command="{x:Static internal:ClearText.ClearCommand}"
                           Focusable="False"
                           Style="{DynamicResource MaterialDesignToolButton}">
@@ -253,6 +266,16 @@
                 </Setter.Value>
               </Setter>
             </MultiTrigger>
+
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                <Condition Property="VerticalContentAlignment" Value="Center" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="-6" />
+            </MultiTrigger>
+
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
             </Trigger>
@@ -485,11 +508,11 @@
           </ControlTemplate.Resources>
           <Grid x:Name="PART_Root">
             <wpf:TimePickerTextBox x:Name="PART_TextBox"
-                                   Grid.Row="0"
-                                   Grid.Column="0"
+                                   Padding="{TemplateBinding Padding, Converter={StaticResource TimePickerTextBoxPaddingConverter}}"
                                    HorizontalAlignment="Stretch"
+                                   VerticalAlignment="Stretch"
                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                   VerticalContentAlignment="Center"
+                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                    wpf:HintAssist.FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
                                    wpf:HintAssist.FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
                                    wpf:HintAssist.Foreground="{TemplateBinding wpf:HintAssist.Foreground}"
@@ -512,21 +535,12 @@
                                    wpf:TextFieldAssist.UnderlineCornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
                                    BorderBrush="{TemplateBinding BorderBrush}"
                                    Focusable="{TemplateBinding Focusable}"
-                                   Style="{DynamicResource MaterialDesignTimePickerTextBox}">
-              <wpf:TimePickerTextBox.Padding>
-                <MultiBinding Converter="{StaticResource PickerInnerPaddingConverter}">
-                  <Binding Path="Padding" RelativeSource="{RelativeSource TemplatedParent}" />
-                  <Binding ElementName="PART_Button"
-                           Mode="OneWay"
-                           Path="ActualWidth" />
-                </MultiBinding>
-              </wpf:TimePickerTextBox.Padding>
-            </wpf:TimePickerTextBox>
+                                   Style="{DynamicResource MaterialDesignTimePickerTextBox}" />
             <Button x:Name="PART_Button"
                     Height="16"
-                    Margin="{TemplateBinding Padding, Converter={StaticResource PickerInnerPaddingConverter}}"
+                    Margin="{TemplateBinding Padding, Converter={StaticResource PartButtonMarginConverter}}"
                     HorizontalAlignment="Right"
-                    VerticalAlignment="Center"
+                    VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
                     Focusable="False"
                     Foreground="{TemplateBinding BorderBrush}"
                     Template="{StaticResource ClockButtonTemplate}" />
@@ -539,6 +553,16 @@
                    StaysOpen="False" />
           </Grid>
           <ControlTemplate.Triggers>
+
+            <!-- PART_Button margins adhering to VerticalContentAlignment for default/filled style when VerticalContentAlignment=Top (other cases handled by default value) -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition SourceName="PART_Button" Property="VerticalAlignment" Value="Top" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_Button" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource PartButtonMarginConverterTop}}" />
+            </MultiTrigger>
+
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
               <Setter Property="Background" Value="{DynamicResource MaterialDesignTextFieldBoxBackground}" />
             </Trigger>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -231,7 +231,8 @@
                          MaxWidth="{Binding ActualWidth, ElementName=border}"
                          FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                          Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                         Text="{TemplateBinding wpf:HintAssist.HelperText}" />
+                         Text="{TemplateBinding wpf:HintAssist.HelperText}"
+                         Style="{Binding Path=(wpf:HintAssist.HelperTextStyle), RelativeSource={RelativeSource TemplatedParent}}"/>
             </Canvas>
           </Grid>
           <ControlTemplate.Triggers>
@@ -521,6 +522,7 @@
                                    wpf:HintAssist.Foreground="{TemplateBinding wpf:HintAssist.Foreground}"
                                    wpf:HintAssist.HelperText="{TemplateBinding wpf:HintAssist.HelperText}"
                                    wpf:HintAssist.HelperTextFontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
+                                   wpf:HintAssist.HelperTextStyle="{TemplateBinding wpf:HintAssist.HelperTextStyle}"
                                    wpf:HintAssist.Hint="{TemplateBinding wpf:HintAssist.Hint}"
                                    wpf:HintAssist.HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                    wpf:HintAssist.IsFloating="{TemplateBinding wpf:HintAssist.IsFloating}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -497,6 +497,7 @@
     <Setter Property="ClockStyle" Value="{DynamicResource MaterialDesignClock}" />
     <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="IsHeaderVisible" Value="True" />
     <Setter Property="Padding" Value="{x:Static wpf:Constants.TextBoxDefaultPadding}" />
     <Setter Property="Template">


### PR DESCRIPTION
Fixes #3174

A number of issues (including the one above) have been reported with the alignment of the `SmartHint`, and there are also several different approaches to "solving the same problem" for the different controls.

This PR aims to align this across the control styles for:
* `TextBox`
* `RichTextBox`
* `PasswordBox`
* `ComboBox`
* `DatePicker`
* `TimePicker`

There are a number of variables to consider when figuring out the hint placement, and I don't believe any of the current controls handle all of them. As mentioned, this PR aims to align the approach across the above templates taking the following into account for the placement of the hint (and leading/trailing icons, buttons, prefix texts, and suffix texts):

* `Control.Padding`
* `Control.VerticalContentAlignment`
* `Control.HorizontalContentAlignment`
* `Control.Height`
* `Control.FontSize` - 🔴 Currently only partially supported; similar to before this PR
* `HintAssist.FloatingScale`
* `HintAssist.FloatingOffset`
* `HintAssist.FloatingHintHorizontalAlignment`
* `HintAssist.FontFamily`
* Styles ("Floating", "Filled", "Outlined")

The `Smart Hint` demo app page is extended to include manual testing options for all of this. Please check out the branch and take "this for a spin" playing around with the various options. As noted below, you can configure some combinations which are a bit strange, but I believe you could do that before this PR as well. Additional clean up could be done.
<img width="189" src="https://user-images.githubusercontent.com/19572699/235677921-2bfdfd7b-8499-4077-98ca-deab761887b2.png">
![image](https://user-images.githubusercontent.com/19572699/235625100-44a66f2a-df8a-4eeb-814d-ed88180efba2.png)

In the current state of the PR, the `FontSize` is only supported when no explicit `Height` is applied, and even then it is only partially supported if a non-default `FontSize` is applied. It was like that before this PR as well, although it there may be some differences in certain scenarios; it is a bit hard to say. I am still working on my local branch trying to make this work for all font sizes, but that might end up being a different PR in the end as I think it may require some significant changes to the many converters that are in play for adjusting `Padding`/`Margin` in the `Top`/`Center`/`Bottom`/`Stretch` cases of `VerticalContentAlignment`.

The `TextBox` styles support all of the properties that can be modified in these panels, but the other control styles only support a sub-set of them. Each control style seemingly supporting a different sub-set 🤔. This PR does not seek to align that. If people need it, I hope/assume they will create an issue in the repo.

It is quite possible for consumers of the controls to configure a combination of the features which end up not looking as nice as you would hope. I believe these are separate issues though, and could be handled as such.

As we've discussed, I believe it might be a good idea to split some of the templates apart going forward. Having a single control template trying to juggle 3 different styles (via attached properties) and placing/moving content accordingly makes the templates quite complex. The changes - in particular added use of converters - in this PR does not make it any less complex!