### PR TITLE
Add support for TextFieldAssist.HasClearButton in RichTextBox

### DIFF
--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -465,6 +465,7 @@
               <Setter Property="local:SmartHint.RichTextBoxText" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
               <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />

--- a/MaterialDesignThemes.Wpf/Internal/ClearText.cs
+++ b/MaterialDesignThemes.Wpf/Internal/ClearText.cs
@@ -52,6 +52,9 @@ public static class ClearText
                     comboBox.SetCurrentValue(ComboBox.TextProperty, null);
                     comboBox.SetCurrentValue(Selector.SelectedItemProperty, null);
                     break;
+                case RichTextBox richTextBox:
+                    richTextBox.Document.Blocks.Clear();
+                    break;
                 case PasswordBox passwordBox:
                     passwordBox.Password = null;
                     break;


### PR DESCRIPTION
Fixes #3313 

Adds clear button support in `RichTextBox` by simply clearing the document blocks when the button is clicked.