### PR TITLE
Removed netcoreapp3.1 tfm

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            3.1.x
             6.x
             7.x
           

--- a/MahMaterialDragablzMashUp/MahAppsDragablzDemo.csproj
+++ b/MahMaterialDragablzMashUp/MahAppsDragablzDemo.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0-windows;net7.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/MainDemo.Wpf/MaterialDesignDemo.csproj
+++ b/MainDemo.Wpf/MaterialDesignDemo.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0-windows;net7.0-windows</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Prefer32Bit Condition="'$(TargetFramework)' == 'net472'">true</Prefer32Bit>
     <ApplicationIcon>favicon.ico</ApplicationIcon>

--- a/MaterialDesign3.Demo.Wpf/MaterialDesign3Demo.csproj
+++ b/MaterialDesign3.Demo.Wpf/MaterialDesign3Demo.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0-windows;net7.0-windows</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Prefer32Bit Condition="'$(TargetFramework)' == 'net472'">true</Prefer32Bit>
     <ApplicationIcon>favicon.ico</ApplicationIcon>

--- a/MaterialDesignColors.Wpf.Tests/MaterialDesignColors.Wpf.Tests.csproj
+++ b/MaterialDesignColors.Wpf.Tests/MaterialDesignColors.Wpf.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0-windows;net7.0-windows</TargetFrameworks>
     <AssemblyTitle>MaterialDesignColors.Wpf.Tests</AssemblyTitle>
     <Product>MaterialDesignColors.Wpf.Tests</Product>
   </PropertyGroup>

--- a/MaterialDesignColors.Wpf/MaterialDesignColors.Wpf.csproj
+++ b/MaterialDesignColors.Wpf/MaterialDesignColors.Wpf.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>MaterialDesignColors</RootNamespace>
     <AssemblyName>MaterialDesignColors</AssemblyName>
-    <TargetFrameworks>net462;netcoreapp3.1;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <MDIXColorsVersion Condition="$(MDIXColorsVersion) == '' Or $(MDIXColorsVersion) == '*Undefined*'">1.0.1</MDIXColorsVersion>
     <MDIXColorsVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(MDIXColorsVersion)", "-ci\d+$", ""))</MDIXColorsVersion>

--- a/MaterialDesignColors.nuspec
+++ b/MaterialDesignColors.nuspec
@@ -16,15 +16,13 @@
     <tags>WPF XAML Material Design Colour Color UI UX</tags>
     <dependencies>
       <group targetFramework="net462" />
-      <group targetFramework="netcoreapp3.1" />
       <group targetFramework="net6.0" />
       <group targetFramework="net7.0" />
     </dependencies>
   </metadata>
   <files>
     <file src="MaterialDesignColors.Wpf\bin\$configuration$\net462\MaterialDesignColors.*" target="lib\net462" exclude="**\*.json" />
-    <file src="MaterialDesignColors.Wpf\bin\$configuration$\netcoreapp3.1\MaterialDesignColors.*" target="lib\netcoreapp3.1" exclude="**\*.json" />
-    <file src="MaterialDesignColors.Wpf\bin\$configuration$\net6.0-windows\MaterialDesignColors.*" target="lib\net6.0" exclude="**\*.json" />
+\    <file src="MaterialDesignColors.Wpf\bin\$configuration$\net6.0-windows\MaterialDesignColors.*" target="lib\net6.0" exclude="**\*.json" />
     <file src="MaterialDesignColors.Wpf\bin\$configuration$\net7.0-windows\MaterialDesignColors.*" target="lib\net7.0" exclude="**\*.json" />
   </files>
 </package>

--- a/MaterialDesignColors.nuspec
+++ b/MaterialDesignColors.nuspec
@@ -22,7 +22,7 @@
   </metadata>
   <files>
     <file src="MaterialDesignColors.Wpf\bin\$configuration$\net462\MaterialDesignColors.*" target="lib\net462" exclude="**\*.json" />
-\    <file src="MaterialDesignColors.Wpf\bin\$configuration$\net6.0-windows\MaterialDesignColors.*" target="lib\net6.0" exclude="**\*.json" />
+    <file src="MaterialDesignColors.Wpf\bin\$configuration$\net6.0-windows\MaterialDesignColors.*" target="lib\net6.0" exclude="**\*.json" />
     <file src="MaterialDesignColors.Wpf\bin\$configuration$\net7.0-windows\MaterialDesignColors.*" target="lib\net7.0" exclude="**\*.json" />
   </files>
 </package>

--- a/MaterialDesignThemes.MahApps.nuspec
+++ b/MaterialDesignThemes.MahApps.nuspec
@@ -20,11 +20,6 @@
         <dependency id="MaterialDesignThemes" version="0.0.0" />
         <dependency id="MahApps.Metro" version="2.0.0" />
       </group>
-      <group targetFramework="netcoreapp3.1">
-        <dependency id="MaterialDesignColors" version="0.0.0" />
-        <dependency id="MaterialDesignThemes" version="0.0.0" />
-        <dependency id="MahApps.Metro" version="2.0.0" />
-      </group>
       <group targetFramework="net6.0">
         <dependency id="MaterialDesignColors" version="0.0.0" />
         <dependency id="MaterialDesignThemes" version="0.0.0" />
@@ -39,7 +34,6 @@
   </metadata>
   <files>
     <file src="MaterialDesignThemes.MahApps\bin\$configuration$\net462\MaterialDesignThemes.MahApps.*" target="lib\net462" exclude="**\*.json" />
-    <file src="MaterialDesignThemes.MahApps\bin\$configuration$\netcoreapp3.1\MaterialDesignThemes.MahApps.*" target="lib\netcoreapp3.1" exclude="**\*.json" />
     <file src="MaterialDesignThemes.MahApps\bin\$configuration$\net6.0-windows\MaterialDesignThemes.MahApps.*" target="lib\net6.0" exclude="**\*.json" />
     <file src="MaterialDesignThemes.MahApps\bin\$configuration$\net7.0-windows\MaterialDesignThemes.MahApps.*" target="lib\net7.0" exclude="**\*.json" />
   </files>

--- a/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.csproj
+++ b/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp3.1;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <MDIXMahAppsVersion Condition="$(MDIXMahAppsVersion) == '' Or $(MDIXMahAppsVersion) == '*Undefined*'">1.0.1</MDIXMahAppsVersion>
     <MDIXMahAppsVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(MDIXMahAppsVersion)", "-ci\d+$", ""))</MDIXMahAppsVersion>

--- a/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
+++ b/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0-windows;net7.0-windows</TargetFrameworks>
     <AssemblyTitle>MaterialDesignThemes.Wpf.Tests</AssemblyTitle>
     <Product>MaterialDesignThemes.Wpf.Tests</Product>
   </PropertyGroup>

--- a/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
+++ b/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp3.1;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <MDIXVersion Condition="$(MDIXVersion) == '' Or $(MDIXVersion) == '*Undefined*'">1.0.1</MDIXVersion>
     <MDIXVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(MDIXVersion)", "-ci\d+$", ""))</MDIXVersion>

--- a/MaterialDesignThemes.nuspec
+++ b/MaterialDesignThemes.nuspec
@@ -19,10 +19,6 @@
         <dependency id="MaterialDesignColors" version="0.0.0" />
         <dependency id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" />
       </group>
-      <group targetFramework="netcoreapp3.1">
-        <dependency id="MaterialDesignColors" version="0.0.0" />
-        <dependency id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" />
-      </group>
       <group targetFramework="net6.0">
         <dependency id="MaterialDesignColors" version="0.0.0" />
         <dependency id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" />
@@ -35,7 +31,6 @@
   </metadata>
   <files>
     <file src="MaterialDesignThemes.Wpf\bin\$configuration$\net462\MaterialDesignThemes.Wpf.*" target="lib\net462" exclude="**\*.json" />
-    <file src="MaterialDesignThemes.Wpf\bin\$configuration$\netcoreapp3.1\MaterialDesignThemes.Wpf.*" target="lib\netcoreapp3.1" exclude="**\*.json" />
     <file src="MaterialDesignThemes.Wpf\bin\$configuration$\net6.0-windows\MaterialDesignThemes.Wpf.*" target="lib\net6.0" exclude="**\*.json" />
     <file src="MaterialDesignThemes.Wpf\bin\$configuration$\net7.0-windows\MaterialDesignThemes.Wpf.*" target="lib\net7.0" exclude="**\*.json" />
     <file src="MaterialDesignThemes.Wpf\Resources\Roboto\*.ttf" target="build\Resources\Roboto" />


### PR DESCRIPTION
I removed the .NET Core 3.1 TFM due to [reaching its end-of-life on December 13th, 2022](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).