### PR TITLE
Add support for RippleAssist.IsCentered and RippleAssist.ClipToBounds on PopupBox

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -89,6 +89,8 @@
     <Setter Property="PopupElevation" Value="Dp6" />
     <Setter Property="PopupVerticalOffset" Value="0" />
     <Setter Property="ToolTipService.IsEnabled" Value="{Binding IsPopupOpen, RelativeSource={RelativeSource Self}, Converter={StaticResource NotConverter}}"/>
+    <Setter Property="wpf:RippleAssist.ClipToBounds" Value="False" />
+    <Setter Property="wpf:RippleAssist.IsCentered" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type wpf:PopupBox}">
@@ -105,8 +107,6 @@
                     <wpf:Ripple Padding="{TemplateBinding Padding}"
                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                wpf:RippleAssist.IsCentered="True"
-                                ClipToBounds="False"
                                 Content="{TemplateBinding Content}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}"
                                 Focusable="False"
@@ -198,6 +198,7 @@
     <Setter Property="HorizontalAlignment" Value="Left" />
     <Setter Property="PlacementMode" Value="TopAndAlignCentres" />
     <Setter Property="PopupMode" Value="Click" />
+    <Setter Property="wpf:RippleAssist.IsCentered" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type wpf:PopupBox}">
@@ -268,7 +269,6 @@
                       <wpf:Ripple Padding="{TemplateBinding Padding}"
                                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                  wpf:RippleAssist.IsCentered="True"
                                   Clip="{Binding ElementName=GeometryEllipse, Path=RenderedGeometry}"
                                   ClipToBounds="True"
                                   Focusable="False"


### PR DESCRIPTION
As mentioned in [discussion 3196](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/discussions/3196) `RippleAssist.IsCentered` and `RippleAssist.ClipToBounds` have no effect on the `PopupBox`.

This PR adds support for controlling both these properties for the default style, and only the `RippleAssist.IsCentered` for the floating action style; because the latter has bordered button and as such I don't think it makes sense to let the ripple flow outside of that button.

This shows both `PopupBox` styles with `RippleAssist.IsCentered=false` and `RippleAssist.ClipToBounds=false`:
![PopupBox](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/c5494dc7-3f3b-462d-8f76-eb99d443cd4b)
