### PR TITLE
Refactor GroupBox elevation

### DIFF
--- a/MainDemo.Wpf/GroupBoxes.xaml
+++ b/MainDemo.Wpf/GroupBoxes.xaml
@@ -32,6 +32,7 @@
       <RowDefinition />
       <RowDefinition />
       <RowDefinition />
+      <RowDefinition />
     </Grid.RowDefinitions>
     <smtx:XamlDisplay Grid.Row="0"
                       Grid.Column="0"
@@ -176,6 +177,44 @@
         <Image HorizontalAlignment="Center"
                VerticalAlignment="Center"
                Source="Resources/Contact.png" />
+      </GroupBox>
+    </smtx:XamlDisplay>
+
+    <smtx:XamlDisplay Grid.Row="3"
+                      Grid.Column="0"
+                      UniqueKey="groupbox_9">
+      <GroupBox Margin="16"
+                Header="Elevation"
+                materialDesign:ElevationAssist.Elevation="Dp6"
+                Style="{StaticResource MaterialDesignGroupBox}">
+        <Grid Height="50">
+          <TextBlock Text="GroupBox (with border) and elevation" VerticalAlignment="Center" />
+        </Grid>
+      </GroupBox>
+    </smtx:XamlDisplay>
+    <smtx:XamlDisplay Grid.Row="3"
+                      Grid.Column="1"
+                      UniqueKey="groupbox_10">
+      <GroupBox Margin="16"
+                Header="Elevation (no border)"
+                materialDesign:ElevationAssist.Elevation="Dp6"
+                BorderThickness="0"
+                Style="{StaticResource MaterialDesignGroupBox}">
+        <Grid Height="50">
+          <TextBlock Text="GroupBox (without border) and elevation" VerticalAlignment="Center" />
+        </Grid>
+      </GroupBox>
+    </smtx:XamlDisplay>
+    <smtx:XamlDisplay Grid.Row="3"
+                      Grid.Column="2"
+                      UniqueKey="groupbox_11">
+      <GroupBox Margin="16"
+                Header="Elevation on Card"
+                materialDesign:ElevationAssist.Elevation="Dp6"
+                Style="{StaticResource MaterialDesignCardGroupBox}">
+        <Grid Height="50">
+          <TextBlock Text="GroupBox (using Card style) and elevation" VerticalAlignment="Center" />
+        </Grid>
       </GroupBox>
     </smtx:XamlDisplay>
   </Grid>

--- a/MainDemo.Wpf/GroupBoxes.xaml
+++ b/MainDemo.Wpf/GroupBoxes.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="MaterialDesignDemo.GroupBoxes"
+<UserControl x:Class="MaterialDesignDemo.GroupBoxes"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -185,6 +185,7 @@
                       UniqueKey="groupbox_9">
       <GroupBox Margin="16"
                 Header="Elevation"
+                Background="White"
                 materialDesign:ElevationAssist.Elevation="Dp6"
                 Style="{StaticResource MaterialDesignGroupBox}">
         <Grid Height="50">
@@ -197,6 +198,7 @@
                       UniqueKey="groupbox_10">
       <GroupBox Margin="16"
                 Header="Elevation (no border)"
+                Background="White"
                 materialDesign:ElevationAssist.Elevation="Dp6"
                 BorderThickness="0"
                 Style="{StaticResource MaterialDesignGroupBox}">

--- a/MainDemo.Wpf/GroupBoxes.xaml
+++ b/MainDemo.Wpf/GroupBoxes.xaml
@@ -14,6 +14,10 @@
       <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.GroupBox.xaml" />
       </ResourceDictionary.MergedDictionaries>
+
+      <Style TargetType="smtx:XamlDisplay" BasedOn="{StaticResource {x:Type smtx:XamlDisplay}}">
+        <Setter Property="MaxWidth" Value="350" />
+      </Style>
     </ResourceDictionary>
   </UserControl.Resources>
 

--- a/MaterialDesignThemes.Wpf/Converters/IsTransparentBrushConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/IsTransparentBrushConverter.cs
@@ -1,0 +1,14 @@
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace MaterialDesignThemes.Wpf.Converters;
+
+public class IsTransparentBrushConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => Equals(value, Brushes.Transparent);
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/MaterialDesignThemes.Wpf/Converters/IsTransparentBrushConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/IsTransparentBrushConverter.cs
@@ -4,7 +4,7 @@ using System.Windows.Media;
 
 namespace MaterialDesignThemes.Wpf.Converters;
 
-public class IsTransparentBrushConverter : IValueConverter
+public sealed class IsTransparentBrushConverter : IValueConverter
 {
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         => Equals(value, Brushes.Transparent);

--- a/MaterialDesignThemes.Wpf/Converters/IsTransparentBrushConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/IsTransparentBrushConverter.cs
@@ -7,7 +7,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 public sealed class IsTransparentBrushConverter : IValueConverter
 {
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => Equals(value, Brushes.Transparent);
+        => value is null || Equals(value, Brushes.Transparent);
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotImplementedException();

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.GroupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.GroupBox.xaml
@@ -1,7 +1,9 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+
+  <converters:IsTransparentBrushConverter x:Key="IsTransparentBrushConverter" />
 
   <Style x:Key="MaterialDesignHeaderedContentControl" TargetType="{x:Type HeaderedContentControl}">
     <Setter Property="Template">
@@ -28,18 +30,17 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type GroupBox}">
-          <Grid>
-            <Border Background="{TemplateBinding Background}"
+          <Grid x:Name="OuterGrid">
+            <Border x:Name="Border"
+                    Background="{TemplateBinding Background}"
                     BorderBrush="{Binding Path=Background, ElementName=PART_ColorZone}"
                     BorderThickness="{TemplateBinding BorderThickness}" />
-            <DockPanel Background="{TemplateBinding Background}">
+            <DockPanel Margin="{TemplateBinding BorderThickness}">
               <wpf:ColorZone x:Name="PART_ColorZone"
                              Padding="{TemplateBinding Padding}"
                              wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
                              wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}"
-                             wpf:ShadowAssist.ShadowEdges="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowEdges)}"
                              DockPanel.Dock="Top"
-                             Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}"
                              Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}"
                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                              UseLayoutRounding="True">
@@ -57,6 +58,14 @@
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
             </DockPanel>
           </Grid>
+          <ControlTemplate.Triggers>
+            <DataTrigger Binding="{Binding ElementName=Border, Path=Background, Converter={StaticResource IsTransparentBrushConverter}}" Value="True">
+              <Setter TargetName="PART_ColorZone" Property="Effect" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding ElementName=Border, Path=Background, Converter={StaticResource IsTransparentBrushConverter}}" Value="False">
+              <Setter TargetName="OuterGrid" Property="Effect" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}" />
+            </DataTrigger>
+          </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
@@ -73,14 +82,14 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type GroupBox}">
-          <wpf:Card VerticalAlignment="Stretch">
+          <wpf:Card VerticalAlignment="Stretch"
+                    wpf:ElevationAssist.Elevation="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation)}">
             <DockPanel Background="{TemplateBinding Background}">
               <wpf:ColorZone x:Name="PART_ColorZone"
                              Padding="{TemplateBinding Padding}"
                              wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
                              wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}"
                              DockPanel.Dock="Top"
-                             Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}"
                              Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}">
                 <ContentPresenter ContentSource="Header"
                                   ContentStringFormat="{TemplateBinding HeaderStringFormat}"
@@ -100,6 +109,6 @@
       </Setter.Value>
     </Setter>
     <Setter Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid" />
-    <Setter Property="wpf:ElevationAssist.Elevation" Value="Dp0" />
+    <Setter Property="wpf:ElevationAssist.Elevation" Value="Dp1" />
   </Style>
 </ResourceDictionary>


### PR DESCRIPTION
As mentioned in discussion #3201, there is something that does not work as expected with the elevation in combination with `GroupBox`.

The demo app already includes a sample of a `GroupBox` with elevation only applied on the header (`ColorZone`), so I am assuming this is a needed feature, and thus this PR will retain it.

![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/0048f4d8-d95b-4895-9796-d410f8198624)

However, if the `GroupBox` has a border, or a background, or is using the "card" style, then I would also assume elevation should work, but that does not seem to be the case.

It currently looks like this:
![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/8975eee0-71e5-4cf8-8cd6-6c30aa354ae3)
You'll notice that the elevation is still only applied at the header. This seems wrong to me.

This PR changes it into this instead:
![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/1a6c3b6a-1a8f-4b31-b691-1db2be1a7b93)

Since the drop shadow is done using an `DropShadowEffect`, there is a bit of funkyness to this. If the `GroupBox.Background` property is left at its default value (`Transparent`), then the effect is applied only at the header to retain the current feature. However, if the it is set to any other value, then the effect is applied at the root grid instead, which effectively - in the case of a "reasonably opaque" brush - will let the shadow cover the whole body of the `GroupBox`. You can of course provide a funky value with a very low opacity and then you may not get the result you want. I could not really see any other good way to solve this. Hints/input is very welcome.

Another thing: I removed the use of the `ShadowAssist.ShadowEdges` attached property as I don't believe it has any effect. Perhaps it needs to be removed completely as part of the 5.0 release?
