### PR TITLE
Fix issue that IME gets misplaced when text input control is on a Popup

### DIFF
--- a/Directory.packages.props
+++ b/Directory.packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="ShowMeTheXAML.AvalonEdit" Version="2.0.0" />
     <PackageVersion Include="ShowMeTheXAML.MSBuild" Version="2.0.0" />
     <PackageVersion Include="VirtualizingWrapPanel" Version="1.5.7" />
-    <PackageVersion Include="XAMLTest" Version="1.0.0-ci417" />
+    <PackageVersion Include="XAMLTest" Version="1.0.0-ci451" />
     <PackageVersion Include="xunit" Version="2.5.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageVersion Include="Xunit.StaFact" Version="1.1.11" />

--- a/MaterialDesignThemes.UITests/WPF/ListBoxes/ListBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/ListBoxes/ListBoxTests.cs
@@ -105,17 +105,17 @@ ScrollViewer.VerticalScrollBarVisibility=""Visible"">
         var verticalScrollBar = await listBox.GetElement<ScrollBar>("PART_VerticalScrollBar");
         var horizontalScrollBar = await listBox.GetElement<ScrollBar>("PART_HorizontalScrollBar");
 
-        Assert.Equal(17, await verticalScrollBar.GetActualWidth());
+        Assert.Equal(17.0, await verticalScrollBar.GetActualWidth(), 1.0);
         var verticalThumb = await verticalScrollBar.GetElement<Border>("/Thumb~border");
-        Assert.Equal(10, await verticalThumb.GetActualWidth());
+        Assert.Equal(10.0, await verticalThumb.GetActualWidth(), 1.0);
         var upButton = await verticalScrollBar.GetElement<RepeatButton>("PART_LineUpButton");
         Assert.False(await upButton.GetIsVisible());
         var downButton = await verticalScrollBar.GetElement<RepeatButton>("PART_LineDownButton");
         Assert.False(await downButton.GetIsVisible());
 
-        Assert.Equal(17, await horizontalScrollBar.GetActualHeight());
+        Assert.Equal(17.0, await horizontalScrollBar.GetActualHeight(), 1.0);
         var horizontalThumb = await horizontalScrollBar.GetElement<Border>("/Thumb~border");
-        Assert.Equal(10, await horizontalThumb.GetActualHeight());
+        Assert.Equal(10.0, await horizontalThumb.GetActualHeight(), 1.0);
         var leftButton = await horizontalScrollBar.GetElement<RepeatButton>("PART_LineLeftButton");
         Assert.False(await leftButton.GetIsVisible());
         var rightButton = await horizontalScrollBar.GetElement<RepeatButton>("PART_LineRightButton");

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -1,4 +1,7 @@
+using System.Runtime.InteropServices;
+using System.Security;
 using System.Windows.Data;
+using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Threading;
 
@@ -284,6 +287,7 @@ public class DialogHost : ContentControl
     {
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
+        PreviewGotKeyboardFocus += OnPreviewGotKeyboardFocus;
 
         CommandBindings.Add(new CommandBinding(CloseDialogCommand, CloseDialogHandler, CloseDialogCanExecute));
         CommandBindings.Add(new CommandBinding(OpenDialogCommand, OpenDialogHandler));
@@ -947,4 +951,17 @@ public class DialogHost : ContentControl
             }
         }
     }
+
+    private void OnPreviewGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+    {
+        if (_popup != null &&
+            PresentationSource.FromVisual(_popup.Child) is HwndSource hwndSource)
+        {
+            SetFocus(hwndSource.Handle);
+        }
+    }
+
+    [SecurityCritical]
+    [DllImport("user32.dll", EntryPoint = "SetFocus", SetLastError = true)]
+    private static extern IntPtr SetFocus(IntPtr hWnd);
 }


### PR DESCRIPTION
This applies the workaround mentioned in this [issue](https://github.com/dotnet/wpf/issues/4315) on the WPF repo.
I confirmed that works with Japanese IME.

Fixes #3147.