### PR TITLE
Add leading icon support in PasswordBox variants

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:behaviors="http://schemas.microsoft.com/xaml/behaviors"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
@@ -22,6 +22,18 @@
   <converters:CursorConverter x:Key="ArrowCursorConverter" FallbackCursor="Arrow" />
   <converters:CursorConverter x:Key="IBeamCursorConverter" FallbackCursor="IBeam" />
   <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left" />
+  <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleLeadingIconMarginConverterTop"
+                                      AdditionalOffsetTop="-2"
+                                      CloneEdges="Top"
+                                      FixedRight="6" />
+  <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleLeadingIconMarginConverterCenter"
+                                      AdditionalOffsetTop="-12"
+                                      CloneEdges="Top"
+                                      FixedRight="6" />
+  <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleLeadingIconMarginConverterBottom"
+                                      CloneEdges="Top"
+                                      FixedBottom="-2"
+                                      FixedRight="6" />
   <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleTrailingIconMarginConverterTop"
                                       AdditionalOffsetTop="-2"
                                       CloneEdges="Top" />
@@ -31,6 +43,19 @@
   <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleTrailingIconMarginConverterBottom"
                                       CloneEdges="Top"
                                       FixedBottom="-2" />
+  <converters:ThicknessCloneConverter x:Key="OutlinedStyleLeadingIconMarginConverterTop"
+                                      AdditionalOffsetTop="-2"
+                                      CloneEdges="Top"
+                                      FixedRight="6" />
+  <converters:ThicknessCloneConverter x:Key="OutlinedStyleLeadingIconMarginConverterCenter"
+                                      AdditionalOffsetTop="0"
+                                      CloneEdges="Top"
+                                      FixedRight="6" />
+  <converters:ThicknessCloneConverter x:Key="OutlinedStyleLeadingIconMarginConverterBottom"
+                                      AdditionalOffsetTop="0"
+                                      CloneEdges="Top"
+                                      FixedBottom="-2"
+                                      FixedRight="6" />
   <converters:ThicknessCloneConverter x:Key="OutlinedStyleTrailingIconMarginConverterTop"
                                       AdditionalOffsetTop="-2"
                                       CloneEdges="Top" />
@@ -41,6 +66,8 @@
                                       AdditionalOffsetTop="0"
                                       CloneEdges="Top"
                                       FixedBottom="-2" />
+
+
   <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
   <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
 
@@ -156,10 +183,21 @@
                       SnapsToDevicePixels="True">
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                   <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
                     <ColumnDefinition />
                     <ColumnDefinition Width="Auto" />
                   </Grid.ColumnDefinitions>
+                  <wpf:PackIcon x:Name="LeadingPackIcon"
+                                Grid.Column="0"
+                                Width="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
+                                Height="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
+                                Margin="0,0,6,0"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
+                                Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
+                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
                   <Grid x:Name="grid"
+                        Grid.Column="1"
                         MinWidth="1"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch">
@@ -220,7 +258,7 @@
                                Visibility="{TemplateBinding wpf:TextFieldAssist.SuffixText, Converter={StaticResource NullableToVisibilityConverter}}" />
                   </Grid>
                   <Button x:Name="PART_ClearButton"
-                          Grid.Column="1"
+                          Grid.Column="2"
                           Height="Auto"
                           Padding="2,0,0,0"
                           VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
@@ -310,6 +348,7 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="-6" />
               <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterCenter}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleLeadingIconMarginConverterCenter}}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -317,6 +356,7 @@
                 <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Top" />
               </MultiTrigger.Conditions>
               <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterTop}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleLeadingIconMarginConverterTop}}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -324,6 +364,7 @@
                 <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Bottom" />
               </MultiTrigger.Conditions>
               <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterBottom}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleLeadingIconMarginConverterBottom}}" />
             </MultiTrigger>
 
             <!-- Icon margins adhering to VerticalContentAlignment for outlined style -->
@@ -333,6 +374,7 @@
                 <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Center" />
               </MultiTrigger.Conditions>
               <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterCenter}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleLeadingIconMarginConverterCenter}}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -340,6 +382,7 @@
                 <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Top" />
               </MultiTrigger.Conditions>
               <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterTop}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleLeadingIconMarginConverterTop}}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -347,6 +390,7 @@
                 <Condition SourceName="PART_ClearButton" Property="VerticalAlignment" Value="Bottom" />
               </MultiTrigger.Conditions>
               <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterBottom}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleLeadingIconMarginConverterBottom}}" />
             </MultiTrigger>
 
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
@@ -680,11 +724,22 @@
                       SnapsToDevicePixels="True">
                 <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                   <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
                   </Grid.ColumnDefinitions>
+                  <wpf:PackIcon x:Name="LeadingPackIcon"
+                                Grid.Column="0"
+                                Width="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
+                                Height="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
+                                Margin="0,0,6,0"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
+                                Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
+                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
                   <Grid x:Name="grid"
+                        Grid.Column="1"
                         MinWidth="1"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch">
@@ -774,7 +829,7 @@
                                Visibility="{TemplateBinding wpf:TextFieldAssist.SuffixText, Converter={StaticResource NullableToVisibilityConverter}}" />
                   </Grid>
                   <ToggleButton x:Name="RevealPasswordButton"
-                                Grid.Column="1"
+                                Grid.Column="2"
                                 Height="Auto"
                                 Padding="2,0,0,0"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
@@ -785,7 +840,7 @@
                                   Foreground="{Binding ElementName=PART_ClearButton, Path=Foreground}" />
                   </ToggleButton>
                   <Button x:Name="PART_ClearButton"
-                          Grid.Column="2"
+                          Grid.Column="3"
                           Height="Auto"
                           Padding="2,0,0,0"
                           VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
@@ -876,6 +931,7 @@
               <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="-6" />
               <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterCenter}}" />
               <Setter TargetName="RevealPasswordButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterCenter}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleLeadingIconMarginConverterCenter}}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -884,6 +940,7 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterTop}}" />
               <Setter TargetName="RevealPasswordButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterTop}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleLeadingIconMarginConverterTop}}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -892,6 +949,7 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterBottom}}" />
               <Setter TargetName="RevealPasswordButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleTrailingIconMarginConverterBottom}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource DefaultOrFilledStyleLeadingIconMarginConverterBottom}}" />
             </MultiTrigger>
 
             <!-- Icon margins adhering to VerticalContentAlignment for outlined style -->
@@ -902,6 +960,7 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterCenter}}" />
               <Setter TargetName="RevealPasswordButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterCenter}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleLeadingIconMarginConverterCenter}}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -910,6 +969,7 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterTop}}" />
               <Setter TargetName="RevealPasswordButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterTop}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleLeadingIconMarginConverterTop}}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -918,6 +978,7 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="PART_ClearButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterBottom}}" />
               <Setter TargetName="RevealPasswordButton" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleTrailingIconMarginConverterBottom}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Margin" Value="{Binding ElementName=grid, Path=Margin, Converter={StaticResource OutlinedStyleLeadingIconMarginConverterBottom}}" />
             </MultiTrigger>
 
             <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">


### PR DESCRIPTION
Fixes #3267 

This PR adds "leading icon" support to the `PasswordBox` variants. Basically a copy from the `TextBox` variants, slightly adjusted to fit the templates for the `PasswordBox`.

I tested it using the `Smart Hint` demo page to ensure variable height and vertical alignment is also respected. There weren't any UI tests in this area, so I decided not to add one.

![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/a789b4e4-9979-4abf-bdab-6e8597d56037)
