### PR TITLE
Clear button does not clear uncommitted text in DatePicker and TimePicker

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
@@ -61,6 +61,35 @@ public class DatePickerTests : TestBase
     }
 
     [Fact]
+    [Description("Issue 3369")]
+    public async Task OnDatePicker_WithClearButton_ClearsSelectedUncommittedText()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // Arrange
+        var stackPanel = await LoadXaml<StackPanel>("""
+            <StackPanel>
+              <DatePicker materialDesign:TextFieldAssist.HasClearButton="True"/>
+            </StackPanel>
+            """);
+        var datePicker = await stackPanel.GetElement<DatePicker>("/DatePicker");
+        var datePickerTextBox = await stackPanel.GetElement<DatePickerTextBox>("/DatePickerTextBox");
+        var clearButton = await datePicker.GetElement<Button>("PART_ClearButton");
+
+        await datePickerTextBox.SendKeyboardInput($"invalid date");
+        Assert.Equal("invalid date", await datePickerTextBox.GetText());
+
+        // Act
+        await clearButton.LeftClick();
+        await Task.Delay(50);
+
+        // Assert
+        Assert.Null(await datePickerTextBox.GetText());
+
+        recorder.Success();
+    }
+
+    [Fact]
     [Description("Issue 2737")]
     public async Task OutlinedDatePicker_RespectsActiveAndInactiveBorderThickness_WhenAttachedPropertiesAreSet()
     {

--- a/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Globalization;
 using MaterialDesignThemes.UITests.WPF.TextBoxes;
 
@@ -506,6 +506,36 @@ public class TimePickerTests : TestBase
 
         // Assert
         Assert.Null(await timePicker.GetSelectedTime());
+
+        recorder.Success();
+    }
+
+    [Fact]
+    [Description("Issue 3369")]
+    public async Task TimePicker_WithClearButton_ClearButtonClearsUncommittedText()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // Arrange
+        var stackPanel = await LoadXaml<StackPanel>($"""
+        <StackPanel>
+          <materialDesign:TimePicker
+             materialDesign:TextFieldAssist.HasClearButton="True" />
+        </StackPanel>
+        """);
+        var timePicker = await stackPanel.GetElement<TimePicker>("/TimePicker");
+        var timePickerTextBox = await timePicker.GetElement<TimePickerTextBox>("/TimePickerTextBox");
+        var clearButton = await timePicker.GetElement<Button>("PART_ClearButton");
+
+        await timePickerTextBox.SendKeyboardInput($"invalid time");
+        Assert.Equal("invalid time", await timePickerTextBox.GetText());
+
+        // Act
+        await clearButton.LeftClick();
+        await Task.Delay(50);
+
+        // Assert
+        Assert.Null(await timePickerTextBox.GetText());
 
         recorder.Success();
     }

--- a/MaterialDesignThemes.Wpf/Internal/ClearText.cs
+++ b/MaterialDesignThemes.Wpf/Internal/ClearText.cs
@@ -39,9 +39,11 @@ public static class ClearText
             {
                 case DatePicker datePicker:
                     datePicker.SetCurrentValue(DatePicker.SelectedDateProperty, null);
+                    datePicker.Text = string.Empty; // Clears the text in the DatePickerTextBox which could contain uncommitted text
                     break;
                 case TimePicker timePicker:
                     timePicker.SetCurrentValue(TimePicker.SelectedTimeProperty, null);
+                    timePicker.Clear(); // Clears the text in the TimePickerTextBox which could contain uncommitted text
                     break;
                 case TextBox textBox:
                     textBox.SetCurrentValue(TextBox.TextProperty, null);

--- a/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -312,6 +312,10 @@ public class TimePicker : Control
         base.OnApplyTemplate();
     }
 
+    internal void Clear()
+        => _textBox?.Clear();
+
+
     private void TextBoxOnLostFocus(object sender, RoutedEventArgs routedEventArgs)
     {
         string? text = _textBox?.Text;


### PR DESCRIPTION
Fixes #3369 

For `DatePicker` and `TimePicker` the clear button only cleared the underlying dependency property. This assumes that it actually has a value set. In case where arbitrary text is entered (valid or invalid) the clear button does not have an effect.

This PR effectively clears the underlying `TextBox`. It could probably be argued that the clearing of the DP may not be necessary anymore, but I have not (yet) removed that code. What are your thoughts?