### PR TITLE
ListBoxAssist.IsToggle - Ensure last clicked item is always selected

### DIFF
--- a/MainDemo.Wpf/Toggles.xaml
+++ b/MainDemo.Wpf/Toggles.xaml
@@ -338,11 +338,11 @@
 
       <smtx:XamlDisplay HorizontalAlignment="Left" UniqueKey="buttons_63">
         <!-- the following based on https://material.io/guidelines/components/buttons.html#buttons-toggle-buttons -->
-        <ListBox SelectedIndex="0" Style="{StaticResource MaterialDesignToolVerticalToggleListBox}">
+        <ListBox SelectedIndex="0" Style="{StaticResource MaterialDesignToolVerticalToggleListBox}" materialDesign:ListBoxAssist.CanUserToggleSelectedItem="True">
           <ListBox.ToolTip>
             <StackPanel>
               <TextBlock Text="MaterialDesignToolToggleListBox" />
-              <TextBlock Text="Exclusive selection" />
+              <TextBlock Text="Exclusive selection (allows un-toggling selected item)" />
               <TextBlock Text="ListBoxAssist.IsToggle allows more natural toggle behaviour" />
             </StackPanel>
           </ListBox.ToolTip>

--- a/MaterialDesign3.Demo.Wpf/Toggles.xaml
+++ b/MaterialDesign3.Demo.Wpf/Toggles.xaml
@@ -336,11 +336,11 @@
 
       <smtx:XamlDisplay HorizontalAlignment="Left" UniqueKey="buttons_63">
         <!-- the following based on https://material.io/guidelines/components/buttons.html#buttons-toggle-buttons -->
-        <ListBox SelectedIndex="0" Style="{StaticResource MaterialDesignToolVerticalToggleListBox}">
+        <ListBox SelectedIndex="0" Style="{StaticResource MaterialDesignToolVerticalToggleListBox}" materialDesign:ListBoxAssist.CanUserToggleSelectedItem="True">
           <ListBox.ToolTip>
             <StackPanel>
               <TextBlock Text="MaterialDesignToolToggleListBox" />
-              <TextBlock Text="Exclusive selection" />
+              <TextBlock Text="Exclusive selection (allows un-toggling selected item)" />
               <TextBlock Text="ListBoxAssist.IsToggle allows more natural toggle behaviour" />
             </StackPanel>
           </ListBox.ToolTip>

--- a/MaterialDesignThemes.Wpf/ListBoxAssist.cs
+++ b/MaterialDesignThemes.Wpf/ListBoxAssist.cs
@@ -32,7 +32,7 @@ public static class ListBoxAssist
 
         if (listBoxItem is null || !listBoxItem.IsEnabled) return;
 
-        listBoxItem.SetCurrentValue(ListBoxItem.IsSelectedProperty, true);
+        listBoxItem.SetCurrentValue(ListBoxItem.IsSelectedProperty, !GetCanUserToggleSelectedItem(senderElement) || !listBoxItem.IsSelected);
         mouseButtonEventArgs.Handled = true;
 
         listBoxItem.Focus();
@@ -55,4 +55,13 @@ public static class ListBoxAssist
 
     public static bool GetIsToggle(DependencyObject element)
         => (bool)element.GetValue(IsToggleProperty);
+
+    public static readonly DependencyProperty CanUserToggleSelectedItemProperty = DependencyProperty.RegisterAttached(
+        "CanUserToggleSelectedItem", typeof(bool), typeof(ListBoxAssist), new FrameworkPropertyMetadata(default(bool)));
+
+    public static void SetCanUserToggleSelectedItem(DependencyObject element, bool value)
+        => element.SetValue(CanUserToggleSelectedItemProperty, value);
+
+    public static bool GetCanUserToggleSelectedItem(DependencyObject element)
+        => (bool)element.GetValue(CanUserToggleSelectedItemProperty);
 }

--- a/MaterialDesignThemes.Wpf/ListBoxAssist.cs
+++ b/MaterialDesignThemes.Wpf/ListBoxAssist.cs
@@ -32,7 +32,7 @@ public static class ListBoxAssist
 
         if (listBoxItem is null || !listBoxItem.IsEnabled) return;
 
-        listBoxItem.SetCurrentValue(ListBoxItem.IsSelectedProperty, !listBoxItem.IsSelected);
+        listBoxItem.SetCurrentValue(ListBoxItem.IsSelectedProperty, true);
         mouseButtonEventArgs.Handled = true;
 
         listBoxItem.Focus();


### PR DESCRIPTION
Fixes #3235 

As the last comment in the issue states, when explicitly applying `ListBoxAssist.IsToggle=true`, the expected behavior is most likely that the items should behave similar to a radio button group. This ensures that the user cannot do anything to end up in a situation where no elements are selected. However, there are still no guards around selection being "removed" from code.

To fix the latter part, we could attach a `PropertyChangedCallback` on the `IsToggle` DP, but we would probably also need to listen for changes in the `ListBox.Items` collection which I think is probably taking it a step too far. If the developer explicitly sets `ListBoxAssist.IsToggle=true`, let's assume that he/she also knows not to do anything weird.