### PR TITLE
Fix 3499

### DIFF
--- a/MainDemo.Wpf/Cards.xaml
+++ b/MainDemo.Wpf/Cards.xaml
@@ -286,10 +286,21 @@
       <smtx:XamlDisplay Margin="4,4,0,16" UniqueKey="cards_5">
         <materialDesign:Card Width="200"
                              Padding="8"
+                             materialDesign:ElevationAssist.Elevation="Dp12"
                              Background="{DynamicResource PrimaryHueDarkBrush}"
                              Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}"
                              UniformCornerRadius="6">
           <TextBlock Text="You can adjust the corner radius" TextWrapping="Wrap" />
+        </materialDesign:Card>
+      </smtx:XamlDisplay>
+
+      <smtx:XamlDisplay Margin="4,4,0,16" UniqueKey="cards_outline_1">
+        <materialDesign:Card Width="200"
+                             Padding="8"
+                             Style="{StaticResource MaterialDesignOutlinedCard}"
+                             materialDesign:ElevationAssist.Elevation="Dp12"
+                             UniformCornerRadius="6">
+          <TextBlock Text="Cards can use the outline style" TextWrapping="Wrap" />
         </materialDesign:Card>
       </smtx:XamlDisplay>
     </StackPanel>

--- a/MaterialDesignThemes.UITests/WPF/Cards/OutlinedCardTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/Cards/OutlinedCardTests.cs
@@ -16,7 +16,7 @@ public class OutlinedCardTests : TestBase
         //Arrange
         IVisualElement<Card> card = await LoadXaml<Card>(
             @"<materialDesign:Card Content=""Hello World"" Style=""{StaticResource MaterialDesignOutlinedCard}""/>");
-        Color dividerColor = await GetThemeColor("MaterialDesignDivider");
+        Color dividerColor = await GetThemeColor("MaterialDesign.Brush.Card.Border");
         IVisualElement<Border> internalBorder = await card.GetElement<Border>();
 
         //Act

--- a/MaterialDesignThemes.UITests/WPF/Theme/ThemeTests.g.cs
+++ b/MaterialDesignThemes.UITests/WPF/Theme/ThemeTests.g.cs
@@ -36,6 +36,7 @@ partial class ThemeTests
           <TextBlock Text="SnackBar.Background" Background="{StaticResource MaterialDesign.Brush.SnackBar.Background}" />
           <TextBlock Text="SnackBar.MouseOver" Background="{StaticResource MaterialDesign.Brush.SnackBar.MouseOver}" />
           <TextBlock Text="Card.Background" Background="{StaticResource MaterialDesign.Brush.Card.Background}" />
+          <TextBlock Text="Card.Border" Background="{StaticResource MaterialDesign.Brush.Card.Border}" />
           <TextBlock Text="CheckBox.Disabled" Background="{StaticResource MaterialDesign.Brush.CheckBox.Disabled}" />
           <TextBlock Text="CheckBox.UncheckedBorder" Background="{StaticResource MaterialDesign.Brush.CheckBox.UncheckedBorder}" />
           <TextBlock Text="CheckBox.Off" Background="{StaticResource MaterialDesign.Brush.CheckBox.Off}" />
@@ -229,6 +230,11 @@ partial class ThemeTests
             IVisualElement<TextBlock> textBlock = await panel.GetElement<TextBlock>("[Text=\"Card.Background\"]");
             Color? textBlockBackground = await textBlock.GetBackgroundColor();
             Assert.Equal(await GetResourceColor("MaterialDesign.Brush.Card.Background"), textBlockBackground);
+        }
+        {
+            IVisualElement<TextBlock> textBlock = await panel.GetElement<TextBlock>("[Text=\"Card.Border\"]");
+            Color? textBlockBackground = await textBlock.GetBackgroundColor();
+            Assert.Equal(await GetResourceColor("MaterialDesign.Brush.Card.Border"), textBlockBackground);
         }
         {
             IVisualElement<TextBlock> textBlock = await panel.GetElement<TextBlock>("[Text=\"CheckBox.Disabled\"]");
@@ -758,6 +764,7 @@ partial class ThemeTests
         yield return "MaterialDesign.Brush.SnackBar.Background";
         yield return "MaterialDesign.Brush.SnackBar.MouseOver";
         yield return "MaterialDesign.Brush.Card.Background";
+        yield return "MaterialDesign.Brush.Card.Border";
         yield return "MaterialDesign.Brush.CheckBox.Disabled";
         yield return "MaterialDesign.Brush.CheckBox.UncheckedBorder";
         yield return "MaterialDesign.Brush.CheckBox.Off";

--- a/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.g.cs
+++ b/MaterialDesignThemes.Wpf/ResourceDictionaryExtensions.g.cs
@@ -25,6 +25,7 @@ static partial class ResourceDictionaryExtensions
         theme.SnackBars.Background = GetColor(resourceDictionary, "MaterialDesign.Brush.SnackBar.Background", "MaterialDesignSnackbarBackground");
         theme.SnackBars.MouseOver = GetColor(resourceDictionary, "MaterialDesign.Brush.SnackBar.MouseOver", "MaterialDesignSnackbarMouseOver");
         theme.Cards.Background = GetColor(resourceDictionary, "MaterialDesign.Brush.Card.Background", "MaterialDesignBackground", "MaterialDesignCardBackground");
+        theme.Cards.Border = GetColor(resourceDictionary, "MaterialDesign.Brush.Card.Border");
         theme.CheckBoxes.Disabled = GetColor(resourceDictionary, "MaterialDesign.Brush.CheckBox.Disabled", "MaterialDesignCheckBoxDisabled");
         theme.CheckBoxes.UncheckedBorder = GetColor(resourceDictionary, "MaterialDesign.Brush.CheckBox.UncheckedBorder");
         theme.CheckBoxes.Off = GetColor(resourceDictionary, "MaterialDesign.Brush.CheckBox.Off", "MaterialDesignBodyLight", "MaterialDesignCheckBoxOff", "MaterialDesignTextBoxBorder");
@@ -120,6 +121,7 @@ static partial class ResourceDictionaryExtensions
         SetSolidColorBrush(resourceDictionary, "MaterialDesign.Brush.Card.Background", theme.Cards.Background);
         SetSolidColorBrush(resourceDictionary, "MaterialDesignBackground", theme.Cards.Background);
         SetSolidColorBrush(resourceDictionary, "MaterialDesignCardBackground", theme.Cards.Background);
+        SetSolidColorBrush(resourceDictionary, "MaterialDesign.Brush.Card.Border", theme.Cards.Border);
         SetSolidColorBrush(resourceDictionary, "MaterialDesign.Brush.CheckBox.Disabled", theme.CheckBoxes.Disabled);
         SetSolidColorBrush(resourceDictionary, "MaterialDesignCheckBoxDisabled", theme.CheckBoxes.Disabled);
         SetSolidColorBrush(resourceDictionary, "MaterialDesign.Brush.CheckBox.UncheckedBorder", theme.CheckBoxes.UncheckedBorder);

--- a/MaterialDesignThemes.Wpf/RippleAssist.cs
+++ b/MaterialDesignThemes.Wpf/RippleAssist.cs
@@ -4,7 +4,7 @@ namespace MaterialDesignThemes.Wpf;
 
 public static class RippleAssist
 {
-    #region ClipToBound
+    #region ClipToBounds
 
     public static readonly DependencyProperty ClipToBoundsProperty = DependencyProperty.RegisterAttached(
         "ClipToBounds", typeof(bool), typeof(RippleAssist), new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.Inherits));

--- a/MaterialDesignThemes.Wpf/Theme.g.cs
+++ b/MaterialDesignThemes.Wpf/Theme.g.cs
@@ -219,6 +219,13 @@ partial class Theme
            set => _background = value;
         }
 
+        private ColorReference _border;
+        public ColorReference Border
+        {
+           get => _theme.Resolve(_border);
+           set => _border = value;
+        }
+
     }
 
     public class CheckBox

--- a/MaterialDesignThemes.Wpf/ThemeExtensions.g.cs
+++ b/MaterialDesignThemes.Wpf/ThemeExtensions.g.cs
@@ -30,6 +30,7 @@ static partial class ThemeExtensions
         theme.SnackBars.Background = BaseThemeColors.Neutral100;
         theme.SnackBars.MouseOver = BaseThemeColors.Neutral200;
         theme.Cards.Background = BaseThemeColors.White1000;
+        theme.Cards.Border = BaseThemeColors.Neutral700;
         theme.CheckBoxes.Disabled = BaseThemeColors.Neutral700;
         theme.CheckBoxes.UncheckedBorder = BaseThemeColors.Black100;
         theme.CheckBoxes.Off = BaseThemeColors.Black500;
@@ -108,6 +109,7 @@ static partial class ThemeExtensions
         theme.SnackBars.Background = BaseThemeColors.Neutral800;
         theme.SnackBars.MouseOver = BaseThemeColors.Neutral700;
         theme.Cards.Background = BaseThemeColors.Neutral200;
+        theme.Cards.Border = BaseThemeColors.Neutral500;
         theme.CheckBoxes.Disabled = BaseThemeColors.Neutral300;
         theme.CheckBoxes.UncheckedBorder = BaseThemeColors.White100;
         theme.CheckBoxes.Off = BaseThemeColors.White500;

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -9,6 +9,8 @@
 
   <Style x:Key="MaterialDesignElevatedCard" TargetType="{x:Type wpf:Card}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Card.Background}" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.Card.Border}" />
     <Setter Property="Focusable" Value="False" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
     <Setter Property="Template">
@@ -26,46 +28,18 @@
                   <Binding Path="(wpf:ElevationAssist.Elevation)" RelativeSource="{RelativeSource TemplatedParent}" />
                 </MultiBinding>
               </AdornerDecorator.OpacityMask>
-              <Border CornerRadius="{TemplateBinding UniformCornerRadius, Converter={x:Static converters:DoubleToCornerRadiusConverter.Instance}}" Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}">
-                <Border x:Name="PART_ClipBorder"
-                        Padding="{TemplateBinding Padding}"
+              <Border
+                CornerRadius="{TemplateBinding UniformCornerRadius, Converter={x:Static converters:DoubleToCornerRadiusConverter.Instance}}"
+                Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}"
+                >
+                <Border Padding="{TemplateBinding Padding}"
                         Background="{TemplateBinding Background}"
-                        Clip="{TemplateBinding ContentClip}">
-                  <ContentPresenter x:Name="ContentPresenter"
-                                    Margin="{TemplateBinding Padding}"
-                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                    Content="{TemplateBinding ContentControl.Content}"
-                                    ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}"
-                                    ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}"
-                                    ContentTemplateSelector="{TemplateBinding ContentControl.ContentTemplateSelector}" />
-                </Border>
+                        Clip="{TemplateBinding ContentClip}"/>
               </Border>
             </AdornerDecorator>
-          </Grid>
-          <ControlTemplate.Triggers>
-            <Trigger Property="ClipContent" Value="True">
-              <Setter TargetName="ContentPresenter" Property="Clip" Value="{Binding ContentClip, RelativeSource={RelativeSource TemplatedParent}}" />
-            </Trigger>
-          </ControlTemplate.Triggers>
-        </ControlTemplate>
-      </Setter.Value>
-    </Setter>
-    <Setter Property="VerticalContentAlignment" Value="Stretch" />
-    <Setter Property="wpf:ElevationAssist.Elevation" Value="Dp1" />
-  </Style>
-
-  <Style x:Key="MaterialDesignOutlinedCard" TargetType="{x:Type wpf:Card}">
-    <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Card.Background}" />
-    <Setter Property="Focusable" Value="False" />
-    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-    <Setter Property="Template">
-      <Setter.Value>
-        <ControlTemplate TargetType="{x:Type wpf:Card}">
-          <Grid Background="Transparent">
-            <Border BorderBrush="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
-                    BorderThickness="1"
-                    CornerRadius="{TemplateBinding UniformCornerRadius, Converter={x:Static converters:DoubleToCornerRadiusConverter.Instance}}">
+            <Border CornerRadius="{TemplateBinding UniformCornerRadius, Converter={x:Static converters:DoubleToCornerRadiusConverter.Instance}}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}">
               <Border x:Name="PART_ClipBorder"
                       Padding="{TemplateBinding Padding}"
                       Background="{TemplateBinding Background}"
@@ -81,6 +55,44 @@
               </Border>
             </Border>
           </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="ClipContent" Value="True">
+              <Setter TargetName="ContentPresenter" Property="Clip" Value="{Binding ContentClip, RelativeSource={RelativeSource TemplatedParent}}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="VerticalContentAlignment" Value="Stretch" />
+    <Setter Property="wpf:ElevationAssist.Elevation" Value="Dp1" />
+  </Style>
+
+  <Style x:Key="MaterialDesignOutlinedCard" TargetType="{x:Type wpf:Card}">
+    <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Card.Background}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.Card.Border}" />
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type wpf:Card}">
+          <Border BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  CornerRadius="{TemplateBinding UniformCornerRadius, Converter={x:Static converters:DoubleToCornerRadiusConverter.Instance}}">
+            <Border x:Name="PART_ClipBorder"
+                    Padding="{TemplateBinding Padding}"
+                    Background="{TemplateBinding Background}"
+                    Clip="{TemplateBinding ContentClip}">
+              <ContentPresenter x:Name="ContentPresenter"
+                                Margin="{TemplateBinding Padding}"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Content="{TemplateBinding ContentControl.Content}"
+                                ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}"
+                                ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}"
+                                ContentTemplateSelector="{TemplateBinding ContentControl.ContentTemplateSelector}" />
+            </Border>
+          </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="ClipContent" Value="True">
               <Setter TargetName="ContentPresenter" Property="Clip" Value="{Binding ContentClip, RelativeSource={RelativeSource TemplatedParent}}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Dark.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Dark.xaml
@@ -15,6 +15,7 @@
   <colors:StaticResource x:Key="MaterialDesign.Brush.Button.FlatRipple" ResourceKey="Neutral700" />
   <colors:StaticResource x:Key="MaterialDesign.Brush.SnackBar.Ripple" ResourceKey="Neutral700" />
   <colors:StaticResource x:Key="MaterialDesign.Brush.Card.Background" ResourceKey="Neutral200" />
+  <colors:StaticResource x:Key="MaterialDesign.Brush.Card.Border" ResourceKey="Neutral500" />
   <colors:StaticResource x:Key="MaterialDesign.Brush.CheckBox.Disabled" ResourceKey="Neutral300" />
   <colors:StaticResource x:Key="MaterialDesign.Brush.CheckBox.UncheckedBorder" ResourceKey="White100" />
   <SolidColorBrush x:Key="MaterialDesign.Brush.Chip.Background" Color="#FF2E3C43" po:Freeze="True" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Light.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Light.xaml
@@ -15,6 +15,7 @@
   <colors:StaticResource x:Key="MaterialDesign.Brush.Button.FlatRipple" ResourceKey="Neutral700" />
   <colors:StaticResource x:Key="MaterialDesign.Brush.SnackBar.Ripple" ResourceKey="Neutral700" />
   <colors:StaticResource x:Key="MaterialDesign.Brush.Card.Background" ResourceKey="White1000" />
+  <colors:StaticResource x:Key="MaterialDesign.Brush.Card.Border" ResourceKey="Neutral700" />
   <colors:StaticResource x:Key="MaterialDesign.Brush.CheckBox.Disabled" ResourceKey="Neutral700" />
   <colors:StaticResource x:Key="MaterialDesign.Brush.CheckBox.UncheckedBorder" ResourceKey="Black100" />
   <SolidColorBrush x:Key="MaterialDesign.Brush.Chip.Background" Color="#12000000" po:Freeze="True" />

--- a/mdresgen/ThemeColors.json
+++ b/mdresgen/ThemeColors.json
@@ -123,6 +123,15 @@
         ]
     },
     {
+        "name": "MaterialDesign.Brush.Card.Border",
+        "themeValues": {
+            "light": "Neutral700",
+            "dark": "Neutral500"
+        },
+        "alternateKeys": [],
+        "obsoleteKeys": []
+    },
+    {
         "name": "MaterialDesign.Brush.CheckBox.Disabled",
         "themeValues": {
             "light": "Neutral700",


### PR DESCRIPTION
Cards now maintain ClearType.
Added new theme brush for card borders.
Elevated card now supports borders.

Fixes #3499
