### PR TITLE
Propagate HintAssist.Background into TimePicker and DatePicker

### DIFF
--- a/MainDemo.Wpf/Properties/launchSettings.json
+++ b/MainDemo.Wpf/Properties/launchSettings.json
@@ -2,7 +2,7 @@
     "profiles": {
         "Demo App": {
             "commandName": "Project",
-            "commandLineArgs": "-p Trees -t Inherit -f LeftToRight"
+            "commandLineArgs": "-p Home -t Inherit -f LeftToRight"
         }
     }
 }

--- a/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Globalization;
+using System.Windows.Media;
 using MaterialDesignThemes.UITests.WPF.TextBoxes;
 
 namespace MaterialDesignThemes.UITests.WPF.DatePickers;
@@ -229,6 +230,74 @@ public class DatePickerTests : TestBase
 
         Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - hintCoordinates.Value.Left), 0, tolerance);
         Assert.InRange(Math.Abs(contentHostCoordinates.Value.Left - errorViewerCoordinates.Value.Left), 0, tolerance);
+
+        recorder.Success();
+    }
+
+    [Fact]
+    [Description("Issue 3365")]
+    public async Task DatePicker_WithoutOutlinedStyleAndNoCustomHintBackgroundSet_ShouldApplyDefaultBackgroundWhenFloated()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // Arrange
+        var stackPanel = await LoadXaml<StackPanel>("""
+            <StackPanel>
+            <DatePicker
+              Style="{StaticResource MaterialDesignOutlinedDatePicker}"
+              materialDesign:HintAssist.Hint="Hint text" />
+            </StackPanel>
+            """);
+        var datePicker = await stackPanel.GetElement<DatePicker>("/DatePicker");
+        var datePickerTextBox = await datePicker.GetElement<DatePickerTextBox>("/DatePickerTextBox");
+        var hintBackgroundBorder = await datePicker.GetElement<Border>("HintBackgroundBorder");
+
+        var defaultBackground = Colors.Transparent;
+        var defaultFloatedBackground = await GetThemeColor("MaterialDesign.Brush.Background");
+
+        // Assert (unfocused state)
+        Assert.Equal(defaultBackground, await hintBackgroundBorder.GetBackgroundColor());
+
+        // Act
+        await datePickerTextBox.MoveKeyboardFocus();
+
+        // Assert (focused state)
+        Assert.Equal(defaultFloatedBackground, await hintBackgroundBorder.GetBackgroundColor());
+
+        recorder.Success();
+    }
+
+    [Theory]
+    [Description("Issue 3365")]
+    [InlineData("MaterialDesignDatePicker")]
+    [InlineData("MaterialDesignFloatingHintDatePicker")]
+    [InlineData("MaterialDesignFilledDatePicker")]
+    [InlineData("MaterialDesignOutlinedDatePicker")]
+    public async Task DatePicker_WithCustomHintBackgroundSet_ShouldApplyHintBackground(string style)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // Arrange
+        var stackPanel = await LoadXaml<StackPanel>($$"""
+            <StackPanel>
+              <DatePicker
+                Style="{StaticResource {{style}}}"
+                materialDesign:HintAssist.Hint="Hint text"
+                materialDesign:HintAssist.Background="Red" />
+            </StackPanel>
+            """);
+        var datePicker = await stackPanel.GetElement<DatePicker>("/DatePicker");
+        var datePickerTextBox = await datePicker.GetElement<DatePickerTextBox>("/DatePickerTextBox");
+        var hintBackgroundBorder = await datePicker.GetElement<Border>("HintBackgroundBorder");
+
+        // Assert (unfocused state)
+        Assert.Equal(Colors.Red, await hintBackgroundBorder.GetBackgroundColor());
+
+        // Act
+        await datePickerTextBox.MoveKeyboardFocus();
+
+        // Assert (focused state)
+        Assert.Equal(Colors.Red, await hintBackgroundBorder.GetBackgroundColor());
 
         recorder.Success();
     }

--- a/MaterialDesignThemes.Wpf/Converters/OutlinedStyleFloatingHintBackgroundConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/OutlinedStyleFloatingHintBackgroundConverter.cs
@@ -1,0 +1,22 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace MaterialDesignThemes.Wpf.Converters;
+
+public class OutlinedStyleFloatingHintBackgroundConverter : IMultiValueConverter
+{
+    public object? Convert(object[]? values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values is { Length: 2 } &&
+            values[0] is Brush hintAssistBrush &&
+            values[1] is Brush defaultBackgroundBrush)
+        {
+            return Equals(HintAssist.DefaultBackground, hintAssistBrush) ? defaultBackgroundBrush : hintAssistBrush;
+        }
+        return Binding.DoNothing;
+    }
+
+    public object[]? ConvertBack(object? value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/MaterialDesignThemes.Wpf/HintAssist.cs
+++ b/MaterialDesignThemes.Wpf/HintAssist.cs
@@ -7,7 +7,7 @@ public static class HintAssist
     private const double DefaultFloatingScale = 0.74;
     private const double DefaultHintOpacity = 0.56;
     internal static readonly Point DefaultFloatingOffset = new(0, -16);
-    private static readonly Brush DefaultBackground = new SolidColorBrush(Colors.Transparent);
+    internal static readonly Brush DefaultBackground = new SolidColorBrush(Colors.Transparent);
     private static readonly double DefaultHelperTextFontSize = 10;
 
     #region AttachedProperty : IsFloatingProperty

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -32,6 +32,9 @@
   <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
 
   <Style x:Key="MaterialDesignDatePickerTextBox" TargetType="{x:Type DatePickerTextBox}">
+    <Style.Resources>
+      <converters:OutlinedStyleFloatingHintBackgroundConverter x:Key="OutlinedStyleFloatingHintBackgroundConverter" />
+    </Style.Resources>
     <Setter Property="AllowDrop" Value="true" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
@@ -190,7 +193,8 @@
                       <wpf:SmartHint.Hint>
                         <Border x:Name="HintBackgroundBorder"
                                 Background="{TemplateBinding wpf:HintAssist.Background}"
-                                CornerRadius="2">
+                                CornerRadius="2"
+                                Tag="{DynamicResource MaterialDesign.Brush.Background}">
                           <ContentPresenter x:Name="HintWrapper" Content="{TemplateBinding wpf:HintAssist.Hint}" />
                         </Border>
                       </wpf:SmartHint.Hint>
@@ -322,7 +326,14 @@
                 <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
                 <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
               </MultiTrigger.Conditions>
-              <Setter Property="wpf:HintAssist.Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
+              <Setter TargetName="HintBackgroundBorder" Property="Background">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource OutlinedStyleFloatingHintBackgroundConverter}">
+                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.Background)" />
+                    <Binding ElementName="HintBackgroundBorder" Path="Tag" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
               <Setter TargetName="HintBackgroundBorder" Property="Padding" Value="4,0" />
             </MultiTrigger>
             <MultiTrigger>
@@ -519,6 +530,7 @@
                                wpf:HintAssist.FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
                                wpf:HintAssist.FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
                                wpf:HintAssist.Foreground="{TemplateBinding wpf:HintAssist.Foreground}"
+                               wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
                                wpf:HintAssist.HelperText="{TemplateBinding wpf:HintAssist.HelperText}"
                                wpf:HintAssist.HelperTextFontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                                wpf:HintAssist.HelperTextStyle="{TemplateBinding wpf:HintAssist.HelperTextStyle}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal"
@@ -30,6 +30,9 @@
   <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
 
   <Style x:Key="MaterialDesignTimePickerTextBox" TargetType="{x:Type wpf:TimePickerTextBox}">
+    <Style.Resources>
+      <converters:OutlinedStyleFloatingHintBackgroundConverter x:Key="OutlinedStyleFloatingHintBackgroundConverter" />
+    </Style.Resources>
     <Setter Property="AllowDrop" Value="true" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
@@ -188,7 +191,8 @@
                       <wpf:SmartHint.Hint>
                         <Border x:Name="HintBackgroundBorder"
                                 Background="{TemplateBinding wpf:HintAssist.Background}"
-                                CornerRadius="2">
+                                CornerRadius="2"
+                                Tag="{DynamicResource MaterialDesign.Brush.Background}">
                           <ContentPresenter x:Name="HintWrapper" Content="{TemplateBinding wpf:HintAssist.Hint}" />
                         </Border>
                       </wpf:SmartHint.Hint>
@@ -320,7 +324,14 @@
                 <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
                 <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
               </MultiTrigger.Conditions>
-              <Setter Property="wpf:HintAssist.Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
+              <Setter TargetName="HintBackgroundBorder" Property="Background">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource OutlinedStyleFloatingHintBackgroundConverter}">
+                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.Background)" />
+                    <Binding ElementName="HintBackgroundBorder" Path="Tag" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
               <Setter TargetName="HintBackgroundBorder" Property="Padding" Value="4,0" />
             </MultiTrigger>
             <MultiTrigger>
@@ -531,6 +542,7 @@
                                    wpf:HintAssist.FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
                                    wpf:HintAssist.FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
                                    wpf:HintAssist.Foreground="{TemplateBinding wpf:HintAssist.Foreground}"
+                                   wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
                                    wpf:HintAssist.HelperText="{TemplateBinding wpf:HintAssist.HelperText}"
                                    wpf:HintAssist.HelperTextFontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                                    wpf:HintAssist.HelperTextStyle="{TemplateBinding wpf:HintAssist.HelperTextStyle}"


### PR DESCRIPTION
Should eventually fix #3365

This PR originates from a discussion topic where a MDIX consumer was trying to set `HintAssist.Background` for the `TimePicker` but the value was not propagating through.

The PR now propagates the value through and is applied as the background of the `Border` containing the hint. The background property has always been set to the value of the attached property, but it has just never been propagated through and therefore had no effect. Because the background setter is using the attached property, my assumption is that the original intention has been to propagate it through.

The OP of the discussion topic needed it for the outlined style, but I assume it should be applied for all the styles.

It does, in my opinion, look somewhat wacky, but at least there is now an opt-in opportunity to actually change it if you so desire. Note that there is also an opacity difference between the styles. I am wondering whether that is desirable.

Also note that there is special handling of the outlined style when the hint is floating. For the "standard" control it changes from `Transparent` to the theme background color in order to "mask out" the outline which it covers. I had to introduce a converter to make sure this only falls back to the theme background in the case where the attached property is set to its default value. Any other value than the default will not cause a fallback to the theme background. I also added special UI tests covering this particular case (both default and non-default).

![TimePickerHintBackground](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/a7817012-efa0-48ff-9e5e-78f779e08599)
