### PR TITLE
Ensure clear button does not overlap editable text in ComboBox

### DIFF
--- a/MaterialDesignThemes.Wpf/Converters/DoubleToThicknessConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/DoubleToThicknessConverter.cs
@@ -5,13 +5,15 @@ namespace MaterialDesignThemes.Wpf.Converters
 {
     internal class DoubleToThicknessConverter : IValueConverter
     {
+        public double InitialOffset { get; set; }
+
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
             => (Dock)parameter switch
             {
-                Dock.Left => new Thickness((double)value, 0, 0, 0),
-                Dock.Top => new Thickness(0, (double)value, 0, 0),
-                Dock.Right => new Thickness(0, 0, (double)value, 0),
-                Dock.Bottom => new Thickness(0, 0, 0, (double)value),
+                Dock.Left => new Thickness(InitialOffset + (double)value, 0, 0, 0),
+                Dock.Top => new Thickness(0, InitialOffset + (double)value, 0, 0),
+                Dock.Right => new Thickness(0, 0, InitialOffset + (double)value, 0),
+                Dock.Bottom => new Thickness(0, 0, 0, InitialOffset + (double)value),
                 _ => Binding.DoNothing
             };
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -26,6 +26,7 @@
   <converters:FloatingHintOffsetCalculationConverter x:Key="FloatingHintOffsetCalculationConverter" />
   <converters:ComboBoxClearButtonMarginConverter x:Key="ComboBoxClearButtonMarginConverter" />
   <converters:DoubleToThicknessConverter x:Key="DoubleToThicknessConverter" />
+  <converters:DoubleToThicknessConverter x:Key="DoubleToThicknessConverterWithNegativeOffset" InitialOffset="-8" />
   <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left" />
   <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleTrailingIconPaddingConverterTop"
                                       AdditionalOffsetTop="2"
@@ -848,6 +849,11 @@
         <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
         <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesign.Brush.ComboBox.Popup.DarkBackground}" />
       </MultiTrigger>
+
+      <!-- PART_ClearButton -->
+      <DataTrigger Binding="{Binding ElementName=PART_ClearButton, Path=IsVisible}" Value="True">
+        <Setter TargetName="PART_EditableTextBox" Property="Margin" Value="{Binding ActualWidth, ElementName=PART_ClearButton, Converter={StaticResource DoubleToThicknessConverterWithNegativeOffset}, ConverterParameter={x:Static Dock.Right}}" />
+      </DataTrigger>
     </ControlTemplate.Triggers>
   </ControlTemplate>
 


### PR DESCRIPTION
Fixes #3276 

This PR ensures the `PART_ClearButton` does not overlap the editable text in `PART_EditableTextBox` of the `ComboBox` template.

The reason for the somewhat weird initial offset of -8 is because of some internal margin/padding between the "selected content (text)" and the "chevron arrow" which is already in place and thus should not be included in the margin added to the right side of the `PART_EditableTextBox`. If you have a better approach of dynamically getting this value, feel free to update the code 😛 

![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/ceeb29d9-590f-4802-838a-2ff82f93b7e8)
