### PR TITLE
Fix HorizontalContentAlignment on ComboBox (selected value)

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
@@ -257,4 +257,34 @@ public class ComboBoxTests : TestBase
 
         recorder.Success();
     }
+
+    [Theory]
+    [InlineData(HorizontalAlignment.Left, 0)]
+    [InlineData(HorizontalAlignment.Right, 1554)]   // Value obtained by inspection
+    [InlineData(HorizontalAlignment.Center, 778)]   // Value obtained by inspection
+    [InlineData(HorizontalAlignment.Stretch, 0)]
+    [Description("Issue 3433")]
+    public async Task ComboBox_WithHorizontalContentAlignment_RespectsAlignment(HorizontalAlignment alignment, double expectedOffset)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        const double tolerance = 2;
+
+        var stackPanel = await LoadXaml<StackPanel>($"""
+            <StackPanel>
+              <ComboBox HorizontalContentAlignment="{alignment}">
+                <ComboBoxItem Content="TEST" IsSelected="True" />
+              </ComboBox>
+            </StackPanel>
+            """);
+        var comboBox = await stackPanel.GetElement<ComboBox>("/ComboBox");
+        var selectedItemPresenter = await comboBox.GetElement<ContentPresenter>("contentPresenter");
+
+        double comboBoxLeftEdge = (await comboBox.GetCoordinates()).Left;
+        double selectedItemLeftEdge = (await selectedItemPresenter.GetCoordinates()).Left;
+
+        Assert.InRange(selectedItemLeftEdge - comboBoxLeftEdge, expectedOffset, expectedOffset + tolerance);
+
+        recorder.Success();
+    }
 }

--- a/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
@@ -259,16 +259,14 @@ public class ComboBoxTests : TestBase
     }
 
     [Theory]
-    [InlineData(HorizontalAlignment.Left, 0)]
-    [InlineData(HorizontalAlignment.Right, 1554)]   // Value obtained by inspection
-    [InlineData(HorizontalAlignment.Center, 778)]   // Value obtained by inspection
-    [InlineData(HorizontalAlignment.Stretch, 0)]
+    [InlineData(HorizontalAlignment.Left)]
+    [InlineData(HorizontalAlignment.Right)]   // Value obtained by inspection
+    [InlineData(HorizontalAlignment.Center)]   // Value obtained by inspection
+    [InlineData(HorizontalAlignment.Stretch)]
     [Description("Issue 3433")]
-    public async Task ComboBox_WithHorizontalContentAlignment_RespectsAlignment(HorizontalAlignment alignment, double expectedOffset)
+    public async Task ComboBox_WithHorizontalContentAlignment_RespectsAlignment(HorizontalAlignment alignment)
     {
         await using var recorder = new TestRecorder(App);
-
-        const double tolerance = 2;
 
         var stackPanel = await LoadXaml<StackPanel>($"""
             <StackPanel>
@@ -280,10 +278,7 @@ public class ComboBoxTests : TestBase
         var comboBox = await stackPanel.GetElement<ComboBox>("/ComboBox");
         var selectedItemPresenter = await comboBox.GetElement<ContentPresenter>("contentPresenter");
 
-        double comboBoxLeftEdge = (await comboBox.GetCoordinates()).Left;
-        double selectedItemLeftEdge = (await selectedItemPresenter.GetCoordinates()).Left;
-
-        Assert.InRange(selectedItemLeftEdge - comboBoxLeftEdge, expectedOffset, expectedOffset + tolerance);
+        Assert.Equal(alignment, await selectedItemPresenter.GetHorizontalAlignment());
 
         recorder.Success();
     }

--- a/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
@@ -260,8 +260,8 @@ public class ComboBoxTests : TestBase
 
     [Theory]
     [InlineData(HorizontalAlignment.Left)]
-    [InlineData(HorizontalAlignment.Right)]   // Value obtained by inspection
-    [InlineData(HorizontalAlignment.Center)]   // Value obtained by inspection
+    [InlineData(HorizontalAlignment.Right)]
+    [InlineData(HorizontalAlignment.Center)]
     [InlineData(HorizontalAlignment.Stretch)]
     [Description("Issue 3433")]
     public async Task ComboBox_WithHorizontalContentAlignment_RespectsAlignment(HorizontalAlignment alignment)

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -363,6 +363,7 @@
                                   ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
                                   ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
                                   ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   IsHitTestVisible="False" />
                 <TextBox x:Name="PART_EditableTextBox"
                          Grid.Column="1"


### PR DESCRIPTION
Fixes #3433 

The `ContentPresenter` showing the selected value always defaulted to `HorizontalAlignment=Stretch` which effectively always left-aligned the selected item content. Passing in the `HorizontalContentAlignment` from the templated parent seems like the right thing to do.