### PR TITLE
TabControl should honor TabItem.ContentTemplate (and others)

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/TabControls/TabControlTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TabControls/TabControlTests.cs
@@ -121,4 +121,38 @@ public class TabControlTests : TestBase
 
         recorder.Success();
     }
+
+    [Fact]
+    [Description("Issue 3271")]
+    public async Task TabControl_ShouldRespectSelectedContentTemplate_WhenSetDirectlyOnTabItem()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        //Arrange
+        IVisualElement<TabControl> tabControl = await LoadXaml<TabControl>("""
+            <TabControl materialDesign:ColorZoneAssist.Mode="PrimaryMid"
+                        Style="{StaticResource MaterialDesignFilledTabControl}">
+              <TabControl.Resources>
+                <DataTemplate x:Key="CustomContentTemplate">
+                  <Border Background="Fuchsia" Padding="10" Margin="10" CornerRadius="10">
+                    <TextBlock Text="{Binding .}" />
+                  </Border>
+                </DataTemplate>
+              </TabControl.Resources>
+              <TabItem Content="Tab content string" ContentTemplate="{StaticResource CustomContentTemplate}" />
+            </TabControl>
+            """);
+
+        IVisualElement<Border> selectedContentBorder = await tabControl.GetElement<Border>("PART_BorderSelectedContent");
+
+        //Act
+        var customContentBorder = await selectedContentBorder.GetElement<Border>("/Border");
+        IVisualElement<TextBlock> customContent = await customContentBorder.GetElement<TextBlock>(@"/TextBlock");
+
+        //Assert
+        Assert.Equal(Colors.Fuchsia, await customContentBorder.GetBackgroundColor());
+        Assert.Equal("Tab content string", await customContent.GetText());
+
+        recorder.Success();
+    }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -72,9 +72,9 @@
               <ContentPresenter x:Name="PART_SelectedContentHost"
                                 Margin="{TemplateBinding Padding}"
                                 ContentSource="SelectedContent"
-                                ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                ContentTemplate="{TemplateBinding ContentTemplate}"
-                                ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                ContentStringFormat="{TemplateBinding SelectedContentStringFormat}"
+                                ContentTemplate="{TemplateBinding SelectedContentTemplate}"
+                                ContentTemplateSelector="{TemplateBinding SelectedContentTemplateSelector}"
                                 Focusable="False"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
             </Border>


### PR DESCRIPTION
Fixes #3271

This PR fixes the issue that the `TabControl` template does not honor the `TabItem.ContentTemplate` property (and the other `TabItem.ContentXyz` properties).

I added a UI test which asserts that the `TabItem.ContentTemplate` is now honored, but I did not bother testing all the properties.