### PR TITLE
Add DialogHost.DialogCardStyle DP to allow control from calling code

### DIFF
--- a/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
@@ -480,4 +480,56 @@ public class DialogHostTests : TestBase
 
         recorder.Success();
     }
+
+    [Theory]
+    [InlineData("MaterialDesignElevatedCard")]
+    [InlineData("MaterialDesignOutlinedCard")]
+    [Description("Issue 3430")]
+    public async Task DialogHost_DefaultStyleWithDialogCardStyleApplied_PassesStyleToNestedCard(string dialogCardStyle)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        IVisualElement grid = await LoadXaml<Grid>($$"""
+           <Grid>
+             <materialDesign:DialogHost x:Name="DialogHost" IsOpen="True" DialogCardStyle="{StaticResource {{dialogCardStyle}}}">
+               <materialDesign:DialogHost.DialogContent>
+                 <TextBlock Text="Some Text" Margin="100" />
+               </materialDesign:DialogHost.DialogContent>
+             </materialDesign:DialogHost>
+           </Grid>
+           """);
+
+        IVisualElement<DialogHost> dialogHost = await grid.GetElement<DialogHost>("DialogHost");
+        IVisualElement<Card> nestedCard = await dialogHost.GetElement<Card>("PART_PopupContentElement");
+
+        // TODO: Assert the style on the nested card matches what is set in DialogHost.DialogCardStyle
+
+        recorder.Success();
+    }
+
+    [Theory]
+    [InlineData("MaterialDesignElevatedCard")]
+    [InlineData("MaterialDesignOutlinedCard")]
+    [Description("Issue 3430")]
+    public async Task DialogHost_EmbeddedStyleWithDialogCardStyleApplied_PassesStyleToNestedCard(string dialogCardStyle)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        IVisualElement grid = await LoadXaml<Grid>($$"""
+            <Grid>
+              <materialDesign:DialogHost x:Name="DialogHost" Style="{StaticResource MaterialDesignEmbeddedDialogHost}" IsOpen="True" DialogCardStyle="{StaticResource {{dialogCardStyle}}}">
+                <materialDesign:DialogHost.DialogContent>
+                  <TextBlock Text="Some Text" Margin="100" />
+                </materialDesign:DialogHost.DialogContent>
+              </materialDesign:DialogHost>
+            </Grid>
+            """);
+
+        IVisualElement<DialogHost> dialogHost = await grid.GetElement<DialogHost>("DialogHost");
+        IVisualElement<Card> nestedCard = await dialogHost.GetElement<Card>("PART_PopupContentElement");
+
+        // TODO: Assert the style on the nested card matches what is set in DialogHost.DialogCardStyle
+
+        recorder.Success();
+    }
 }

--- a/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
@@ -6,12 +6,8 @@ using static MaterialDesignThemes.UITests.MaterialDesignSpec;
 
 namespace MaterialDesignThemes.UITests.WPF.DialogHosts;
 
-public class DialogHostTests : TestBase
+public class DialogHostTests(ITestOutputHelper output) : TestBase(output)
 {
-    public DialogHostTests(ITestOutputHelper output) : base(output)
-    {
-    }
-
     [Fact]
     public async Task OnOpenDialog_OverlayCoversContent()
     {
@@ -491,7 +487,12 @@ public class DialogHostTests : TestBase
 
         IVisualElement grid = await LoadXaml<Grid>($$"""
            <Grid>
-             <materialDesign:DialogHost x:Name="DialogHost" IsOpen="True" DialogCardStyle="{StaticResource {{dialogCardStyle}}}">
+             <Grid.Resources>
+                <Style x:Key="TestStyle" TargetType="materialDesign:Card" BasedOn="{StaticResource {{dialogCardStyle}}}">
+                 <Setter Property="Padding" Value="42" />
+               </Style>
+             </Grid.Resources>
+             <materialDesign:DialogHost x:Name="DialogHost" IsOpen="True" DialogCardStyle="{StaticResource TestStyle}">
                <materialDesign:DialogHost.DialogContent>
                  <TextBlock Text="Some Text" Margin="100" />
                </materialDesign:DialogHost.DialogContent>
@@ -502,7 +503,7 @@ public class DialogHostTests : TestBase
         IVisualElement<DialogHost> dialogHost = await grid.GetElement<DialogHost>("DialogHost");
         IVisualElement<Card> nestedCard = await dialogHost.GetElement<Card>("PART_PopupContentElement");
 
-        // TODO: Assert the style on the nested card matches what is set in DialogHost.DialogCardStyle
+        Assert.Equal(new Thickness(42), await nestedCard.GetPadding());
 
         recorder.Success();
     }

--- a/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Threading;
 using System.Windows.Threading;
-using Xunit;
 
 namespace MaterialDesignThemes.Wpf.Tests;
 

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -494,6 +494,15 @@ public class DialogHost : ContentControl
     public static readonly DependencyProperty OpenDialogCommandDataContextSourceProperty = DependencyProperty.Register(
         nameof(OpenDialogCommandDataContextSource), typeof(DialogHostOpenDialogCommandDataContextSource), typeof(DialogHost), new PropertyMetadata(default(DialogHostOpenDialogCommandDataContextSource)));
 
+    public static readonly DependencyProperty DialogCardStyleProperty = DependencyProperty.Register(
+        nameof(DialogCardStyle), typeof(Style), typeof(DialogHost), new PropertyMetadata(default(Style)));
+
+    public Style DialogCardStyle
+    {
+        get => (Style) GetValue(DialogCardStyleProperty);
+        set => SetValue(DialogCardStyleProperty, value);
+    }
+
     /// <summary>
     /// Defines how a data context is sourced for a dialog if a <see cref="FrameworkElement"/>
     /// is passed as the command parameter when using <see cref="DialogHost.OpenDialogCommand"/>.

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -483,7 +483,7 @@ public class DialogHost : ContentControl
     }
 
     public static readonly DependencyProperty DialogMarginProperty = DependencyProperty.Register(
-        "DialogMargin", typeof(Thickness), typeof(DialogHost), new PropertyMetadata(default(Thickness)));
+        nameof(DialogMargin), typeof(Thickness), typeof(DialogHost), new PropertyMetadata(default(Thickness)));
 
     public Thickness DialogMargin
     {
@@ -505,7 +505,7 @@ public class DialogHost : ContentControl
     }
 
     public static readonly DependencyProperty CloseOnClickAwayProperty = DependencyProperty.Register(
-        "CloseOnClickAway", typeof(bool), typeof(DialogHost), new PropertyMetadata(default(bool)));
+        nameof(CloseOnClickAway), typeof(bool), typeof(DialogHost), new PropertyMetadata(default(bool)));
 
     /// <summary>
     /// Indicates whether the dialog will close if the user clicks off the dialog, on the obscured background.
@@ -517,7 +517,7 @@ public class DialogHost : ContentControl
     }
 
     public static readonly DependencyProperty CloseOnClickAwayParameterProperty = DependencyProperty.Register(
-        "CloseOnClickAwayParameter", typeof(object), typeof(DialogHost), new PropertyMetadata(default(object)));
+        nameof(CloseOnClickAwayParameter), typeof(object), typeof(DialogHost), new PropertyMetadata(default(object)));
 
     /// <summary>
     /// Parameter to provide to close handlers if an close due to click away is instigated.
@@ -529,7 +529,7 @@ public class DialogHost : ContentControl
     }
 
     public static readonly DependencyProperty SnackbarMessageQueueProperty = DependencyProperty.Register(
-        "SnackbarMessageQueue", typeof(SnackbarMessageQueue), typeof(DialogHost), new PropertyMetadata(default(SnackbarMessageQueue), SnackbarMessageQueuePropertyChangedCallback));
+        nameof(SnackbarMessageQueue), typeof(SnackbarMessageQueue), typeof(DialogHost), new PropertyMetadata(default(SnackbarMessageQueue), SnackbarMessageQueuePropertyChangedCallback));
 
     private static void SnackbarMessageQueuePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
     {
@@ -642,7 +642,7 @@ public class DialogHost : ContentControl
 
     public static readonly RoutedEvent DialogOpenedEvent =
         EventManager.RegisterRoutedEvent(
-            "DialogOpened",
+            nameof(DialogOpened),
             RoutingStrategy.Bubble,
             typeof(DialogOpenedEventHandler),
             typeof(DialogHost));
@@ -689,7 +689,7 @@ public class DialogHost : ContentControl
 
     public static readonly RoutedEvent DialogClosingEvent =
         EventManager.RegisterRoutedEvent(
-            "DialogClosing",
+            nameof(DialogClosing),
             RoutingStrategy.Bubble,
             typeof(DialogClosingEventHandler),
             typeof(DialogHost));
@@ -732,7 +732,7 @@ public class DialogHost : ContentControl
 
     public static readonly RoutedEvent DialogClosedEvent =
         EventManager.RegisterRoutedEvent(
-            "DialogClosed",
+            nameof(DialogClosed),
             RoutingStrategy.Bubble,
             typeof(DialogClosedEventHandler),
             typeof(DialogHost));

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -158,7 +158,6 @@
                   </Border.InputBindings>
                 </Border>
                 <wpf:Card x:Name="PART_PopupContentElement"
-                          Margin="{TemplateBinding DialogMargin}"
                           wpf:ElevationAssist.Elevation="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation)}"
                           Background="{Binding Tag, RelativeSource={RelativeSource Self}}"
                           Content="{TemplateBinding DialogContent}"
@@ -170,6 +169,7 @@
                           Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
                           IsHitTestVisible="True"
                           IsTabStop="False"
+                          Margin="{TemplateBinding DialogMargin}"
                           Opacity="0"
                           RenderTransformOrigin=".5,.5"
                           Style="{TemplateBinding DialogCardStyle}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -160,6 +160,7 @@
                 <wpf:Card x:Name="PART_PopupContentElement"
                           Margin="{TemplateBinding DialogMargin}"
                           wpf:ElevationAssist.Elevation="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation)}"
+                          Background="{Binding Tag, RelativeSource={RelativeSource Self}}"
                           Content="{TemplateBinding DialogContent}"
                           ContentStringFormat="{TemplateBinding DialogContentStringFormat}"
                           ContentTemplate="{TemplateBinding DialogContentTemplate}"
@@ -171,19 +172,10 @@
                           IsTabStop="False"
                           Opacity="0"
                           RenderTransformOrigin=".5,.5"
+                          Style="{TemplateBinding DialogCardStyle}"
                           Tag="{TemplateBinding DialogBackground}"
                           TextElement.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
                           UniformCornerRadius="{TemplateBinding DialogContentUniformCornerRadius}">
-                  <wpf:Card.Style>
-                    <Style TargetType="wpf:Card" BasedOn="{StaticResource {x:Type wpf:Card}}">
-                      <Setter Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}}" />
-                      <Style.Triggers>
-                        <Trigger Property="Tag" Value="{x:Null}">
-                          <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
-                        </Trigger>
-                      </Style.Triggers>
-                    </Style>
-                  </wpf:Card.Style>
                   <wpf:Card.RenderTransform>
                     <TransformGroup>
                       <ScaleTransform x:Name="CardScaleTransform" ScaleX="0" ScaleY="0" />
@@ -227,6 +219,9 @@
           <ControlTemplate.Triggers>
             <Trigger Property="IsOpen" Value="True">
               <Setter TargetName="PART_ContentCoverGrid" Property="IsHitTestVisible" Value="True" />
+            </Trigger>
+            <Trigger SourceName="PART_PopupContentElement" Property="Tag" Value="{x:Null}">
+              <Setter TargetName="PART_PopupContentElement" Property="Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
             </Trigger>
           </ControlTemplate.Triggers>
         </ControlTemplate>
@@ -406,6 +401,7 @@
               <wpf:Card x:Name="PART_PopupContentElement"
                         Margin="{TemplateBinding DialogMargin}"
                         wpf:ElevationAssist.Elevation="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation)}"
+                        Background="{Binding Tag, RelativeSource={RelativeSource Self}}"
                         Content="{TemplateBinding DialogContent}"
                         ContentStringFormat="{TemplateBinding DialogContentStringFormat}"
                         ContentTemplate="{TemplateBinding DialogContentTemplate}"
@@ -416,6 +412,7 @@
                         IsTabStop="False"
                         Opacity="0"
                         RenderTransformOrigin=".5,.5"
+                        Style="{TemplateBinding DialogCardStyle}"
                         Tag="{TemplateBinding DialogBackground}"
                         TextElement.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
                         UniformCornerRadius="{TemplateBinding DialogContentUniformCornerRadius}">
@@ -424,22 +421,15 @@
                     <ScaleTransform x:Name="CardScaleTransform" ScaleX="0" ScaleY="0" />
                   </TransformGroup>
                 </wpf:Card.RenderTransform>
-                <wpf:Card.Style>
-                  <Style TargetType="wpf:Card" BasedOn="{StaticResource {x:Type wpf:Card}}">
-                    <Setter Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}}" />
-                    <Style.Triggers>
-                      <Trigger Property="Tag" Value="{x:Null}">
-                        <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
-                      </Trigger>
-                    </Style.Triggers>
-                  </Style>
-                </wpf:Card.Style>
               </wpf:Card>
             </Grid>
           </Grid>
           <ControlTemplate.Triggers>
             <Trigger Property="IsOpen" Value="True">
               <Setter TargetName="PART_ContentCoverGrid" Property="IsHitTestVisible" Value="True" />
+            </Trigger>
+            <Trigger SourceName="PART_PopupContentElement" Property="Tag" Value="{x:Null}">
+              <Setter TargetName="PART_PopupContentElement" Property="Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
             </Trigger>
           </ControlTemplate.Triggers>
         </ControlTemplate>


### PR DESCRIPTION
Fixes #3430 

### UPDATE
The outstanding issue we have with this PR is the fact that calling code can effectively set a (card) style, but several properties from that style will be ignored because they are "passed-in/hardcoded" in the `PART_PopupContentElement` element in the `DialogHost` style.

---

This PR allows the calling code to control the style of the nested `Card` in the `DialogHost`. Default `Background` property is now set directly on the card, and the trigger to fall back to the default background is moved to the `ControlTemplate.Triggers` collection.

@Keboo I started on writing some UI test to verify this gets passed down, but I hit a roadblock around getting the `Style` (or perhaps just the name of the style) out of an `IVisualElement`, any hints you can provide?