### PR TITLE
Adding launchSettings.json to demo apps

### DIFF
--- a/MainDemo.Wpf/App.xaml.cs
+++ b/MainDemo.Wpf/App.xaml.cs
@@ -7,8 +7,15 @@ namespace MaterialDesignDemo;
 /// </summary>
 public partial class App : Application
 {
+    internal static string? StartupItem { get; private set; }
+
     protected override void OnStartup(StartupEventArgs e)
     {
+        if (e.Args.Length > 0)
+        {
+            StartupItem = e.Args[0];
+        }
+
         //This is an alternate way to initialize MaterialDesignInXAML if you don't use the MaterialDesignResourceDictionary in App.xaml
         //Color primaryColor = SwatchHelper.Lookup[MaterialDesignColor.DeepPurple];
         //Color accentColor = SwatchHelper.Lookup[MaterialDesignColor.Lime];

--- a/MainDemo.Wpf/Domain/MainWindowViewModel.cs
+++ b/MainDemo.Wpf/Domain/MainWindowViewModel.cs
@@ -31,7 +31,7 @@ public class MainWindowViewModel : ViewModelBase
         {
             DemoItems.Add(item);
         }
-        SelectedItem = DemoItems.First();
+        SelectedItem = DemoItems.FirstOrDefault(di => string.Equals(di.Name, App.StartupItem, StringComparison.CurrentCultureIgnoreCase)) ?? DemoItems.First();
         _demoItemsView = CollectionViewSource.GetDefaultView(DemoItems);
         _demoItemsView.Filter = DemoItemsFilter;
         

--- a/MainDemo.Wpf/Properties/launchSettings.json
+++ b/MainDemo.Wpf/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+    "profiles": {
+        "Demo App": {
+            "commandName": "Project",
+            "commandLineArgs": "Home"
+        }
+    }
+}

--- a/MaterialDesign3.Demo.Wpf/App.xaml.cs
+++ b/MaterialDesign3.Demo.Wpf/App.xaml.cs
@@ -7,8 +7,15 @@ namespace MaterialDesign3Demo;
 /// </summary>
 public partial class App : Application
 {
+    internal static string? StartupItem { get; private set; }
+
     protected override void OnStartup(StartupEventArgs e)
     {
+        if (e.Args.Length > 0)
+        {
+            StartupItem = e.Args[0];
+        }
+
         //This is an alternate way to initialize MaterialDesignInXAML if you don't use the MaterialDesignResourceDictionary in App.xaml
         //Color primaryColor = SwatchHelper.Lookup[MaterialDesignColor.DeepPurple];
         //Color accentColor = SwatchHelper.Lookup[MaterialDesignColor.Lime];

--- a/MaterialDesign3.Demo.Wpf/Domain/MainWindowViewModel.cs
+++ b/MaterialDesign3.Demo.Wpf/Domain/MainWindowViewModel.cs
@@ -41,7 +41,7 @@ public class MainWindowViewModel : ViewModelBase
             DemoItems.First(x => x.Name == "Fields"),
             DemoItems.First(x => x.Name == "Pickers")
         };
-
+        SelectedItem = DemoItems.FirstOrDefault(di => string.Equals(di.Name, App.StartupItem, StringComparison.CurrentCultureIgnoreCase)) ?? DemoItems.First();
         _demoItemsView = CollectionViewSource.GetDefaultView(DemoItems);
         _demoItemsView.Filter = DemoItemsFilter;
 

--- a/MaterialDesign3.Demo.Wpf/Properties/launchSettings.json
+++ b/MaterialDesign3.Demo.Wpf/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+    "profiles": {
+        "Demo App": {
+            "commandName": "Project",
+            "commandLineArgs": "Home"
+        }
+    }
+}


### PR DESCRIPTION
I saw you mention this in your stream, and I have also wanted it for a while. It allows you to start the demo app(s) directly into a given demo item page.

It is a very simple implementation, simply using the first CLI argument (if any) to match on the name of the `DemoItem`. If not found (or not supplied), it defaults to the first one as it did before.

I put "Home" in the launchSettings.json files just to make it easier to see where you need to make a change if/when you have the need.