### PR TITLE
Fix DialogHost (temporary) binding error

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -205,7 +205,7 @@
                   IsHitTestVisible="False"
                   Visibility="{Binding ElementName=ContentCoverBorder, Path=Visibility}">
               <Grid.OpacityMask>
-                <VisualBrush Visual="{Binding ElementName=ContentCoverBorder}" />
+                <VisualBrush Visual="{x:Reference ContentCoverBorder}" />
               </Grid.OpacityMask>
               <Border x:Name="ContentCoverBorder"
                       Background="{Binding OverlayBackground, RelativeSource={RelativeSource TemplatedParent}}"
@@ -380,7 +380,7 @@
                   IsHitTestVisible="False"
                   Visibility="{Binding ElementName=ContentCoverBorder, Path=Visibility}">
               <Grid.OpacityMask>
-                <VisualBrush Visual="{Binding ElementName=ContentCoverBorder}" />
+                <VisualBrush Visual="{x:Reference ContentCoverBorder}" />
               </Grid.OpacityMask>
               <Border x:Name="ContentCoverBorder"
                       Background="{Binding OverlayBackground, RelativeSource={RelativeSource TemplatedParent}}"


### PR DESCRIPTION
Fixes #3228 

Replaces the binding with an `{x:Reference}` which avoids the temporary binding error.

Inspection with Snoop:
![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/272209a1-4d7c-4aed-ac23-d688693641e4)
