### PR TITLE
fix 3526

### DIFF
--- a/MaterialDesignThemes.Wpf/Theme.cs
+++ b/MaterialDesignThemes.Wpf/Theme.cs
@@ -20,7 +20,7 @@ public partial class Theme
 
             if (registryValue is null)
             {
-                return null;
+                return BaseTheme.Light;
             }
 
             return Convert.ToBoolean(registryValue) ? BaseTheme.Light : BaseTheme.Dark;


### PR DESCRIPTION
Fixes #3526 

When AppsUseLightTheme does not exist in the corresponding path of the registry, give it a default value, otherwise an error will be reported, and there will be no prompt in DemoAppexe