### PR TITLE
Change default VerticalContentAlignment to Stretch on Expander

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
@@ -360,7 +360,7 @@
         </ControlTemplate>
       </Setter.Value>
     </Setter>
-    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="VerticalContentAlignment" Value="Stretch" />
     <Setter Property="wpf:ExpanderAssist.HeaderBackground" Value="Transparent" />
   </Style>
 </ResourceDictionary>


### PR DESCRIPTION
Fixes #3436 

Changes the default `VerticalContentAlignment` to `Stretch` on the `Expander` style to match the default value of the default style.

I have checked the Expander page in the demo app, and all samples still seem to work as expected. We'll see if any UI tests are affected 😃 