### PR TITLE
Minor refactor of SplitButton

### DIFF
--- a/MaterialDesignThemes.Wpf/SplitButton.cs
+++ b/MaterialDesignThemes.Wpf/SplitButton.cs
@@ -136,11 +136,6 @@ public class SplitButton : Button
             WeakEventManager<Button, RoutedEventArgs>.AddHandler(_rightButton, nameof(Click), OpenPopupBox);
         }
 
-        void SetClickEventAsHandled(object? sender, RoutedEventArgs e)
-        {
-            e.Handled = true;
-        }
-
         void OpenPopupBox(object? sender, RoutedEventArgs e)
         {
             if (_popupBox is not null)

--- a/MaterialDesignThemes.Wpf/SplitButton.cs
+++ b/MaterialDesignThemes.Wpf/SplitButton.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.Xaml.Behaviors.Core;
-
-namespace MaterialDesignThemes.Wpf;
+﻿namespace MaterialDesignThemes.Wpf;
 
 [TemplatePart(Name = PopupBoxPartName, Type = typeof(PopupBox))]
+[TemplatePart(Name = RightButtonPartName, Type = typeof(Button))]
 public class SplitButton : Button
 {
     public const string PopupBoxPartName = "PART_PopupBox";
+    public const string RightButtonPartName = "PART_RightButton";
 
     static SplitButton()
     {
@@ -111,52 +111,43 @@ public class SplitButton : Button
         set => SetValue(SplitContentTemplateSelectorProperty, value);
     }
 
-    internal static readonly DependencyProperty ButtonStyleProperty = DependencyProperty.Register(
+    public static readonly DependencyProperty ButtonStyleProperty = DependencyProperty.Register(
         nameof(ButtonStyle), typeof(Style), typeof(SplitButton), new PropertyMetadata(default(Style)));
 
-    internal Style ButtonStyle
+    public Style ButtonStyle
     {
         get => (Style) GetValue(ButtonStyleProperty);
         set => SetValue(ButtonStyleProperty, value);
     }
 
-    internal static readonly DependencyProperty PopupBoxButtonClickedCommandProperty = DependencyProperty.Register(
-        nameof(PopupBoxButtonClickedCommand), typeof(ICommand), typeof(SplitButton), new PropertyMetadata(default(ICommand)));
-
-    internal ICommand PopupBoxButtonClickedCommand
-    {
-        get => (ICommand)GetValue(PopupBoxButtonClickedCommandProperty);
-        set => SetValue(PopupBoxButtonClickedCommandProperty, value);
-    }
-
     private PopupBox? _popupBox;
-
-    public SplitButton()
-    {
-        PopupBoxButtonClickedCommand = new ActionCommand(OpenPopupBox);
-    }
+    private Button? _rightButton;
 
     public override void OnApplyTemplate()
     {
         base.OnApplyTemplate();
 
         _popupBox = GetTemplateChild(PopupBoxPartName) as PopupBox;
+        _rightButton = GetTemplateChild(RightButtonPartName) as Button;
 
-        if (_popupBox is not null)
+        if (_rightButton is not null)
         {
-            _popupBox.RemoveHandler(ButtonBase.ClickEvent, (RoutedEventHandler)ChildClickedHandler);
-            _popupBox.AddHandler(ButtonBase.ClickEvent, (RoutedEventHandler)ChildClickedHandler);
+            WeakEventManager<Button, RoutedEventArgs>.RemoveHandler(_rightButton, nameof(Click), OpenPopupBox);
+            WeakEventManager<Button, RoutedEventArgs>.AddHandler(_rightButton, nameof(Click), OpenPopupBox);
         }
-    }
 
-    private static void ChildClickedHandler(object sender, RoutedEventArgs e)
-        => e.Handled = true;
-
-    private void OpenPopupBox()
-    {
-        if (_popupBox is not null)
+        void SetClickEventAsHandled(object? sender, RoutedEventArgs e)
         {
-            _popupBox.IsPopupOpen = true;
+            e.Handled = true;
+        }
+
+        void OpenPopupBox(object? sender, RoutedEventArgs e)
+        {
+            if (_popupBox is not null)
+            {
+                _popupBox.IsPopupOpen = true;
+                e.Handled = true;
+            }
         }
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SplitButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SplitButton.xaml
@@ -71,7 +71,7 @@
                           PlacementTarget="{Binding ElementName=OuterGrid}"
                           Opacity="1">
               <wpf:PopupBox.ToggleContent>
-                <Button Command="{TemplateBinding PopupBoxButtonClickedCommand}"
+                <Button x:Name="PART_RightButton"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         Height="{Binding ElementName=PART_LeftButton, Path=ActualHeight}"
                         IsHitTestVisible="True"


### PR DESCRIPTION
Removed use of MVVM in internal `Click` handling and made `ButtonStyle` public to allow consumers to copy-paste-modify the style if they so desire.