### PR TITLE
Amend demo to display fix for Issue 3440

### DIFF
--- a/MainDemo.Wpf/Fields.xaml
+++ b/MainDemo.Wpf/Fields.xaml
@@ -598,7 +598,8 @@
                        materialDesign:HintAssist.Hint="Password"
                        materialDesign:TextFieldAssist.HasClearButton="True"
                        IsEnabled="{Binding ElementName=RevealPasswordOutlinedEnabled, Path=IsChecked}"
-                       Style="{StaticResource MaterialDesignOutlinedRevealPasswordBox}" />
+                       Style="{StaticResource MaterialDesignOutlinedRevealPasswordBox}"
+                       VerticalContentAlignment="Bottom"/>
         </StackPanel>
       </smtx:XamlDisplay>
 


### PR DESCRIPTION
Whilst issue #3440  is not a bug, changing the  ```VerticalContentAlignment``` of a ```PasswordBox``` styled with ```MaterialDesignOutlinedRevealPasswordBox```to ```Bottom``` does make the alignment look better.