### PR TITLE
SplitButton using custom control

### DIFF
--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -45,6 +45,9 @@
       <RowDefinition Height="Auto" />
       <RowDefinition Height="Auto" />
       <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
     </Grid.RowDefinitions>
     <TextBlock Style="{StaticResource MaterialDesignHeadline5TextBlock}" Text="Buttons" />
     <StackPanel Grid.Row="1">
@@ -962,6 +965,26 @@
         <Button materialDesign:ShadowAssist.ShadowAnimationDuration="0:0:0.5" Style="{StaticResource MaterialDesignRaisedDarkButton}">
           Long Duration
         </Button>
+      </smtx:XamlDisplay>
+    </StackPanel>
+
+    <Rectangle Grid.Row="14"
+               Height="1"
+               Margin="0,24,0,0"
+               Fill="{DynamicResource MaterialDesignDivider}" />
+
+    <TextBlock Grid.Row="15"
+               Margin="0,24"
+               Style="{StaticResource MaterialDesignHeadline5TextBlock}"
+               Text="SplitButtons" />
+
+    <StackPanel Grid.Row="16" Orientation="Horizontal">
+      <smtx:XamlDisplay Margin="0,0,20,0" UniqueKey="splitbutton_1">
+        <materialDesign:SplitButton Height="40" Content="Split Button">
+          <materialDesign:SplitButton.PopupContent>
+           <TextBlock Text="This is the content of the SplitButton popup" Foreground="Black" Margin="4"/>
+          </materialDesign:SplitButton.PopupContent>
+        </materialDesign:SplitButton>
       </smtx:XamlDisplay>
     </StackPanel>
   </Grid>

--- a/MainDemo.Wpf/Properties/launchSettings.json
+++ b/MainDemo.Wpf/Properties/launchSettings.json
@@ -2,7 +2,7 @@
     "profiles": {
         "Demo App": {
             "commandName": "Project",
-            "commandLineArgs": "-p Home -t Inherit -f LeftToRight"
+            "commandLineArgs": "-p Buttons -t Inherit -f LeftToRight"
         }
     }
 }

--- a/MaterialDesignThemes.Wpf/Card.cs
+++ b/MaterialDesignThemes.Wpf/Card.cs
@@ -6,7 +6,7 @@ namespace MaterialDesignThemes.Wpf;
 public class Card : ContentControl
 {
     private Border? _clipBorder;
-    private const double DefaultUniformCornerRadius = 4.0;
+    public const double DefaultUniformCornerRadius = 4.0;
     public const string ClipBorderPartName = "PART_ClipBorder";
 
     #region DependencyProperty : UniformCornerRadiusProperty

--- a/MaterialDesignThemes.Wpf/SplitButton.cs
+++ b/MaterialDesignThemes.Wpf/SplitButton.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.Xaml.Behaviors.Core;
+
+namespace MaterialDesignThemes.Wpf;
+
+public class SplitButton : Button
+{
+    static SplitButton()
+    {
+        DefaultStyleKeyProperty.OverrideMetadata(typeof(SplitButton), new FrameworkPropertyMetadata(typeof(SplitButton)));
+    }
+
+    public static readonly DependencyProperty IsOpenProperty = DependencyProperty.Register(
+        nameof(IsOpen), typeof(bool), typeof(SplitButton), new PropertyMetadata(default(bool)));
+
+    public bool IsOpen
+    {
+        get => (bool) GetValue(IsOpenProperty);
+        set => SetValue(IsOpenProperty, value);
+    }
+
+    public static readonly DependencyProperty PopupElevationProperty = DependencyProperty.Register(
+        nameof(PopupElevation), typeof(Elevation), typeof(SplitButton), new PropertyMetadata(default(Elevation)));
+
+    public Elevation PopupElevation
+    {
+        get => (Elevation) GetValue(PopupElevationProperty);
+        set => SetValue(PopupElevationProperty, value);
+    }
+
+    public static readonly DependencyProperty PopupUniformCornerRadiusProperty = DependencyProperty.Register(
+        nameof(PopupUniformCornerRadius), typeof(double), typeof(SplitButton), new PropertyMetadata(default(double)));
+
+    public double PopupUniformCornerRadius
+    {
+        get => (double) GetValue(PopupUniformCornerRadiusProperty);
+        set => SetValue(PopupUniformCornerRadiusProperty, value);
+    }
+
+    public static readonly DependencyProperty PopupContentStyleProperty = DependencyProperty.Register(
+        nameof(PopupContentStyle), typeof(Style), typeof(SplitButton), new PropertyMetadata(default(Style)));
+
+    public Style PopupContentStyle
+    {
+        get => (Style) GetValue(PopupContentStyleProperty);
+        set => SetValue(PopupContentStyleProperty, value);
+    }
+
+    public static readonly DependencyProperty PopupContentProperty = DependencyProperty.Register(
+        nameof(PopupContent), typeof(object), typeof(SplitButton), new PropertyMetadata(default(object)));
+
+    public object PopupContent
+    {
+        get => (object) GetValue(PopupContentProperty);
+        set => SetValue(PopupContentProperty, value);
+    }
+
+    public static readonly DependencyProperty PopupContentTemplateProperty = DependencyProperty.Register(
+        nameof(PopupContentTemplate), typeof(DataTemplate), typeof(SplitButton), new PropertyMetadata(default(DataTemplate)));
+
+    public DataTemplate PopupContentTemplate
+    {
+        get => (DataTemplate) GetValue(PopupContentTemplateProperty);
+        set => SetValue(PopupContentTemplateProperty, value);
+    }
+
+    public static readonly DependencyProperty PopupContentTemplateSelectorProperty = DependencyProperty.Register(
+        nameof(PopupContentTemplateSelector), typeof(DataTemplateSelector), typeof(SplitButton), new PropertyMetadata(default(DataTemplateSelector)));
+
+    public DataTemplateSelector PopupContentTemplateSelector
+    {
+        get => (DataTemplateSelector) GetValue(PopupContentTemplateSelectorProperty);
+        set => SetValue(PopupContentTemplateSelectorProperty, value);
+    }
+
+    public ICommand OpenCommand { get; }
+
+    public SplitButton() => OpenCommand = new ActionCommand(() => IsOpen = true);
+}

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -30,6 +30,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SmartHint.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Snackbar.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.AutoSuggestBox.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SplitButton.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
   <!-- set up default styles for our custom Material Design in XAML Toolkit controls -->
@@ -39,6 +40,7 @@
   <Style TargetType="{x:Type local:PopupBox}" BasedOn="{StaticResource MaterialDesignPopupBox}" />
   <Style TargetType="{x:Type local:TimePicker}" BasedOn="{StaticResource MaterialDesignTimePicker}" />
   <Style TargetType="{x:Type local:AutoSuggestBox}" BasedOn="{StaticResource MaterialDesignAutoSuggestBox}" />
+  <Style TargetType="{x:Type local:SplitButton}" BasedOn="{StaticResource MaterialDesignRaisedSplitButton}" />
 
   <converters:BrushToRadialGradientBrushConverter x:Key="BrushToRadialGradientBrushConverter" />
   <converters:DrawerOffsetConverter x:Key="DrawerOffsetConverter" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesign2.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesign2.Defaults.xaml
@@ -31,6 +31,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ScrollViewer.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Slider.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SplitButton.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TabControl.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBlock.xaml" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Defaults.xaml
@@ -38,6 +38,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ScrollViewer.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Slider.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SplitButton.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TabControl.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TimePicker.xaml" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
@@ -30,6 +30,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ScrollViewer.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Slider.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SplitButton.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TabControl.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBlock.xaml" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SplitButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SplitButton.xaml
@@ -1,0 +1,198 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Card.xaml" />
+  </ResourceDictionary.MergedDictionaries>
+
+  <Style x:Key="FocusVisual">
+    <Setter Property="Control.Template">
+      <Setter.Value>
+        <ControlTemplate>
+          <Rectangle Margin="2"
+                     SnapsToDevicePixels="true"
+                     Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                     StrokeDashArray="1 2"
+                     StrokeThickness="1" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
+  <Style x:Key="MaterialDesignSplitButtonPopupElevatedCardStyle" TargetType="{x:Type ContentControl}">
+    <Style.Resources>
+      <wpf:ElevationMarginConverter x:Key="ElevationMarginConverter" />
+    </Style.Resources>
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ContentControl}">
+          <wpf:Card wpf:ElevationAssist.Elevation="{TemplateBinding wpf:ElevationAssist.Elevation}"
+                    Margin="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ElevationAssist.Elevation), Converter={StaticResource ElevationMarginConverter}}"
+                    UniformCornerRadius="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:SplitButton}, Path=PopupUniformCornerRadius}">
+            <ContentControl Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" />
+          </wpf:Card>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
+  <Style x:Key="MaterialDesignSplitButtonPopupOutlinedCardStyle" TargetType="{x:Type ContentControl}">
+    <Style.Resources>
+      <wpf:ElevationMarginConverter x:Key="ElevationMarginConverter" />
+    </Style.Resources>
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ContentControl}">
+          <wpf:Card Style="{StaticResource MaterialDesignOutlinedCard}"
+                    Margin="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ElevationAssist.Elevation), Converter={StaticResource ElevationMarginConverter}}"
+                    UniformCornerRadius="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:SplitButton}, Path=PopupUniformCornerRadius}">
+            <ContentControl Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" />
+          </wpf:Card>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
+  <Style x:Key="MaterialDesignRaisedSplitButton" TargetType="{x:Type wpf:SplitButton}">
+    <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Cursor" Value="Hand" />
+    <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}" />
+    <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary.Foreground}" />
+    <Setter Property="Height" Value="32" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="Padding" Value="16,4,16,4" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type wpf:SplitButton}">
+          <Grid>
+            <Grid.Resources>
+              <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+              <converters:BorderClipConverter x:Key="BorderClipConverter" />
+            </Grid.Resources>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="*" />
+              <ColumnDefinition Width="Auto" />
+              <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Popup PlacementTarget="{Binding ElementName=border}"
+                   Placement="Bottom"
+                   StaysOpen="False"
+                   AllowsTransparency="True"
+                   IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsOpen}">
+              <ContentControl Style="{TemplateBinding PopupContentStyle}"
+                              Content="{TemplateBinding PopupContent}"
+                              ContentTemplate="{TemplateBinding PopupContentTemplate}"
+                              ContentTemplateSelector="{TemplateBinding PopupContentTemplateSelector}"
+                              wpf:ElevationAssist.Elevation="{TemplateBinding PopupElevation}"/>
+            </Popup>
+            <AdornerDecorator Grid.Column="0" Grid.ColumnSpan="3" CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
+              <Grid>
+                <Border x:Name="border"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{Binding Path=(wpf:ButtonAssist.CornerRadius), RelativeSource={RelativeSource TemplatedParent}}"
+                        Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}" />
+                <ProgressBar x:Name="ProgressBar"
+                             Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type wpf:SplitButton}}, Path=ActualWidth}"
+                             Height="{TemplateBinding Height}"
+                             HorizontalAlignment="Left"
+                             VerticalAlignment="Center"
+                             Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IndicatorBackground)}"
+                             BorderBrush="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IndicatorBackground)}"
+                             Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IndicatorForeground)}"
+                             IsIndeterminate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IsIndeterminate)}"
+                             Maximum="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Maximum)}"
+                             Minimum="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Minimum)}"
+                             Opacity="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Opacity)}"
+                             Style="{DynamicResource MaterialDesignLinearProgressBar}"
+                             Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IsIndicatorVisible), Converter={StaticResource BooleanToVisibilityConverter}}"
+                             Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Value)}">
+                  <ProgressBar.Clip>
+                    <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                      <Binding ElementName="border" Path="ActualWidth" />
+                      <Binding ElementName="border" Path="ActualHeight" />
+                      <Binding ElementName="border" Path="CornerRadius" />
+                      <Binding ElementName="border" Path="BorderThickness" />
+                    </MultiBinding>
+                  </ProgressBar.Clip>
+                </ProgressBar>
+              </Grid>
+            </AdornerDecorator>
+            <wpf:Ripple Grid.Column="0"
+                        Padding="{TemplateBinding Padding}"
+                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                        Content="{TemplateBinding Content}"
+                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                        Focusable="False"
+                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+              <wpf:Ripple.Clip>
+                <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                  <Binding ElementName="border" Path="ActualWidth" />
+                  <Binding ElementName="border" Path="ActualHeight" />
+                  <Binding ElementName="border" Path="CornerRadius" />
+                  <Binding ElementName="border" Path="BorderThickness" />
+                </MultiBinding>
+              </wpf:Ripple.Clip>
+            </wpf:Ripple>
+            <Rectangle Grid.Column="1"
+                       Width="1"
+                       Fill="{DynamicResource MaterialDesignLightSeparatorBackground}"/>
+            <Button Grid.Column="2"
+                    VerticalAlignment="Stretch"
+                    Style="{x:Null}"
+                    Foreground="{TemplateBinding Foreground}"
+                    Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=OpenCommand}">
+              <Button.Template>
+                <ControlTemplate>
+                  <Grid Background="Transparent">
+                    <wpf:PackIcon Kind="ChevronDown"
+                                  Margin="4,0"
+                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                  </Grid>
+                </ControlTemplate>
+              </Button.Template>
+            </Button>
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+              <Setter TargetName="border" Property="wpf:ShadowAssist.Darken" Value="True" />
+            </Trigger>
+            <Trigger Property="IsKeyboardFocused" Value="true">
+              <Setter TargetName="border" Property="wpf:ShadowAssist.Darken" Value="True" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+              <Setter Property="Opacity" Value="0.38" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="TextBlock.FontSize" Value="14" />
+    <Setter Property="TextBlock.FontWeight" Value="Medium" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="wpf:ButtonAssist.CornerRadius" Value="2" />
+    <Setter Property="wpf:ButtonProgressAssist.IndicatorBackground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
+    <Setter Property="wpf:ButtonProgressAssist.IndicatorForeground" Value="{DynamicResource MaterialDesign.Brush.Primary.Foreground}" />
+    <Setter Property="wpf:ButtonProgressAssist.IsIndicatorVisible" Value="False" />
+    <Setter Property="wpf:ButtonProgressAssist.Opacity" Value=".4" />
+    <Setter Property="wpf:ElevationAssist.Elevation" Value="Dp2" />
+    <Setter Property="wpf:RippleAssist.Feedback" Value="White" />
+    <Setter Property="PopupContentStyle" Value="{StaticResource MaterialDesignSplitButtonPopupElevatedCardStyle}" />
+    <Setter Property="PopupElevation" Value="Dp3" />
+    <Setter Property="PopupUniformCornerRadius" Value="{x:Static wpf:Card.DefaultUniformCornerRadius}" />
+  </Style>
+
+</ResourceDictionary>


### PR DESCRIPTION
This draft PR adds a SplitButton to the MDIX library by introducing a `SplitButton` custom control which currently is a copy paste of the `MaterialDesignRaisedButton` style extended with split button behavior.

**NOTE**: This is just a simple POC so we can figure out which direction we want to take this. There is another draft PR for a different approach (i.e. attached properties) to adding a SplitButton to the library.

<br/>

**PROs**:
* Discoverability (independent control residing in the MDIX namespace)
* Fine grained control if tweaks are needed that should not affect normal buttons
* Does not impact the visual tree of normal buttons
* Easy to add control- and style-specific brushes targeting specific areas of the control

**CONs**:
* Style creation/maintenance is more or less duplications of the normal button styles

<br/>
<br/>

![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/f8f85977-f434-40d3-ad07-cad88413fe83)

```xaml
<materialDesign:SplitButton
  Height="40"
  Content="Split Button">
  <materialDesign:SplitButton.PopupContent>
    <TextBlock
      Text="This is the content of the SplitButton popup"
      Foreground="Black"
      Margin="4" />
  </materialDesign:SplitButton.PopupContent>
</materialDesign:SplitButton>
```