### PR TITLE
Let the ScrollViewer in PasswordBox styles bubble up the mouse wheel events

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -227,7 +227,8 @@
                                   HorizontalScrollBarVisibility="Hidden"
                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                   UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
-                                  VerticalScrollBarVisibility="Hidden" />
+                                  VerticalScrollBarVisibility="Hidden"
+                                  wpf:ScrollViewerAssist.BubbleVerticalScroll="True"/>
                     <wpf:SmartHint x:Name="Hint"
                                    Grid.Column="1"
                                    VerticalAlignment="Stretch"
@@ -775,7 +776,8 @@
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                     UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
                                     VerticalScrollBarVisibility="Hidden"
-                                    Visibility="{Binding ElementName=ContentGrid, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed), Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                                    Visibility="{Binding ElementName=ContentGrid, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed), Converter={StaticResource InverseBooleanToVisibilityConverter}}"
+                                    wpf:ScrollViewerAssist.BubbleVerticalScroll="True" />
                       <TextBox x:Name="RevealPasswordTextBox"
                                Grid.Column="0"
                                Padding="{Binding ElementName=PART_ContentHost, Path=Padding}"


### PR DESCRIPTION
Fixes #3480 

Bubble up the mouse wheel events to avoid "blocking" a fluid scroll operation inside a `ScrollViewer` higher up in the visual tree.