### PR TITLE
SplitButton using attached properties

### DIFF
--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -45,6 +45,9 @@
       <RowDefinition Height="Auto" />
       <RowDefinition Height="Auto" />
       <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
     </Grid.RowDefinitions>
     <TextBlock Style="{StaticResource MaterialDesignHeadline5TextBlock}" Text="Buttons" />
     <StackPanel Grid.Row="1">
@@ -961,6 +964,26 @@
       <smtx:XamlDisplay Margin="0,0,20,0" UniqueKey="button_duration_3">
         <Button materialDesign:ShadowAssist.ShadowAnimationDuration="0:0:0.5" Style="{StaticResource MaterialDesignRaisedDarkButton}">
           Long Duration
+        </Button>
+      </smtx:XamlDisplay>
+    </StackPanel>
+
+    <Rectangle Grid.Row="14"
+               Height="1"
+               Margin="0,24,0,0"
+               Fill="{DynamicResource MaterialDesignDivider}" />
+
+    <TextBlock Grid.Row="15"
+               Margin="0,24"
+               Style="{StaticResource MaterialDesignHeadline5TextBlock}"
+               Text="SplitButtons" />
+
+    <StackPanel Grid.Row="16" Orientation="Horizontal">
+      <smtx:XamlDisplay Margin="0,0,20,0" UniqueKey="splitbutton_1">
+        <Button Height="40" Content="Split Button">
+          <materialDesign:SplitButtonAssist.PopupContent>
+            <TextBlock Text="This is the content of the SplitButton popup" Foreground="Black" Margin="4"/>
+          </materialDesign:SplitButtonAssist.PopupContent>
         </Button>
       </smtx:XamlDisplay>
     </StackPanel>

--- a/MainDemo.Wpf/Properties/launchSettings.json
+++ b/MainDemo.Wpf/Properties/launchSettings.json
@@ -2,7 +2,7 @@
     "profiles": {
         "Demo App": {
             "commandName": "Project",
-            "commandLineArgs": "-p Home -t Inherit -f LeftToRight"
+            "commandLineArgs": "-p Buttons -t Inherit -f LeftToRight"
         }
     }
 }

--- a/MaterialDesignThemes.Wpf/SplitButtonAssist.cs
+++ b/MaterialDesignThemes.Wpf/SplitButtonAssist.cs
@@ -1,0 +1,59 @@
+﻿namespace MaterialDesignThemes.Wpf
+{
+    public static class SplitButtonAssist
+    {
+        public static readonly DependencyProperty PopupElevationProperty = DependencyProperty.RegisterAttached(
+            "PopupElevation", typeof(Elevation), typeof(SplitButtonAssist), new PropertyMetadata(default(Elevation)));
+
+        public static void SetPopupElevation(DependencyObject element, Elevation value)
+            => element.SetValue(PopupElevationProperty, value);
+
+        public static Elevation GetPopupElevation(DependencyObject element)
+            => (Elevation) element.GetValue(PopupElevationProperty);
+
+        public static readonly DependencyProperty PopupUniformCornerRadiusProperty = DependencyProperty.RegisterAttached(
+            "PopupUniformCornerRadius", typeof(double), typeof(SplitButtonAssist), new PropertyMetadata(default(double)));
+
+        public static void SetPopupUniformCornerRadius(DependencyObject element, double value)
+            => element.SetValue(PopupUniformCornerRadiusProperty, value);
+
+        public static double GetPopupUniformCornerRadius(DependencyObject element)
+            => (double) element.GetValue(PopupUniformCornerRadiusProperty);
+
+        public static readonly DependencyProperty PopupContentStyleProperty = DependencyProperty.RegisterAttached(
+            "PopupContentStyle", typeof(Style), typeof(SplitButtonAssist), new PropertyMetadata(default(Style)));
+
+        public static void SetPopupContentStyle(DependencyObject element, Style value)
+            => element.SetValue(PopupContentStyleProperty, value);
+
+        public static Style GetPopupContentStyle(DependencyObject element)
+            => (Style) element.GetValue(PopupContentStyleProperty);
+
+        public static readonly DependencyProperty PopupContentProperty = DependencyProperty.RegisterAttached(
+            "PopupContent", typeof(object), typeof(SplitButtonAssist), new PropertyMetadata(default(object)));
+
+        public static void SetPopupContent(DependencyObject element, object value)
+            => element.SetValue(PopupContentProperty, value);
+
+        public static object GetPopupContent(DependencyObject element)
+            => element.GetValue(PopupContentProperty);
+
+        public static readonly DependencyProperty PopupContentTemplateProperty = DependencyProperty.RegisterAttached(
+            "PopupContentTemplate", typeof(DataTemplate), typeof(SplitButtonAssist), new PropertyMetadata(default(DataTemplate)));
+
+        public static void SetPopupContentTemplate(DependencyObject element, DataTemplate value)
+            => element.SetValue(PopupContentTemplateProperty, value);
+
+        public static DataTemplate GetPopupContentTemplate(DependencyObject element)
+            => (DataTemplate) element.GetValue(PopupContentTemplateProperty);
+
+        public static readonly DependencyProperty PopupContentTemplateSelectorProperty = DependencyProperty.RegisterAttached(
+            "PopupContentTemplateSelector", typeof(DataTemplateSelector), typeof(SplitButtonAssist), new PropertyMetadata(default(DataTemplateSelector)));
+
+        public static void SetPopupContentTemplateSelector(DependencyObject element, DataTemplateSelector value)
+            => element.SetValue(PopupContentTemplateSelectorProperty, value);
+
+        public static DataTemplateSelector GetPopupContentTemplateSelector(DependencyObject element)
+            => (DataTemplateSelector) element.GetValue(PopupContentTemplateSelectorProperty);
+    }
+}

--- a/MaterialDesignThemes.Wpf/SplitButtonContent.cs
+++ b/MaterialDesignThemes.Wpf/SplitButtonContent.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.Xaml.Behaviors.Core;
+
+namespace MaterialDesignThemes.Wpf;
+
+public class SplitButtonContent : ContentControl
+{
+    static SplitButtonContent() => DefaultStyleKeyProperty.OverrideMetadata(typeof(SplitButtonContent), new FrameworkPropertyMetadata(typeof(SplitButtonContent)));
+
+    public static readonly DependencyProperty IsOpenProperty = DependencyProperty.Register(
+        nameof(IsOpen), typeof(bool), typeof(SplitButtonContent), new PropertyMetadata(default(bool)));
+
+    public bool IsOpen
+    {
+        get => (bool)GetValue(IsOpenProperty);
+        set => SetValue(IsOpenProperty, value);
+    }
+
+    public static readonly DependencyProperty PopupPlacementTargetProperty = DependencyProperty.Register(
+        nameof(PopupPlacementTarget), typeof(UIElement), typeof(SplitButtonContent), new PropertyMetadata(default(UIElement)));
+
+    public UIElement PopupPlacementTarget
+    {
+        get => (UIElement) GetValue(PopupPlacementTargetProperty);
+        set => SetValue(PopupPlacementTargetProperty, value);
+    }
+
+    public static readonly DependencyProperty PopupElevationProperty = DependencyProperty.Register(
+        nameof(PopupElevation), typeof(Elevation), typeof(SplitButtonContent), new PropertyMetadata(default(Elevation)));
+
+    public Elevation PopupElevation
+    {
+        get => (Elevation)GetValue(PopupElevationProperty);
+        set => SetValue(PopupElevationProperty, value);
+    }
+
+    public static readonly DependencyProperty PopupUniformCornerRadiusProperty = DependencyProperty.Register(
+        nameof(PopupUniformCornerRadius), typeof(double), typeof(SplitButtonContent), new PropertyMetadata(default(double)));
+
+    public double PopupUniformCornerRadius
+    {
+        get => (double)GetValue(PopupUniformCornerRadiusProperty);
+        set => SetValue(PopupUniformCornerRadiusProperty, value);
+    }
+
+    public static readonly DependencyProperty PopupContentStyleProperty = DependencyProperty.Register(
+        nameof(PopupContentStyle), typeof(Style), typeof(SplitButtonContent), new PropertyMetadata(default(Style)));
+
+    public Style PopupContentStyle
+    {
+        get => (Style)GetValue(PopupContentStyleProperty);
+        set => SetValue(PopupContentStyleProperty, value);
+    }
+
+    public static readonly DependencyProperty PopupContentProperty = DependencyProperty.Register(
+        nameof(PopupContent), typeof(object), typeof(SplitButtonContent), new PropertyMetadata(default(object)));
+
+    public object PopupContent
+    {
+        get => (object)GetValue(PopupContentProperty);
+        set => SetValue(PopupContentProperty, value);
+    }
+
+    public static readonly DependencyProperty PopupContentTemplateProperty = DependencyProperty.Register(
+        nameof(PopupContentTemplate), typeof(DataTemplate), typeof(SplitButtonContent), new PropertyMetadata(default(DataTemplate)));
+
+    public DataTemplate PopupContentTemplate
+    {
+        get => (DataTemplate)GetValue(PopupContentTemplateProperty);
+        set => SetValue(PopupContentTemplateProperty, value);
+    }
+
+    public static readonly DependencyProperty PopupContentTemplateSelectorProperty = DependencyProperty.Register(
+        nameof(PopupContentTemplateSelector), typeof(DataTemplateSelector), typeof(SplitButtonContent), new PropertyMetadata(default(DataTemplateSelector)));
+
+    public DataTemplateSelector PopupContentTemplateSelector
+    {
+        get => (DataTemplateSelector)GetValue(PopupContentTemplateSelectorProperty);
+        set => SetValue(PopupContentTemplateSelectorProperty, value);
+    }
+
+    public ICommand OpenCommand { get; }
+
+    public SplitButtonContent() => OpenCommand = new ActionCommand(() => IsOpen = true);
+}

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -30,6 +30,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SmartHint.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Snackbar.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.AutoSuggestBox.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SplitButtonContent.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
   <!-- set up default styles for our custom Material Design in XAML Toolkit controls -->
@@ -39,6 +40,7 @@
   <Style TargetType="{x:Type local:PopupBox}" BasedOn="{StaticResource MaterialDesignPopupBox}" />
   <Style TargetType="{x:Type local:TimePicker}" BasedOn="{StaticResource MaterialDesignTimePicker}" />
   <Style TargetType="{x:Type local:AutoSuggestBox}" BasedOn="{StaticResource MaterialDesignAutoSuggestBox}" />
+  <Style TargetType="{x:Type local:SplitButtonContent}" BasedOn="{StaticResource MaterialDesignSplitButtonContent}" />
 
   <converters:BrushToRadialGradientBrushConverter x:Key="BrushToRadialGradientBrushConverter" />
   <converters:DrawerOffsetConverter x:Key="DrawerOffsetConverter" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesign2.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesign2.Defaults.xaml
@@ -31,6 +31,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ScrollViewer.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Slider.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SplitButtonContent.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TabControl.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBlock.xaml" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Defaults.xaml
@@ -38,6 +38,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ScrollViewer.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Slider.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SplitButtonContent.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TabControl.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TimePicker.xaml" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
@@ -7,6 +7,7 @@
 
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SplitButtonContent.xaml" />
     <ResourceDictionary>
       <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
       <converters:BorderClipConverter x:Key="BorderClipConverter" />
@@ -35,6 +36,9 @@
   <!--#region Raised Button-->
 
   <Style x:Key="MaterialDesignRaisedButton" TargetType="{x:Type ButtonBase}">
+    <Style.Resources>
+      <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
+    </Style.Resources>
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
     <Setter Property="BorderThickness" Value="1" />
@@ -47,8 +51,13 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ButtonBase}">
-          <Grid>
-            <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
+          <Grid x:Name="OuterGrid">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="*" />
+              <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <AdornerDecorator Grid.ColumnSpan="2"
+                              CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
               <Grid>
                 <Border x:Name="border"
                         Background="{TemplateBinding Background}"
@@ -82,7 +91,8 @@
                 </ProgressBar>
               </Grid>
             </AdornerDecorator>
-            <wpf:Ripple Padding="{TemplateBinding Padding}"
+            <wpf:Ripple Grid.Column="0"
+                        Padding="{TemplateBinding Padding}"
                         HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                         VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                         Content="{TemplateBinding Content}"
@@ -99,6 +109,15 @@
                 </MultiBinding>
               </wpf:Ripple.Clip>
             </wpf:Ripple>
+            <wpf:SplitButtonContent Grid.Column="1"
+                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:SplitButtonAssist.PopupContent), Converter={StaticResource NullableToVisibilityConverter}}"
+                                    PopupPlacementTarget="{Binding ElementName=OuterGrid}"
+                                    PopupElevation="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:SplitButtonAssist.PopupElevation)}"
+                                    PopupUniformCornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:SplitButtonAssist.PopupUniformCornerRadius)}"
+                                    PopupContentStyle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:SplitButtonAssist.PopupContentStyle)}"
+                                    PopupContent="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:SplitButtonAssist.PopupContent)}"
+                                    PopupContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:SplitButtonAssist.PopupContentTemplate)}"
+                                    PopupContentTemplateSelector="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:SplitButtonAssist.PopupContentTemplateSelector)}"/>
           </Grid>
           <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
@@ -124,6 +143,7 @@
     <Setter Property="wpf:ButtonProgressAssist.Opacity" Value=".4" />
     <Setter Property="wpf:ElevationAssist.Elevation" Value="Dp2" />
     <Setter Property="wpf:RippleAssist.Feedback" Value="White" />
+    <Setter Property="wpf:SplitButtonAssist.PopupContentStyle" Value="{StaticResource MaterialDesignSplitButtonPopupOutlinedCardStyle}" />
   </Style>
 
   <Style x:Key="MaterialDesignRaisedLightButton"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
@@ -30,6 +30,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ScrollViewer.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Slider.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SplitButtonContent.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TabControl.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBlock.xaml" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SplitButtonContent.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SplitButtonContent.xaml
@@ -1,0 +1,95 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Card.xaml" />
+  </ResourceDictionary.MergedDictionaries>
+
+  <Style x:Key="MaterialDesignSplitButtonPopupElevatedCardStyle" TargetType="{x:Type ContentControl}">
+    <Style.Resources>
+      <wpf:ElevationMarginConverter x:Key="ElevationMarginConverter" />
+    </Style.Resources>
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ContentControl}">
+          <wpf:Card wpf:ElevationAssist.Elevation="{TemplateBinding wpf:ElevationAssist.Elevation}"
+                    Margin="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ElevationAssist.Elevation), Converter={StaticResource ElevationMarginConverter}}"
+                    UniformCornerRadius="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:SplitButtonContent}, Path=PopupUniformCornerRadius}">
+            <ContentControl Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" />
+          </wpf:Card>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
+  <Style x:Key="MaterialDesignSplitButtonPopupOutlinedCardStyle" TargetType="{x:Type ContentControl}">
+    <Style.Resources>
+      <wpf:ElevationMarginConverter x:Key="ElevationMarginConverter" />
+    </Style.Resources>
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ContentControl}">
+          <wpf:Card Style="{StaticResource MaterialDesignOutlinedCard}"
+                    Margin="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ElevationAssist.Elevation), Converter={StaticResource ElevationMarginConverter}}"
+                    UniformCornerRadius="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:SplitButtonContent}, Path=PopupUniformCornerRadius}">
+            <ContentControl Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" />
+          </wpf:Card>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
+  <Style x:Key="MaterialDesignSplitButtonContent" TargetType="{x:Type wpf:SplitButtonContent}">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type wpf:SplitButtonContent}">
+          <Grid>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="Auto" />
+              <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <Popup PlacementTarget="{TemplateBinding PopupPlacementTarget}"
+                   Placement="Bottom"
+                   StaysOpen="False"
+                   AllowsTransparency="True"
+                   IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsOpen}">
+              <ContentControl Style="{TemplateBinding PopupContentStyle}"
+                              Content="{TemplateBinding PopupContent}"
+                              ContentTemplate="{TemplateBinding PopupContentTemplate}"
+                              ContentTemplateSelector="{TemplateBinding PopupContentTemplateSelector}"
+                              wpf:ElevationAssist.Elevation="{TemplateBinding PopupElevation}"/>
+            </Popup>
+
+            <Rectangle Grid.Column="0"
+                       Width="1"
+                       Fill="{DynamicResource MaterialDesignLightSeparatorBackground}"/>
+            <Button Grid.Column="1"
+                    VerticalAlignment="Stretch"
+                    Style="{x:Null}"
+                    Foreground="{TemplateBinding Foreground}"
+                    Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=OpenCommand}">
+              <Button.Template>
+                <ControlTemplate>
+                  <Grid Background="Transparent">
+                    <wpf:PackIcon Kind="ChevronDown"
+                                  Margin="4,0"
+                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                  </Grid>
+                </ControlTemplate>
+              </Button.Template>
+            </Button>
+            
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
+</ResourceDictionary>


### PR DESCRIPTION
This draft PR adds SplitButton functionality to the MDIX library by introducing a `SplitButtonAssist` class exposing attached properties which can be applied to (a selection of) the existing button styles with very little effort.

**NOTE**: This is just a simple POC so we can figure out which direction we want to take this. There is another draft PR for a different approach (i.e. custom control) to adding a SplitButton to the library.

<br/>

**PROs**:
* Style creation/maintenance is minimal. Rather simple addition to the selected styles is needed.

**CONs**:
* Discoverability (attached properties are inherently less discoverable)
* Less fine grained control
* Slight impact on visual tree of al (or select) button styles
* Slight challenge to add control- and style-specific brushes targeting specific areas of the control


<br/>
<br/>

![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/a6811e82-bf2d-40c7-a647-f4902dc96fba)

```xaml
<Button
  Height="40"
  Content="Split Button">
  <materialDesign:SplitButtonAssist.PopupContent>
    <TextBlock
      Text="This is the content of the SplitButton popup"
      Foreground="Black"
      Margin="4" />
  </materialDesign:SplitButtonAssist.PopupContent>
</Button>
```