### PR TITLE
TreeListView issues found while playing with the control

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewDataBinding.xaml.cs
+++ b/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewDataBinding.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Diagnostics;
 
 namespace MaterialDesignThemes.UITests.WPF.TreeListViews;
 
@@ -53,6 +54,7 @@ public partial class TreeListViewDataBinding
     }
 }
 
+[DebuggerDisplay("{Value} (Children: {Children.Count})")]
 public class TreeItem
 {
     public string Value { get; }

--- a/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewTests.cs
@@ -1,4 +1,6 @@
-﻿namespace MaterialDesignThemes.UITests.WPF.TreeListViews;
+using System.ComponentModel;
+
+namespace MaterialDesignThemes.UITests.WPF.TreeListViews;
 
 public class TreeListViewTests : TestBase
 {
@@ -159,6 +161,44 @@ public class TreeListViewTests : TestBase
         recorder.Success();
     }
 
+    [Fact]
+    [Description("Denoted as Issue 1 in the PR")]
+    public async Task AddingChildrenToItemWithAlreadyExpandedChildren_InsertsNewChildAtCorrectIndex()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        IVisualElement<Grid> root = (await LoadUserControl<TreeListViewDataBinding>()).As<Grid>();
+        IVisualElement<TreeListView> treeListView = await root.GetElement<TreeListView>();
+        IVisualElement<Button> addButton = await root.GetElement(ElementQuery.PropertyExpression<Button>(x => x.Content, "Add"));
+        IVisualElement<Button> removeButton = await root.GetElement(ElementQuery.PropertyExpression<Button>(x => x.Content, "Remove"));
+
+        IVisualElement<TreeListViewItem> secondItem = await treeListView.GetElement<TreeListViewItem>("/TreeListViewItem[1]");
+
+        //Add child to second item and expand
+        await AddChildren(secondItem, 1, addButton);
+        await Task.Delay(250);  // TODO: Unsure why this is needed, I suspect it is the double-click that could be interfering. Needed for consistent test results.
+        await secondItem.LeftClickExpander();
+
+        //NB: Needs to be long enough delay so the next clicks does not register as a double click
+        await Task.Delay(250);
+
+        //Add child to newly added child and expand
+        IVisualElement<TreeListViewItem> newChild1 = await treeListView.GetElement<TreeListViewItem>("/TreeListViewItem[2]");
+        await AddChildren(newChild1, 1, addButton);
+        await Task.Delay(250);  // TODO: Unsure why this is needed, I suspect it is the double-click that could be interfering. Needed for consistent test results.
+        await newChild1.LeftClickExpander();
+
+        //NB: Needs to be long enough delay so the next clicks does not register as a double click
+        await Task.Delay(250);
+
+        //Select secondItem again, and add another child
+        await AddChildren(secondItem, 1, addButton);
+
+        //Assert the the child added last is below the child added first (and its children)
+        await AssertTreeItemContent(treeListView, 4, "1_1");
+
+        recorder.Success();
+    }
 
     private static async Task AssertTreeItemContent(IVisualElement<TreeListView> treeListView, int index, string content)
     {


### PR DESCRIPTION
Hi Kevin, as I mentioned earlier I have an interest in refactoring my own multi-select `TreeView` implementation into a `ListView` based version, so I'm watching your streams with great interest. I was a bit unsure about especially the handling in the switch cases for `NotifyCollectionChangedEventArgs`. My gut feeling is that expansion states of children/grand-children are not appropriately accounted for in all situations.

After playing with it, I can solidly reproduce 2 error scenarios which I believe are related to this. They reproduce consistently when doing them manually, but I was struggling a bit to get 100% consistent results with the UI tests I have added for the scenarios. I have added some (seemingly) random delays just to get closer to a consistent result, but several consecutive runs can still occasionally produce a couple of "odd results".

#### UI tests added
* `AddingChildrenToItemWithAlreadyExpandedChildren_InsertsNewChildAtCorrectIndex()`
* `RemovingChildrenFromItemWithAlreadyExpandedChildren_ShouldDeleteSelectedChild()`

I had a quick glance at trying to spot the bug, but it was not dead obvious to me how to fix it. I do believe, as mentioned above, that both issues are somewhat related to the code not accounting for expansion states of grand-children in particular.

#### Issue 1
When adding a child to an item which already contains an expanded child, the new child is inserted at the wrong index.
![Issue1](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/e4c89c67-43df-43cf-b2bf-6dab549bf753)

#### Issue 2
When deleting children from an item which contains an expanded child (with lower index), the deletion does not always work.
![Issue2](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/85bfaff6-4699-4a0d-883f-27f300284d26)
