### PR TITLE
Fix ListBox focus issue when ListBoxAssist.IsToggle=True

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/ListBoxes/ListBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/ListBoxes/ListBoxTests.cs
@@ -143,4 +143,39 @@ ScrollViewer.VerticalScrollBarVisibility=""Visible"">
 
         recorder.Success();
     }
+
+    [Fact]
+    [Description("Issue 3188")]
+    public async Task OnToggle_ShouldGrabFocus()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        var stackPanel = await LoadXaml<StackPanel>("""
+            <StackPanel Orientation="Vertical">
+                <ListBox MinWidth="200"
+                         materialDesign:ListBoxAssist.IsToggle="True">
+                    <ListBoxItem Content="Item1" />
+                    <ListBoxItem Content="Item2" />
+                    <ListBoxItem Content="Item3" />
+                    <ListBoxItem Content="Item4" />
+                </ListBox>
+                <TextBox />
+            </StackPanel>
+            """);
+
+        var listBox = await stackPanel.GetElement<ListBox>("/ListBox");
+        var textBox = await stackPanel.GetElement<TextBox>("/TextBox");
+        var listBoxItem = await listBox.GetElement<ListBoxItem>("/ListBoxItem[2]");
+
+        await textBox.LeftClick();
+        Assert.True(await textBox.GetIsKeyboardFocusWithin());
+
+        // Act
+        await listBoxItem.LeftClick();
+
+        // Assert
+        await Wait.For(async () => Assert.True(await listBox.GetIsKeyboardFocusWithin()));
+
+        recorder.Success();
+    }
 }

--- a/MaterialDesignThemes.Wpf/ListBoxAssist.cs
+++ b/MaterialDesignThemes.Wpf/ListBoxAssist.cs
@@ -35,6 +35,7 @@ namespace MaterialDesignThemes.Wpf
             listBoxItem.SetCurrentValue(ListBoxItem.IsSelectedProperty, !listBoxItem.IsSelected);
             mouseButtonEventArgs.Handled = true;
 
+            listBoxItem.Focus();
             if (ripple != null && listBoxItem.IsSelected)
             {
                 ripple.RaiseEvent(


### PR DESCRIPTION
Fixes #3188 

`ListBoxAssist.IsToggle=true` adds custom click handling but does not grab focus. This PR ensures the `ListBox` will gain focus when an item is toggled.