### PR TITLE
Create the slider theme for md3 guideline

### DIFF
--- a/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml
+++ b/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml
@@ -17,7 +17,7 @@
       <StackPanel Orientation="Horizontal">
         <StackPanel>
           <StackPanel.Resources>
-            <Style TargetType="Slider" BasedOn="{StaticResource MaterialDesignSlider}">
+            <Style TargetType="Slider" BasedOn="{StaticResource MaterialDesign3.MaterialDesignSlider}">
               <Setter Property="IsSnapToTickEnabled" Value="True" />
               <Setter Property="Margin" Value="10,0" />
               <Setter Property="VerticalAlignment" Value="Center" />

--- a/MaterialDesign3.Demo.Wpf/Sliders.xaml
+++ b/MaterialDesign3.Demo.Wpf/Sliders.xaml
@@ -15,7 +15,7 @@
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <!-- note you only need bring in these extra resource dictionaries when using non-default styles, so only bring them into your controls where the default style is not what you want -->
-        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Slider.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign3.Slider.xaml" />
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
   </UserControl.Resources>
@@ -136,7 +136,7 @@
           <smtx:XamlDisplay Margin="0,24,0,0" UniqueKey="discrete_slider_h_1">
             <Slider Maximum="{Binding DiscreteHorizontal.Maximum}"
                     Minimum="0"
-                    Style="{StaticResource MaterialDesignDiscreteSlider}"
+                    Style="{StaticResource MaterialDesign3.MaterialDesignDiscreteSlider}"
                     TickFrequency="{Binding DiscreteHorizontal.TickFrequency}"
                     TickPlacement="BottomRight"
                     Value="40" />
@@ -148,7 +148,7 @@
                     Minimum="0"
                     SelectionEnd="90"
                     SelectionStart="70"
-                    Style="{StaticResource MaterialDesignDiscreteSlider}"
+                    Style="{StaticResource MaterialDesign3.MaterialDesignDiscreteSlider}"
                     TickFrequency="{Binding DiscreteHorizontal.TickFrequency}"
                     TickPlacement="TopLeft"
                     Value="20" />
@@ -157,7 +157,7 @@
           <smtx:XamlDisplay Margin="0,24,0,0" UniqueKey="discrete_slider_h_3">
             <Slider Maximum="{Binding DiscreteHorizontal.Maximum}"
                     Minimum="0"
-                    Style="{StaticResource MaterialDesignDiscreteSlider}"
+                    Style="{StaticResource MaterialDesign3.MaterialDesignDiscreteSlider}"
                     TickFrequency="{Binding DiscreteHorizontal.TickFrequency}"
                     TickPlacement="Both"
                     Value="60" />
@@ -167,7 +167,7 @@
             <Slider IsEnabled="False"
                     Maximum="{Binding DiscreteHorizontal.Maximum}"
                     Minimum="0"
-                    Style="{StaticResource MaterialDesignDiscreteSlider}"
+                    Style="{StaticResource MaterialDesign3.MaterialDesignDiscreteSlider}"
                     TickFrequency="{Binding DiscreteHorizontal.TickFrequency}"
                     TickPlacement="BottomRight"
                     Value="50" />
@@ -208,7 +208,7 @@
             <Slider Maximum="{Binding DiscreteVertical.Maximum}"
                     Minimum="0"
                     Orientation="Vertical"
-                    Style="{StaticResource MaterialDesignDiscreteSlider}"
+                    Style="{StaticResource MaterialDesign3.MaterialDesignDiscreteSlider}"
                     TickFrequency="{Binding DiscreteVertical.TickFrequency}"
                     TickPlacement="BottomRight"
                     Value="70000" />
@@ -221,7 +221,7 @@
                     Orientation="Vertical"
                     SelectionEnd="90000"
                     SelectionStart="60000"
-                    Style="{StaticResource MaterialDesignDiscreteSlider}"
+                    Style="{StaticResource MaterialDesign3.MaterialDesignDiscreteSlider}"
                     TickFrequency="{Binding DiscreteVertical.TickFrequency}"
                     TickPlacement="TopLeft"
                     Value="30000" />
@@ -231,7 +231,7 @@
             <Slider Maximum="{Binding DiscreteVertical.Maximum}"
                     Minimum="0"
                     Orientation="Vertical"
-                    Style="{StaticResource MaterialDesignDiscreteSlider}"
+                    Style="{StaticResource MaterialDesign3.MaterialDesignDiscreteSlider}"
                     TickFrequency="{Binding DiscreteVertical.TickFrequency}"
                     TickPlacement="Both"
                     Value="90000" />
@@ -242,7 +242,7 @@
                     Maximum="{Binding DiscreteVertical.Maximum}"
                     Minimum="0"
                     Orientation="Vertical"
-                    Style="{StaticResource MaterialDesignDiscreteSlider}"
+                    Style="{StaticResource MaterialDesign3.MaterialDesignDiscreteSlider}"
                     TickFrequency="{Binding DiscreteVertical.TickFrequency}"
                     TickPlacement="BottomRight"
                     Value="50000" />
@@ -253,7 +253,7 @@
                     Maximum="{Binding DiscreteVertical.Maximum}"
                     Minimum="0"
                     Orientation="Vertical"
-                    Style="{StaticResource MaterialDesignDiscreteSlider}"
+                    Style="{StaticResource MaterialDesign3.MaterialDesignDiscreteSlider}"
                     TickFrequency="{Binding DiscreteVertical.TickFrequency}"
                     TickPlacement="BottomRight"
                     Value="70000" />
@@ -264,7 +264,7 @@
                     Maximum="{Binding DiscreteVertical.Maximum}"
                     Minimum="0"
                     Orientation="Vertical"
-                    Style="{StaticResource MaterialDesignDiscreteSlider}"
+                    Style="{StaticResource MaterialDesign3.MaterialDesignDiscreteSlider}"
                     TickFrequency="{Binding DiscreteVertical.TickFrequency}"
                     TickPlacement="BottomRight"
                     Value="70000" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Defaults.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
   <!-- use this resource dictionary to set up the most common themes for standard controls -->
@@ -10,6 +10,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign3.NavigationRail.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign3.NavigationBar.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign3.NavigationDrawer.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign3.Slider.xaml" />
 
     <!-- MaterialDesign2 -->
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Badged.xaml" />
@@ -37,7 +38,6 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ScrollBar.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ScrollViewer.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
-    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Slider.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TabControl.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TimePicker.xaml" />
@@ -86,7 +86,7 @@
   <Style TargetType="{x:Type RichTextBox}" BasedOn="{StaticResource MaterialDesignRichTextBox}" />
   <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource MaterialDesignScrollBar}" />
   <Style TargetType="{x:Type ScrollViewer}" BasedOn="{StaticResource MaterialDesignScrollViewer}" />
-  <Style TargetType="{x:Type Slider}" BasedOn="{StaticResource MaterialDesignSlider}" />
+  <Style TargetType="{x:Type Slider}" BasedOn="{StaticResource MaterialDesign3.MaterialDesignSlider}" />
   <Style TargetType="{x:Type TabControl}" BasedOn="{StaticResource MaterialDesignTabControl}" />
   <Style TargetType="{x:Type TabItem}" BasedOn="{StaticResource MaterialDesignTabItem}" />
   <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignTextBox}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Slider.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Slider.xaml
@@ -1,0 +1,1061 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
+  </ResourceDictionary.MergedDictionaries>
+
+  <converters:SliderValueLabelPositionConverter x:Key="SliderValueLabelPositionConverter" />
+  <converters:BooleanAllConverter x:Key="BooleanAllConverter" />
+  <converters:InvertBooleanConverter x:Key="InvertBooleanConverter" />
+  <converters:SliderToolTipConverter x:Key="SliderToolTipConverter" />
+
+  <Style x:Key="MaterialDesign3.MaterialDesignRepeatButton" TargetType="{x:Type RepeatButton}">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="OverridesDefaultStyle" Value="True" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type RepeatButton}">
+          <Rectangle Fill="Transparent" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
+  <ControlTemplate x:Key="MaterialDesign3.MaterialDesignSliderThumb" TargetType="{x:Type Thumb}">
+    <ControlTemplate.Resources>
+      <Storyboard x:Key="MaterialDesign3.ShowFocusVisualStoryboard">
+        <DoubleAnimation Storyboard.TargetName="focusedHalo"
+                         Storyboard.TargetProperty="Opacity"
+                         To="0.15"
+                         Duration="0" />
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)">
+          <EasingDoubleKeyFrame KeyTime="0:0:0.0" Value="0" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="1">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)">
+          <EasingDoubleKeyFrame KeyTime="0:0:0.0" Value="0" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="1">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+      </Storyboard>
+      <Storyboard x:Key="MaterialDesign3.HideFocusVisualStoryboard">
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo" Storyboard.TargetProperty="Opacity">
+          <EasingDoubleKeyFrame KeyTime="0:0:0" Value="0.15" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo"
+                                       Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
+                                       Duration="0">
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0" />
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo"
+                                       Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
+                                       Duration="0">
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0" />
+        </DoubleAnimationUsingKeyFrames>
+      </Storyboard>
+    </ControlTemplate.Resources>
+    <Grid x:Name="thumbGrid"
+          Width="18"
+          Height="20">
+      <Ellipse x:Name="halo"
+               Width="48"
+               Height="48"
+               Margin="-24"
+               Fill="{TemplateBinding Foreground}"
+               Opacity="0" />
+      <Ellipse x:Name="focusedHalo"
+               Width="48"
+               Height="48"
+               Margin="-24"
+               Fill="{TemplateBinding Foreground}"
+               Opacity="0.15"
+               RenderTransformOrigin="0.5,0.5">
+        <Ellipse.RenderTransform>
+          <ScaleTransform ScaleX="0" ScaleY="0" />
+        </Ellipse.RenderTransform>
+      </Ellipse>
+      <AdornerDecorator>
+        <AdornerDecorator.CacheMode>
+          <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+        </AdornerDecorator.CacheMode>
+        <Ellipse x:Name="grip"
+                 Margin="-1,0"
+                 Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}"
+                 Fill="{TemplateBinding Foreground}" />
+      </AdornerDecorator>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <DataTrigger Binding="{Binding Orientation, RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}}" Value="{x:Static Orientation.Vertical}">
+        <Setter TargetName="grip" Property="Margin" Value="0,-1" />
+        <Setter TargetName="thumbGrid" Property="Height" Value="18" />
+        <Setter TargetName="thumbGrid" Property="Width" Value="20" />
+      </DataTrigger>
+      <Trigger Property="IsMouseOver" Value="true">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="halo"
+                               Storyboard.TargetProperty="Opacity"
+                               To="0.15"
+                               Duration="0:0:0.2" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="halo"
+                               Storyboard.TargetProperty="Opacity"
+                               To="0"
+                               Duration="0:0:0.2" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+      <DataTrigger Value="True">
+        <DataTrigger.Binding>
+          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+            <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
+            <Binding Converter="{StaticResource InvertBooleanConverter}"
+                     Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)"
+                     RelativeSource="{RelativeSource FindAncestor,
+                                                     AncestorType=RangeBase}" />
+          </MultiBinding>
+        </DataTrigger.Binding>
+        <DataTrigger.EnterActions>
+          <BeginStoryboard Storyboard="{StaticResource MaterialDesign3.ShowFocusVisualStoryboard}" />
+        </DataTrigger.EnterActions>
+        <DataTrigger.ExitActions>
+          <BeginStoryboard Storyboard="{StaticResource MaterialDesign3.HideFocusVisualStoryboard}" />
+        </DataTrigger.ExitActions>
+      </DataTrigger>
+      <DataTrigger Value="True">
+        <DataTrigger.Binding>
+          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+            <Binding Path="IsDragging" RelativeSource="{RelativeSource Self}" />
+            <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
+          </MultiBinding>
+        </DataTrigger.Binding>
+        <DataTrigger.EnterActions>
+          <BeginStoryboard Storyboard="{StaticResource MaterialDesign3.ShowFocusVisualStoryboard}" />
+        </DataTrigger.EnterActions>
+        <DataTrigger.ExitActions>
+          <BeginStoryboard Storyboard="{StaticResource MaterialDesign3.HideFocusVisualStoryboard}" />
+        </DataTrigger.ExitActions>
+      </DataTrigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+
+  <ControlTemplate x:Key="MaterialDesign3.MaterialDesignDiscreteSliderThumb" TargetType="{x:Type Thumb}">
+    <ControlTemplate.Resources>
+      <Storyboard x:Key="MaterialDesign3.ShowFocusVisualStoryboard">
+        <DoubleAnimation Storyboard.TargetName="focusedHalo"
+                         Storyboard.TargetProperty="Opacity"
+                         To="0.15"
+                         Duration="0" />
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)">
+          <EasingDoubleKeyFrame KeyTime="0:0:0.0" Value="0" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="1">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)">
+          <EasingDoubleKeyFrame KeyTime="0:0:0.0" Value="0" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="1">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="label"
+                                       Storyboard.TargetProperty="Visibility"
+                                       Duration="0">
+          <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+        </ObjectAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="label" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleX)">
+          <EasingDoubleKeyFrame KeyTime="0:0:0" Value="0" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="1">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="label" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleY)">
+          <EasingDoubleKeyFrame KeyTime="0:0:0" Value="0" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="1">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+      </Storyboard>
+      <Storyboard x:Key="MaterialDesign3.HideFocusVisualStoryboard">
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo" Storyboard.TargetProperty="Opacity">
+          <EasingDoubleKeyFrame KeyTime="0:0:0" Value="0.15" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo"
+                                       Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
+                                       Duration="0">
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0" />
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo"
+                                       Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
+                                       Duration="0">
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0" />
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="label" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleX)">
+          <EasingDoubleKeyFrame KeyTime="0:0:0" Value="1" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="label" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleY)">
+          <EasingDoubleKeyFrame KeyTime="0:0:0" Value="1" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="label"
+                                       Storyboard.TargetProperty="Visibility"
+                                       Duration="0">
+          <DiscreteObjectKeyFrame KeyTime="0:0:0.1" Value="{x:Static Visibility.Collapsed}" />
+        </ObjectAnimationUsingKeyFrames>
+      </Storyboard>
+    </ControlTemplate.Resources>
+    <Grid Width="18" Height="20">
+      <Ellipse x:Name="halo"
+               Width="48"
+               Height="48"
+               Margin="-24"
+               Fill="{TemplateBinding Foreground}"
+               Opacity="0" />
+      <Ellipse x:Name="focusedHalo"
+               Width="48"
+               Height="48"
+               Margin="-24"
+               Fill="{TemplateBinding Foreground}"
+               Opacity="0.15"
+               RenderTransformOrigin="0.5,0.5">
+        <Ellipse.RenderTransform>
+          <ScaleTransform ScaleX="0" ScaleY="0" />
+        </Ellipse.RenderTransform>
+      </Ellipse>
+      <Canvas>
+        <Grid x:Name="label"
+              Height="36"
+              IsHitTestVisible="False"
+              RenderTransformOrigin="0.5,1"
+              Visibility="Collapsed">
+          <Grid.RenderTransform>
+            <TransformGroup>
+              <ScaleTransform ScaleX="0" ScaleY="0" />
+              <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={StaticResource SliderValueLabelPositionConverter}, ConverterParameter={x:Static Orientation.Horizontal}}" Y="-40" />
+            </TransformGroup>
+          </Grid.RenderTransform>
+          <AdornerDecorator>
+            <AdornerDecorator.CacheMode>
+              <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+            </AdornerDecorator.CacheMode>
+            <Grid Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}">
+              <Rectangle Margin="0,0,0,5"
+                         Fill="{DynamicResource MaterialDesign.Brush.ToolTip.Background}"
+                         RadiusX="2"
+                         RadiusY="2" />
+              <Polygon HorizontalAlignment="Center"
+                       VerticalAlignment="Bottom"
+                       Fill="{DynamicResource MaterialDesign.Brush.ToolTip.Background}"
+                       Points="0,0 4.5,5 9,0" />
+            </Grid>
+          </AdornerDecorator>
+          <TextBlock Margin="12,0,12,5"
+                     VerticalAlignment="Center"
+                     Foreground="{DynamicResource MaterialDesign.Brush.Background}"
+                     TextAlignment="Center">
+            <TextBlock.Text>
+              <MultiBinding Converter="{StaticResource SliderToolTipConverter}"
+                            NotifyOnValidationError="True"
+                            TargetNullValue=""
+                            ValidatesOnDataErrors="True">
+                <Binding Path="Value"
+                         RelativeSource="{RelativeSource FindAncestor,
+                                                         AncestorType=RangeBase}"
+                         TargetNullValue="" />
+                <Binding Path="(wpf:SliderAssist.ToolTipFormat)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
+              </MultiBinding>
+            </TextBlock.Text>
+          </TextBlock>
+        </Grid>
+      </Canvas>
+      <AdornerDecorator>
+        <AdornerDecorator.CacheMode>
+          <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+        </AdornerDecorator.CacheMode>
+        <Ellipse x:Name="grip"
+                 Margin="-1,0"
+                 Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}"
+                 Fill="{TemplateBinding Foreground}" />
+      </AdornerDecorator>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsMouseOver" Value="true">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="halo"
+                               Storyboard.TargetProperty="Opacity"
+                               To="0.15"
+                               Duration="0:0:0.2" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="halo"
+                               Storyboard.TargetProperty="Opacity"
+                               To="0"
+                               Duration="0:0:0.2" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+      <DataTrigger Value="True">
+        <DataTrigger.Binding>
+          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+            <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
+            <Binding Converter="{StaticResource InvertBooleanConverter}"
+                     Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)"
+                     RelativeSource="{RelativeSource FindAncestor,
+                                                     AncestorType=RangeBase}" />
+          </MultiBinding>
+        </DataTrigger.Binding>
+        <DataTrigger.EnterActions>
+          <BeginStoryboard Storyboard="{StaticResource MaterialDesign3.ShowFocusVisualStoryboard}" />
+        </DataTrigger.EnterActions>
+        <DataTrigger.ExitActions>
+          <BeginStoryboard Storyboard="{StaticResource MaterialDesign3.HideFocusVisualStoryboard}" />
+        </DataTrigger.ExitActions>
+      </DataTrigger>
+      <DataTrigger Value="True">
+        <DataTrigger.Binding>
+          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+            <Binding Path="IsDragging" RelativeSource="{RelativeSource Self}" />
+            <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
+          </MultiBinding>
+        </DataTrigger.Binding>
+        <DataTrigger.EnterActions>
+          <BeginStoryboard Storyboard="{StaticResource MaterialDesign3.ShowFocusVisualStoryboard}" />
+        </DataTrigger.EnterActions>
+        <DataTrigger.ExitActions>
+          <BeginStoryboard Storyboard="{StaticResource MaterialDesign3.HideFocusVisualStoryboard}" />
+        </DataTrigger.ExitActions>
+      </DataTrigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+
+  <ControlTemplate x:Key="MaterialDesign3.MaterialDesignLeftDiscreteSliderThumb" TargetType="{x:Type Thumb}">
+    <ControlTemplate.Resources>
+      <Storyboard x:Key="MaterialDesign3.ShowFocusVisualStoryboard">
+        <DoubleAnimation Storyboard.TargetName="focusedHalo"
+                         Storyboard.TargetProperty="Opacity"
+                         To="0.15"
+                         Duration="0" />
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)">
+          <EasingDoubleKeyFrame KeyTime="0:0:0.0" Value="0" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="1">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)">
+          <EasingDoubleKeyFrame KeyTime="0:0:0.0" Value="0" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="1">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="label"
+                                       Storyboard.TargetProperty="Visibility"
+                                       Duration="0">
+          <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+        </ObjectAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="label" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleX)">
+          <EasingDoubleKeyFrame KeyTime="0:0:0" Value="0" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="1">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="label" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleY)">
+          <EasingDoubleKeyFrame KeyTime="0:0:0" Value="0" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="1">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+      </Storyboard>
+      <Storyboard x:Key="MaterialDesign3.HideFocusVisualStoryboard">
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo" Storyboard.TargetProperty="Opacity">
+          <EasingDoubleKeyFrame KeyTime="0:0:0" Value="0.15" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo"
+                                       Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
+                                       Duration="0">
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0" />
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="focusedHalo"
+                                       Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
+                                       Duration="0">
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0" />
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="label" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleX)">
+          <EasingDoubleKeyFrame KeyTime="0:0:0" Value="1" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="label" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleY)">
+          <EasingDoubleKeyFrame KeyTime="0:0:0" Value="1" />
+          <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="0">
+            <EasingDoubleKeyFrame.EasingFunction>
+              <SineEase EasingMode="EaseInOut" />
+            </EasingDoubleKeyFrame.EasingFunction>
+          </EasingDoubleKeyFrame>
+        </DoubleAnimationUsingKeyFrames>
+        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="label"
+                                       Storyboard.TargetProperty="Visibility"
+                                       Duration="0">
+          <DiscreteObjectKeyFrame KeyTime="0:0:0.1" Value="{x:Static Visibility.Collapsed}" />
+        </ObjectAnimationUsingKeyFrames>
+      </Storyboard>
+    </ControlTemplate.Resources>
+    <Grid Width="20" Height="18">
+      <Ellipse x:Name="halo"
+               Width="48"
+               Height="48"
+               Margin="-24"
+               Fill="{TemplateBinding Foreground}"
+               Opacity="0" />
+      <Ellipse x:Name="focusedHalo"
+               Width="48"
+               Height="48"
+               Margin="-24"
+               Fill="{TemplateBinding Foreground}"
+               Opacity="0.15"
+               RenderTransformOrigin="0.5,0.5">
+        <Ellipse.RenderTransform>
+          <ScaleTransform ScaleX="0" ScaleY="0" />
+        </Ellipse.RenderTransform>
+      </Ellipse>
+      <Canvas>
+        <Grid x:Name="label"
+              Height="31"
+              IsHitTestVisible="False"
+              RenderTransformOrigin="1,0.5"
+              Visibility="Collapsed">
+          <Grid.RenderTransform>
+            <TransformGroup>
+              <ScaleTransform ScaleX="0" ScaleY="0" />
+              <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={StaticResource SliderValueLabelPositionConverter}, ConverterParameter={x:Static Orientation.Vertical}}" Y="-7" />
+            </TransformGroup>
+          </Grid.RenderTransform>
+          <AdornerDecorator>
+            <AdornerDecorator.CacheMode>
+              <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+            </AdornerDecorator.CacheMode>
+            <Grid Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}">
+              <Rectangle Margin="0,0,5,0"
+                         Fill="{DynamicResource MaterialDesign.Brush.ToolTip.Background}"
+                         RadiusX="2"
+                         RadiusY="2" />
+              <Polygon HorizontalAlignment="Right"
+                       VerticalAlignment="Center"
+                       Fill="{DynamicResource MaterialDesign.Brush.ToolTip.Background}"
+                       Points="0,0 6,5 0,10" />
+            </Grid>
+          </AdornerDecorator>
+          <TextBlock Margin="12,0,17,0"
+                     VerticalAlignment="Center"
+                     Foreground="{DynamicResource MaterialDesign.Brush.Background}"
+                     TextAlignment="Center">
+            <TextBlock.Text>
+              <MultiBinding Converter="{StaticResource SliderToolTipConverter}"
+                            NotifyOnValidationError="True"
+                            TargetNullValue=""
+                            ValidatesOnDataErrors="True">
+                <Binding Path="Value"
+                         RelativeSource="{RelativeSource FindAncestor,
+                                                         AncestorType=RangeBase}"
+                         TargetNullValue="" />
+                <Binding Path="(wpf:SliderAssist.ToolTipFormat)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
+              </MultiBinding>
+            </TextBlock.Text>
+          </TextBlock>
+        </Grid>
+      </Canvas>
+      <AdornerDecorator>
+        <AdornerDecorator.CacheMode>
+          <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+        </AdornerDecorator.CacheMode>
+        <Ellipse x:Name="grip"
+                 Margin="0,-1"
+                 Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}"
+                 Fill="{TemplateBinding Foreground}" />
+      </AdornerDecorator>
+    </Grid>
+    <ControlTemplate.Triggers>
+      <Trigger Property="IsMouseOver" Value="true">
+        <Trigger.EnterActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="halo"
+                               Storyboard.TargetProperty="Opacity"
+                               To="0.15"
+                               Duration="0:0:0.2" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.EnterActions>
+        <Trigger.ExitActions>
+          <BeginStoryboard>
+            <Storyboard>
+              <DoubleAnimation Storyboard.TargetName="halo"
+                               Storyboard.TargetProperty="Opacity"
+                               To="0"
+                               Duration="0:0:0.2" />
+            </Storyboard>
+          </BeginStoryboard>
+        </Trigger.ExitActions>
+      </Trigger>
+      <DataTrigger Value="True">
+        <DataTrigger.Binding>
+          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+            <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
+            <Binding Converter="{StaticResource InvertBooleanConverter}"
+                     Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)"
+                     RelativeSource="{RelativeSource FindAncestor,
+                                                     AncestorType=RangeBase}" />
+          </MultiBinding>
+        </DataTrigger.Binding>
+        <DataTrigger.EnterActions>
+          <BeginStoryboard Storyboard="{StaticResource MaterialDesign3.ShowFocusVisualStoryboard}" />
+        </DataTrigger.EnterActions>
+        <DataTrigger.ExitActions>
+          <BeginStoryboard Storyboard="{StaticResource MaterialDesign3.HideFocusVisualStoryboard}" />
+        </DataTrigger.ExitActions>
+      </DataTrigger>
+      <DataTrigger Value="True">
+        <DataTrigger.Binding>
+          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+            <Binding Path="IsDragging" RelativeSource="{RelativeSource Self}" />
+            <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
+          </MultiBinding>
+        </DataTrigger.Binding>
+        <DataTrigger.EnterActions>
+          <BeginStoryboard Storyboard="{StaticResource MaterialDesign3.ShowFocusVisualStoryboard}" />
+        </DataTrigger.EnterActions>
+        <DataTrigger.ExitActions>
+          <BeginStoryboard Storyboard="{StaticResource MaterialDesign3.HideFocusVisualStoryboard}" />
+        </DataTrigger.ExitActions>
+      </DataTrigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+
+  <ControlTemplate x:Key="MaterialDesign3.MaterialDesignSliderHorizontal" TargetType="{x:Type Slider}">
+    <Border Background="{TemplateBinding Background}"
+            BorderBrush="{TemplateBinding BorderBrush}"
+            BorderThickness="{TemplateBinding BorderThickness}"
+            SnapsToDevicePixels="True"
+            UseLayoutRounding="True">
+      <Grid SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" UseLayoutRounding="{TemplateBinding UseLayoutRounding}">
+        <Grid.RowDefinitions>
+          <RowDefinition Height="Auto" />
+          <RowDefinition Height="Auto" MinHeight="{TemplateBinding MinHeight}" />
+          <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TickBar x:Name="TopTick"
+                 Grid.Row="0"
+                 Height="4"
+                 Margin="0,0,0,2"
+                 Fill="{TemplateBinding Foreground}"
+                 Placement="Top"
+                 Visibility="Collapsed" />
+        <TickBar x:Name="BottomTick"
+                 Grid.Row="2"
+                 Height="4"
+                 Margin="0,2,0,0"
+                 Fill="{TemplateBinding Foreground}"
+                 Placement="Bottom"
+                 Visibility="Collapsed" />
+        <Rectangle Grid.Row="1"
+                   Height="4"
+                   VerticalAlignment="Center"
+                   Fill="{TemplateBinding Foreground}"
+                   Opacity="0.38"
+                   RadiusX="2"
+                   RadiusY="2" />
+        <Border x:Name="activeTrack"
+                Grid.Row="1"
+                Width="{Binding DecreaseRepeatButton.ActualWidth, ElementName=PART_Track}"
+                Height="4"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                Background="{TemplateBinding Foreground}"
+                CornerRadius="3,0,0,3" />
+        <!-- Selection range must be wrapped in a Canvas for the position to be updated correctly -->
+        <Canvas Grid.Row="1"
+                Height="6"
+                VerticalAlignment="Center">
+          <Rectangle x:Name="PART_SelectionRange"
+                     Height="6"
+                     Fill="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"
+                     RadiusX="2"
+                     RadiusY="2"
+                     Visibility="Collapsed" />
+        </Canvas>
+        <Track x:Name="PART_Track"
+               Grid.Row="1"
+               Height="20">
+          <Track.DecreaseRepeatButton>
+            <RepeatButton Command="{x:Static Slider.DecreaseLarge}" Style="{StaticResource MaterialDesign3.MaterialDesignRepeatButton}" />
+          </Track.DecreaseRepeatButton>
+          <Track.IncreaseRepeatButton>
+            <RepeatButton Command="{x:Static Slider.IncreaseLarge}" Style="{StaticResource MaterialDesign3.MaterialDesignRepeatButton}" />
+          </Track.IncreaseRepeatButton>
+          <!-- It's important that the Thumb gets added last in the XAML to make sure it is drawn on top of both repeat buttons -->
+          <Track.Thumb>
+            <Thumb Foreground="{TemplateBinding Foreground}"
+                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                   Template="{StaticResource MaterialDesign3.MaterialDesignSliderThumb}" />
+          </Track.Thumb>
+        </Track>
+      </Grid>
+    </Border>
+    <ControlTemplate.Triggers>
+      <Trigger Property="TickPlacement" Value="TopLeft">
+        <Setter TargetName="TopTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="TickPlacement" Value="BottomRight">
+        <Setter TargetName="BottomTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="TickPlacement" Value="Both">
+        <Setter TargetName="BottomTick" Property="Visibility" Value="Visible" />
+        <Setter TargetName="TopTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="IsSelectionRangeEnabled" Value="true">
+        <Setter TargetName="PART_SelectionRange" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="IsDirectionReversed" Value="True">
+        <Setter TargetName="activeTrack" Property="CornerRadius" Value="0,3,3,0" />
+        <Setter TargetName="activeTrack" Property="HorizontalAlignment" Value="Right" />
+      </Trigger>
+      <Trigger Property="wpf:SliderAssist.HideActiveTrack" Value="True">
+        <Setter TargetName="activeTrack" Property="Visibility" Value="Hidden" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+
+  <ControlTemplate x:Key="MaterialDesign3.MaterialDesignSliderVertical" TargetType="{x:Type Slider}">
+    <Border Background="{TemplateBinding Background}"
+            BorderBrush="{TemplateBinding BorderBrush}"
+            BorderThickness="{TemplateBinding BorderThickness}"
+            SnapsToDevicePixels="True"
+            UseLayoutRounding="True">
+      <Grid SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" UseLayoutRounding="{TemplateBinding UseLayoutRounding}">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" MinWidth="{TemplateBinding MinWidth}" />
+          <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <TickBar x:Name="TopTick"
+                 Grid.Column="0"
+                 Width="4"
+                 Margin="0,0,2,0"
+                 Fill="{TemplateBinding Foreground}"
+                 Placement="Left"
+                 Visibility="Collapsed" />
+        <TickBar x:Name="BottomTick"
+                 Grid.Column="2"
+                 Width="4"
+                 Margin="2,0,0,0"
+                 Fill="{TemplateBinding Foreground}"
+                 Placement="Right"
+                 Visibility="Collapsed" />
+        <Rectangle Grid.Column="1"
+                   Width="4"
+                   HorizontalAlignment="Center"
+                   Fill="{TemplateBinding Foreground}"
+                   Opacity="0.38"
+                   RadiusX="2"
+                   RadiusY="2" />
+        <Border x:Name="activeTrack"
+                Grid.Column="1"
+                Width="4"
+                Height="{Binding DecreaseRepeatButton.ActualHeight, ElementName=PART_Track}"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Bottom"
+                Background="{TemplateBinding Foreground}"
+                CornerRadius="0,0,3,3" />
+        <!-- Selection range must be wrapped in a Canvas for the position to be updated correctly -->
+        <Canvas Grid.Column="1"
+                Width="6"
+                HorizontalAlignment="Center">
+          <Rectangle x:Name="PART_SelectionRange"
+                     Width="6"
+                     Fill="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"
+                     RadiusX="2"
+                     RadiusY="2"
+                     Visibility="Collapsed" />
+        </Canvas>
+        <Track x:Name="PART_Track"
+               Grid.Column="1"
+               Width="20">
+          <Track.DecreaseRepeatButton>
+            <RepeatButton Command="{x:Static Slider.DecreaseLarge}" Style="{StaticResource MaterialDesign3.MaterialDesignRepeatButton}" />
+          </Track.DecreaseRepeatButton>
+          <Track.IncreaseRepeatButton>
+            <RepeatButton Command="{x:Static Slider.IncreaseLarge}" Style="{StaticResource MaterialDesign3.MaterialDesignRepeatButton}" />
+          </Track.IncreaseRepeatButton>
+          <!-- It's important that the Thumb gets added last in the XAML to make sure it is drawn on top of both repeat buttons -->
+          <Track.Thumb>
+            <Thumb Foreground="{TemplateBinding Foreground}"
+                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                   Template="{StaticResource MaterialDesign3.MaterialDesignSliderThumb}" />
+          </Track.Thumb>
+        </Track>
+      </Grid>
+    </Border>
+    <ControlTemplate.Triggers>
+      <Trigger Property="TickPlacement" Value="TopLeft">
+        <Setter TargetName="TopTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="TickPlacement" Value="BottomRight">
+        <Setter TargetName="BottomTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="TickPlacement" Value="Both">
+        <Setter TargetName="BottomTick" Property="Visibility" Value="Visible" />
+        <Setter TargetName="TopTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="IsSelectionRangeEnabled" Value="true">
+        <Setter TargetName="PART_SelectionRange" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="IsDirectionReversed" Value="True">
+        <Setter TargetName="activeTrack" Property="CornerRadius" Value="3,3,0,0" />
+        <Setter TargetName="activeTrack" Property="VerticalAlignment" Value="Top" />
+      </Trigger>
+      <Trigger Property="wpf:SliderAssist.HideActiveTrack" Value="True">
+        <Setter TargetName="activeTrack" Property="Visibility" Value="Hidden" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+
+  <ControlTemplate x:Key="MaterialDesign3.MaterialDesignDiscreteSliderHorizontal" TargetType="{x:Type Slider}">
+    <Border Background="{TemplateBinding Background}"
+            BorderBrush="{TemplateBinding BorderBrush}"
+            BorderThickness="{TemplateBinding BorderThickness}"
+            SnapsToDevicePixels="True"
+            UseLayoutRounding="True">
+      <Grid SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" UseLayoutRounding="{TemplateBinding UseLayoutRounding}">
+        <Grid.RowDefinitions>
+          <RowDefinition Height="Auto" />
+          <RowDefinition Height="Auto" MinHeight="{TemplateBinding MinHeight}" />
+          <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TickBar x:Name="TopTick"
+                 Grid.Row="0"
+                 Height="4"
+                 Margin="0,0,0,2"
+                 Fill="{TemplateBinding Foreground}"
+                 Placement="Top"
+                 Visibility="Collapsed" />
+        <TickBar x:Name="BottomTick"
+                 Grid.Row="2"
+                 Height="4"
+                 Margin="0,2,0,0"
+                 Fill="{TemplateBinding Foreground}"
+                 Placement="Bottom"
+                 Visibility="Collapsed" />
+        <Rectangle Grid.Row="1"
+                   Height="4"
+                   VerticalAlignment="Center"
+                   Fill="{TemplateBinding Foreground}"
+                   Opacity="0.38"
+                   RadiusX="2"
+                   RadiusY="2" />
+        <Border x:Name="activeTrack"
+                Grid.Row="1"
+                Width="{Binding DecreaseRepeatButton.ActualWidth, ElementName=PART_Track}"
+                Height="4"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                Background="{TemplateBinding Foreground}"
+                CornerRadius="3,0,0,3" />
+        <!-- Selection range must be wrapped in a Canvas for the position to be updated correctly -->
+        <Canvas Grid.Row="1"
+                Height="6"
+                VerticalAlignment="Center">
+          <Rectangle x:Name="PART_SelectionRange"
+                     Height="6"
+                     Fill="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"
+                     RadiusX="2"
+                     RadiusY="2"
+                     Visibility="Collapsed" />
+        </Canvas>
+        <Track x:Name="PART_Track"
+               Grid.Row="1"
+               Height="20">
+          <Track.DecreaseRepeatButton>
+            <RepeatButton Command="{x:Static Slider.DecreaseLarge}" Style="{StaticResource MaterialDesign3.MaterialDesignRepeatButton}" />
+          </Track.DecreaseRepeatButton>
+          <Track.IncreaseRepeatButton>
+            <RepeatButton Command="{x:Static Slider.IncreaseLarge}" Style="{StaticResource MaterialDesign3.MaterialDesignRepeatButton}" />
+          </Track.IncreaseRepeatButton>
+          <!-- It's important that the Thumb gets added last in the XAML to make sure it is drawn on top of both repeat buttons -->
+          <Track.Thumb>
+            <Thumb Foreground="{TemplateBinding Foreground}"
+                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                   Template="{StaticResource MaterialDesign3.MaterialDesignDiscreteSliderThumb}" />
+          </Track.Thumb>
+        </Track>
+      </Grid>
+    </Border>
+    <ControlTemplate.Triggers>
+      <Trigger Property="TickPlacement" Value="TopLeft">
+        <Setter TargetName="TopTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="TickPlacement" Value="BottomRight">
+        <Setter TargetName="BottomTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="TickPlacement" Value="Both">
+        <Setter TargetName="BottomTick" Property="Visibility" Value="Visible" />
+        <Setter TargetName="TopTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="IsSelectionRangeEnabled" Value="true">
+        <Setter TargetName="PART_SelectionRange" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="IsDirectionReversed" Value="True">
+        <Setter TargetName="activeTrack" Property="CornerRadius" Value="0,3,3,0" />
+        <Setter TargetName="activeTrack" Property="HorizontalAlignment" Value="Right" />
+      </Trigger>
+      <Trigger Property="wpf:SliderAssist.HideActiveTrack" Value="True">
+        <Setter TargetName="activeTrack" Property="Visibility" Value="Hidden" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+
+  <ControlTemplate x:Key="MaterialDesign3.MaterialDesignDiscreteSliderVertical" TargetType="{x:Type Slider}">
+    <Border Background="{TemplateBinding Background}"
+            BorderBrush="{TemplateBinding BorderBrush}"
+            BorderThickness="{TemplateBinding BorderThickness}"
+            SnapsToDevicePixels="True"
+            UseLayoutRounding="True">
+      <Grid SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" UseLayoutRounding="{TemplateBinding UseLayoutRounding}">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" MinWidth="{TemplateBinding MinWidth}" />
+          <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <TickBar x:Name="TopTick"
+                 Grid.Column="0"
+                 Width="4"
+                 Margin="0,0,2,0"
+                 Fill="{TemplateBinding Foreground}"
+                 Placement="Left"
+                 Visibility="Collapsed" />
+        <TickBar x:Name="BottomTick"
+                 Grid.Column="2"
+                 Width="4"
+                 Margin="2,0,0,0"
+                 Fill="{TemplateBinding Foreground}"
+                 Placement="Right"
+                 Visibility="Collapsed" />
+        <Rectangle Grid.Column="1"
+                   Width="4"
+                   HorizontalAlignment="Center"
+                   Fill="{TemplateBinding Foreground}"
+                   Opacity="0.38"
+                   RadiusX="2"
+                   RadiusY="2" />
+        <Border x:Name="activeTrack"
+                Grid.Column="1"
+                Width="4"
+                Height="{Binding DecreaseRepeatButton.ActualHeight, ElementName=PART_Track}"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Bottom"
+                Background="{TemplateBinding Foreground}"
+                CornerRadius="0,0,3,3" />
+        <!-- Selection range must be wrapped in a Canvas for the position to be updated correctly -->
+        <Canvas Grid.Column="1"
+                Width="6"
+                HorizontalAlignment="Center">
+          <Rectangle x:Name="PART_SelectionRange"
+                     Width="6"
+                     Fill="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"
+                     RadiusX="2"
+                     RadiusY="2"
+                     Visibility="Collapsed" />
+        </Canvas>
+        <Track x:Name="PART_Track"
+               Grid.Column="1"
+               Width="20">
+          <Track.DecreaseRepeatButton>
+            <RepeatButton Command="{x:Static Slider.DecreaseLarge}" Style="{StaticResource MaterialDesign3.MaterialDesignRepeatButton}" />
+          </Track.DecreaseRepeatButton>
+          <Track.IncreaseRepeatButton>
+            <RepeatButton Command="{x:Static Slider.IncreaseLarge}" Style="{StaticResource MaterialDesign3.MaterialDesignRepeatButton}" />
+          </Track.IncreaseRepeatButton>
+          <!-- It's important that the Thumb gets added last in the XAML to make sure it is drawn on top of both repeat buttons -->
+          <Track.Thumb>
+            <Thumb Foreground="{TemplateBinding Foreground}"
+                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                   Template="{StaticResource MaterialDesign3.MaterialDesignLeftDiscreteSliderThumb}" />
+          </Track.Thumb>
+        </Track>
+      </Grid>
+    </Border>
+    <ControlTemplate.Triggers>
+      <Trigger Property="TickPlacement" Value="TopLeft">
+        <Setter TargetName="TopTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="TickPlacement" Value="BottomRight">
+        <Setter TargetName="BottomTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="TickPlacement" Value="Both">
+        <Setter TargetName="BottomTick" Property="Visibility" Value="Visible" />
+        <Setter TargetName="TopTick" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="IsSelectionRangeEnabled" Value="true">
+        <Setter TargetName="PART_SelectionRange" Property="Visibility" Value="Visible" />
+      </Trigger>
+      <Trigger Property="IsDirectionReversed" Value="True">
+        <Setter TargetName="activeTrack" Property="CornerRadius" Value="3,3,0,0" />
+        <Setter TargetName="activeTrack" Property="VerticalAlignment" Value="Top" />
+      </Trigger>
+      <Trigger Property="wpf:SliderAssist.HideActiveTrack" Value="True">
+        <Setter TargetName="activeTrack" Property="Visibility" Value="Hidden" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+
+  <Style x:Key="MaterialDesign3.MaterialDesignSlider" TargetType="{x:Type Slider}">
+    <Setter Property="Background" Value="{x:Null}" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
+    <Setter Property="IsMoveToPointEnabled" Value="True" />
+    <Setter Property="SnapsToDevicePixels" Value="False" />
+    <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false" />
+    <Setter Property="Template" Value="{StaticResource MaterialDesign3.MaterialDesignSliderHorizontal}" />
+    <Setter Property="UseLayoutRounding" Value="False" />
+    <Setter Property="wpf:ElevationAssist.Elevation" Value="Dp1" />
+    <Style.Triggers>
+      <Trigger Property="Orientation" Value="Vertical">
+        <Setter Property="Template" Value="{StaticResource MaterialDesign3.MaterialDesignSliderVertical}" />
+      </Trigger>
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.CheckBox.Disabled}" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+
+  <Style x:Key="MaterialDesign3.MaterialDesignDiscreteHorizontalSlider" TargetType="{x:Type Slider}">
+    <Setter Property="Background" Value="{x:Null}" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
+    <Setter Property="IsMoveToPointEnabled" Value="True" />
+    <Setter Property="IsSnapToTickEnabled" Value="True" />
+    <Setter Property="Orientation" Value="Horizontal" />
+    <Setter Property="SnapsToDevicePixels" Value="False" />
+    <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false" />
+    <Setter Property="Template" Value="{StaticResource MaterialDesign3.MaterialDesignDiscreteSliderHorizontal}" />
+    <Setter Property="UseLayoutRounding" Value="False" />
+    <Setter Property="wpf:ElevationAssist.Elevation" Value="Dp1" />
+    <Style.Triggers>
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.CheckBox.Disabled}" />
+      </Trigger>
+      <Trigger Property="wpf:SliderAssist.OnlyShowFocusVisualWhileDragging" Value="False">
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+
+  <Style x:Key="MaterialDesign3.MaterialDesignDiscreteVerticalSlider" TargetType="{x:Type Slider}">
+    <Setter Property="Background" Value="{x:Null}" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
+    <Setter Property="IsMoveToPointEnabled" Value="True" />
+    <Setter Property="IsSnapToTickEnabled" Value="True" />
+    <Setter Property="Orientation" Value="Vertical" />
+    <Setter Property="SnapsToDevicePixels" Value="False" />
+    <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false" />
+    <Setter Property="Template" Value="{StaticResource MaterialDesign3.MaterialDesignDiscreteSliderVertical}" />
+    <Setter Property="UseLayoutRounding" Value="False" />
+    <Setter Property="wpf:ElevationAssist.Elevation" Value="Dp1" />
+    <Style.Triggers>
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.CheckBox.Disabled}" />
+      </Trigger>
+      <Trigger Property="wpf:SliderAssist.OnlyShowFocusVisualWhileDragging" Value="False">
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+
+  <Style x:Key="MaterialDesign3.MaterialDesignDiscreteSlider"
+         TargetType="{x:Type Slider}"
+         BasedOn="{StaticResource MaterialDesign3.MaterialDesignDiscreteHorizontalSlider}">
+    <Style.Triggers>
+      <Trigger Property="IsEnabled" Value="False">
+        <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.CheckBox.Disabled}" />
+      </Trigger>
+      <Trigger Property="Orientation" Value="Horizontal">
+        <Setter Property="Template" Value="{StaticResource MaterialDesign3.MaterialDesignDiscreteSliderHorizontal}" />
+      </Trigger>
+      <Trigger Property="Orientation" Value="Vertical">
+        <Setter Property="Template" Value="{StaticResource MaterialDesign3.MaterialDesignDiscreteSliderVertical}" />
+      </Trigger>
+      <Trigger Property="wpf:SliderAssist.OnlyShowFocusVisualWhileDragging" Value="False">
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+</ResourceDictionary>


### PR DESCRIPTION
### Preface
Hello everyone and happy new year,

This is my first contribution to a GitHub project and I hope it's the right way to do it.
Feel free to give me some feedback or asking for changes if required.

Thanks you =)

### Description
This pull request create a new slider to better match the MaterialDesign 3 guideline. It's a small change required in one of my project and I decided to share it as I think it's usefull. The only change is the height of the active track who need to match the track height. Here's the md3 [slider spec](https://m3.material.io/components/sliders/specs) :

![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/4752251/c4d682fb-e972-47fc-b7a6-10c7467c2b08)

I follow some guideline found here and there on this repo about handeling the version 3 of material design:
- Creating a new themes for specific md3 element
- Adding to the md3 default theme
- Update the demo project

Result on the demo app :
![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/4752251/724a1a65-ca59-47df-b4ab-66c35830e8ed)

Current master of the demo app :
![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/4752251/92bf61f6-cf20-417b-b499-a6cef5730235)

### Changes Made
- Create a new slider theme md3
  -  Changing the height of the selected line (activeTrack) of the slider line to match the md3 guideline (So the activeTrack and the Track have the same height : 4 )
- Use this new slider them on the demo app

### Related Issues
None

### Additional Notes
If theses changes are validate it could be possible to do the same for the range slider (on project `MaterialDesignThemes.MahApps` ). But this project does not include a md3 theme so you'll have to decide if a default md3 theme file should be created or if the current RangeSlider should be updated.