### PR TITLE
Add AP to control SmartHint resting position

### DIFF
--- a/MainDemo.Wpf/Domain/SmartHintViewModel.cs
+++ b/MainDemo.Wpf/Domain/SmartHintViewModel.cs
@@ -10,6 +10,7 @@ internal class SmartHintViewModel : ViewModelBase
 
     private bool _floatHint = true;
     private FloatingHintHorizontalAlignment _selectedAlignment = FloatingHintHorizontalAlignment.Inherit;
+    private FloatingHintHorizontalAlignment _selectedFloatingAlignment = FloatingHintHorizontalAlignment.Inherit;
     private double _selectedFloatingScale = 0.75;
     private bool _showClearButton = true;
     private bool _showLeadingIcon = true;
@@ -53,6 +54,12 @@ internal class SmartHintViewModel : ViewModelBase
     {
         get => _selectedAlignment;
         set => SetProperty(ref _selectedAlignment, value);
+    }
+
+    public FloatingHintHorizontalAlignment SelectedFloatingAlignment
+    {
+        get => _selectedFloatingAlignment;
+        set => SetProperty(ref _selectedFloatingAlignment, value);
     }
 
     public double SelectedFloatingScale

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -21,7 +21,8 @@
       <Style TargetType="{x:Type local:InputElementContentControl}">
         <Setter Property="Margin" Value="10,10,10,16" />
         <Setter Property="VerticalAlignment" Value="Top" />
-        <Setter Property="materialDesign:HintAssist.FloatingHintHorizontalAlignment" Value="{Binding SelectedAlignment}" />
+        <Setter Property="materialDesign:HintAssist.HintHorizontalAlignment" Value="{Binding SelectedAlignment}" />
+        <Setter Property="materialDesign:HintAssist.FloatingHintHorizontalAlignment" Value="{Binding SelectedFloatingAlignment}" />
         <Setter Property="materialDesign:HintAssist.FloatingOffset" Value="{Binding SelectedFloatingOffset}" />
         <Setter Property="materialDesign:HintAssist.FloatingScale" Value="{Binding SelectedFloatingScale}" />
         <Setter Property="materialDesign:HintAssist.HelperText" Value="{Binding HelperText}" />
@@ -75,14 +76,21 @@
       <StackPanel Orientation="Vertical">
         <StackPanel Margin="10" Orientation="Horizontal">
           <CheckBox Content="IsFloating" IsChecked="{Binding FloatHint}" />
-          <TextBlock Margin="20,0,0,0"
+          <TextBlock Margin="15,0,0,0"
                      VerticalAlignment="Center"
                      Text="Alignment:" />
           <ComboBox Margin="5,0,0,0"
                     VerticalAlignment="Center"
                     ItemsSource="{Binding HorizontalAlignmentOptions}"
                     SelectedItem="{Binding SelectedAlignment, Mode=TwoWay}" />
-          <TextBlock Margin="20,0,0,0"
+          <TextBlock Margin="15,0,0,0"
+                     VerticalAlignment="Center"
+                     Text="FloatingAlignment:" />
+          <ComboBox Margin="5,0,0,0"
+                    VerticalAlignment="Center"
+                    ItemsSource="{Binding HorizontalAlignmentOptions}"
+                    SelectedItem="{Binding SelectedFloatingAlignment, Mode=TwoWay}" />
+          <TextBlock Margin="15,0,0,0"
                      VerticalAlignment="Center"
                      Text="FloatingScale:" />
           <ComboBox Margin="5,0,0,0"
@@ -90,7 +98,7 @@
                     ItemStringFormat="F2"
                     ItemsSource="{Binding FloatingScaleOptions}"
                     SelectedItem="{Binding SelectedFloatingScale, Mode=TwoWay}" />
-          <TextBlock Margin="20,0,0,0"
+          <TextBlock Margin="15,0,0,0"
                      VerticalAlignment="Center"
                      Text="FloatingOffset:" />
           <ComboBox Margin="5,0,0,0"
@@ -98,7 +106,7 @@
                     ItemTemplate="{StaticResource FloatingOffsetTemplate}"
                     ItemsSource="{Binding FloatingOffsetOptions}"
                     SelectedItem="{Binding SelectedFloatingOffset, Mode=TwoWay}" />
-          <CheckBox Margin="20,0,0,0"
+          <CheckBox Margin="15,0,0,0"
                     Content="HasClearButton"
                     IsChecked="{Binding ShowClearButton}" />
           <CheckBox Margin="20,0,0,0"

--- a/MaterialDesignThemes.Wpf/Converters/FloatingHintTextBlockMarginConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/FloatingHintTextBlockMarginConverter.cs
@@ -23,7 +23,7 @@ internal class FloatingHintTextBlockMarginConverter : IMultiValueConverter
 
         double scaleMultiplier = upper + (lower - upper) * scale;
 
-        HorizontalAlignment alignment = restingAlignmentOverride switch
+        HorizontalAlignment restAlignment = restingAlignmentOverride switch
         {
             FloatingHintHorizontalAlignment.Inherit => restingAlignment,
             FloatingHintHorizontalAlignment.Left => HorizontalAlignment.Left,
@@ -33,7 +33,7 @@ internal class FloatingHintTextBlockMarginConverter : IMultiValueConverter
             _ => throw new ArgumentOutOfRangeException(),
         };
 
-        HorizontalAlignment floatAlignment = alignment;
+        HorizontalAlignment floatAlignment = restAlignment;
         if (scale != 0)
         {
             floatAlignment = floatingAlignment switch
@@ -57,13 +57,13 @@ internal class FloatingHintTextBlockMarginConverter : IMultiValueConverter
 
         double FloatLeft()
         {
-            if (alignment == HorizontalAlignment.Center)
+            if (restAlignment == HorizontalAlignment.Center)
             {
                 // Animate from center to left
                 double offset = Math.Max(0, (availableWidth - desiredWidth) / 2);
                 return offset - offset * scale;
             }
-            if (alignment == HorizontalAlignment.Right)
+            if (restAlignment == HorizontalAlignment.Right)
             {
                 // Animate from right to left
                 double offset = Math.Max(0, availableWidth - desiredWidth);
@@ -74,13 +74,13 @@ internal class FloatingHintTextBlockMarginConverter : IMultiValueConverter
 
         double FloatCenter()
         {
-            if (alignment == HorizontalAlignment.Left || alignment == HorizontalAlignment.Stretch)
+            if (restAlignment == HorizontalAlignment.Left || restAlignment == HorizontalAlignment.Stretch)
             {
                 // Animate from left to center
                 double offset = Math.Max(0, (availableWidth - desiredWidth * scaleMultiplier) / 2);
                 return offset * scale;
             }
-            if (alignment == HorizontalAlignment.Right)
+            if (restAlignment == HorizontalAlignment.Right)
             {
                 // Animate from right to center
                 double startOffset = Math.Max(0, availableWidth - desiredWidth);
@@ -93,13 +93,13 @@ internal class FloatingHintTextBlockMarginConverter : IMultiValueConverter
 
         double FloatRight()
         {
-            if (alignment == HorizontalAlignment.Left || alignment == HorizontalAlignment.Stretch)
+            if (restAlignment == HorizontalAlignment.Left || restAlignment == HorizontalAlignment.Stretch)
             {
                 // Animate from left to right
                 double offset = Math.Max(0, availableWidth - desiredWidth * scaleMultiplier);
                 return offset * scale;
             }
-            if (alignment == HorizontalAlignment.Center)
+            if (restAlignment == HorizontalAlignment.Center)
             {
                 // Animate from center to right
                 double startOffset = Math.Max(0, (availableWidth - desiredWidth) / 2);

--- a/MaterialDesignThemes.Wpf/HintAssist.cs
+++ b/MaterialDesignThemes.Wpf/HintAssist.cs
@@ -66,6 +66,17 @@ public static class HintAssist
         => element.SetValue(HintOpacityProperty, value);
     #endregion
 
+    #region AttachedProperty : HintHorizontalAlignment
+    public static readonly DependencyProperty HintHorizontalAlignmentProperty
+        = DependencyProperty.RegisterAttached("HintHorizontalAlignment", typeof(FloatingHintHorizontalAlignment), typeof(HintAssist),
+            new FrameworkPropertyMetadata(FloatingHintHorizontalAlignment.Inherit, FrameworkPropertyMetadataOptions.Inherits));
+
+    public static void SetHintHorizontalAlignment(DependencyObject element, FloatingHintHorizontalAlignment value)
+        => element.SetValue(HintHorizontalAlignmentProperty, value);
+    public static FloatingHintHorizontalAlignment GetHintHorizontalAlignment(DependencyObject element)
+        => (FloatingHintHorizontalAlignment)element.GetValue(HintHorizontalAlignmentProperty);
+    #endregion
+
     #region AttachedProperty : FloatingHintHorizontalAlignment
     public static readonly DependencyProperty FloatingHintHorizontalAlignmentProperty
         = DependencyProperty.RegisterAttached("FloatingHintHorizontalAlignment", typeof(FloatingHintHorizontalAlignment), typeof(HintAssist),

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -169,6 +169,7 @@
                                     Visibility="{TemplateBinding UseFloating, Converter={StaticResource BoolToVisConverter}}">
                       <ContentControl.Margin>
                         <MultiBinding Converter="{StaticResource FloatingHintTextBlockMarginConverter}">
+                          <Binding Path="(wpf:HintAssist.HintHorizontalAlignment)" RelativeSource="{RelativeSource TemplatedParent}" />
                           <Binding Path="(wpf:HintAssist.FloatingHintHorizontalAlignment)" RelativeSource="{RelativeSource TemplatedParent}" />
                           <Binding Path="HorizontalContentAlignment" RelativeSource="{RelativeSource TemplatedParent}" />
                           <Binding Path="ActualWidth" RelativeSource="{RelativeSource Self}" />


### PR DESCRIPTION
Fixes #3460 

This PR adds an opt-in feature for the `SmartHint` to control the `HorizontalAlignment` of the hint in the resting position as requested in the issue above.

This will conflict with my PR for refactoring the `SmartHint` positioning, but it shouldn't be too much of an issue to merge/rebase it and let the new scheme respect this new AP.

Animations below slowed down for demonstration purposes.

I wanted to add a UI test for this, but my attempts turned out too fragile IMO, so I left it out. Basically the horizontal positioning of the hint is controlled using the `Margin` (left) property of the `ContentControl` containing the hint. This PR does not change that fact, it simply takes the new AP into account in the calculation of the left margin.

## Rest = Left, Float = Inherit
![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/ba8a6a27-1818-4e8e-8a08-2fda316d4c5b)
![SmartHint1](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/00d53855-1fe4-4bd0-9eb8-ee3f5f911847)


## Rest = Center, Float = Inherit
![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/636619f4-35a4-419c-bc38-1dac8bae6f4e)
![SmartHint2](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/577e1ee5-0bcc-4a2b-8e12-eda2373b0631)


## Rest = Right, Float = Inherit
![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/6b7aa81a-4ef3-402d-8953-8f4bac4c4e24)
![SmartHint3](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/79023aa4-11b5-4beb-9b73-46d62f988c21)
