### PR TITLE
Fix tree list view bug and demo apps

### DIFF
--- a/MainDemo.Wpf/Trees.xaml
+++ b/MainDemo.Wpf/Trees.xaml
@@ -184,23 +184,12 @@
           <materialDesign:TreeListView MinWidth="220" MaxHeight="450"
                                      ItemsSource="{Binding TreeItems}"
                                      SelectedItem="{Binding SelectedTreeItem}">
-            <materialDesign:TreeListView.Resources>
+            <materialDesign:TreeListView.ItemTemplate>
               <HierarchicalDataTemplate DataType="{x:Type domain:TestItem}"
-                          ItemsSource="{Binding Items, Mode=OneTime}">
-                <TextBlock Margin="3,2" Text="{Binding Name, Mode=OneTime}" />
+                                        ItemsSource="{Binding Items, Mode=OneWay}">
+                <TextBlock Margin="3,2" Text="{Binding Name, Mode=OneWay}" />
               </HierarchicalDataTemplate>
-
-              <HierarchicalDataTemplate DataType="{x:Type domain:MovieCategory}"
-                                      ItemsSource="{Binding Movies, Mode=OneTime}">
-                <TextBlock Margin="3,2" Text="{Binding Name, Mode=OneTime}" />
-              </HierarchicalDataTemplate>
-
-              <DataTemplate DataType="{x:Type domain:Movie}">
-                <TextBlock Margin="3,2"
-                           Text="{Binding Name, Mode=OneTime}"
-                           ToolTip="{Binding Director, Mode=OneTime}" />
-              </DataTemplate>
-            </materialDesign:TreeListView.Resources>
+            </materialDesign:TreeListView.ItemTemplate>
 
           </materialDesign:TreeListView>
           <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" HorizontalAlignment="Right">

--- a/MainDemo.Wpf/Trees.xaml
+++ b/MainDemo.Wpf/Trees.xaml
@@ -201,12 +201,6 @@
                            ToolTip="{Binding Director, Mode=OneTime}" />
               </DataTemplate>
             </materialDesign:TreeListView.Resources>
-            <!--<materialDesign:TreeListView.ItemTemplate>
-              <HierarchicalDataTemplate DataType="{x:Type domain:TestItem}"
-                                        ItemsSource="{Binding Items, Mode=OneWay}">
-                <TextBlock Margin="3,2" Text="{Binding Name, Mode=OneWay}" />
-              </HierarchicalDataTemplate>
-            </materialDesign:TreeListView.ItemTemplate>-->
 
           </materialDesign:TreeListView>
           <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" HorizontalAlignment="Right">

--- a/MainDemo.Wpf/Trees.xaml
+++ b/MainDemo.Wpf/Trees.xaml
@@ -184,12 +184,29 @@
           <materialDesign:TreeListView MinWidth="220" MaxHeight="450"
                                      ItemsSource="{Binding TreeItems}"
                                      SelectedItem="{Binding SelectedTreeItem}">
-            <materialDesign:TreeListView.ItemTemplate>
+            <materialDesign:TreeListView.Resources>
+              <HierarchicalDataTemplate DataType="{x:Type domain:TestItem}"
+                          ItemsSource="{Binding Items, Mode=OneTime}">
+                <TextBlock Margin="3,2" Text="{Binding Name, Mode=OneTime}" />
+              </HierarchicalDataTemplate>
+
+              <HierarchicalDataTemplate DataType="{x:Type domain:MovieCategory}"
+                                      ItemsSource="{Binding Movies, Mode=OneTime}">
+                <TextBlock Margin="3,2" Text="{Binding Name, Mode=OneTime}" />
+              </HierarchicalDataTemplate>
+
+              <DataTemplate DataType="{x:Type domain:Movie}">
+                <TextBlock Margin="3,2"
+                           Text="{Binding Name, Mode=OneTime}"
+                           ToolTip="{Binding Director, Mode=OneTime}" />
+              </DataTemplate>
+            </materialDesign:TreeListView.Resources>
+            <!--<materialDesign:TreeListView.ItemTemplate>
               <HierarchicalDataTemplate DataType="{x:Type domain:TestItem}"
                                         ItemsSource="{Binding Items, Mode=OneWay}">
                 <TextBlock Margin="3,2" Text="{Binding Name, Mode=OneWay}" />
               </HierarchicalDataTemplate>
-            </materialDesign:TreeListView.ItemTemplate>
+            </materialDesign:TreeListView.ItemTemplate>-->
 
           </materialDesign:TreeListView>
           <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" HorizontalAlignment="Right">

--- a/MaterialDesign3.Demo.Wpf/Domain/TreesViewModel.cs
+++ b/MaterialDesign3.Demo.Wpf/Domain/TreesViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections;
+using System.Collections.ObjectModel;
 using MaterialDesignThemes.Wpf;
 
 namespace MaterialDesign3Demo.Domain;
@@ -45,6 +46,19 @@ public class Planet
     public double Velocity { get; set; }
 }
 
+public class TestItem
+{
+    public TestItem? Parent { get; set; }
+    public string Name { get; }
+    public ObservableCollection<TestItem> Items { get; }
+
+    public TestItem(string name, IEnumerable<TestItem> items)
+    {
+        Name = name;
+        Items = new ObservableCollection<TestItem>(items);
+    }
+}
+
 public sealed class MovieCategory
 {
     public MovieCategory(string name, params Movie[] movies)
@@ -61,12 +75,25 @@ public sealed class MovieCategory
 public sealed class TreesViewModel : ViewModelBase
 {
     private object? _selectedItem;
+    private TestItem? _selectedTreeItem;
+
+    public ObservableCollection<TestItem> TreeItems { get; } = new();
 
     public ObservableCollection<MovieCategory> MovieCategories { get; }
 
     public AnotherCommandImplementation AddCommand { get; }
 
     public AnotherCommandImplementation RemoveSelectedItemCommand { get; }
+
+    public AnotherCommandImplementation AddListTreeItemCommand { get; }
+
+    public AnotherCommandImplementation RemoveListTreeItemCommand { get; }
+
+    public TestItem? SelectedTreeItem
+    {
+        get => _selectedTreeItem;
+        set => SetProperty(ref _selectedTreeItem, value);
+    }
 
     public object? SelectedItem
     {
@@ -76,6 +103,68 @@ public sealed class TreesViewModel : ViewModelBase
 
     public TreesViewModel()
     {
+        Random random = new();
+        for (int i = 0; i < 10; i++)
+        {
+            TreeItems.Add(CreateTestItem(random, 1));
+        }
+
+        static TestItem CreateTestItem(Random random, int depth)
+        {
+            int numberOfChildren = depth < 5 ? random.Next(0, 6) : 0;
+            var children = Enumerable.Range(0, numberOfChildren).Select(_ => CreateTestItem(random, depth + 1));
+            var rv = new TestItem(GenerateString(random.Next(4, 10)), children);
+            foreach (var child in rv.Items)
+            {
+                child.Parent = rv;
+            }
+            return rv;
+        }
+
+        AddListTreeItemCommand = new(_ =>
+        {
+            if (SelectedTreeItem is { } treeItem)
+            {
+                var newItem = CreateTestItem(random, 1);
+                newItem.Parent = treeItem;
+                treeItem.Items.Add(newItem);
+            }
+            else
+            {
+                TreeItems.Add(CreateTestItem(random, 1));
+            }
+        });
+
+        RemoveListTreeItemCommand = new(items =>
+        {
+            if (items is IEnumerable enumerable)
+            {
+                foreach (TestItem testItem in enumerable)
+                {
+                    if (testItem.Parent is { } parent)
+                    {
+                        parent.Items.Remove(testItem);
+                    }
+                    else
+                    {
+                        TreeItems.Remove(testItem);
+                    }
+                }
+            }
+            if (SelectedTreeItem is { } selectedItem)
+            {
+                if (selectedItem.Parent is { } parent)
+                {
+                    parent.Items.Remove(selectedItem);
+                }
+                else
+                {
+                    TreeItems.Remove(selectedItem);
+                }
+                SelectedTreeItem = null;
+            }
+        });
+
         MovieCategories = new ObservableCollection<MovieCategory>
         {
             new MovieCategory("Action",

--- a/MaterialDesign3.Demo.Wpf/Trees.xaml
+++ b/MaterialDesign3.Demo.Wpf/Trees.xaml
@@ -175,11 +175,42 @@
         </Grid>
       </smtx:XamlDisplay>
 
+      <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Multi-Select Tree View:"
+                 Grid.Column="2"/>
+      <smtx:XamlDisplay Grid.Row="1"
+                        Grid.Column="2"
+                        VerticalContentAlignment="Top"
+                        UniqueKey="trees_3">
+        <Grid>
+          <materialDesign:TreeListView MinWidth="220" MaxHeight="450"
+                                       ItemsSource="{Binding TreeItems}"
+                                       SelectedItem="{Binding SelectedTreeItem}">
+            <materialDesign:TreeListView.ItemTemplate>
+              <HierarchicalDataTemplate DataType="{x:Type domain:TestItem}"
+                                        ItemsSource="{Binding Items, Mode=OneWay}">
+                <TextBlock Margin="3,2" Text="{Binding Name, Mode=OneWay}" />
+              </HierarchicalDataTemplate>
+            </materialDesign:TreeListView.ItemTemplate>
+
+          </materialDesign:TreeListView>
+          <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" HorizontalAlignment="Right">
+            <Button Command="{Binding AddListTreeItemCommand}"
+                    ToolTip="Add an item"
+                    Content="{materialDesign:PackIcon Kind=Add}"/>
+
+            <Button Command="{Binding RemoveListTreeItemCommand}"
+                    ToolTip="Remove selected item(s)"
+                    Content="{materialDesign:PackIcon Kind=Remove}"/>
+
+          </StackPanel>
+        </Grid>
+      </smtx:XamlDisplay>
+
       <TextBlock Grid.Row="2"
                  Style="{StaticResource MaterialDesignHeadline6TextBlock}"
                  Text="Additional node content, syntax 1:" />
 
-      <smtx:XamlDisplay Grid.Row="3" UniqueKey="trees_3">
+      <smtx:XamlDisplay Grid.Row="3" UniqueKey="trees_4">
         <TreeView>
           <materialDesign:TreeViewAssist.AdditionalTemplate>
             <DataTemplate>
@@ -221,7 +252,7 @@
       <smtx:XamlDisplay Grid.Row="3"
                         Grid.Column="1"
                         Margin="32,0,0,0"
-                        UniqueKey="trees_4">
+                        UniqueKey="trees_5">
         <TreeView>
           <materialDesign:TreeViewAssist.AdditionalTemplateSelector>
             <domain:TreeExampleSimpleTemplateSelector>
@@ -271,7 +302,7 @@
       <smtx:XamlDisplay Grid.Row="3"
                         Grid.Column="2"
                         Margin="32,0,0,0"
-                        UniqueKey="trees_5">
+                        UniqueKey="trees_6">
         <TreeView MinWidth="220" DisplayMemberPath="Name">
           <TreeView.Resources>
             <DataTemplate DataType="{x:Type domain:Planet}">

--- a/MaterialDesignThemes.UITests/TestBase.cs
+++ b/MaterialDesignThemes.UITests/TestBase.cs
@@ -36,11 +36,14 @@ public abstract class TestBase : IAsyncLifetime
         return await App.CreateWindowWith<T>(xaml, additionalNamespaceDeclarations);
     }
 
-    protected async Task<IVisualElement> LoadUserControl<TControl>()
+    protected Task<IVisualElement> LoadUserControl<TControl>()
         where TControl : UserControl
+        => LoadUserControl(typeof(TControl));
+
+    protected async Task<IVisualElement> LoadUserControl(Type userControlType)
     {
         await App.InitializeWithMaterialDesign();
-        return await App.CreateWindowWithUserControl<TControl>();
+        return await App.CreateWindowWithUserControl(userControlType);
     }
 
     public async Task InitializeAsync() =>

--- a/MaterialDesignThemes.UITests/WPF/TreeListViews/TestableCollection.cs
+++ b/MaterialDesignThemes.UITests/WPF/TreeListViews/TestableCollection.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Threading;
+
+namespace MaterialDesignThemes.UITests.WPF.TreeListViews;
+
+public class TestableCollection<T> : ObservableCollection<T>
+{
+    private int _blockCollectionChanges;
+
+    protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+    {
+        if (Interlocked.CompareExchange(ref _blockCollectionChanges, 0, 0) == 0)
+        {
+            base.OnCollectionChanged(e);
+        }
+    }
+
+    public void ReplaceAllItems(params T[] newItems)
+    {
+        Interlocked.Exchange(ref _blockCollectionChanges, 1);
+
+        Clear();
+        foreach (T newItem in newItems)
+        {
+            Add(newItem);
+        }
+
+        Interlocked.Exchange(ref _blockCollectionChanges, 0);
+
+        OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+    }
+}

--- a/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeItem.cs
+++ b/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeItem.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics;
+
+namespace MaterialDesignThemes.UITests.WPF.TreeListViews;
+
+[DebuggerDisplay("{Value} (Children: {Children.Count})")]
+public class TreeItem
+{
+    public string Value { get; }
+
+    public TreeItem? Parent { get; }
+
+    //NB: making the assumption changes occur ont he UI thread
+    public TestableCollection<TreeItem> Children { get; } = new();
+
+    public TreeItem(string value, TreeItem? parent)
+    {
+        Value = value;
+        Parent = parent;
+    }
+}

--- a/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewImplicitTemplate.xaml
+++ b/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewImplicitTemplate.xaml
@@ -1,0 +1,35 @@
+﻿<UserControl x:Class="MaterialDesignThemes.UITests.WPF.TreeListViews.TreeListViewImplicitTemplate"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:MaterialDesignThemes.UITests.WPF.TreeListViews"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             mc:Ignorable="d"
+             DataContext="{Binding RelativeSource={RelativeSource Self}}"
+             d:DesignHeight="450" d:DesignWidth="800">
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+    <materialDesign:TreeListView
+      x:Name="TreeListView"
+      ItemsSource="{Binding Items}">
+      <materialDesign:TreeListView.Resources>
+        <HierarchicalDataTemplate DataType="{x:Type local:TreeItem}"
+            ItemsSource="{Binding Children}">
+          <TextBlock Text="{Binding Value}" />
+        </HierarchicalDataTemplate>
+      </materialDesign:TreeListView.Resources>
+    </materialDesign:TreeListView>
+    <StackPanel Grid.Row="1" Orientation="Horizontal">
+      <Button Content="Add" Click="Add_OnClick" />
+      <Button Content="Remove" Click="Remove_OnClick" />
+      <Button Content="Replace" Click="Replace_OnClick" />
+      <Button Content="Down" Click="MoveDown_OnClick" />
+      <Button Content="Up" Click="MoveUp_OnClick" />
+      <Button Content="Reset" Click="Reset_OnClick" />
+    </StackPanel>
+  </Grid>
+</UserControl>

--- a/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewImplicitTemplate.xaml.cs
+++ b/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewImplicitTemplate.xaml.cs
@@ -3,14 +3,14 @@
 namespace MaterialDesignThemes.UITests.WPF.TreeListViews;
 
 /// <summary>
-/// Interaction logic for TreeListViewDataBinding.xaml
+/// Interaction logic for TreeListViewImplicitTemplate.xaml
 /// </summary>
-public partial class TreeListViewDataBinding
+public partial class TreeListViewImplicitTemplate
 {
     //NB: making the assumption changes occur on the UI thread
     public ObservableCollection<TreeItem> Items { get; } = new();
 
-    public TreeListViewDataBinding()
+    public TreeListViewImplicitTemplate()
     {
         InitializeComponent();
         AddItem();

--- a/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewTests.cs
@@ -10,12 +10,19 @@ public class TreeListViewTests : TestBase
         AttachedDebuggerToRemoteProcess = false;
     }
 
-    [Fact]
-    public async Task CanResetNestedElements()
+    public static IEnumerable<object[]> GetTestControls()
+    {
+        yield return new object[] { typeof(TreeListViewDataBinding) };
+        yield return new object[] { typeof(TreeListViewImplicitTemplate) };
+    }
+
+    [Theory]
+    [MemberData(nameof(GetTestControls))]
+    public async Task CanResetNestedElements(Type userControlType)
     {
         await using var recorder = new TestRecorder(App);
 
-        IVisualElement<Grid> root = (await LoadUserControl<TreeListViewDataBinding>()).As<Grid>();
+        IVisualElement<Grid> root = (await LoadUserControl(userControlType)).As<Grid>();
         IVisualElement<TreeListView> treeListView = await root.GetElement<TreeListView>();
         IVisualElement<Button> addButton = await root.GetElement(ElementQuery.PropertyExpression<Button>(x => x.Content, "Add"));
         IVisualElement<Button> resetButton = await root.GetElement(ElementQuery.PropertyExpression<Button>(x => x.Content, "Reset"));
@@ -29,7 +36,6 @@ public class TreeListViewTests : TestBase
         await secondItem.LeftClickExpander();
         await secondItem.LeftClick();
         await Wait.For(() => secondItem.GetIsSelected());
-
 
         //Reset children
         await resetButton.LeftClick();
@@ -359,21 +365,6 @@ public class TreeListViewTests : TestBase
         recorder.Success();
     }
 
-    //[Fact]
-    //public async Task Foo()
-    //{
-    //    await using var recorder = new TestRecorder(App);
-
-    //    IVisualElement<Grid> root = (await LoadUserControl<TreeListViewDataBinding>()).As<Grid>();
-    //    IVisualElement<TreeListView> treeListView = await root.GetElement<TreeListView>();
-    //    IVisualElement<Button> replaceButton = await root.GetElement(ElementQuery.PropertyExpression<Button>(x => x.Content, "Replace"));
-    //    IVisualElement<Button> addButton = await root.GetElement(ElementQuery.PropertyExpression<Button>(x => x.Content, "Add"));
-
-    //    await Task.Delay(TimeSpan.FromMinutes(30));
-
-    //    recorder.Success();
-    //}
-
     [Fact]
     public async Task CanReplaceTopLevelElementWithExpandedChildren()
     {
@@ -486,12 +477,13 @@ public class TreeListViewTests : TestBase
         recorder.Success();
     }
 
-    [Fact]
-    public async Task WithHierarchicalDataTemplate_CanRemoveTopLevelElement()
+    [Theory]
+    [MemberData(nameof(GetTestControls))]
+    public async Task WithHierarchicalDataTemplate_CanRemoveTopLevelElement(Type userControlType)
     {
         await using var recorder = new TestRecorder(App);
 
-        IVisualElement<Grid> root = (await LoadUserControl<TreeListViewDataBinding>()).As<Grid>();
+        IVisualElement<Grid> root = (await LoadUserControl(userControlType)).As<Grid>();
         IVisualElement<TreeListView> treeListView = await root.GetElement<TreeListView>();
         IVisualElement<Button> addButton = await root.GetElement(ElementQuery.PropertyExpression<Button>(x => x.Content, "Add"));
         IVisualElement<Button> removeButton = await root.GetElement(ElementQuery.PropertyExpression<Button>(x => x.Content, "Remove"));
@@ -513,13 +505,14 @@ public class TreeListViewTests : TestBase
         recorder.Success();
     }
 
-    [Fact]
-    public async Task WithHierarchicalDataTemplate_CanRemoveNestedElement()
+    [Theory]
+    [MemberData(nameof(GetTestControls))]
+    public async Task WithHierarchicalDataTemplate_CanRemoveNestedElement(Type userControlType)
     {
         await using var recorder = new TestRecorder(App);
 
         //Arrange
-        IVisualElement<Grid> root = (await LoadUserControl<TreeListViewDataBinding>()).As<Grid>();
+        IVisualElement<Grid> root = (await LoadUserControl(userControlType)).As<Grid>();
         IVisualElement<TreeListView> treeListView = await root.GetElement<TreeListView>();
         IVisualElement<Button> addButton = await root.GetElement(ElementQuery.PropertyExpression<Button>(x => x.Content, "Add"));
         IVisualElement<Button> removeButton = await root.GetElement(ElementQuery.PropertyExpression<Button>(x => x.Content, "Remove"));
@@ -640,12 +633,13 @@ public class TreeListViewTests : TestBase
         recorder.Success();
     }
 
-    [Fact]
-    public async Task AddingChildrenToItemWithAlreadyExpandedChildren_InsertsNewChildAtCorrectIndex()
+    [Theory]
+    [MemberData(nameof(GetTestControls))]
+    public async Task AddingChildrenToItemWithAlreadyExpandedChildren_InsertsNewChildAtCorrectIndex(Type userControlType)
     {
         await using var recorder = new TestRecorder(App);
 
-        IVisualElement<Grid> root = (await LoadUserControl<TreeListViewDataBinding>()).As<Grid>();
+        IVisualElement<Grid> root = (await LoadUserControl(userControlType)).As<Grid>();
         IVisualElement<TreeListView> treeListView = await root.GetElement<TreeListView>();
         IVisualElement<Button> addButton = await root.GetElement(ElementQuery.PropertyExpression<Button>(x => x.Content, "Add"));
 
@@ -675,12 +669,13 @@ public class TreeListViewTests : TestBase
         recorder.Success();
     }
 
-    [Fact]
-    public async Task RemovingChildrenFromItemWithAlreadyExpandedChildren_ShouldDeleteSelectedChild()
+    [Theory]
+    [MemberData(nameof(GetTestControls))]
+    public async Task RemovingChildrenFromItemWithAlreadyExpandedChildren_ShouldDeleteSelectedChild(Type userControlType)
     {
         await using var recorder = new TestRecorder(App);
 
-        IVisualElement<Grid> root = (await LoadUserControl<TreeListViewDataBinding>()).As<Grid>();
+        IVisualElement<Grid> root = (await LoadUserControl(userControlType)).As<Grid>();
         IVisualElement<TreeListView> treeListView = await root.GetElement<TreeListView>();
         IVisualElement<Button> addButton = await root.GetElement(ElementQuery.PropertyExpression<Button>(x => x.Content, "Add"));
         IVisualElement<Button> removeButton = await root.GetElement(ElementQuery.PropertyExpression<Button>(x => x.Content, "Remove"));

--- a/MaterialDesignThemes.UITests/XamlTestExtensions.cs
+++ b/MaterialDesignThemes.UITests/XamlTestExtensions.cs
@@ -94,8 +94,7 @@ xmlns:materialDesign=""http://materialdesigninxaml.net/winfx/xaml/themes"">
         return await window.GetElement(".Content");
     }
 
-    public static async Task<IVisualElement> CreateWindowWithUserControl<TControl>(this IApp app)
-        where TControl : UserControl
+    public static async Task<IVisualElement> CreateWindowWithUserControl(this IApp app, Type userControlType)
     {
         string windowXaml = @$"<Window
         xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
@@ -103,7 +102,7 @@ xmlns:materialDesign=""http://materialdesigninxaml.net/winfx/xaml/themes"">
         xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
         xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
         xmlns:materialDesign=""http://materialdesigninxaml.net/winfx/xaml/themes""
-        xmlns:local=""clr-namespace:{typeof(TControl).Namespace};assembly={typeof(TControl).Assembly.GetName().Name}""
+        xmlns:local=""clr-namespace:{userControlType.Namespace};assembly={userControlType.Assembly.GetName().Name}""
         mc:Ignorable=""d""
         Height=""800"" Width=""1100""
         TextElement.Foreground=""{{DynamicResource MaterialDesignBody}}""
@@ -116,7 +115,7 @@ xmlns:materialDesign=""http://materialdesigninxaml.net/winfx/xaml/themes"">
         Title=""Test Window""
         Topmost=""False""
         WindowStartupLocation=""CenterScreen"">
-        <local:{typeof(TControl).Name} />
+        <local:{userControlType.Name} />
 </Window>";
         IWindow window = await app.CreateWindow(windowXaml);
         return await window.GetElement(".Content.Content");

--- a/MaterialDesignThemes.Wpf/Internal/TreeListViewContentPresenter.cs
+++ b/MaterialDesignThemes.Wpf/Internal/TreeListViewContentPresenter.cs
@@ -1,0 +1,16 @@
+﻿
+namespace MaterialDesignThemes.Wpf.Internal;
+
+public class TreeListViewContentPresenter : ContentPresenter
+{
+    public event EventHandler<EventArgs>? TemplateChanged;
+
+    public DataTemplate? Template { get; private set; }
+
+    protected override void OnTemplateChanged(DataTemplate oldTemplate, DataTemplate newTemplate)
+    {
+        Template = newTemplate;
+        base.OnTemplateChanged(oldTemplate, newTemplate);
+        TemplateChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TreeListView.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TreeListView.xaml
@@ -1,8 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
-                    xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal"
-                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
+                    xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal">
 
   <Style x:Key="MaterialDesignTreeListViewToggleButtonStyle" TargetType="{x:Type ToggleButton}">
     <Setter Property="Background" Value="Transparent" />
@@ -272,7 +272,7 @@
                           Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
                           Focusable="False"
                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                <ContentPresenter x:Name="PART_Header" ContentSource="Content" />
+                <internal:TreeListViewContentPresenter x:Name="PART_ContentPresenter" ContentSource="Content" />
               </wpf:Ripple>
             </Grid>
 
@@ -328,17 +328,6 @@
     <Setter Property="wpf:TreeViewAssist.ExpanderSize" Value="16" />
     <Setter Property="wpf:TreeViewAssist.HasNoItemsExpanderVisibility" Value="{Binding RelativeSource={RelativeSource AncestorType=TreeView}, Path=(wpf:TreeViewAssist.HasNoItemsExpanderVisibility)}" />
     <Setter Property="wpf:TreeViewAssist.ShowSelection" Value="True" />
-    <!--<Style.Triggers>
-      <Trigger Property="VirtualizingPanel.IsVirtualizing" Value="true">
-        <Setter Property="ItemsPanel">
-          <Setter.Value>
-            <ItemsPanelTemplate>
-              <VirtualizingStackPanel />
-            </ItemsPanelTemplate>
-          </Setter.Value>
-        </Setter>
-      </Trigger>
-    </Style.Triggers>-->
   </Style>
 
   <Style x:Key="MaterialDesignTreeListView" TargetType="{x:Type wpf:TreeListView}">

--- a/MaterialDesignThemes.Wpf/TreeListViewItem.cs
+++ b/MaterialDesignThemes.Wpf/TreeListViewItem.cs
@@ -99,9 +99,9 @@ public class TreeListViewItem : ListViewItem
         Level = level;
         TreeListView = treeListView;
 
-        DataTemplate GetTemplate()
+        DataTemplate? GetTemplate()
         {
-            return ContentTemplate ?? ContentTemplateSelector.SelectTemplate(item, this);
+            return ContentTemplate ?? ContentTemplateSelector?.SelectTemplate(item, this);
         }
     }
 


### PR DESCRIPTION
Adds the null propagation in `TreeListViewItem` and fixes the data template issue in the demo app. Also copies over the `TreeListView` sample from the demo app to the MD3 demo app.

UPDATE: As we talked about, this PR should not merge until the `TreeListView` has been updated to support implicit data template which is what was originally used in the demo app (and stopped working).