### PR TITLE
[RFC] New TextBox style

### DIFF
--- a/MainDemo.Wpf/Domain/SmartHintViewModel.cs
+++ b/MainDemo.Wpf/Domain/SmartHintViewModel.cs
@@ -28,6 +28,7 @@ internal class SmartHintViewModel : ViewModelBase
     private double _selectedFontSize = double.NaN;
     private FontFamily? _selectedFontFamily = DefaultFontFamily;
     private bool? controlsEnabled = true;
+    private int _maxLength = 50;
 
     public IEnumerable<FloatingHintHorizontalAlignment> HorizontalAlignmentOptions { get; } = Enum.GetValues(typeof(FloatingHintHorizontalAlignment)).OfType<FloatingHintHorizontalAlignment>();
     public IEnumerable<double> FloatingScaleOptions { get; } = new[] {0.25, 0.5, 0.75, 1.0};
@@ -234,5 +235,17 @@ internal class SmartHintViewModel : ViewModelBase
     {
         get => controlsEnabled;
         set => SetProperty(ref controlsEnabled, value);
+    }
+
+    public bool? ShowCharacterCounter
+    {
+        get => MaxLength > 0;
+        set => MaxLength = value == true ? 50 : 0;
+    }
+
+    public int MaxLength
+    {
+        get => _maxLength;
+        set => SetProperty(ref _maxLength, value);
     }
 }

--- a/MainDemo.Wpf/Domain/SmartHintViewModel.cs
+++ b/MainDemo.Wpf/Domain/SmartHintViewModel.cs
@@ -27,6 +27,7 @@ internal class SmartHintViewModel : ViewModelBase
     private string? _suffixText;
     private double _selectedFontSize = double.NaN;
     private FontFamily? _selectedFontFamily = DefaultFontFamily;
+    private bool? controlsEnabled = true;
 
     public IEnumerable<FloatingHintHorizontalAlignment> HorizontalAlignmentOptions { get; } = Enum.GetValues(typeof(FloatingHintHorizontalAlignment)).OfType<FloatingHintHorizontalAlignment>();
     public IEnumerable<double> FloatingScaleOptions { get; } = new[] {0.25, 0.5, 0.75, 1.0};
@@ -227,5 +228,11 @@ internal class SmartHintViewModel : ViewModelBase
             _selectedFontFamily = value;
             OnPropertyChanged();
         }
+    }
+
+    public bool? ControlsEnabled
+    {
+        get => controlsEnabled;
+        set => SetProperty(ref controlsEnabled, value);
     }
 }

--- a/MainDemo.Wpf/Properties/launchSettings.json
+++ b/MainDemo.Wpf/Properties/launchSettings.json
@@ -2,7 +2,7 @@
     "profiles": {
         "Demo App": {
             "commandName": "Project",
-            "commandLineArgs": "-p Home -t Inherit -f LeftToRight"
+            "commandLineArgs": "-p \"Smart Hint\" -t Inherit -f LeftToRight"
         }
     }
 }

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -164,7 +164,11 @@
               Header="Control Settings"
               Style="{StaticResource MaterialDesignCardGroupBox}">
       <StackPanel Margin="10" Orientation="Horizontal">
+        <CheckBox x:Name="IsEnabledCheckBox"
+                  Content="Enabled"
+                  IsChecked="{Binding ControlsEnabled}" />
         <CheckBox x:Name="CustomPaddingCheckBox"
+                  Margin="5,0,0,0"
                   Content="Custom Padding"
                   IsChecked="{Binding ApplyCustomPadding}" />
         <ComboBox Margin="5,0,0,0"
@@ -281,10 +285,172 @@
       <StackPanel x:Name="ControlsPanel"
                   Margin="8,0,16,0"
                   HorizontalAlignment="Stretch"
-                  VerticalAlignment="Top">
+                  VerticalAlignment="Top"
+                  IsEnabled="{Binding ControlsEnabled}">
+
+        <!-- TextBoxNew variants -->
+        <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="TextBoxNew styles" />
+        <Grid HorizontalAlignment="Stretch">
+          <Grid.Resources>
+            <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFloatingHintTextBoxNew}">
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFloatingHintTextBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.RippleOnFocusEnabled" Value="True" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFloatingHintTextBoxNew</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="textbox_floating_new_left">
+            <TextBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="textbox_floating_new_center">
+            <TextBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="textbox_floating_new_right">
+            <TextBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="textbox_floating_new_stretch">
+            <TextBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFilledTextBoxNew}">
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFilledTextBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.RippleOnFocusEnabled" Value="True" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFilledTextBoxNew</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="textbox_filled_new_left">
+            <TextBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="textbox_filled_new_center">
+            <TextBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="textbox_filled_new_right">
+            <TextBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="textbox_filled_new_stretch">
+            <TextBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignOutlinedTextBoxNew}">
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignOutlinedTextBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.RippleOnFocusEnabled" Value="True" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignOutlinedTextBoxNew</TextBlock>
+          <smtx:XamlDisplay Grid.Column="1" UniqueKey="textbox_outlined_new_left">
+            <TextBox HorizontalContentAlignment="Left" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="2" UniqueKey="textbox_outlined_new_center">
+            <TextBox HorizontalContentAlignment="Center" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="3" UniqueKey="textbox_outlined_new_right">
+            <TextBox HorizontalContentAlignment="Right" />
+          </smtx:XamlDisplay>
+          <smtx:XamlDisplay Grid.Column="4" UniqueKey="textbox_outlined_new_stretch">
+            <TextBox HorizontalContentAlignment="Stretch" />
+          </smtx:XamlDisplay>
+        </Grid>
 
         <!-- TextBox variants -->
-        <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="TextBox styles" />
+        <TextBlock Margin="0,40,0,0"
+                   Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                   Text="TextBox styles" />
         <Grid HorizontalAlignment="Stretch">
           <Grid.Resources>
             <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}">
@@ -309,6 +475,7 @@
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.RippleOnFocusEnabled" Value="True" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
@@ -360,6 +527,7 @@
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.RippleOnFocusEnabled" Value="True" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
@@ -411,6 +579,7 @@
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
               <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.RippleOnFocusEnabled" Value="True" />
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -155,6 +155,10 @@
                     IsEnabled="{Binding ElementName=CheckBoxTrailingIcon, Path=IsChecked}"
                     ItemsSource="{Binding IconSizeOptions}"
                     SelectedItem="{Binding SelectedTrailingIconSize, Mode=TwoWay}" />
+          <CheckBox x:Name="CheckBoxCharacterCounter"
+                    Margin="20,0,0,0"
+                    Content="CharacterCounter"
+                    IsChecked="{Binding ShowCharacterCounter}"/>
         </StackPanel>
       </StackPanel>
     </GroupBox>
@@ -255,8 +259,11 @@
     <!-- Invisible controls only used to be able to fallback to default style values -->
     <StackPanel Grid.Row="3" Visibility="Collapsed">
       <TextBox x:Name="MaterialDesignFloatingHintTextBoxDefaults" Style="{StaticResource MaterialDesignFloatingHintTextBox}" />
+      <TextBox x:Name="MaterialDesignFloatingHintTextBoxNewDefaults" Style="{StaticResource MaterialDesignFloatingHintTextBoxNew}" />
       <TextBox x:Name="MaterialDesignFilledTextBoxDefaults" Style="{StaticResource MaterialDesignFilledTextBox}" />
+      <TextBox x:Name="MaterialDesignFilledTextBoxNewDefaults" Style="{StaticResource MaterialDesignFilledTextBoxNew}" />
       <TextBox x:Name="MaterialDesignOutlinedTextBoxDefaults" Style="{StaticResource MaterialDesignOutlinedTextBox}" />
+      <TextBox x:Name="MaterialDesignOutlinedTextBoxNewDefaults" Style="{StaticResource MaterialDesignOutlinedTextBoxNew}" />
       <RichTextBox x:Name="MaterialDesignRichTextBoxDefaults" Style="{StaticResource MaterialDesignRichTextBox}" />
       <PasswordBox x:Name="MaterialDesignFloatingHintPasswordBoxDefaults" Style="{StaticResource MaterialDesignFloatingHintPasswordBox}" />
       <PasswordBox x:Name="MaterialDesignFilledPasswordBoxDefaults" Style="{StaticResource MaterialDesignFilledPasswordBox}" />
@@ -289,7 +296,12 @@
                   IsEnabled="{Binding ControlsEnabled}">
 
         <!-- TextBoxNew variants -->
-        <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="TextBoxNew styles" />
+        <StackPanel Orientation="Horizontal">
+          <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="TextBoxNew styles" />
+          <CheckBox x:Name="TextBoxesAcceptsReturnCheckBox"
+                    Margin="20,0,0,0"
+                    Content="AcceptsReturn" />
+        </StackPanel>
         <Grid HorizontalAlignment="Stretch">
           <Grid.Resources>
             <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFloatingHintTextBoxNew}">
@@ -298,7 +310,7 @@
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
-                    <Binding ElementName="MaterialDesignFloatingHintTextBoxDefaults" Path="Padding" />
+                    <Binding ElementName="MaterialDesignFloatingHintTextBoxNewDefaults" Path="Padding" />
                     <Binding Path="ApplyCustomPadding" />
                     <Binding Path="SelectedCustomPadding" />
                   </MultiBinding>
@@ -318,6 +330,8 @@
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="AcceptsReturn" Value="{Binding ElementName=TextBoxesAcceptsReturnCheckBox, Path=IsChecked}" />
+              <Setter Property="MaxLength" Value="{Binding MaxLength}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -332,6 +346,7 @@
           <smtx:XamlDisplay Grid.Column="1" UniqueKey="textbox_floating_new_left">
             <TextBox HorizontalContentAlignment="Left" />
           </smtx:XamlDisplay>
+          <!--
           <smtx:XamlDisplay Grid.Column="2" UniqueKey="textbox_floating_new_center">
             <TextBox HorizontalContentAlignment="Center" />
           </smtx:XamlDisplay>
@@ -341,6 +356,7 @@
           <smtx:XamlDisplay Grid.Column="4" UniqueKey="textbox_floating_new_stretch">
             <TextBox HorizontalContentAlignment="Stretch" />
           </smtx:XamlDisplay>
+          -->
         </Grid>
         <Grid>
           <Grid.Resources>
@@ -350,7 +366,7 @@
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
-                    <Binding ElementName="MaterialDesignFilledTextBoxDefaults" Path="Padding" />
+                    <Binding ElementName="MaterialDesignFilledTextBoxNewDefaults" Path="Padding" />
                     <Binding Path="ApplyCustomPadding" />
                     <Binding Path="SelectedCustomPadding" />
                   </MultiBinding>
@@ -370,6 +386,8 @@
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="AcceptsReturn" Value="{Binding ElementName=TextBoxesAcceptsReturnCheckBox, Path=IsChecked}" />
+              <Setter Property="MaxLength" Value="{Binding MaxLength}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -384,6 +402,7 @@
           <smtx:XamlDisplay Grid.Column="1" UniqueKey="textbox_filled_new_left">
             <TextBox HorizontalContentAlignment="Left" />
           </smtx:XamlDisplay>
+          <!--
           <smtx:XamlDisplay Grid.Column="2" UniqueKey="textbox_filled_new_center">
             <TextBox HorizontalContentAlignment="Center" />
           </smtx:XamlDisplay>
@@ -393,6 +412,7 @@
           <smtx:XamlDisplay Grid.Column="4" UniqueKey="textbox_filled_new_stretch">
             <TextBox HorizontalContentAlignment="Stretch" />
           </smtx:XamlDisplay>
+          -->
         </Grid>
         <Grid>
           <Grid.Resources>
@@ -402,7 +422,7 @@
               <Setter Property="Padding">
                 <Setter.Value>
                   <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
-                    <Binding ElementName="MaterialDesignOutlinedTextBoxDefaults" Path="Padding" />
+                    <Binding ElementName="MaterialDesignOutlinedTextBoxNewDefaults" Path="Padding" />
                     <Binding Path="ApplyCustomPadding" />
                     <Binding Path="SelectedCustomPadding" />
                   </MultiBinding>
@@ -422,6 +442,8 @@
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="AcceptsReturn" Value="{Binding ElementName=TextBoxesAcceptsReturnCheckBox, Path=IsChecked}" />
+              <Setter Property="MaxLength" Value="{Binding MaxLength}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -436,6 +458,7 @@
           <smtx:XamlDisplay Grid.Column="1" UniqueKey="textbox_outlined_new_left">
             <TextBox HorizontalContentAlignment="Left" />
           </smtx:XamlDisplay>
+          <!--
           <smtx:XamlDisplay Grid.Column="2" UniqueKey="textbox_outlined_new_center">
             <TextBox HorizontalContentAlignment="Center" />
           </smtx:XamlDisplay>
@@ -445,6 +468,7 @@
           <smtx:XamlDisplay Grid.Column="4" UniqueKey="textbox_outlined_new_stretch">
             <TextBox HorizontalContentAlignment="Stretch" />
           </smtx:XamlDisplay>
+          -->
         </Grid>
 
         <!-- TextBox variants -->
@@ -479,6 +503,8 @@
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="AcceptsReturn" Value="{Binding ElementName=TextBoxesAcceptsReturnCheckBox, Path=IsChecked}" />
+              <Setter Property="MaxLength" Value="{Binding MaxLength}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -531,6 +557,8 @@
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="AcceptsReturn" Value="{Binding ElementName=TextBoxesAcceptsReturnCheckBox, Path=IsChecked}" />
+              <Setter Property="MaxLength" Value="{Binding MaxLength}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -583,6 +611,8 @@
               <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="AcceptsReturn" Value="{Binding ElementName=TextBoxesAcceptsReturnCheckBox, Path=IsChecked}" />
+              <Setter Property="MaxLength" Value="{Binding MaxLength}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>

--- a/MaterialDesignThemes.Wpf/BottomDashedLineAdorner.cs
+++ b/MaterialDesignThemes.Wpf/BottomDashedLineAdorner.cs
@@ -59,6 +59,16 @@ public class BottomDashedLineAdorner : Adorner
         => element.SetValue(BrushOpacityProperty, value);
     #endregion
 
+    #region AttachedProperty : DashStyleProperty
+    public static readonly DependencyProperty DashStyleProperty
+        = DependencyProperty.RegisterAttached("DashStyle", typeof(DashStyle), typeof(BottomDashedLineAdorner), new PropertyMetadata(default(DashStyle)));
+
+    public static void SetDashStyle(DependencyObject element, DashStyle? value)
+        => element.SetValue(DashStyleProperty, value);
+    public static DashStyle? GetDashStyle(DependencyObject element)
+        => (DashStyle?) element.GetValue(DashStyleProperty);
+    #endregion
+
     public BottomDashedLineAdorner(UIElement adornedElement) : base(adornedElement)
     {
     }
@@ -72,7 +82,7 @@ public class BottomDashedLineAdorner : Adorner
 
         var pen = new Pen(lineBrush, lineThickness)
         {
-            DashStyle = DashStyles.Dash,
+            DashStyle = GetDashStyle(AdornedElement) ?? DashStyles.Dash,
             DashCap = PenLineCap.Round
         };
 

--- a/MaterialDesignThemes.Wpf/Constants.cs
+++ b/MaterialDesignThemes.Wpf/Constants.cs
@@ -3,7 +3,9 @@ namespace MaterialDesignThemes.Wpf;
 public static class Constants
 {
     public static readonly Thickness TextBoxDefaultPadding = new Thickness(0, 4, 0, 4);
+    public static readonly Thickness TextBoxDefaultPaddingNew = new Thickness(0, 8, 0, 4);
     public static readonly Thickness FilledTextBoxDefaultPadding = new Thickness(16, 8, 12, 8);
+    public static readonly Thickness FilledTextBoxDefaultPaddingNew = new Thickness(16, 12, 12, 8);
     public static readonly Thickness OutlinedTextBoxDefaultPadding = new Thickness(16, 16, 12, 16);
     public static readonly Thickness DefaultTextBoxViewMargin = new Thickness(1, 0, 1, 0);
     public static readonly Thickness DefaultTextBoxViewMarginEmbedded = new Thickness(0);

--- a/MaterialDesignThemes.Wpf/Converters/BooleanToDashStyleConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/BooleanToDashStyleConverter.cs
@@ -1,0 +1,17 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace MaterialDesignThemes.Wpf.Converters;
+
+public class BooleanToDashStyleConverter : IValueConverter
+{
+    public DashStyle? TrueValue { get; set; }
+    public DashStyle? FalseValue { get; set; }
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is true ? TrueValue : FalseValue;
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/MaterialDesignThemes.Wpf/Converters/TextFieldClearButtonVisibilityConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/TextFieldClearButtonVisibilityConverter.cs
@@ -5,13 +5,15 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 internal class TextFieldClearButtonVisibilityConverter : IMultiValueConverter
 {
+    public Visibility ContentEmptyVisibility { get; set; } = Visibility.Hidden;
+
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
     {
         if (!(bool)values[0]) // TextFieldAssist.HasClearButton
             return Visibility.Collapsed;
 
         return (bool)values[1] // Hint.IsContentNullOrEmpty
-            ? Visibility.Hidden
+            ? ContentEmptyVisibility
             : Visibility.Visible;
     }
 

--- a/MaterialDesignThemes.Wpf/Converters/TextFieldPrefixTextVisibilityConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/TextFieldPrefixTextVisibilityConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class TextFieldPrefixTextVisibilityConverter : IMultiValueConverter
 {
+    public Visibility HiddenState { get; set; } = Visibility.Hidden;
+
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
     {
         string prefixText = (string)values[1];
@@ -14,7 +16,7 @@ public class TextFieldPrefixTextVisibilityConverter : IMultiValueConverter
         }
 
         bool isHintInFloatingPosition = (bool)values[0];
-        return isHintInFloatingPosition ? Visibility.Visible : Visibility.Hidden;
+        return isHintInFloatingPosition ? Visibility.Visible : HiddenState;
     }
 
     public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) => throw new NotImplementedException();

--- a/MaterialDesignThemes.Wpf/Converters/VerticalAlignmentConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/VerticalAlignmentConverter.cs
@@ -1,0 +1,14 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+
+namespace MaterialDesignThemes.Wpf.Converters;
+
+public class VerticalAlignmentConverter : IValueConverter
+{
+    public VerticalAlignment StretchReplacement { get; set; } = VerticalAlignment.Top;
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is VerticalAlignment.Stretch ? StretchReplacement : value;
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/MaterialDesignThemes.Wpf/SmartHint.cs
+++ b/MaterialDesignThemes.Wpf/SmartHint.cs
@@ -1,6 +1,4 @@
 ﻿using System.ComponentModel;
-using System.Globalization;
-using System.Windows.Data;
 using MaterialDesignThemes.Wpf.Converters;
 
 namespace MaterialDesignThemes.Wpf;
@@ -236,14 +234,4 @@ public class SmartHint : Control
             Dispatcher.BeginInvoke(action);
         }
     }
-}
-
-public class VerticalAlignmentConverter : IValueConverter
-{
-    public VerticalAlignment StretchReplacement { get; set; } = VerticalAlignment.Top;
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        => value is VerticalAlignment.Stretch ? StretchReplacement : value;
-
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        => throw new NotImplementedException();
 }

--- a/MaterialDesignThemes.Wpf/SmartHintNew.cs
+++ b/MaterialDesignThemes.Wpf/SmartHintNew.cs
@@ -1,0 +1,18 @@
+﻿using MaterialDesignThemes.Wpf.Converters;
+
+namespace MaterialDesignThemes.Wpf;
+
+/// <summary>
+/// A control that implement placeholder behavior. Can work as a simple placeholder either as a floating hint, see <see cref="UseFloating"/> property.
+/// <para/>
+/// To set a target control you should set the HintProxy property. Use the <see cref="HintProxyFabricConverter.Instance"/> converter which converts a control into the IHintProxy interface.
+/// </summary>
+[TemplateVisualState(GroupName = ContentStatesGroupName, Name = HintRestingPositionName)]
+[TemplateVisualState(GroupName = ContentStatesGroupName, Name = HintFloatingPositionName)]
+public class SmartHintNew : SmartHint
+{
+    static SmartHintNew()
+    {
+        DefaultStyleKeyProperty.OverrideMetadata(typeof(SmartHintNew), new FrameworkPropertyMetadata(typeof(SmartHintNew)));
+    }
+}

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -28,6 +28,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TimePicker.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SmartHint.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SmartHintNew.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Snackbar.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.AutoSuggestBox.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SplitButton.xaml" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesign2.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesign2.Defaults.xaml
@@ -33,6 +33,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Slider.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TabControl.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBoxNew.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBlock.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TimePicker.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ToggleButton.xaml" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Defaults.xaml
@@ -40,6 +40,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Slider.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TabControl.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBoxNew.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TimePicker.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ToolBar.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ToolBarTray.xaml" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -35,7 +35,7 @@
   <converters:ThicknessCloneConverter x:Key="DefaultOrFilledStyleTrailingIconPaddingConverterBottom"
                                       AdditionalOffsetBottom="4"
                                       CloneEdges="All" />
-  <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
+  <converters:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
   <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
 
   <system:Double x:Key="PopupContentPresenterExtend">4</system:Double>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -28,7 +28,7 @@
                                       AdditionalOffsetTop="12"
                                       CloneEdges="Top,Right,Bottom"
                                       FixedLeft="0" />
-  <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
+  <converters:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
   <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
 
   <Style x:Key="MaterialDesignDatePickerTextBox" TargetType="{x:Type DatePickerTextBox}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
@@ -32,6 +32,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Slider.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TabControl.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBoxNew.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBlock.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TimePicker.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ToggleButton.xaml" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -68,7 +68,7 @@
                                       FixedBottom="-2" />
 
 
-  <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
+  <converters:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
   <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
 
   <Style x:Key="MaterialDesignPasswordCharacterCounterTextBlock"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -11,7 +11,7 @@
   <converters:FloatingHintTransformConverter x:Key="FloatingHintClippingGridTransformConverter" ApplyScaleTransform="False" />
   <converters:FloatingHintTransformConverter x:Key="FloatingHintTransformConverter" ApplyTranslateTransform="False" />
   <converters:FloatingHintTextBlockMarginConverter x:Key="FloatingHintTextBlockMarginConverter" />
-  <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
+  <converters:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
   <system:Double x:Key="NoContentFloatingScale">1.0</system:Double>
   <CubicEase x:Key="AnimationEasingFunction" EasingMode="EaseInOut" />
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHintNew.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHintNew.xaml
@@ -1,0 +1,204 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib"
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+
+  <converters:BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
+  <converters:BooleanToVisibilityConverter x:Key="InverseBoolToVisConverter"
+                                           FalseValue="Visible"
+                                           TrueValue="Collapsed" />
+  <converters:FloatingHintTransformConverter x:Key="FloatingHintClippingGridTransformConverter" ApplyScaleTransform="False" />
+  <converters:FloatingHintTransformConverter x:Key="FloatingHintTransformConverter" ApplyTranslateTransform="False" />
+  <converters:FloatingHintTextBlockMarginConverter x:Key="FloatingHintTextBlockMarginConverter" />
+  <converters:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
+  <system:Double x:Key="NoContentFloatingScale">1.0</system:Double>
+  <CubicEase x:Key="AnimationEasingFunction" EasingMode="EaseInOut" />
+
+  <Style TargetType="{x:Type wpf:SmartHintNew}">
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="IsHitTestVisible" Value="False" />
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type wpf:SmartHintNew}">
+          <Grid Margin="{TemplateBinding Padding}"
+                HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                VerticalAlignment="{TemplateBinding VerticalAlignment}">
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="ContentStates">
+                <VisualStateGroup.Transitions>
+                  <VisualTransition From="*" To="HintFloatingPosition">
+                    <Storyboard>
+                      <DoubleAnimation Storyboard.TargetName="SimpleHintTextBlock"
+                                       Storyboard.TargetProperty="Opacity"
+                                       To="0"
+                                       Duration="0:0:0" />
+                    </Storyboard>
+                  </VisualTransition>
+                  <VisualTransition From="*" To="HintRestingPosition">
+                    <Storyboard>
+                      <DoubleAnimation EasingFunction="{StaticResource AnimationEasingFunction}"
+                                       Storyboard.TargetName="SimpleHintTextBlock"
+                                       Storyboard.TargetProperty="Opacity"
+                                       Duration="0:0:0.15" />
+                    </Storyboard>
+                  </VisualTransition>
+                </VisualStateGroup.Transitions>
+                <VisualState x:Name="HintFloatingPosition">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="SimpleHintTextBlock"
+                                     Storyboard.TargetProperty="Opacity"
+                                     To="0"
+                                     Duration="0" />
+                  </Storyboard>
+                </VisualState>
+                <VisualState x:Name="HintRestingPosition">
+                  <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="SimpleHintTextBlock"
+                                     Storyboard.TargetProperty="Opacity"
+                                     Duration="0" />
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <ContentControl x:Name="SimpleHintTextBlock"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            Content="{TemplateBinding Hint}"
+                            FontSize="{TemplateBinding FontSize}"
+                            IsHitTestVisible="False"
+                            IsTabStop="False"
+                            Opacity="{TemplateBinding HintOpacity}"
+                            Visibility="{TemplateBinding UseFloating, Converter={StaticResource InverseBoolToVisConverter}}" />
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="VerticalAlignment" Value="Top" />
+    <Setter Property="VerticalContentAlignment" Value="Bottom" />
+    <Style.Triggers>
+      <Trigger Property="UseFloating" Value="True">
+        <Setter Property="Template">
+          <Setter.Value>
+            <ControlTemplate TargetType="{x:Type wpf:SmartHintNew}">
+              <Grid Margin="{TemplateBinding Padding}"
+                    HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                    VerticalAlignment="{TemplateBinding VerticalAlignment}">
+                <VisualStateManager.VisualStateGroups>
+                  <VisualStateGroup x:Name="ContentStates">
+                    <VisualStateGroup.Transitions>
+                      <VisualTransition From="*" To="HintFloatingPosition">
+                        <Storyboard>
+                          <DoubleAnimation EasingFunction="{StaticResource AnimationEasingFunction}"
+                                           Storyboard.TargetName="FloatingHintTextBlock"
+                                           Storyboard.TargetProperty="Opacity"
+                                           To="{TemplateBinding HintOpacity}"
+                                           Duration="0:0:0.15" />
+                          <DoubleAnimation EasingFunction="{StaticResource AnimationEasingFunction}"
+                                           Storyboard.TargetName="ScaleHost"
+                                           Storyboard.TargetProperty="Scale"
+                                           To="1"
+                                           Duration="0:0:0.15" />
+                        </Storyboard>
+                      </VisualTransition>
+                      <VisualTransition From="*" To="HintRestingPosition">
+                        <Storyboard>
+                          <DoubleAnimation EasingFunction="{StaticResource AnimationEasingFunction}"
+                                           Storyboard.TargetName="FloatingHintTextBlock"
+                                           Storyboard.TargetProperty="Opacity"
+                                           Duration="0:0:0.15" />
+                          <DoubleAnimation EasingFunction="{StaticResource AnimationEasingFunction}"
+                                           Storyboard.TargetName="ScaleHost"
+                                           Storyboard.TargetProperty="Scale"
+                                           Duration="0:0:0.15" />
+                        </Storyboard>
+                      </VisualTransition>
+                    </VisualStateGroup.Transitions>
+                    <VisualState x:Name="HintFloatingPosition">
+                      <Storyboard>
+                        <DoubleAnimation Storyboard.TargetName="FloatingHintTextBlock"
+                                         Storyboard.TargetProperty="Opacity"
+                                         To="{TemplateBinding HintOpacity}"
+                                         Duration="0" />
+                        <DoubleAnimation Storyboard.TargetName="ScaleHost"
+                                         Storyboard.TargetProperty="Scale"
+                                         To="1"
+                                         Duration="0" />
+                      </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="HintRestingPosition">
+                      <Storyboard>
+                        <DoubleAnimation Storyboard.TargetName="FloatingHintTextBlock"
+                                         Storyboard.TargetProperty="Opacity"
+                                         Duration="0" />
+                        <DoubleAnimation Storyboard.TargetName="ScaleHost"
+                                         Storyboard.TargetProperty="Scale"
+                                         Duration="0" />
+                      </Storyboard>
+                    </VisualState>
+                  </VisualStateGroup>
+                </VisualStateManager.VisualStateGroups>
+                <wpf:ScaleHost x:Name="ScaleHost" />
+                <Grid x:Name="HintClippingGrid"
+                      VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
+                      ClipToBounds="True" Background="Fuchsia">
+                  <Grid.RenderTransform>
+                    <MultiBinding Converter="{StaticResource FloatingHintClippingGridTransformConverter}">
+                      <Binding ElementName="ScaleHost" Path="Scale" />
+                      <Binding Path="FloatingScale" RelativeSource="{RelativeSource TemplatedParent}" />
+                      <Binding Source="{StaticResource NoContentFloatingScale}" />
+                      <Binding Path="FloatingOffset" RelativeSource="{RelativeSource TemplatedParent}" />
+                      <Binding Path="InitialVerticalOffset" RelativeSource="{RelativeSource TemplatedParent}" />
+                    </MultiBinding>
+                  </Grid.RenderTransform>
+                  <Canvas Width="{Binding ElementName=FloatingHintTextBlock, Path=ActualWidth}"
+                          Height="{Binding ElementName=FloatingHintTextBlock, Path=ActualHeight}"
+                          HorizontalAlignment="Left">
+                    <ContentControl x:Name="FloatingHintTextBlock"
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    Content="{TemplateBinding Hint}"
+                                    FontFamily="{TemplateBinding FontFamily}"
+                                    FontSize="{TemplateBinding FontSize}"
+                                    IsHitTestVisible="False"
+                                    IsTabStop="False"
+                                    Opacity="{TemplateBinding HintOpacity}"
+                                    RenderTransformOrigin="0,0"
+                                    Visibility="{TemplateBinding UseFloating, Converter={StaticResource BoolToVisConverter}}">
+                      <ContentControl.Margin>
+                        <MultiBinding Converter="{StaticResource FloatingHintTextBlockMarginConverter}">
+                          <Binding Path="(wpf:HintAssist.FloatingHintHorizontalAlignment)" RelativeSource="{RelativeSource TemplatedParent}" />
+                          <Binding Path="HorizontalContentAlignment" RelativeSource="{RelativeSource TemplatedParent}" />
+                          <Binding Path="ActualWidth" RelativeSource="{RelativeSource Self}" />
+                          <Binding Path="ActualWidth" RelativeSource="{RelativeSource TemplatedParent}" />
+                          <Binding ElementName="ScaleHost" Path="Scale" />
+                          <Binding Path="FloatingScale" RelativeSource="{RelativeSource TemplatedParent}" />
+                          <Binding Source="{StaticResource NoContentFloatingScale}" />
+                        </MultiBinding>
+                      </ContentControl.Margin>
+                      <ContentControl.Tag>
+                        <system:Double>0.0</system:Double>
+                      </ContentControl.Tag>
+                      <ContentControl.RenderTransform>
+                        <MultiBinding Converter="{StaticResource FloatingHintTransformConverter}">
+                          <Binding ElementName="ScaleHost" Path="Scale" />
+                          <Binding Path="FloatingScale" RelativeSource="{RelativeSource TemplatedParent}" />
+                          <Binding Source="{StaticResource NoContentFloatingScale}" />
+                          <Binding Path="FloatingOffset" RelativeSource="{RelativeSource TemplatedParent}" />
+                          <Binding Path="InitialVerticalOffset" RelativeSource="{RelativeSource TemplatedParent}" />
+                        </MultiBinding>
+                      </ContentControl.RenderTransform>
+                    </ContentControl>
+                  </Canvas>
+                </Grid>
+              </Grid>
+            </ControlTemplate>
+          </Setter.Value>
+        </Setter>
+      </Trigger>
+    </Style.Triggers>
+  </Style>
+
+</ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHintNew.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHintNew.xaml
@@ -143,7 +143,7 @@
                 <wpf:ScaleHost x:Name="ScaleHost" />
                 <Grid x:Name="HintClippingGrid"
                       VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
-                      ClipToBounds="True" Background="Fuchsia">
+                      ClipToBounds="True">
                   <Grid.RenderTransform>
                     <MultiBinding Converter="{StaticResource FloatingHintClippingGridTransformConverter}">
                       <Binding ElementName="ScaleHost" Path="Scale" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -31,7 +31,7 @@
   <converters:ThicknessCloneConverter x:Key="OutlinedStyleTrailingIconMarginConverterTop" CloneEdges="Top" AdditionalOffsetTop="-2" />
   <converters:ThicknessCloneConverter x:Key="OutlinedStyleTrailingIconMarginConverterCenter" CloneEdges="Top" AdditionalOffsetTop="0" />
   <converters:ThicknessCloneConverter x:Key="OutlinedStyleTrailingIconMarginConverterBottom" CloneEdges="Top" FixedBottom="-2" AdditionalOffsetTop="0" />
-  <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
+  <converters:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
   <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
 
   <Style x:Key="MaterialDesignCharacterCounterTextBlock"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBoxNew.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBoxNew.xaml
@@ -15,8 +15,10 @@
       <converters:CursorConverter x:Key="IBeamCursorConverter" FallbackCursor="IBeam" />
       <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
       <converters:StringLengthValueConverter x:Key="StringLengthValueConverter" />
-      <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearButtonVisibilityConverter" />
+      <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearButtonVisibilityConverter" ContentEmptyVisibility="Collapsed" />
       <converters:TextFieldPrefixTextVisibilityConverter x:Key="PrefixSuffixTextVisibilityConverter" HiddenState="Collapsed" />
+      <converters:BooleanToDashStyleConverter x:Key="BooleanToDashStyleConverter" TrueValue="{x:Static DashStyles.Solid}" />
+      <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left,Right" />
 
       <Style x:Key="MaterialDesignCharacterCounterTextBlock"
              TargetType="TextBlock"
@@ -56,8 +58,8 @@
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
     <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="KeyboardNavigation.TabNavigation" Value="Local" />
-    <Setter Property="Padding" Value="{x:Static wpf:Constants.TextBoxDefaultPadding}" />
     <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
     <Setter Property="SelectionBrush" Value="{DynamicResource MaterialDesign.Brush.Primary.Light}" />
     <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
@@ -139,10 +141,20 @@
                     <ColumnDefinition Width="Auto" />
                   </Grid.ColumnDefinitions>
 
+                  <wpf:PackIcon x:Name="LeadingPackIcon"
+                                Grid.Column="0"
+                                Width="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
+                                Height="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
+                                Margin="0,0,6,0"
+                                VerticalAlignment="Center"
+                                Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
+                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
                   <TextBlock x:Name="PrefixTextBlock"
                              Grid.Column="1"
                              Margin="0,0,2,0"
-                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                             VerticalAlignment="Center"
                              FontSize="{TemplateBinding FontSize}"
                              Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                              Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}">
@@ -157,7 +169,7 @@
                   <ScrollViewer x:Name="PART_ContentHost"
                                 Grid.Column="2"
                                 HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
+                                VerticalAlignment="Center"
                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Panel.ZIndex="1"
@@ -171,7 +183,7 @@
 
                   <wpf:SmartHint x:Name="Hint"
                                  Grid.Column="2"
-                                 VerticalAlignment="Stretch"
+                                 VerticalAlignment="Center"
                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                  FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
@@ -193,7 +205,7 @@
                   <TextBlock x:Name="SuffixTextBlock"
                              Grid.Column="3"
                              Margin="2,0,0,0"
-                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                             VerticalAlignment="Center"
                              FontSize="{TemplateBinding FontSize}"
                              Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                              Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}">
@@ -205,11 +217,23 @@
                     </TextBlock.Visibility>
                   </TextBlock>
 
+                  <wpf:PackIcon x:Name="TrailingPackIcon"
+                                Grid.Column="4"
+                                Width="{TemplateBinding wpf:TextFieldAssist.TrailingIconSize}"
+                                Height="{TemplateBinding wpf:TextFieldAssist.TrailingIconSize}"
+                                Margin="4,0,0,0"
+                                VerticalAlignment="Center"
+                                Kind="{TemplateBinding wpf:TextFieldAssist.TrailingIcon}"
+                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
                   <Button x:Name="PART_ClearButton"
                           Grid.Column="5"
+                          Height="Auto"
                           Padding="2,0,0,0"
                           Command="{x:Static internal:ClearText.ClearCommand}"
                           Focusable="False"
+                          VerticalAlignment="Center"
                           Style="{StaticResource MaterialDesignToolButton}">
                     <Button.Visibility>
                       <MultiBinding Converter="{StaticResource ClearButtonVisibilityConverter}">
@@ -228,9 +252,49 @@
                            Background="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
                            CornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
                            Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}" />
+
+            <Canvas VerticalAlignment="Bottom">
+              <Border Canvas.Top="2"
+                      Padding="{TemplateBinding Padding, Converter={StaticResource HelperTextMarginConverter}}"
+                      Width="{Binding ActualWidth, ElementName=OuterBorder}">
+                <Grid x:Name="FooterGrid">
+                  <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition Width="Auto" />
+                  </Grid.ColumnDefinitions>
+                  <TextBlock x:Name="HelperTextTextBlock" Style="{Binding Path=(wpf:HintAssist.HelperTextStyle), RelativeSource={RelativeSource TemplatedParent}}" />
+                  <Border x:Name="CharacterCounterContainer" Grid.Column="1">
+                    <TextBlock x:Name="CharacterCounterTextBlock" Style="{Binding Path=(wpf:TextFieldAssist.CharacterCounterStyle), RelativeSource={RelativeSource TemplatedParent}}" />
+                  </Border>
+                </Grid>
+              </Border>
+            </Canvas>
           </Grid>
 
           <ControlTemplate.Triggers>
+            <!-- Multi-line TextBox (i.e. AcceptsReturn) edge case -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="AcceptsReturn" Value="True" />
+                <Condition Property="VerticalContentAlignment" Value="Stretch" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_ContentHost" Property="VerticalAlignment" Value="Stretch" />
+              <Setter TargetName="Hint" Property="VerticalAlignment" Value="Top" />
+              <!--
+
+              If we want the icons, buttons and pre-/suffix texts to align with the "first" line, we need to move them to the top.
+              However, since the icons in particular can be individually sized, this presents a problem with aligning the
+              "first line" in the center of the tallest of the icons.
+              Instead of tackling this challenge, the template will simply align the icons, buttons and pre-/suffix texts to the center of the control (i.e. their default)
+              
+              <Setter TargetName="PrefixTextBlock" Property="VerticalAlignment" Value="Stretch" />
+              <Setter TargetName="SuffixTextBlock" Property="VerticalAlignment" Value="Stretch" />
+              <Setter TargetName="LeadingPackIcon" Property="VerticalAlignment" Value="Top" />
+              <Setter TargetName="TrailingPackIcon" Property="VerticalAlignment" Value="Top" />
+              <Setter TargetName="PART_ClearButton" Property="VerticalAlignment" Value="Top" />
+              -->
+            </MultiTrigger>
+
             <!-- Floating hint -->
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -240,7 +304,20 @@
               <Setter TargetName="Hint" Property="Foreground" Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
             </MultiTrigger>
-            
+
+            <!-- Character counter -->
+            <DataTrigger Value="0">
+              <DataTrigger.Binding>
+                <PriorityBinding>
+                  <Binding FallbackValue="0"
+                           Path="MaxLength"
+                           RelativeSource="{RelativeSource Self}" />
+                  <Binding Source="0" />
+                </PriorityBinding>
+              </DataTrigger.Binding>
+              <Setter TargetName="CharacterCounterContainer" Property="Visibility" Value="Collapsed" />
+            </DataTrigger>
+
             <!-- Outlined text field -->
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
               <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
@@ -258,11 +335,10 @@
               <MultiTrigger.Conditions>
                 <Condition Property="IsEnabled" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
-                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
               </MultiTrigger.Conditions>
               <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
               <Setter TargetName="OuterBorder" Property="wpf:BottomDashedLineAdorner.IsAttached" Value="True" />
-              <!--<Setter TargetName="borderUnderline" Property="Height" Value="0" />-->
+              <Setter TargetName="OuterBorder" Property="wpf:BottomDashedLineAdorner.DashStyle" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TextFieldAssist.HasFilledTextField), Converter={StaticResource BooleanToDashStyleConverter}}" />
               <Setter TargetName="ContentGrid" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
             </MultiTrigger>
             <MultiTrigger>
@@ -272,9 +348,6 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="PART_ClearButton" Property="Opacity" Value="1" />
               <Setter TargetName="OuterBorder" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <!--<Setter TargetName="borderUnderline" Property="Height" Value="1" />
-              <Setter TargetName="borderUnderline" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />-->
-              <!-- Opacity already applied on 'OuterBorder' -->
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -307,14 +380,7 @@
               </MultiTrigger.Conditions>
               <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
               <Setter Property="BorderThickness" Value="2" />
-              <Setter TargetName="OuterBorder" Property="Margin" Value="-1" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsKeyboardFocused" Value="True" />
-                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
-              </MultiTrigger.Conditions>
-              <!--<Setter TargetName="borderUnderline" Property="Height" Value="2" />-->
+              <Setter TargetName="ContentGrid" Property="Margin" Value="-1" />
             </MultiTrigger>
 
             <!-- IsMouseOver -->
@@ -327,7 +393,7 @@
               </MultiTrigger.Conditions>
               <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
             </MultiTrigger>
-            <MultiTrigger>
+            <!--<MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="IsMouseOver" Value="True" />
                 <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
@@ -336,7 +402,7 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="0,0,0,2" />
               <Setter TargetName="OuterBorder" Property="Padding" Value="0,4,0,3" />
-            </MultiTrigger>
+            </MultiTrigger>-->
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="IsMouseOver" Value="True" />
@@ -351,7 +417,7 @@
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
               </MultiTrigger.Conditions>
               <Setter Property="BorderThickness" Value="2" />
-              <Setter TargetName="OuterBorder" Property="Margin" Value="-1" />
+              <Setter TargetName="ContentGrid" Property="Margin" Value="-1" />
             </MultiTrigger>
 
             <!-- Validation.HasError -->
@@ -365,15 +431,14 @@
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
               </MultiTrigger.Conditions>
               <Setter Property="BorderThickness" Value="2" />
-              <!--<Setter TargetName="FooterGrid" Property="Margin" Value="0,0,1,0" />-->
-              <!--<Setter TargetName="OuterBorder" Property="Margin" Value="-1" />-->
+              <Setter TargetName="FooterGrid" Property="Margin" Value="0,0,1,0" />
+              <!--<Setter TargetName="OuterBorder" Property="Margin" Value="-1" />-->   <!-- Squeeze content because of the red border? -->
             </MultiTrigger>
           </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
     <Setter Property="Validation.ErrorTemplate" Value="{StaticResource MaterialDesignValidationErrorTemplate}" />
-    <Setter Property="VerticalContentAlignment" Value="Stretch" />
     <Setter Property="internal:ClearText.HandlesClearCommand" Value="True" />
     <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
     <Setter Property="wpf:HintAssist.HelperTextStyle" Value="{StaticResource MaterialDesignHelperTextBlock}" />
@@ -386,7 +451,9 @@
 
   <Style x:Key="MaterialDesignTextBoxNew"
          TargetType="{x:Type TextBox}"
-         BasedOn="{StaticResource MaterialDesignTextBoxNewBase}" />
+         BasedOn="{StaticResource MaterialDesignTextBoxNewBase}">
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.TextBoxDefaultPaddingNew}" />
+  </Style>
 
   <Style x:Key="MaterialDesignFloatingHintTextBoxNew"
          TargetType="{x:Type TextBox}"
@@ -398,7 +465,7 @@
          TargetType="{x:Type TextBox}"
          BasedOn="{StaticResource MaterialDesignFloatingHintTextBoxNew}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.FilledBackground}" />
-    <Setter Property="Padding" Value="{x:Static wpf:Constants.FilledTextBoxDefaultPadding}" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.FilledTextBoxDefaultPaddingNew}" />
     <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />
     <Setter Property="wpf:TextFieldAssist.UnderlineCornerRadius" Value="0" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBoxNew.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBoxNew.xaml
@@ -1,0 +1,417 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
+                    xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal"
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Button.xaml" />
+  </ResourceDictionary.MergedDictionaries>
+
+  <Style x:Key="MaterialDesignTextBoxNewBase" TargetType="{x:Type TextBoxBase}">
+    <Style.Resources>
+      <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+      <converters:CursorConverter x:Key="ArrowCursorConverter" FallbackCursor="Arrow" />
+      <converters:CursorConverter x:Key="IBeamCursorConverter" FallbackCursor="IBeam" />
+      <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
+      <converters:StringLengthValueConverter x:Key="StringLengthValueConverter" />
+      <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearButtonVisibilityConverter" />
+      <converters:TextFieldPrefixTextVisibilityConverter x:Key="PrefixSuffixTextVisibilityConverter" HiddenState="Collapsed" />
+
+      <Style x:Key="MaterialDesignCharacterCounterTextBlock"
+             TargetType="TextBlock"
+             BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="10" />
+        <Setter Property="Opacity" Value="0.56" />
+        <Setter Property="Text">
+          <Setter.Value>
+            <MultiBinding StringFormat="{}{0} / {1}">
+              <Binding Converter="{StaticResource StringLengthValueConverter}"
+                       Path="Text"
+                       RelativeSource="{RelativeSource FindAncestor,
+                                                       AncestorType=TextBoxBase}" />
+              <Binding Path="MaxLength" RelativeSource="{RelativeSource FindAncestor, AncestorType=TextBoxBase}" />
+            </MultiBinding>
+          </Setter.Value>
+        </Setter>
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Visibility" Value="{Binding Path=(wpf:TextFieldAssist.CharacterCounterVisibility), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TextBox}}}" />
+      </Style>
+
+      <Style x:Key="MaterialDesignHelperTextBlock"
+             TargetType="TextBlock"
+             BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="{Binding Path=(wpf:HintAssist.HelperTextFontSize), RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+        <Setter Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+        <Setter Property="Text" Value="{Binding Path=(wpf:HintAssist.HelperText), RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+      </Style>
+    </Style.Resources>
+
+    <Setter Property="AllowDrop" Value="true" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.Border}" />
+    <Setter Property="BorderThickness" Value="0,0,0,1" />
+    <Setter Property="CaretBrush" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
+    <Setter Property="ContextMenu" Value="{StaticResource MaterialDesignDefaultContextMenu}" />
+    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="KeyboardNavigation.TabNavigation" Value="Local" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.TextBoxDefaultPadding}" />
+    <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
+    <Setter Property="SelectionBrush" Value="{DynamicResource MaterialDesign.Brush.Primary.Light}" />
+    <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type TextBoxBase}">
+          <Grid Cursor="{TemplateBinding Cursor, Converter={StaticResource ArrowCursorConverter}}">
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="FocusStates">
+                <VisualState x:Name="Focused">
+                  <Storyboard TargetName="RippleOnFocusScaleTransform">
+                    <DoubleAnimation Storyboard.TargetProperty="ScaleX"
+                                     From="0"
+                                     To="1"
+                                     Duration="0:0:0.3">
+                      <DoubleAnimation.EasingFunction>
+                        <SineEase EasingMode="EaseOut" />
+                      </DoubleAnimation.EasingFunction>
+                    </DoubleAnimation>
+                    <DoubleAnimation Storyboard.TargetProperty="ScaleY"
+                                     From="0"
+                                     To="1"
+                                     Duration="0:0:0.3">
+                      <DoubleAnimation.EasingFunction>
+                        <SineEase EasingMode="EaseOut" />
+                      </DoubleAnimation.EasingFunction>
+                    </DoubleAnimation>
+                    <DoubleAnimation BeginTime="0:0:0.45"
+                                     Storyboard.TargetProperty="ScaleX"
+                                     To="0"
+                                     Duration="0" />
+                    <DoubleAnimation BeginTime="0:0:0.45"
+                                     Storyboard.TargetProperty="ScaleY"
+                                     To="0"
+                                     Duration="0" />
+                  </Storyboard>
+                </VisualState>
+                <VisualState x:Name="Unfocused">
+                  <Storyboard TargetName="RippleOnFocusScaleTransform">
+                    <DoubleAnimation Storyboard.TargetProperty="ScaleX"
+                                     To="0"
+                                     Duration="0" />
+                    <DoubleAnimation Storyboard.TargetProperty="ScaleY"
+                                     To="0"
+                                     Duration="0" />
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <Border HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Background="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
+                    CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
+                    RenderTransformOrigin="0.5,0.5"
+                    Visibility="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+              <Border.RenderTransform>
+                <ScaleTransform x:Name="RippleOnFocusScaleTransform" ScaleX="0" ScaleY="0" />
+              </Border.RenderTransform>
+            </Border>
+            <AdornerDecorator>
+              <Border x:Name="OuterBorder"
+                      Padding="{TemplateBinding Padding}"
+                      wpf:BottomDashedLineAdorner.Brush="{TemplateBinding BorderBrush}"
+                      wpf:BottomDashedLineAdorner.Thickness="{TemplateBinding BorderThickness}"
+                      Background="{TemplateBinding Background}"
+                      BorderBrush="{TemplateBinding BorderBrush}"
+                      BorderThickness="{TemplateBinding BorderThickness}"
+                      CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
+                      SnapsToDevicePixels="True">
+
+                <Grid x:Name="ContentGrid"
+                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                  <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                  </Grid.ColumnDefinitions>
+
+                  <TextBlock x:Name="PrefixTextBlock"
+                             Grid.Column="1"
+                             Margin="0,0,2,0"
+                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                             FontSize="{TemplateBinding FontSize}"
+                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                             Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}">
+                    <TextBlock.Visibility>
+                      <MultiBinding Converter="{StaticResource PrefixSuffixTextVisibilityConverter}">
+                        <Binding ElementName="Hint" Path="IsHintInFloatingPosition" />
+                        <Binding Path="(wpf:TextFieldAssist.PrefixText)" RelativeSource="{RelativeSource TemplatedParent}" />
+                      </MultiBinding>
+                    </TextBlock.Visibility>
+                  </TextBlock>
+
+                  <ScrollViewer x:Name="PART_ContentHost"
+                                Grid.Column="2"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Panel.ZIndex="1"
+                                wpf:ScrollViewerAssist.IgnorePadding="True"
+                                Cursor="{TemplateBinding Cursor, Converter={StaticResource IBeamCursorConverter}}"
+                                Focusable="False"
+                                HorizontalScrollBarVisibility="Hidden"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
+                                VerticalScrollBarVisibility="Hidden" />
+
+                  <wpf:SmartHint x:Name="Hint"
+                                 Grid.Column="2"
+                                 VerticalAlignment="Stretch"
+                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                 FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
+                                 FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
+                                 FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
+                                 FontSize="{TemplateBinding FontSize}"
+                                 HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                                 HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
+                                 UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}">
+                    <wpf:SmartHint.Hint>
+                      <Border x:Name="HintBackgroundBorder"
+                              Background="{TemplateBinding wpf:HintAssist.Background}"
+                              CornerRadius="2">
+                        <ContentPresenter x:Name="HintWrapper" Content="{TemplateBinding wpf:HintAssist.Hint}" />
+                      </Border>
+                    </wpf:SmartHint.Hint>
+                  </wpf:SmartHint>
+
+                  <TextBlock x:Name="SuffixTextBlock"
+                             Grid.Column="3"
+                             Margin="2,0,0,0"
+                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                             FontSize="{TemplateBinding FontSize}"
+                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                             Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}">
+                    <TextBlock.Visibility>
+                      <MultiBinding Converter="{StaticResource PrefixSuffixTextVisibilityConverter}">
+                        <Binding ElementName="Hint" Path="IsHintInFloatingPosition" />
+                        <Binding Path="(wpf:TextFieldAssist.SuffixText)" RelativeSource="{RelativeSource TemplatedParent}" />
+                      </MultiBinding>
+                    </TextBlock.Visibility>
+                  </TextBlock>
+
+                  <Button x:Name="PART_ClearButton"
+                          Grid.Column="5"
+                          Padding="2,0,0,0"
+                          Command="{x:Static internal:ClearText.ClearCommand}"
+                          Focusable="False"
+                          Style="{StaticResource MaterialDesignToolButton}">
+                    <Button.Visibility>
+                      <MultiBinding Converter="{StaticResource ClearButtonVisibilityConverter}">
+                        <Binding Path="(wpf:TextFieldAssist.HasClearButton)" RelativeSource="{RelativeSource TemplatedParent}" />
+                        <Binding ElementName="Hint" Path="IsContentNullOrEmpty" />
+                      </MultiBinding>
+                    </Button.Visibility>
+                    <wpf:PackIcon Margin="0" Kind="CloseCircle" />
+                  </Button>
+                </Grid>
+              </Border>
+            </AdornerDecorator>
+
+            <wpf:Underline x:Name="Underline"
+                           VerticalAlignment="Bottom"
+                           Background="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
+                           CornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
+                           Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}" />
+          </Grid>
+
+          <ControlTemplate.Triggers>
+            <!-- Floating hint -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                <Condition Property="IsKeyboardFocused" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Hint" Property="Foreground" Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
+              <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
+            </MultiTrigger>
+            
+            <!-- Outlined text field -->
+            <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
+              <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
+            </Trigger>
+
+            <!-- IsEnabled -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsEnabled" Value="False" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="OuterBorder" Property="BorderBrush" Value="Transparent" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsEnabled" Value="False" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+              <Setter TargetName="OuterBorder" Property="wpf:BottomDashedLineAdorner.IsAttached" Value="True" />
+              <!--<Setter TargetName="borderUnderline" Property="Height" Value="0" />-->
+              <Setter TargetName="ContentGrid" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsEnabled" Value="False" />
+                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="1" />
+              <Setter TargetName="OuterBorder" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+              <!--<Setter TargetName="borderUnderline" Property="Height" Value="1" />
+              <Setter TargetName="borderUnderline" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />-->
+              <!-- Opacity already applied on 'OuterBorder' -->
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsEnabled" Value="False" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.OutlineInactiveBorder}" />
+              <Setter TargetName="HintWrapper" Property="Opacity">
+                <Setter.Value>
+                  <Binding Converter="{StaticResource MathMultiplyConverter}"
+                           ConverterParameter="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}"
+                           Path="(wpf:HintAssist.HintOpacity)"
+                           RelativeSource="{RelativeSource TemplatedParent}" />
+                </Setter.Value>
+              </Setter>
+              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+              <Setter TargetName="PART_ContentHost" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+              <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+              <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+            </MultiTrigger>
+
+            <!-- IsKeyboardFocused -->
+            <Trigger Property="IsKeyboardFocused" Value="True">
+              <Setter TargetName="Underline" Property="IsActive" Value="True" />
+            </Trigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsKeyboardFocused" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
+              <Setter Property="BorderThickness" Value="2" />
+              <Setter TargetName="OuterBorder" Property="Margin" Value="-1" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsKeyboardFocused" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
+              </MultiTrigger.Conditions>
+              <!--<Setter TargetName="borderUnderline" Property="Height" Value="2" />-->
+            </MultiTrigger>
+
+            <!-- IsMouseOver -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                <Condition Property="wpf:TextFieldAssist.NewSpecHighlightingEnabled" Value="False" />
+              </MultiTrigger.Conditions>
+              <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
+                <Condition Property="wpf:TextFieldAssist.NewSpecHighlightingEnabled" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="OuterBorder" Property="BorderThickness" Value="0,0,0,2" />
+              <Setter TargetName="OuterBorder" Property="Padding" Value="0,4,0,3" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
+              <!--<Setter TargetName="borderUnderline" Property="Height" Value="1" />-->
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter Property="BorderThickness" Value="2" />
+              <Setter TargetName="OuterBorder" Property="Margin" Value="-1" />
+            </MultiTrigger>
+
+            <!-- Validation.HasError -->
+            <Trigger Property="Validation.HasError" Value="true">
+              <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
+              <Setter TargetName="Underline" Property="Background" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
+            </Trigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="Validation.HasError" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter Property="BorderThickness" Value="2" />
+              <!--<Setter TargetName="FooterGrid" Property="Margin" Value="0,0,1,0" />-->
+              <!--<Setter TargetName="OuterBorder" Property="Margin" Value="-1" />-->
+            </MultiTrigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Validation.ErrorTemplate" Value="{StaticResource MaterialDesignValidationErrorTemplate}" />
+    <Setter Property="VerticalContentAlignment" Value="Stretch" />
+    <Setter Property="internal:ClearText.HandlesClearCommand" Value="True" />
+    <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
+    <Setter Property="wpf:HintAssist.HelperTextStyle" Value="{StaticResource MaterialDesignHelperTextBlock}" />
+    <Setter Property="wpf:TextFieldAssist.CharacterCounterStyle" Value="{StaticResource MaterialDesignCharacterCounterTextBlock}" />
+    <Setter Property="wpf:TextFieldAssist.CharacterCounterVisibility" Value="Visible" />
+    <Setter Property="wpf:TextFieldAssist.IncludeSpellingSuggestions" Value="{Binding RelativeSource={RelativeSource Self}, Path=(SpellCheck.IsEnabled)}" />
+    <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMargin}" />
+    <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
+  </Style>
+
+  <Style x:Key="MaterialDesignTextBoxNew"
+         TargetType="{x:Type TextBox}"
+         BasedOn="{StaticResource MaterialDesignTextBoxNewBase}" />
+
+  <Style x:Key="MaterialDesignFloatingHintTextBoxNew"
+         TargetType="{x:Type TextBox}"
+         BasedOn="{StaticResource MaterialDesignTextBoxNew}">
+    <Setter Property="wpf:HintAssist.IsFloating" Value="True" />
+  </Style>
+
+  <Style x:Key="MaterialDesignFilledTextBoxNew"
+         TargetType="{x:Type TextBox}"
+         BasedOn="{StaticResource MaterialDesignFloatingHintTextBoxNew}">
+    <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.FilledBackground}" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.FilledTextBoxDefaultPadding}" />
+    <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
+    <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />
+    <Setter Property="wpf:TextFieldAssist.UnderlineCornerRadius" Value="0" />
+  </Style>
+
+  <Style x:Key="MaterialDesignOutlinedTextBoxNew"
+         TargetType="{x:Type TextBox}"
+         BasedOn="{StaticResource MaterialDesignFloatingHintTextBoxNew}">
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.OutlineBorder}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.OutlinedTextBoxDefaultPadding}" />
+    <Setter Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+    <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />
+  </Style>
+
+</ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBoxNew.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBoxNew.xaml
@@ -181,7 +181,7 @@
                                 UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
                                 VerticalScrollBarVisibility="Hidden" />
 
-                  <wpf:SmartHint x:Name="Hint"
+                  <wpf:SmartHintNew x:Name="Hint"
                                  Grid.Column="2"
                                  VerticalAlignment="Center"
                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -193,14 +193,14 @@
                                  HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                  HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                  UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}">
-                    <wpf:SmartHint.Hint>
+                    <wpf:SmartHintNew.Hint>
                       <Border x:Name="HintBackgroundBorder"
                               Background="{TemplateBinding wpf:HintAssist.Background}"
                               CornerRadius="2">
                         <ContentPresenter x:Name="HintWrapper" Content="{TemplateBinding wpf:HintAssist.Hint}" />
                       </Border>
-                    </wpf:SmartHint.Hint>
-                  </wpf:SmartHint>
+                    </wpf:SmartHintNew.Hint>
+                  </wpf:SmartHintNew>
 
                   <TextBlock x:Name="SuffixTextBlock"
                              Grid.Column="3"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -26,7 +26,7 @@
                                       AdditionalOffsetTop="12"
                                       CloneEdges="Top,Right,Bottom"
                                       FixedLeft="0" />
-  <wpf:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
+  <converters:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
   <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
 
   <Style x:Key="MaterialDesignTimePickerTextBox" TargetType="{x:Type wpf:TimePickerTextBox}">


### PR DESCRIPTION
This draft PR is intended as a place for discussing the approach I am currently taking for the rework of the styles using `SmartHint` (`TextBox` being the first one). Sorry about the long write-up! Make sure you have a couple of Mountain Dews at hand before you dive in 😄 

#### Scope
I think the scope of this discussion should not deal with the `SmartHint` as such, but mainly focus on the layout of the `TextBox` style.

#### What am I trying to solve/address
There have been a number of issues opened with elements inside the `TextBox` not aligning nicely (vertically). The current implementation uses a bunch of converters with "magic numbers" applied in order to attempt to align elements nicely for all/most scenarios. The new style should aim to get rid of all/most of these converters, and ideally not use any magic numbers.

#### Basic idea
> Capture all the elements that should align with each other (vertically) in a single grid.

![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/d045dcab-7c5a-4be0-a58f-c9700dc21e71)

The blue box in the image above represents the single grid encapsulating all the elements of the `TextBox` that need to align vertically with each other. The red boxes marks each of the individual elements.
The challenge is that these elements, in various ways, can have their size individually controlled from the calling code. So the basic idea is to simply have `VerticalAlignment=Center` on all the elements with the red boxes, so they vertically align to the middle of the blue box regardless of their individual sizes. The blue box is the element that respects the `TextBox.VerticalContentAlignment` property so that it can align top/center/bottom. This works well for all variations of `VerticalContentAlignment` with the `Stretch` case, when the `TextBox` is also multi-line, being the exception. This is an edge case that I think we need to discuss, because I know people have different opinions on what they expect in this scenario.

#### The edge case
The edge case in question is, as mentioned, when the `TextBox` is multi-line (i.e. `AcceptsReturn=True`) and `VerticalContentAlignment=Stretch`. In this case the element containing the text that the user enters is expected to align to the top but be allowed to stretch downwards to fill up the space. In order to do this, the blue box would then have `VerticalAlignment=Stretch` applied to it, and ,as a minimum, the red box with the user content should also have `VerticalAlignment=Stretch` to fill the space vertically.
But what about the other elements? Should they also top align? And if so, they should probably (vertically) align nicely with the first row of text entered by the user? While this may seem like a good approach at first glance, it comes with a lot of issues to deal with. What if the icons/buttons have been set with non-default sizes, or the `FontSize` has been increased/decreased? Aligning such that those elements vertically center around the first row of text can become a complex calculation per element (i.e. red box). If calculations are not done, the result could look something like this (fixed height set on the `TextBox` in this example, but that is irrelevant) where you can see there really is no vertical alignment between the elements from the red boxes:

![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/5555cf60-a8b2-4421-8fce-94911483bb2b)

Personally I don't like this. If we were to align the elements vertically around the first row of text, I suspect we would end up with a bunch of complex converters, and possibly even some negative margins and `ClipToBounds=False` just to achieve what we want.

My suggestion is to always keep all other "red box" elements, apart from the actual user content (and possibly prefix-/suffix-texts) at `VerticalAlignment=Center` inside of the blue box. This would give a result similar to this.

![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/4031eedd-1fc1-40c2-83ec-377c38431702)

Personally I don't think the prefix-/suffix-text should top-align in this scenario, but since they are `TextBlock` elements which inherit the same `FontSize`, making those align nicely with the first row of text would probably be doable (or even come for free).

### So what am I hoping to achieve with this RFC?
I hope that I have provided enough details above, along with the code in the branch, to give the reader an understanding of how I intend to structure the new `TextBox` styles. I am looking for comments/feedback/pushback/critique; all is welcome.

This is just a first step, because the second issue that I want to address, is actually the placement of the `SmartHint`. This is also done using a bunch of converter magic with magic numbers and a lot of bindings making it complex to understand what is actually happening. But I doubt that one thing can be fixed without also making changes to the other, so I will most likely end up making a PR with changes for all the styles that use the `SmartHint` 😨 In that regard, should such a PR do the same as I am currently doing in this PR and create a parallel implementation rather than modifying the existing one? That definitely makes it easier to compare them, but is probably not ideal to actually push to master branch. Ideas?

If you run the code from the branch, you will open the demo app on the "Smart Hint" page where I have added the new `TextBox` style at the top for comparison with the default ones below it.

![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/39bdc267-9fb5-4b68-bac9-ac05c1512de7)
