### PR TITLE
Adopt new SmartHint in TimePicker style

### DIFF
--- a/MainDemo.Wpf/Domain/SmartHintViewModel.cs
+++ b/MainDemo.Wpf/Domain/SmartHintViewModel.cs
@@ -40,6 +40,8 @@ internal class SmartHintViewModel : ViewModelBase
     private bool _newSpecHighlightingEnabled;
     private ScrollBarVisibility _selectedVerticalScrollBarVisibility = ScrollBarVisibility.Auto;
     private ScrollBarVisibility _selectedHorizontalScrollBarVisibility = ScrollBarVisibility.Auto;
+    private Thickness _outlineStyleBorderThickness = new(1);
+    private Thickness _outlineStyleActiveBorderThickness = new(2);
 
     public IEnumerable<FloatingHintHorizontalAlignment> HorizontalAlignmentOptions { get; } = Enum.GetValues(typeof(FloatingHintHorizontalAlignment)).OfType<FloatingHintHorizontalAlignment>();
     public IEnumerable<double> FloatingScaleOptions { get; } = [0.25, 0.5, 0.75, 1.0];
@@ -54,6 +56,7 @@ internal class SmartHintViewModel : ViewModelBase
     public IEnumerable<PrefixSuffixVisibility> PrefixSuffixVisibilityOptions { get; } = Enum.GetValues(typeof(PrefixSuffixVisibility)).OfType<PrefixSuffixVisibility>();
     public IEnumerable<PrefixSuffixHintBehavior> PrefixSuffixHintBehaviorOptions { get; } = Enum.GetValues(typeof(PrefixSuffixHintBehavior)).OfType<PrefixSuffixHintBehavior>();
     public IEnumerable<ScrollBarVisibility> ScrollBarVisibilityOptions { get; } = Enum.GetValues(typeof(ScrollBarVisibility)).OfType<ScrollBarVisibility>();
+    public IEnumerable<Thickness> CustomOutlineStyleBorderThicknessOptions { get; } = [new Thickness(1), new Thickness(2), new Thickness(3), new Thickness(4), new Thickness(5), new Thickness(6) ];
 
     public bool FloatHint
     {
@@ -257,5 +260,17 @@ internal class SmartHintViewModel : ViewModelBase
     {
         get => _selectedHorizontalScrollBarVisibility;
         set => SetProperty(ref _selectedHorizontalScrollBarVisibility, value);
+    }
+
+    public Thickness OutlineStyleBorderThickness
+    {
+        get => _outlineStyleBorderThickness;
+        set => SetProperty(ref _outlineStyleBorderThickness, value);
+    }
+
+    public Thickness OutlineStyleActiveBorderThickness
+    {
+        get => _outlineStyleActiveBorderThickness;
+        set => SetProperty(ref _outlineStyleActiveBorderThickness, value);
     }
 }

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -328,7 +328,6 @@
     </StackPanel>
 
     <ScrollViewer Grid.Row="3"
-                  Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ScrollViewer}}, Path=ViewportHeight, Converter={StaticResource SubtractConverter}, ConverterParameter=350}"
                   Margin="0,20,0,0"
                   VerticalAlignment="Top"
                   materialDesign:ScrollViewerAssist.BubbleVerticalScroll="False"

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -27,6 +27,7 @@
         <Setter Property="materialDesign:HintAssist.FloatingScale" Value="{Binding SelectedFloatingScale}" />
         <Setter Property="materialDesign:HintAssist.HelperText" Value="{Binding HelperText}" />
         <Setter Property="materialDesign:HintAssist.Hint" Value="{Binding HintText}" />
+        <Setter Property="materialDesign:TextFieldAssist.OutlinedBorderActiveThickness" Value="{Binding OutlineStyleActiveBorderThickness}" />
       </Style>
       <Style x:Key="StyleNameIndicator"
              TargetType="{x:Type TextBlock}"
@@ -242,6 +243,14 @@
                     VerticalAlignment="Center"
                     ItemsSource="{Binding PrefixSuffixHintBehaviorOptions}"
                     SelectedItem="{Binding SelectedPrefixHintBehavior}"/>
+          <TextBlock Margin="40,0,0,0"
+                     VerticalAlignment="Center"
+                     Text="OutlineStyle-BorderThickness:" />
+          <ComboBox Width="62"
+                    Margin="5,0,0,0"
+                    VerticalAlignment="Center"
+                    ItemsSource="{Binding CustomOutlineStyleBorderThicknessOptions}"
+                    SelectedItem="{Binding OutlineStyleBorderThickness}" />
         </StackPanel>
         <StackPanel Margin="10" Orientation="Horizontal">
           <TextBox Width="50"
@@ -265,6 +274,14 @@
                     VerticalAlignment="Center"
                     ItemsSource="{Binding PrefixSuffixHintBehaviorOptions}"
                     SelectedItem="{Binding SelectedSuffixHintBehavior}"/>
+          <TextBlock Margin="40,0,0,0"
+                     VerticalAlignment="Center"
+                     Text="OutlineStyle-ActiveBorderThickness:" />
+          <ComboBox Width="62"
+                    Margin="5,0,0,0"
+                    VerticalAlignment="Center"
+                    ItemsSource="{Binding CustomOutlineStyleBorderThicknessOptions}"
+                    SelectedItem="{Binding OutlineStyleActiveBorderThickness}" />
         </StackPanel>
       </StackPanel>
     </GroupBox>
@@ -493,6 +510,7 @@
           <Grid.Resources>
             <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignOutlinedTextBox}">
               <Setter Property="AcceptsReturn" Value="{Binding TextBoxAcceptsReturn}" />
+              <Setter Property="BorderThickness" Value="{Binding OutlineStyleBorderThickness}" />
               <Setter Property="FontSize" Value="{Binding SelectedFontSize, Converter={StaticResource FontSizeConverter}}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
@@ -746,6 +764,7 @@
         <Grid>
           <Grid.Resources>
             <Style TargetType="{x:Type PasswordBox}" BasedOn="{StaticResource MaterialDesignOutlinedPasswordBox}">
+              <Setter Property="BorderThickness" Value="{Binding OutlineStyleBorderThickness}" />
               <Setter Property="FontSize" Value="{Binding SelectedFontSize, Converter={StaticResource FontSizeConverter}}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
@@ -937,6 +956,7 @@
         <Grid>
           <Grid.Resources>
             <Style TargetType="{x:Type PasswordBox}" BasedOn="{StaticResource MaterialDesignOutlinedRevealPasswordBox}">
+              <Setter Property="BorderThickness" Value="{Binding OutlineStyleBorderThickness}" />
               <Setter Property="FontSize" Value="{Binding SelectedFontSize, Converter={StaticResource FontSizeConverter}}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
@@ -1126,6 +1146,7 @@
         <Grid>
           <Grid.Resources>
             <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource MaterialDesignOutlinedComboBox}">
+              <Setter Property="BorderThickness" Value="{Binding OutlineStyleBorderThickness}" />
               <Setter Property="FontSize" Value="{Binding SelectedFontSize, Converter={StaticResource FontSizeConverter}}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="IsEditable" Value="{Binding ElementName=ComboBoxesEditableCheckBox, Path=IsChecked}" />
@@ -1307,6 +1328,7 @@
         <Grid>
           <Grid.Resources>
             <Style TargetType="{x:Type DatePicker}" BasedOn="{StaticResource MaterialDesignOutlinedDatePicker}">
+              <Setter Property="BorderThickness" Value="{Binding OutlineStyleBorderThickness}" />
               <Setter Property="FontSize" Value="{Binding SelectedFontSize, Converter={StaticResource FontSizeConverter}}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">
@@ -1486,6 +1508,7 @@
         <Grid>
           <Grid.Resources>
             <Style TargetType="{x:Type materialDesign:TimePicker}" BasedOn="{StaticResource MaterialDesignOutlinedTimePicker}">
+              <Setter Property="BorderThickness" Value="{Binding OutlineStyleBorderThickness}" />
               <Setter Property="FontSize" Value="{Binding SelectedFontSize, Converter={StaticResource FontSizeConverter}}" />
               <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
               <Setter Property="Padding">

--- a/MainDemo.Wpf/SmartHint.xaml
+++ b/MainDemo.Wpf/SmartHint.xaml
@@ -1206,6 +1206,7 @@
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
@@ -1263,6 +1264,7 @@
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
@@ -1320,6 +1322,7 @@
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
@@ -1382,6 +1385,7 @@
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
@@ -1439,6 +1443,7 @@
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
@@ -1496,6 +1501,7 @@
               <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
               <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
               <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
               <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
               <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />

--- a/MainDemo.Wpf/SmartHint.xaml.cs
+++ b/MainDemo.Wpf/SmartHint.xaml.cs
@@ -27,8 +27,10 @@ public partial class SmartHint : UserControl
     {
         CheckBox c = (CheckBox) sender;
 
-        foreach (FrameworkElement element in FindVisualChildren<FrameworkElement>(ControlsPanel))
+        foreach (InputElementContentControl container in FindVisualChildren<InputElementContentControl>(ControlsPanel))
         {
+            FrameworkElement element = (FrameworkElement) container.Content;
+
             var binding = GetBinding(element);
             if (binding is null)
                 continue;

--- a/MaterialDesignThemes.UITests/WPF/TextFieldDefaultHeightTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TextFieldDefaultHeightTests.cs
@@ -17,13 +17,11 @@ public class TextFieldDefaultHeightTests : TestBase
     <PasswordBox />
     <ComboBox IsEditable=""True"" />
     <DatePicker />
-    <materialDesign:TimePicker />
 </StackPanel>");
 
         var height = await GetHeight(stackPanel, "PasswordBox");
         Assert.Equal(height, await GetHeight(stackPanel, "ComboBox"), Precision);
         Assert.Equal(height, await GetHeight(stackPanel, "DatePicker"), Precision);
-        Assert.Equal(height, await GetHeight(stackPanel, "TimePicker"), Precision);
 
         recorder.Success();
     }
@@ -37,10 +35,12 @@ public class TextFieldDefaultHeightTests : TestBase
         var stackPanel = await LoadXaml<StackPanel>(@"
 <StackPanel>
     <TextBox />
+    <materialDesign:TimePicker />
 </StackPanel>");
 
         var height = await GetHeight(stackPanel, "TextBox");
         //Assert.Equal(height, await GetHeight(stackPanel, "ComboBox"), Precision);
+        Assert.Equal(height, await GetHeight(stackPanel, "TimePicker"), Precision);
 
         recorder.Success();
     }
@@ -56,14 +56,12 @@ public class TextFieldDefaultHeightTests : TestBase
     <PasswordBox Style=""{StaticResource MaterialDesignFloatingHintPasswordBox}"" materialDesign:HintAssist.Hint=""Hint"" />
     <ComboBox IsEditable=""True"" Style=""{StaticResource MaterialDesignFloatingHintComboBox}"" materialDesign:HintAssist.Hint=""Hint"" />
     <DatePicker Style=""{StaticResource MaterialDesignFloatingHintDatePicker}"" materialDesign:HintAssist.Hint=""Hint"" />
-    <materialDesign:TimePicker Style=""{StaticResource MaterialDesignFloatingHintTimePicker}"" materialDesign:HintAssist.Hint=""Hint"" />
 </StackPanel>");
 
         var height = await GetHeight(stackPanel, "PasswordBox");
         Assert.True(height > 0);
         Assert.Equal(height, await GetHeight(stackPanel, "ComboBox"), Precision);
         Assert.Equal(height, await GetHeight(stackPanel, "DatePicker"), Precision);
-        Assert.Equal(height, await GetHeight(stackPanel, "TimePicker"), Precision);
 
         recorder.Success();
     }
@@ -77,11 +75,13 @@ public class TextFieldDefaultHeightTests : TestBase
         var stackPanel = await LoadXaml<StackPanel>(@"
 <StackPanel>
     <TextBox Style=""{StaticResource MaterialDesignFloatingHintTextBox}"" materialDesign:HintAssist.Hint=""Hint"" />
+    <materialDesign:TimePicker Style=""{StaticResource MaterialDesignFloatingHintTimePicker}"" materialDesign:HintAssist.Hint=""Hint"" />
 </StackPanel>");
 
         var height = await GetHeight(stackPanel, "TextBox");
         Assert.True(height > 0);
         //Assert.Equal(height, await GetHeight(stackPanel, "ComboBox"), Precision);
+        Assert.Equal(height, await GetHeight(stackPanel, "TimePicker"), Precision);
 
         recorder.Success();
     }
@@ -97,14 +97,12 @@ public class TextFieldDefaultHeightTests : TestBase
     <PasswordBox Style=""{StaticResource MaterialDesignFilledPasswordBox}"" materialDesign:HintAssist.Hint=""Hint"" />
     <ComboBox IsEditable=""True"" Style=""{StaticResource MaterialDesignFilledComboBox}"" materialDesign:HintAssist.Hint=""Hint"" />
     <DatePicker Style=""{StaticResource MaterialDesignFilledDatePicker}"" materialDesign:HintAssist.Hint=""Hint"" />
-    <materialDesign:TimePicker Style=""{StaticResource MaterialDesignFilledTimePicker}"" materialDesign:HintAssist.Hint=""Hint"" />
 </StackPanel>");
 
         var height = await GetHeight(stackPanel, "PasswordBox");
         Assert.True(height > 0);
         Assert.Equal(height, await GetHeight(stackPanel, "ComboBox"), Precision);
         Assert.Equal(height, await GetHeight(stackPanel, "DatePicker"), Precision);
-        Assert.Equal(height, await GetHeight(stackPanel, "TimePicker"), Precision);
 
         recorder.Success();
     }
@@ -118,11 +116,13 @@ public class TextFieldDefaultHeightTests : TestBase
         var stackPanel = await LoadXaml<StackPanel>(@"
 <StackPanel>
     <TextBox Style=""{StaticResource MaterialDesignFilledTextBox}"" materialDesign:HintAssist.Hint=""Hint"" />
+    <materialDesign:TimePicker Style=""{StaticResource MaterialDesignFilledTimePicker}"" materialDesign:HintAssist.Hint=""Hint"" />
 </StackPanel>");
 
         var height = await GetHeight(stackPanel, "TextBox");
         Assert.True(height > 0);
         //Assert.Equal(height, await GetHeight(stackPanel, "ComboBox"), Precision);
+        Assert.Equal(height, await GetHeight(stackPanel, "TimePicker"), Precision);
 
         recorder.Success();
     }
@@ -138,14 +138,12 @@ public class TextFieldDefaultHeightTests : TestBase
     <PasswordBox Style=""{StaticResource MaterialDesignOutlinedPasswordBox}"" materialDesign:HintAssist.Hint=""Hint"" />
     <ComboBox IsEditable=""True"" Style=""{StaticResource MaterialDesignOutlinedComboBox}"" />
     <DatePicker Style=""{StaticResource MaterialDesignOutlinedDatePicker}"" materialDesign:HintAssist.Hint=""Hint"" />
-    <materialDesign:TimePicker Style=""{StaticResource MaterialDesignOutlinedTimePicker}"" materialDesign:HintAssist.Hint=""Hint"" />
 </StackPanel>");
 
         var height = await GetHeight(stackPanel, "PasswordBox");
         Assert.True(height > 0);
         Assert.Equal(height, await GetHeight(stackPanel, "ComboBox"), Precision);
         Assert.Equal(height, await GetHeight(stackPanel, "DatePicker"), Precision);
-        Assert.Equal(height, await GetHeight(stackPanel, "TimePicker"), Precision);
 
         recorder.Success();
     }
@@ -159,11 +157,13 @@ public class TextFieldDefaultHeightTests : TestBase
         var stackPanel = await LoadXaml<StackPanel>(@"
 <StackPanel>
     <TextBox Style=""{StaticResource MaterialDesignOutlinedTextBox}"" materialDesign:HintAssist.Hint=""Hint"" />
+    <materialDesign:TimePicker Style=""{StaticResource MaterialDesignOutlinedTimePicker}"" materialDesign:HintAssist.Hint=""Hint"" />
 </StackPanel>");
 
         var height = await GetHeight(stackPanel, "TextBox");
         Assert.True(height > 0);
         //Assert.Equal(height, await GetHeight(stackPanel, "ComboBox"), Precision);
+        Assert.Equal(height, await GetHeight(stackPanel, "TimePicker"), Precision);
 
         recorder.Success();
     }

--- a/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
@@ -367,23 +367,24 @@ public class TimePickerTests : TestBase
         var timePicker = await stackPanel.GetElement<TimePicker>("/TimePicker");
         await timePicker.SetProperty(TimePicker.TextProperty, "10:00");
         var timePickerTextBox = await timePicker.GetElement<TimePickerTextBox>("/TimePickerTextBox");
+        var textBoxOuterBorder = await timePickerTextBox.GetElement<Border>("OuterBorder");
         var button = await stackPanel.GetElement<Button>("Button");
 
         // Act
         await button.MoveCursorTo();
         await Task.Delay(50);   // Wait for the visual change
-        var inactiveBorderThickness = await timePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
+        var inactiveBorderThickness = await textBoxOuterBorder.GetBorderThickness();
         await timePickerTextBox.MoveCursorTo();
         await Task.Delay(50);   // Wait for the visual change
-        var hoverBorderThickness = await timePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
+        var hoverBorderThickness = await textBoxOuterBorder.GetBorderThickness(); ;
         await timePickerTextBox.LeftClick();
         await Task.Delay(50);   // Wait for the visual change
-        var focusedBorderThickness = await timePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
+        var focusedBorderThickness = await textBoxOuterBorder.GetBorderThickness(); ;
 
         // TODO: It would be cool if a validation error could be set via XAMLTest without the need for the Binding and ValidationRules elements in the XAML above.
         await timePicker.SetProperty(TimePicker.TextProperty, "11:00");
         await Task.Delay(50);   // Wait for the visual change
-        var withErrorBorderThickness = await timePickerTextBox.GetProperty<Thickness>(Control.BorderThicknessProperty);
+        var withErrorBorderThickness = await textBoxOuterBorder.GetBorderThickness(); ;
 
         // Assert
         Assert.Equal(expectedInactiveBorderThickness, inactiveBorderThickness);

--- a/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
+++ b/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
@@ -557,19 +557,19 @@ public class TimePickerTests : TestBase
             """);
         var timePicker = await stackPanel.GetElement<TimePicker>("/TimePicker");
         var timePickerTextBox = await timePicker.GetElement<TimePickerTextBox>("/TimePickerTextBox");
-        var hintBackgroundBorder = await timePicker.GetElement<Border>("HintBackgroundBorder");
+        var hintBackgroundGrid = await timePicker.GetElement<Grid>("HintBackgroundGrid");
 
         var defaultBackground = Colors.Transparent; 
         var defaultFloatedBackground = await GetThemeColor("MaterialDesign.Brush.Background");
 
         // Assert (unfocused state)
-        Assert.Equal(defaultBackground, await hintBackgroundBorder.GetBackgroundColor());
+        Assert.Equal(defaultBackground, await hintBackgroundGrid.GetBackgroundColor());
 
         // Act
         await timePickerTextBox.MoveKeyboardFocus();
 
         // Assert (focused state)
-        Assert.Equal(defaultFloatedBackground, await hintBackgroundBorder.GetBackgroundColor());
+        Assert.Equal(defaultFloatedBackground, await hintBackgroundGrid.GetBackgroundColor());
 
         recorder.Success();
     }

--- a/MaterialDesignThemes.Wpf/Constants.cs
+++ b/MaterialDesignThemes.Wpf/Constants.cs
@@ -9,10 +9,12 @@ public static class Constants
     public static readonly Thickness DefaultTextBoxViewMargin = new(1, 0, 1, 0);
     public static readonly Thickness DefaultTextBoxViewMarginStretch = new(1, 18, 1, 0);
     public static readonly Thickness DefaultTextBoxViewMarginEmbedded = new(0);
+    public static readonly Thickness DefaultOutlinedBorderInactiveThickness = new(1);
+    public static readonly Thickness DefaultOutlinedBorderActiveThickness = new(2);
     public const double TextBoxNotEnabledOpacity = 0.56;
     public const double TextBoxInnerButtonSpacing = 2;
     public const double ComboBoxArrowSize = 8;
-
+    
     /// <summary>
     /// Contains temporary constants needed until all styles leveraging SmartHint adopt the new approach.
     /// At that point, they should all use the constants above, the values should be changed to the ones in this class,

--- a/MaterialDesignThemes.Wpf/Converters/NonDefaultThicknessConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/NonDefaultThicknessConverter.cs
@@ -1,0 +1,21 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+
+namespace MaterialDesignThemes.Wpf.Converters;
+
+public class NonDefaultThicknessConverter : IValueConverter
+{
+    public Thickness DefaultThickness { get; set; }
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is Thickness thickness && thickness != DefaultThickness)
+        {
+            return thickness;
+        }
+        return null;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/MaterialDesignThemes.Wpf/Converters/OutlinedDateTimePickerActiveBorderThicknessConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/OutlinedDateTimePickerActiveBorderThicknessConverter.cs
@@ -4,7 +4,7 @@ using System.Windows.Data;
 namespace MaterialDesignThemes.Wpf.Converters;
 
 /* TODO: Should be obsoleted when both TimePicker and DatePicker have adopted the new SmartHint. */
-//[Obsolete("This class is obsolete and will be removed in a future version. Please use the more generic-named OutlinedStyleActiveBorderThicknessConverter instead.")]
+//[Obsolete("This class is obsolete and will be removed in a future version. Please use the more generic-named OutlinedStyleActiveBorderMarginCompensationConverter instead.")]
 public class OutlinedDateTimePickerActiveBorderThicknessConverter : IMultiValueConverter
 {
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)

--- a/MaterialDesignThemes.Wpf/Converters/OutlinedDateTimePickerActiveBorderThicknessConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/OutlinedDateTimePickerActiveBorderThicknessConverter.cs
@@ -3,6 +3,8 @@ using System.Windows.Data;
 
 namespace MaterialDesignThemes.Wpf.Converters;
 
+/* TODO: Should be obsoleted when both TimePicker and DatePicker have adopted the new SmartHint. */
+//[Obsolete("This class is obsolete and will be removed in a future version. Please use the more generic-named OutlinedStyleActiveBorderThicknessConverter instead.")]
 public class OutlinedDateTimePickerActiveBorderThicknessConverter : IMultiValueConverter
 {
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)

--- a/MaterialDesignThemes.Wpf/Converters/OutlinedStyleActiveBorderMarginCompensationConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/OutlinedStyleActiveBorderMarginCompensationConverter.cs
@@ -3,7 +3,7 @@ using System.Windows.Data;
 
 namespace MaterialDesignThemes.Wpf.Converters;
 
-public class OutlinedStyleActiveBorderThicknessConverter : IMultiValueConverter
+public class OutlinedStyleActiveBorderMarginCompensationConverter : IMultiValueConverter
 {
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {

--- a/MaterialDesignThemes.Wpf/Converters/OutlinedStyleActiveBorderThicknessConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/OutlinedStyleActiveBorderThicknessConverter.cs
@@ -1,0 +1,24 @@
+﻿using System.Globalization;
+using System.Windows.Data;
+
+namespace MaterialDesignThemes.Wpf.Converters;
+
+public class OutlinedStyleActiveBorderThicknessConverter : IMultiValueConverter
+{
+    public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values is not [Thickness baseThickness, Thickness thicknessToSubtract])
+        {
+            return default(Thickness);
+        }
+
+        return new Thickness(
+            baseThickness.Left - thicknessToSubtract.Left,
+            baseThickness.Top - thicknessToSubtract.Top,
+            baseThickness.Right - thicknessToSubtract.Right,
+            baseThickness.Bottom - thicknessToSubtract.Bottom);
+    }
+
+    public object?[] ConvertBack(object? value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/MaterialDesignThemes.Wpf/DatePickerAssist.cs
+++ b/MaterialDesignThemes.Wpf/DatePickerAssist.cs
@@ -1,33 +1,16 @@
 ﻿namespace MaterialDesignThemes.Wpf;
 
+/* TODO: We should obsolete this class in favor of the TextBoxAssist equivalents. */
+//[Obsolete("This class is obsolete and will be removed in a future version. Please use the TextBoxAssist equivalents instead. For OutlinedBorderInactiveThickness, simply use BorderThickness property instead.")]
 public static class DatePickerAssist
 {
-    private static Thickness DefaultOutlinedBorderInactiveThickness { get; } = new(1);
-    private static Thickness DefaultOutlinedBorderActiveThickness { get; } = new(2);
-
     public static readonly DependencyProperty OutlinedBorderInactiveThicknessProperty = DependencyProperty.RegisterAttached(
-        "OutlinedBorderInactiveThickness", typeof(Thickness), typeof(DatePickerAssist), new FrameworkPropertyMetadata(DefaultOutlinedBorderInactiveThickness, FrameworkPropertyMetadataOptions.Inherits));
-
-    public static void SetOutlinedBorderInactiveThickness(DependencyObject element, Thickness value)
-    {
-        element.SetValue(OutlinedBorderInactiveThicknessProperty, value);
-    }
-
-    public static Thickness GetOutlinedBorderInactiveThickness(DependencyObject element)
-    {
-        return (Thickness)element.GetValue(OutlinedBorderInactiveThicknessProperty);
-    }
+        "OutlinedBorderInactiveThickness", typeof(Thickness), typeof(DatePickerAssist), new FrameworkPropertyMetadata(Constants.DefaultOutlinedBorderInactiveThickness, FrameworkPropertyMetadataOptions.Inherits));
+    public static void SetOutlinedBorderInactiveThickness(DependencyObject element, Thickness value) => element.SetValue(OutlinedBorderInactiveThicknessProperty, value);
+    public static Thickness GetOutlinedBorderInactiveThickness(DependencyObject element) => (Thickness)element.GetValue(OutlinedBorderInactiveThicknessProperty);
 
     public static readonly DependencyProperty OutlinedBorderActiveThicknessProperty = DependencyProperty.RegisterAttached(
-        "OutlinedBorderActiveThickness", typeof(Thickness), typeof(DatePickerAssist), new FrameworkPropertyMetadata(DefaultOutlinedBorderActiveThickness, FrameworkPropertyMetadataOptions.Inherits));
-
-    public static void SetOutlinedBorderActiveThickness(DependencyObject element, Thickness value)
-    {
-        element.SetValue(OutlinedBorderActiveThicknessProperty, value);
-    }
-
-    public static Thickness GetOutlinedBorderActiveThickness(DependencyObject element)
-    {
-        return (Thickness)element.GetValue(OutlinedBorderActiveThicknessProperty);
-    }
+        "OutlinedBorderActiveThickness", typeof(Thickness), typeof(DatePickerAssist), new FrameworkPropertyMetadata(Constants.DefaultOutlinedBorderActiveThickness, FrameworkPropertyMetadataOptions.Inherits));
+    public static void SetOutlinedBorderActiveThickness(DependencyObject element, Thickness value) => element.SetValue(OutlinedBorderActiveThicknessProperty, value);
+    public static Thickness GetOutlinedBorderActiveThickness(DependencyObject element) => (Thickness)element.GetValue(OutlinedBorderActiveThicknessProperty);
 }

--- a/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -359,6 +359,11 @@ public static class TextFieldAssist
     internal static void SetPasswordBoxCharacterCount(DependencyObject element, int value) => element.SetValue(PasswordBoxCharacterCountProperty, value);
     internal static int GetPasswordBoxCharacterCount(DependencyObject element) => (int)element.GetValue(PasswordBoxCharacterCountProperty);
 
+    public static readonly DependencyProperty OutlinedBorderActiveThicknessProperty = DependencyProperty.RegisterAttached(
+        "OutlinedBorderActiveThickness", typeof(Thickness), typeof(TextFieldAssist), new FrameworkPropertyMetadata(Constants.DefaultOutlinedBorderActiveThickness, FrameworkPropertyMetadataOptions.Inherits));
+    public static void SetOutlinedBorderActiveThickness(DependencyObject element, Thickness value) => element.SetValue(OutlinedBorderActiveThicknessProperty, value);
+    public static Thickness GetOutlinedBorderActiveThickness(DependencyObject element) => (Thickness)element.GetValue(OutlinedBorderActiveThicknessProperty);
+
     #region Methods
 
     private static void IncludeSpellingSuggestionsChanged(DependencyObject element, DependencyPropertyChangedEventArgs e)

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -39,7 +39,11 @@
   <Style TargetType="{x:Type local:Badged}" BasedOn="{StaticResource MaterialDesignBadge}" />
   <Style TargetType="{x:Type local:Card}" BasedOn="{StaticResource MaterialDesignElevatedCard}" />
   <Style TargetType="{x:Type local:PopupBox}" BasedOn="{StaticResource MaterialDesignPopupBox}" />
-  <Style TargetType="{x:Type local:TimePicker}" BasedOn="{StaticResource MaterialDesignTimePicker}" />
+  <Style TargetType="{x:Type local:TimePicker}" BasedOn="{StaticResource MaterialDesignTimePicker}">
+    <Style.Resources>
+      <Style x:Key="NestedTextBoxStyle" TargetType="wpf:TimePickerTextBox" BasedOn="{StaticResource MaterialDesignTextBox}" />
+    </Style.Resources>
+  </Style>
   <Style TargetType="{x:Type local:AutoSuggestBox}" BasedOn="{StaticResource MaterialDesignAutoSuggestBox}" />
   <Style TargetType="{x:Type local:SplitButton}" BasedOn="{StaticResource MaterialDesignRaisedSplitButton}" />
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -194,7 +194,7 @@
                           <Binding Source="{StaticResource NoContentFloatingScale}" />
                         </MultiBinding>
                       </ContentControl.RenderTransform>
-                      <Grid Background="{TemplateBinding wpf:HintAssist.Background}" IsHitTestVisible="False">
+                      <Grid x:Name="HintBackgroundGrid" Background="{TemplateBinding wpf:HintAssist.Background}" IsHitTestVisible="False">
                         <ContentControl Content="{TemplateBinding Hint}" IsTabStop="False">
                           <ContentControl.Margin>
                             <MultiBinding Converter="{StaticResource FloatingHintContainerMarginConverter}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal"
@@ -236,7 +236,7 @@
                     </wpf:SmartHint.Margin>
                     <wpf:SmartHint.Hint>
                       <Border x:Name="HintBackgroundBorder"
-                              Background="{Binding ElementName=Hint, Path=Background}"
+                              Background="{TemplateBinding wpf:HintAssist.Background}"
                               CornerRadius="2">
                         <ContentPresenter x:Name="HintWrapper" Content="{TemplateBinding wpf:HintAssist.Hint}" />
                       </Border>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -34,6 +34,7 @@
       <converters:FloatingHintMarginConverter x:Key="FloatingHintMarginConverter" />
       <converters:ThicknessCloneConverter x:Key="ThicknessCloneConverter" CloneEdges="All" AdditionalOffsetBottom="-1" />
       <converters:InvertBooleanConverter x:Key="InvertBooleanConverter" />
+      <converters:OutlinedStyleActiveBorderThicknessConverter x:Key="OutlinedStyleActiveBorderThicknessConverter" />
 
       <Style x:Key="MaterialDesignCharacterCounterTextBlock"
              TargetType="TextBlock"
@@ -427,8 +428,15 @@
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterBorder" Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource TemplatedParent}}" />
-              <Setter TargetName="OuterBorder" Property="BorderThickness" Value="2" />
-              <Setter TargetName="ContentGrid" Property="Margin" Value="-1" />
+              <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
+              <Setter TargetName="ContentGrid" Property="Margin">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderThicknessConverter}">
+                    <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </MultiTrigger>
 
             <!-- IsMouseOver -->
@@ -466,8 +474,15 @@
                 <Condition Property="wpf:ValidationAssist.HasError" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
               </MultiTrigger.Conditions>
-              <Setter TargetName="OuterBorder" Property="BorderThickness" Value="2" />
-              <Setter TargetName="ContentGrid" Property="Margin" Value="-1" />
+              <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
+              <Setter TargetName="ContentGrid" Property="Margin">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderThicknessConverter}">
+                    <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </MultiTrigger>
 
             <!-- VerticalContentAlignment.Stretch AND AcceptsReturn=False -->
@@ -513,9 +528,16 @@
                 <Condition Property="Validation.HasError" Value="True" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
               </MultiTrigger.Conditions>
-              <Setter TargetName="OuterBorder" Property="BorderThickness" Value="2" />
               <Setter TargetName="FooterGrid" Property="Margin" Value="0,0,1,0" />
-              <Setter TargetName="OuterBorder" Property="Margin" Value="-1" />
+              <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
+              <Setter TargetName="ContentGrid" Property="Margin">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderThicknessConverter}">
+                    <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </MultiTrigger>
             <!-- ValidationAssist.HasError (when TextBox is nested inside another control) -->
             <Trigger Property="wpf:ValidationAssist.HasError" Value="true">
@@ -528,9 +550,16 @@
                 <Condition Property="wpf:ValidationAssist.HasError" Value="True" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
               </MultiTrigger.Conditions>
-              <Setter TargetName="OuterBorder" Property="BorderThickness" Value="2" />
               <Setter TargetName="FooterGrid" Property="Margin" Value="0,0,1,0" />
-              <Setter TargetName="OuterBorder" Property="Margin" Value="-1" />
+              <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
+              <Setter TargetName="ContentGrid" Property="Margin">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderThicknessConverter}">
+                    <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
             </MultiTrigger>
           </ControlTemplate.Triggers>
         </ControlTemplate>
@@ -575,7 +604,7 @@
          TargetType="{x:Type TextBox}"
          BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}">
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.OutlineBorder}" />
-    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="BorderThickness" Value="{x:Static wpf:Constants.DefaultOutlinedBorderInactiveThickness}" />
     <Setter Property="Padding" Value="{x:Static wpf:Constants.OutlinedTextBoxDefaultPadding}" />
     <Setter Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -34,7 +34,7 @@
       <converters:FloatingHintMarginConverter x:Key="FloatingHintMarginConverter" />
       <converters:ThicknessCloneConverter x:Key="ThicknessCloneConverter" CloneEdges="All" AdditionalOffsetBottom="-1" />
       <converters:InvertBooleanConverter x:Key="InvertBooleanConverter" />
-      <converters:OutlinedStyleActiveBorderThicknessConverter x:Key="OutlinedStyleActiveBorderThicknessConverter" />
+      <converters:OutlinedStyleActiveBorderMarginCompensationConverter x:Key="OutlinedStyleActiveBorderMarginCompensationConverter" />
 
       <Style x:Key="MaterialDesignCharacterCounterTextBlock"
              TargetType="TextBlock"
@@ -431,7 +431,7 @@
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="ContentGrid" Property="Margin">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderThicknessConverter}">
+                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
                     <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
@@ -477,7 +477,7 @@
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="ContentGrid" Property="Margin">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderThicknessConverter}">
+                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
                     <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
@@ -532,7 +532,7 @@
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="ContentGrid" Property="Margin">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderThicknessConverter}">
+                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
                     <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
@@ -554,7 +554,7 @@
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="ContentGrid" Property="Margin">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderThicknessConverter}">
+                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
                     <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -28,7 +28,7 @@
       <converters:TextFieldPrefixTextVisibilityConverter x:Key="PrefixSuffixTextVisibilityConverter" HiddenState="Collapsed" />
       <converters:BooleanToDashStyleConverter x:Key="BooleanToDashStyleConverter" TrueValue="{x:Static DashStyles.Solid}" />
       <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left,Right" />
-      <converters:MathConverter x:Key="DivisionConverter"  Operation="Divide" Offset="1" />
+      <converters:MathConverter x:Key="DivisionConverter" Operation="Divide" Offset="1.5" />
       <converters:FloatingHintInitialVerticalOffsetConverter x:Key="FloatingHintInitialVerticalOffsetConverter" />
       <converters:FloatingHintInitialHorizontalOffsetConverter x:Key="FloatingHintInitialHorizontalOffsetConverter" />
       <converters:FloatingHintMarginConverter x:Key="FloatingHintMarginConverter" />
@@ -131,7 +131,7 @@
               <Border x:Name="OuterBorder"
                       Padding="{TemplateBinding Padding}"
                       wpf:BottomDashedLineAdorner.Brush="{TemplateBinding BorderBrush}"
-                      wpf:BottomDashedLineAdorner.Thickness="{TemplateBinding BorderThickness}"
+                      wpf:BottomDashedLineAdorner.Thickness="{Binding RelativeSource={RelativeSource Self}, Path=BorderThickness}"
                       Background="{TemplateBinding Background}"
                       BorderBrush="{TemplateBinding BorderBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}"
@@ -236,7 +236,7 @@
                     </wpf:SmartHint.Margin>
                     <wpf:SmartHint.Hint>
                       <Border x:Name="HintBackgroundBorder"
-                              Background="{TemplateBinding wpf:HintAssist.Background}"
+                              Background="{Binding ElementName=Hint, Path=Background}"
                               CornerRadius="2">
                         <ContentPresenter x:Name="HintWrapper" Content="{TemplateBinding wpf:HintAssist.Hint}" />
                       </Border>
@@ -372,7 +372,7 @@
                 <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
                 <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
               </MultiTrigger.Conditions>
-              <Setter Property="wpf:HintAssist.Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
+              <Setter TargetName="Hint" Property="wpf:HintAssist.Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
             </MultiTrigger>
 
             <!-- IsEnabled -->
@@ -400,7 +400,7 @@
                 <Condition Property="IsEnabled" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
               </MultiTrigger.Conditions>
-              <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.OutlineInactiveBorder}" />
+              <Setter TargetName="OuterBorder" Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.OutlineInactiveBorder}" />
               <Setter TargetName="HintWrapper" Property="Opacity">
                 <Setter.Value>
                   <Binding Converter="{StaticResource MathMultiplyConverter}"
@@ -423,10 +423,11 @@
               <MultiTrigger.Conditions>
                 <Condition Property="IsKeyboardFocused" Value="True" />
                 <Condition Property="Validation.HasError" Value="False" />
+                <Condition Property="wpf:ValidationAssist.HasError" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
               </MultiTrigger.Conditions>
-              <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
-              <Setter Property="BorderThickness" Value="2" />
+              <Setter TargetName="OuterBorder" Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource TemplatedParent}}" />
+              <Setter TargetName="OuterBorder" Property="BorderThickness" Value="2" />
               <Setter TargetName="ContentGrid" Property="Margin" Value="-1" />
             </MultiTrigger>
 
@@ -438,7 +439,7 @@
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.NewSpecHighlightingEnabled" Value="False" />
               </MultiTrigger.Conditions>
-              <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
+              <Setter TargetName="OuterBorder" Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource TemplatedParent}}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -455,16 +456,17 @@
                 <Condition Property="IsMouseOver" Value="True" />
                 <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
               </MultiTrigger.Conditions>
-              <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
-              <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.HoverBorder}" />
+              <Setter TargetName="OuterBorder" Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
+              <Setter TargetName="OuterBorder" Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.HoverBorder}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="IsMouseOver" Value="True" />
                 <Condition Property="Validation.HasError" Value="False" />
+                <Condition Property="wpf:ValidationAssist.HasError" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
               </MultiTrigger.Conditions>
-              <Setter Property="BorderThickness" Value="2" />
+              <Setter TargetName="OuterBorder" Property="BorderThickness" Value="2" />
               <Setter TargetName="ContentGrid" Property="Margin" Value="-1" />
             </MultiTrigger>
 
@@ -502,7 +504,7 @@
 
             <!-- Validation.HasError -->
             <Trigger Property="Validation.HasError" Value="true">
-              <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
+              <Setter TargetName="OuterBorder" Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
               <Setter TargetName="Underline" Property="Background" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
               <Setter TargetName="Hint" Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
             </Trigger>
@@ -511,7 +513,22 @@
                 <Condition Property="Validation.HasError" Value="True" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
               </MultiTrigger.Conditions>
-              <Setter Property="BorderThickness" Value="2" />
+              <Setter TargetName="OuterBorder" Property="BorderThickness" Value="2" />
+              <Setter TargetName="FooterGrid" Property="Margin" Value="0,0,1,0" />
+              <Setter TargetName="OuterBorder" Property="Margin" Value="-1" />
+            </MultiTrigger>
+            <!-- ValidationAssist.HasError (when TextBox is nested inside another control) -->
+            <Trigger Property="wpf:ValidationAssist.HasError" Value="true">
+              <Setter TargetName="OuterBorder" Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
+              <Setter TargetName="Underline" Property="Background" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
+              <Setter TargetName="Hint" Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
+            </Trigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:ValidationAssist.HasError" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="OuterBorder" Property="BorderThickness" Value="2" />
               <Setter TargetName="FooterGrid" Property="Margin" Value="0,0,1,0" />
               <Setter TargetName="OuterBorder" Property="Margin" Value="-1" />
             </MultiTrigger>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -4,492 +4,8 @@
                     xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
   <ResourceDictionary.MergedDictionaries>
-    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml" />
-    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Menu.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
   </ResourceDictionary.MergedDictionaries>
-
-  <converters:TextFieldHintVisibilityConverter x:Key="TextFieldHintVisibilityConverter" />
-  <converters:MathConverter x:Key="DivisionMathConverter" Operation="Divide" />
-  <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearButtonVisibilityConverter" />
-  <converters:NotConverter x:Key="NotConverter" />
-  <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
-  <converters:FloatingHintOffsetCalculationConverter x:Key="FloatingHintOffsetCalculationConverter" />
-  <converters:OutlinedDateTimePickerActiveBorderThicknessConverter x:Key="OutlinedDateTimePickerActiveBorderThicknessConverter" />
-  <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left" />
-  <converters:ThicknessCloneConverter x:Key="TimePickerTextBoxPaddingConverter"
-                                      AdditionalOffsetRight="18"
-                                      CloneEdges="All" />
-  <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverter"
-                                      CloneEdges="Top,Right,Bottom"
-                                      FixedLeft="0" />
-  <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverterTop"
-                                      AdditionalOffsetTop="12"
-                                      CloneEdges="Top,Right,Bottom"
-                                      FixedLeft="0" />
-  <converters:VerticalAlignmentConverter x:Key="VerticalAlignmentConverter" />
-  <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
-
-  <Style x:Key="MaterialDesignTimePickerTextBox" TargetType="{x:Type wpf:TimePickerTextBox}">
-    <Style.Resources>
-      <converters:OutlinedStyleFloatingHintBackgroundConverter x:Key="OutlinedStyleFloatingHintBackgroundConverter" />
-    </Style.Resources>
-    <Setter Property="AllowDrop" Value="true" />
-    <Setter Property="Background" Value="Transparent" />
-    <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
-    <Setter Property="BorderThickness" Value="0,0,0,1" />
-    <Setter Property="CaretBrush" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
-    <Setter Property="ContextMenu" Value="{StaticResource MaterialDesignDefaultContextMenu}" />
-    <Setter Property="Cursor" Value="IBeam" />
-    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-    <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
-    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-    <Setter Property="KeyboardNavigation.TabNavigation" Value="Local" />
-    <Setter Property="Padding" Value="{x:Static wpf:Constants.TextBoxDefaultPadding}" />
-    <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
-    <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
-    <Setter Property="Template">
-      <Setter.Value>
-        <ControlTemplate TargetType="{x:Type wpf:TimePickerTextBox}">
-          <Grid>
-            <VisualStateManager.VisualStateGroups>
-              <VisualStateGroup x:Name="CommonStates">
-                <VisualStateGroup.Transitions>
-                  <VisualTransition GeneratedDuration="0" />
-                  <VisualTransition GeneratedDuration="0:0:0.1" To="MouseOver" />
-                </VisualStateGroup.Transitions>
-                <VisualState x:Name="Normal" />
-                <VisualState x:Name="MouseOver" />
-              </VisualStateGroup>
-              <VisualStateGroup x:Name="WatermarkStates">
-                <VisualStateGroup.Transitions>
-                  <VisualTransition GeneratedDuration="0" />
-                </VisualStateGroup.Transitions>
-                <VisualState x:Name="Unwatermarked" />
-                <VisualState x:Name="Watermarked">
-                  <Storyboard>
-                    <DoubleAnimation Storyboard.TargetName="PART_Watermark"
-                                     Storyboard.TargetProperty="Opacity"
-                                     To=".23"
-                                     Duration="0" />
-                  </Storyboard>
-                </VisualState>
-              </VisualStateGroup>
-              <VisualStateGroup x:Name="FocusStates">
-                <VisualState x:Name="Focused">
-                  <Storyboard TargetName="RippleOnFocusScaleTransform">
-                    <DoubleAnimation Storyboard.TargetProperty="ScaleX"
-                                     From="0"
-                                     To="1"
-                                     Duration="0:0:0.3">
-                      <DoubleAnimation.EasingFunction>
-                        <SineEase EasingMode="EaseOut" />
-                      </DoubleAnimation.EasingFunction>
-                    </DoubleAnimation>
-                    <DoubleAnimation Storyboard.TargetProperty="ScaleY"
-                                     From="0"
-                                     To="1"
-                                     Duration="0:0:0.3">
-                      <DoubleAnimation.EasingFunction>
-                        <SineEase EasingMode="EaseOut" />
-                      </DoubleAnimation.EasingFunction>
-                    </DoubleAnimation>
-                    <DoubleAnimation BeginTime="0:0:0.45"
-                                     Storyboard.TargetProperty="ScaleX"
-                                     To="0"
-                                     Duration="0" />
-                    <DoubleAnimation BeginTime="0:0:0.45"
-                                     Storyboard.TargetProperty="ScaleY"
-                                     To="0"
-                                     Duration="0" />
-                  </Storyboard>
-                </VisualState>
-                <VisualState x:Name="Unfocused">
-                  <Storyboard TargetName="RippleOnFocusScaleTransform">
-                    <DoubleAnimation Storyboard.TargetProperty="ScaleX"
-                                     To="0"
-                                     Duration="0" />
-                    <DoubleAnimation Storyboard.TargetProperty="ScaleY"
-                                     To="0"
-                                     Duration="0" />
-                  </Storyboard>
-                </VisualState>
-              </VisualStateGroup>
-            </VisualStateManager.VisualStateGroups>
-            <Border HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    Background="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
-                    CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
-                    RenderTransformOrigin="0.5,0.5"
-                    Visibility="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
-              <Border.RenderTransform>
-                <ScaleTransform x:Name="RippleOnFocusScaleTransform" ScaleX="0" ScaleY="0" />
-              </Border.RenderTransform>
-            </Border>
-            <AdornerDecorator>
-              <Border x:Name="border"
-                      Padding="{TemplateBinding Padding}"
-                      wpf:BottomDashedLineAdorner.Brush="{TemplateBinding BorderBrush}"
-                      wpf:BottomDashedLineAdorner.Thickness="{TemplateBinding BorderThickness}"
-                      Background="{TemplateBinding Background}"
-                      BorderBrush="{TemplateBinding BorderBrush}"
-                      BorderThickness="{TemplateBinding BorderThickness}"
-                      CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
-                      SnapsToDevicePixels="True">
-                <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                  <Grid.ColumnDefinitions>
-                    <ColumnDefinition />
-                    <ColumnDefinition Width="Auto" />
-                  </Grid.ColumnDefinitions>
-                  <Grid x:Name="grid"
-                        MinWidth="1"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Stretch">
-                    <Grid.ColumnDefinitions>
-                      <ColumnDefinition Width="Auto" />
-                      <ColumnDefinition Width="*" />
-                      <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <TextBlock x:Name="PrefixTextBlock"
-                               Grid.Column="0"
-                               Margin="0,0,2,0"
-                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                               FontSize="{TemplateBinding FontSize}"
-                               Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                               Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}"
-                               Visibility="{TemplateBinding wpf:TextFieldAssist.PrefixText, Converter={StaticResource NullableToVisibilityConverter}}" />
-                    <ContentControl x:Name="PART_Watermark"
-                                    Grid.Column="1"
-                                    Focusable="False"
-                                    IsHitTestVisible="False"
-                                    Opacity="0"
-                                    Visibility="Collapsed" />
-                    <ScrollViewer x:Name="PART_ContentHost"
-                                  Grid.Column="1"
-                                  HorizontalAlignment="Stretch"
-                                  VerticalAlignment="Stretch"
-                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                  Panel.ZIndex="1"
-                                  wpf:ScrollViewerAssist.IgnorePadding="True"
-                                  Focusable="false"
-                                  HorizontalScrollBarVisibility="Hidden"
-                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                  UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
-                                  VerticalScrollBarVisibility="Hidden" />
-                    <wpf:SmartHint x:Name="Hint"
-                                   Grid.Column="1"
-                                   VerticalAlignment="Stretch"
-                                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                   FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
-                                   FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
-                                   FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
-                                   FontSize="{TemplateBinding FontSize}"
-                                   HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                                   HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
-                                   UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}">
-                      <wpf:SmartHint.Hint>
-                        <Border x:Name="HintBackgroundBorder"
-                                Background="{TemplateBinding wpf:HintAssist.Background}"
-                                CornerRadius="2"
-                                Tag="{DynamicResource MaterialDesign.Brush.Background}">
-                          <ContentPresenter x:Name="HintWrapper" Content="{TemplateBinding wpf:HintAssist.Hint}" />
-                        </Border>
-                      </wpf:SmartHint.Hint>
-                    </wpf:SmartHint>
-                    <TextBlock x:Name="SuffixTextBlock"
-                               Grid.Column="2"
-                               Margin="0,0,2,0"
-                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                               FontSize="{TemplateBinding FontSize}"
-                               Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                               Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}"
-                               Visibility="{TemplateBinding wpf:TextFieldAssist.SuffixText, Converter={StaticResource NullableToVisibilityConverter}}" />
-                  </Grid>
-                  <Button x:Name="PART_ClearButton"
-                          Grid.Column="1"
-                          Height="Auto"
-                          Padding="2,0,0,0"
-                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                          Command="{x:Static internal:ClearText.ClearCommand}"
-                          Focusable="False"
-                          Style="{DynamicResource MaterialDesignToolButton}">
-                    <Button.Visibility>
-                      <MultiBinding Converter="{StaticResource ClearButtonVisibilityConverter}">
-                        <Binding Path="(wpf:TextFieldAssist.HasClearButton)" RelativeSource="{RelativeSource TemplatedParent}" />
-                        <Binding ElementName="Hint" Path="IsContentNullOrEmpty" />
-                      </MultiBinding>
-                    </Button.Visibility>
-                    <wpf:PackIcon Margin="0" Kind="CloseCircle" />
-                  </Button>
-                </Grid>
-              </Border>
-            </AdornerDecorator>
-            <Border x:Name="borderUnderline"
-                    Height="0"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Bottom"
-                    Background="{TemplateBinding BorderBrush}"
-                    CornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
-                    SnapsToDevicePixels="True"
-                    Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}" />
-            <wpf:Underline x:Name="Underline"
-                           Background="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
-                           CornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
-                           Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}" />
-            <Canvas x:Name="HelperTextWrapper"
-                    Margin="{TemplateBinding Padding, Converter={StaticResource HelperTextMarginConverter}}"
-                    VerticalAlignment="Bottom">
-              <TextBlock x:Name="HelperTextTextBlock"
-                         Canvas.Top="2"
-                         MaxWidth="{Binding ActualWidth, ElementName=border}"
-                         FontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
-                         Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                         Style="{Binding Path=(wpf:HintAssist.HelperTextStyle), RelativeSource={RelativeSource TemplatedParent}}"
-                         Text="{TemplateBinding wpf:HintAssist.HelperText}" />
-            </Canvas>
-          </Grid>
-          <ControlTemplate.Triggers>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-                <Condition Property="IsKeyboardFocused" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="Hint" Property="Foreground" Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
-              <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="Hint" Property="FloatingOffset">
-                <Setter.Value>
-                  <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding ElementName="Hint" Path="FontFamily" />
-                    <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
-                    <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
-                    <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
-                  </MultiBinding>
-                </Setter.Value>
-              </Setter>
-              <Setter TargetName="grid" Property="Margin">
-                <Setter.Value>
-                  <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding ElementName="Hint" Path="FontFamily" />
-                    <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
-                    <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
-                    <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
-                  </MultiBinding>
-                </Setter.Value>
-              </Setter>
-            </MultiTrigger>
-
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
-                <Condition Property="VerticalContentAlignment" Value="Center" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="-6" />
-            </MultiTrigger>
-
-            <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
-              <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.FilledBackground}" />
-            </Trigger>
-            <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
-              <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.Header.Foreground}" />
-              <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TimePickerAssist.OutlinedBorderInactiveThickness)}" />
-              <Setter Property="VerticalContentAlignment" Value="Top" />
-              <Setter TargetName="Hint" Property="FloatingOffset">
-                <Setter.Value>
-                  <MultiBinding Converter="{StaticResource FloatingHintOffsetCalculationConverter}">
-                    <Binding ElementName="Hint" Path="FontFamily" />
-                    <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
-                    <Binding Path="(wpf:HintAssist.FloatingScale)" RelativeSource="{RelativeSource TemplatedParent}" />
-                    <Binding Path="(wpf:HintAssist.FloatingOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
-                    <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
-                    <Binding Path="Padding" RelativeSource="{RelativeSource TemplatedParent}" />
-                    <Binding Path="VerticalContentAlignment" RelativeSource="{RelativeSource TemplatedParent}" />
-                  </MultiBinding>
-                </Setter.Value>
-              </Setter>
-              <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
-              <Setter TargetName="HintWrapper" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
-              <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
-            </Trigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="HintBackgroundBorder" Property="Background">
-                <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleFloatingHintBackgroundConverter}">
-                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.Background)" />
-                    <Binding ElementName="HintBackgroundBorder" Path="Tag" />
-                  </MultiBinding>
-                </Setter.Value>
-              </Setter>
-              <Setter TargetName="HintBackgroundBorder" Property="Padding" Value="4,0" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-                <Condition Property="IsKeyboardFocused" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="HintWrapper" Property="Opacity" Value="1" />
-            </MultiTrigger>
-
-            <!-- IsEnabled -->
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="False" />
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="border" Property="BorderBrush" Value="Transparent" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="False" />
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
-                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="border" Property="wpf:BottomDashedLineAdorner.IsAttached" Value="True" />
-              <Setter TargetName="borderUnderline" Property="Height" Value="0" />
-              <Setter TargetName="grid" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="False" />
-                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="border" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <Setter TargetName="borderUnderline" Property="Height" Value="1" />
-              <Setter TargetName="borderUnderline" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="False" />
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.OutlineInactiveBorder}" />
-              <Setter TargetName="HintWrapper" Property="Opacity">
-                <Setter.Value>
-                  <Binding Converter="{StaticResource MathMultiplyConverter}"
-                           ConverterParameter="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}"
-                           Path="(wpf:HintAssist.HintOpacity)"
-                           RelativeSource="{RelativeSource TemplatedParent}" />
-                </Setter.Value>
-              </Setter>
-              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <Setter TargetName="PART_ContentHost" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-            </MultiTrigger>
-
-            <!-- IsKeyboardFocused -->
-            <Trigger Property="IsKeyboardFocused" Value="True">
-              <Setter TargetName="Underline" Property="IsActive" Value="True" />
-            </Trigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsKeyboardFocused" Value="True" />
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
-              <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TimePickerAssist.OutlinedBorderActiveThickness)}" />
-              <Setter TargetName="border" Property="Margin">
-                <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedDateTimePickerActiveBorderThicknessConverter}">
-                    <Binding Path="(wpf:TimePickerAssist.OutlinedBorderInactiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
-                    <Binding Path="(wpf:TimePickerAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
-                  </MultiBinding>
-                </Setter.Value>
-              </Setter>
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsKeyboardFocused" Value="True" />
-                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="borderUnderline" Property="Height" Value="2" />
-            </MultiTrigger>
-
-            <!-- IsMouseOver -->
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsMouseOver" Value="True" />
-                <Condition Property="wpf:TextFieldAssist.NewSpecHighlightingEnabled" Value="False" />
-              </MultiTrigger.Conditions>
-              <Setter Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsMouseOver" Value="True" />
-                <Condition Property="wpf:TextFieldAssist.NewSpecHighlightingEnabled" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="border" Property="BorderThickness" Value="0,0,0,2" />
-              <Setter TargetName="border" Property="Padding" Value="0,4,0,3" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsMouseOver" Value="True" />
-                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
-              <Setter TargetName="borderUnderline" Property="Height" Value="1" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsMouseOver" Value="True" />
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TimePickerAssist.OutlinedBorderActiveThickness)}" />
-              <Setter TargetName="border" Property="Margin">
-                <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedDateTimePickerActiveBorderThicknessConverter}">
-                    <Binding Path="(wpf:TimePickerAssist.OutlinedBorderInactiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
-                    <Binding Path="(wpf:TimePickerAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
-                  </MultiBinding>
-                </Setter.Value>
-              </Setter>
-            </MultiTrigger>
-
-            <!-- Validation.HasError -->
-            <Trigger Property="Validation.HasError" Value="true">
-              <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
-              <Setter TargetName="Underline" Property="Background" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
-            </Trigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="Validation.HasError" Value="True" />
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
-              <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TimePickerAssist.OutlinedBorderActiveThickness)}" />
-              <Setter TargetName="border" Property="Margin">
-                <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedDateTimePickerActiveBorderThicknessConverter}">
-                    <Binding Path="(wpf:TimePickerAssist.OutlinedBorderInactiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
-                    <Binding Path="(wpf:TimePickerAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
-                  </MultiBinding>
-                </Setter.Value>
-              </Setter>
-            </MultiTrigger>
-          </ControlTemplate.Triggers>
-        </ControlTemplate>
-      </Setter.Value>
-    </Setter>
-    <Setter Property="Validation.ErrorTemplate" Value="{StaticResource MaterialDesignValidationErrorTemplate}" />
-    <Setter Property="VerticalContentAlignment" Value="Top" />
-    <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
-    <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMargin}" />
-    <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
-  </Style>
-
 
   <Style x:Key="MaterialDesignTimePicker" TargetType="{x:Type wpf:TimePicker}">
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
@@ -524,6 +40,13 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type wpf:TimePicker}">
           <ControlTemplate.Resources>
+            <converters:ThicknessCloneConverter x:Key="TimePickerTextBoxPaddingConverter"
+                                                AdditionalOffsetRight="18"
+                                                CloneEdges="All" />
+            <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverter"
+                                                CloneEdges="Top,Right,Bottom"
+                                                FixedLeft="0" />
+
             <ControlTemplate x:Key="ClockButtonTemplate" TargetType="{x:Type Button}">
               <wpf:PackIcon VerticalAlignment="Center"
                             Background="Transparent"
@@ -531,10 +54,9 @@
                             Kind="ClockOutline" />
             </ControlTemplate>
           </ControlTemplate.Resources>
-          <Grid x:Name="PART_Root">
+          <Grid>
             <wpf:TimePickerTextBox x:Name="PART_TextBox"
                                    Padding="{TemplateBinding Padding, Converter={StaticResource TimePickerTextBoxPaddingConverter}}"
-                                   HorizontalAlignment="Stretch"
                                    VerticalAlignment="Stretch"
                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                    VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -543,32 +65,45 @@
                                    wpf:HintAssist.FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
                                    wpf:HintAssist.Foreground="{TemplateBinding wpf:HintAssist.Foreground}"
                                    wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
-                                   wpf:HintAssist.HelperText="{TemplateBinding wpf:HintAssist.HelperText}"
-                                   wpf:HintAssist.HelperTextFontSize="{TemplateBinding wpf:HintAssist.HelperTextFontSize}"
                                    wpf:HintAssist.HelperTextStyle="{TemplateBinding wpf:HintAssist.HelperTextStyle}"
                                    wpf:HintAssist.Hint="{TemplateBinding wpf:HintAssist.Hint}"
                                    wpf:HintAssist.HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                    wpf:HintAssist.IsFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                                   wpf:TextFieldAssist.HasLeadingIcon="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon}"
+                                   wpf:TextFieldAssist.LeadingIcon="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
+                                   wpf:TextFieldAssist.LeadingIconSize="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
+                                   wpf:TextFieldAssist.HasTrailingIcon="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon}"
+                                   wpf:TextFieldAssist.TrailingIcon="{TemplateBinding wpf:TextFieldAssist.TrailingIcon}"
+                                   wpf:TextFieldAssist.TrailingIconSize="{TemplateBinding wpf:TextFieldAssist.TrailingIconSize}"
                                    wpf:TextFieldAssist.DecorationVisibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}"
                                    wpf:TextFieldAssist.HasClearButton="{TemplateBinding wpf:TextFieldAssist.HasClearButton}"
                                    wpf:TextFieldAssist.HasFilledTextField="{TemplateBinding wpf:TextFieldAssist.HasFilledTextField}"
                                    wpf:TextFieldAssist.HasOutlinedTextField="{TemplateBinding wpf:TextFieldAssist.HasOutlinedTextField}"
                                    wpf:TextFieldAssist.NewSpecHighlightingEnabled="{TemplateBinding wpf:TextFieldAssist.NewSpecHighlightingEnabled}"
                                    wpf:TextFieldAssist.PrefixText="{TemplateBinding wpf:TextFieldAssist.PrefixText}"
+                                   wpf:TextFieldAssist.PrefixTextVisibility="{TemplateBinding wpf:TextFieldAssist.PrefixTextVisibility}"
+                                   wpf:TextFieldAssist.PrefixTextHintBehavior="{TemplateBinding wpf:TextFieldAssist.PrefixTextHintBehavior}"
                                    wpf:TextFieldAssist.RippleOnFocusEnabled="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled}"
                                    wpf:TextFieldAssist.SuffixText="{TemplateBinding wpf:TextFieldAssist.SuffixText}"
+                                   wpf:TextFieldAssist.SuffixTextVisibility="{TemplateBinding wpf:TextFieldAssist.SuffixTextVisibility}"
+                                   wpf:TextFieldAssist.SuffixTextHintBehavior="{TemplateBinding wpf:TextFieldAssist.SuffixTextHintBehavior}"
+                                   wpf:TextFieldAssist.IconVerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
+                                   wpf:TextFieldAssist.TextBoxViewVerticalAlignment="{TemplateBinding wpf:TextFieldAssist.TextBoxViewVerticalAlignment}"
                                    wpf:TextFieldAssist.TextBoxViewMargin="{TemplateBinding wpf:TextFieldAssist.TextBoxViewMargin}"
                                    wpf:TextFieldAssist.TextFieldCornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                                    wpf:TextFieldAssist.UnderlineBrush="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
                                    wpf:TextFieldAssist.UnderlineCornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
+                                   BorderThickness="{TemplateBinding BorderThickness}"
                                    BorderBrush="{TemplateBinding BorderBrush}"
                                    Focusable="{TemplateBinding Focusable}"
-                                   Style="{DynamicResource MaterialDesignTimePickerTextBox}" />
+                                   Style="{DynamicResource NestedTextBoxStyle}" />
+
+            <!-- VerticalAlignment=Center to follow the default ComboBox style where the arrow is always vertically centered. Could be problematic to try to calculate the offset because it needs to be v-centered in relation to the content of the nested TextBox -->
             <Button x:Name="PART_Button"
                     Height="16"
                     Margin="{TemplateBinding Padding, Converter={StaticResource PartButtonMarginConverter}}"
                     HorizontalAlignment="Right"
-                    VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource VerticalAlignmentConverter}}"
+                    VerticalAlignment="Center"
                     Focusable="False"
                     Foreground="{TemplateBinding BorderBrush}"
                     Template="{StaticResource ClockButtonTemplate}" />
@@ -581,30 +116,7 @@
                    StaysOpen="False" />
           </Grid>
           <ControlTemplate.Triggers>
-
-            <!-- PART_Button margins adhering to VerticalContentAlignment for default/filled style when VerticalContentAlignment=Top (other cases handled by default value) -->
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition SourceName="PART_Button" Property="VerticalAlignment" Value="Top" />
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="PART_Button" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource PartButtonMarginConverterTop}}" />
-            </MultiTrigger>
-
-            <Trigger Property="wpf:TextFieldAssist.HasFilledTextField" Value="True">
-              <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.FilledBackground}" />
-            </Trigger>
-            <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
-              <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.Header.Foreground}" />
-            </Trigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
-                <Condition Property="IsMouseOver" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
-            </MultiTrigger>
+            <!-- PART_Button hovering -->
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="IsEnabled" Value="True" />
@@ -615,31 +127,10 @@
             <Trigger Property="IsEnabled" Value="False">
               <Setter TargetName="PART_Button" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
             </Trigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="False" />
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="PART_TextBox" Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.OutlineInactiveBorder}" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition SourceName="PART_TextBox" Property="IsKeyboardFocused" Value="True" />
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="PART_TextBox" Property="BorderBrush" Value="{Binding Path=(wpf:TextFieldAssist.UnderlineBrush), RelativeSource={RelativeSource Self}}" />
-            </MultiTrigger>
 
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsMouseOver" Value="True" />
-                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
-            </MultiTrigger>
-
+            <!-- Validation.HasError -->
             <Trigger Property="Validation.HasError" Value="True">
-              <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
+              <Setter TargetName="PART_TextBox" Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
               <Setter TargetName="PART_TextBox" Property="wpf:ValidationAssist.HasError" Value="True" />
             </Trigger>
           </ControlTemplate.Triggers>
@@ -649,6 +140,7 @@
     <Setter Property="Validation.ErrorTemplate" Value="{StaticResource MaterialDesignValidationErrorTemplate}" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="wpf:HintAssist.HelperTextStyle" Value="{StaticResource MaterialDesignHelperTextBlock}" />
     <Setter Property="internal:ClearText.HandlesClearCommand" Value="True" />
     <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
     <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMargin}" />
@@ -658,13 +150,21 @@
   <Style x:Key="MaterialDesignFloatingHintTimePicker"
          TargetType="{x:Type wpf:TimePicker}"
          BasedOn="{StaticResource MaterialDesignTimePicker}">
+    <Style.Resources>
+      <Style x:Key="NestedTextBoxStyle" TargetType="wpf:TimePickerTextBox" BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}" />
+    </Style.Resources>
     <Setter Property="wpf:HintAssist.IsFloating" Value="True" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.FloatingTextBoxDefaultPadding}" />
   </Style>
 
   <Style x:Key="MaterialDesignFilledTimePicker"
          TargetType="{x:Type wpf:TimePicker}"
          BasedOn="{StaticResource MaterialDesignFloatingHintTimePicker}">
-    <Setter Property="Padding" Value="16,8" />
+    <Style.Resources>
+      <Style x:Key="NestedTextBoxStyle" TargetType="wpf:TimePickerTextBox" BasedOn="{StaticResource MaterialDesignFilledTextBox}" />
+    </Style.Resources>
+    <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.FilledBackground}" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants+TemporaryConstants.FilledTextBoxDefaultPaddingNew}" />
     <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />
     <Setter Property="wpf:TextFieldAssist.UnderlineCornerRadius" Value="0" />
@@ -673,7 +173,12 @@
   <Style x:Key="MaterialDesignOutlinedTimePicker"
          TargetType="{x:Type wpf:TimePicker}"
          BasedOn="{StaticResource MaterialDesignFloatingHintTimePicker}">
-    <Setter Property="Padding" Value="16" />
+    <Style.Resources>
+      <Style x:Key="NestedTextBoxStyle" TargetType="wpf:TimePickerTextBox" BasedOn="{StaticResource MaterialDesignOutlinedTextBox}" />
+    </Style.Resources>
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.OutlineBorder}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.OutlinedTextBoxDefaultPadding}" />
     <Setter Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />
   </Style>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -46,6 +46,8 @@
             <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverter"
                                                 CloneEdges="Top,Right,Bottom"
                                                 FixedLeft="0" />
+            <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderInactiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderInactiveThickness}" />
+            <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderActiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderActiveThickness}" />
 
             <ControlTemplate x:Key="ClockButtonTemplate" TargetType="{x:Type Button}">
               <wpf:PackIcon VerticalAlignment="Center"
@@ -93,10 +95,22 @@
                                    wpf:TextFieldAssist.TextFieldCornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                                    wpf:TextFieldAssist.UnderlineBrush="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
                                    wpf:TextFieldAssist.UnderlineCornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
-                                   BorderThickness="{TemplateBinding BorderThickness}"
                                    BorderBrush="{TemplateBinding BorderBrush}"
                                    Focusable="{TemplateBinding Focusable}"
-                                   Style="{DynamicResource NestedTextBoxStyle}" />
+                                   Style="{DynamicResource NestedTextBoxStyle}">
+              <wpf:TimePickerTextBox.BorderThickness>
+                <PriorityBinding>
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TimePickerAssist.OutlinedBorderInactiveThickness)" Converter="{StaticResource OutlinedBorderInactiveThicknessConverter}" />
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="BorderThickness" />
+                </PriorityBinding>
+              </wpf:TimePickerTextBox.BorderThickness>
+              <wpf:TextFieldAssist.OutlinedBorderActiveThickness>
+                <PriorityBinding>
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TimePickerAssist.OutlinedBorderActiveThickness)" Converter="{StaticResource OutlinedBorderActiveThicknessConverter}" />
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" />
+                </PriorityBinding>
+              </wpf:TextFieldAssist.OutlinedBorderActiveThickness>
+            </wpf:TimePickerTextBox>
 
             <!-- VerticalAlignment=Center to follow the default ComboBox style where the arrow is always vertically centered. Could be problematic to try to calculate the offset because it needs to be v-centered in relation to the content of the nested TextBox -->
             <Button x:Name="PART_Button"
@@ -177,7 +191,7 @@
       <Style x:Key="NestedTextBoxStyle" TargetType="wpf:TimePickerTextBox" BasedOn="{StaticResource MaterialDesignOutlinedTextBox}" />
     </Style.Resources>
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.OutlineBorder}" />
-    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="BorderThickness" Value="{x:Static wpf:Constants.DefaultOutlinedBorderInactiveThickness}" />
     <Setter Property="Padding" Value="{x:Static wpf:Constants.OutlinedTextBoxDefaultPadding}" />
     <Setter Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
     <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />

--- a/MaterialDesignThemes.Wpf/TimePickerAssist.cs
+++ b/MaterialDesignThemes.Wpf/TimePickerAssist.cs
@@ -1,33 +1,16 @@
 ﻿namespace MaterialDesignThemes.Wpf;
 
+/* TODO: We should obsolete this class in favor of the TextBoxAssist equivalents. */
+[Obsolete("This class is obsolete and will be removed in a future version. Please use the TextBoxAssist equivalents instead. For OutlinedBorderInactiveThickness, simply use BorderThickness property instead.")]
 public static class TimePickerAssist
 {
-    private static Thickness DefaultOutlinedBorderInactiveThickness { get; } = new(1);
-    private static Thickness DefaultOutlinedBorderActiveThickness { get; } = new(2);
-
     public static readonly DependencyProperty OutlinedBorderInactiveThicknessProperty = DependencyProperty.RegisterAttached(
-        "OutlinedBorderInactiveThickness", typeof(Thickness), typeof(TimePickerAssist), new FrameworkPropertyMetadata(DefaultOutlinedBorderInactiveThickness, FrameworkPropertyMetadataOptions.Inherits));
-
-    public static void SetOutlinedBorderInactiveThickness(DependencyObject element, Thickness value)
-    {
-        element.SetValue(OutlinedBorderInactiveThicknessProperty, value);
-    }
-
-    public static Thickness GetOutlinedBorderInactiveThickness(DependencyObject element)
-    {
-        return (Thickness)element.GetValue(OutlinedBorderInactiveThicknessProperty);
-    }
+        "OutlinedBorderInactiveThickness", typeof(Thickness), typeof(TimePickerAssist), new FrameworkPropertyMetadata(Constants.DefaultOutlinedBorderInactiveThickness, FrameworkPropertyMetadataOptions.Inherits));
+    public static void SetOutlinedBorderInactiveThickness(DependencyObject element, Thickness value) => element.SetValue(OutlinedBorderInactiveThicknessProperty, value);
+    public static Thickness GetOutlinedBorderInactiveThickness(DependencyObject element) => (Thickness)element.GetValue(OutlinedBorderInactiveThicknessProperty);
 
     public static readonly DependencyProperty OutlinedBorderActiveThicknessProperty = DependencyProperty.RegisterAttached(
-        "OutlinedBorderActiveThickness", typeof(Thickness), typeof(TimePickerAssist), new FrameworkPropertyMetadata(DefaultOutlinedBorderActiveThickness, FrameworkPropertyMetadataOptions.Inherits));
-
-    public static void SetOutlinedBorderActiveThickness(DependencyObject element, Thickness value)
-    {
-        element.SetValue(OutlinedBorderActiveThicknessProperty, value);
-    }
-
-    public static Thickness GetOutlinedBorderActiveThickness(DependencyObject element)
-    {
-        return (Thickness)element.GetValue(OutlinedBorderActiveThicknessProperty);
-    }
+        "OutlinedBorderActiveThickness", typeof(Thickness), typeof(TimePickerAssist), new FrameworkPropertyMetadata(Constants.DefaultOutlinedBorderActiveThickness, FrameworkPropertyMetadataOptions.Inherits));
+    public static void SetOutlinedBorderActiveThickness(DependencyObject element, Thickness value) => element.SetValue(OutlinedBorderActiveThicknessProperty, value);
+    public static Thickness GetOutlinedBorderActiveThickness(DependencyObject element) => (Thickness)element.GetValue(OutlinedBorderActiveThicknessProperty);
 }


### PR DESCRIPTION
This PR adopts the new `SmartHint` approach in the `TimePicker` style.

It modifies the `TextBlock` style slightly, such that it can be leveraged in the `TimePicker` style instead of having a nearly full replica of the `TextBox` style.

* Extends `TextBox` with the option to control inactive/active border thickness. This was already present for `DatePicker`/`TimePicker` and is now generalized for the `TextBox`.
  - Obsoletes the more specific AP's which serve the same purpose but for `DatePicker`/`TimePicker` only.
* Maintains back-compat of obsoletions above using a `PriorityBinding`.
* Removes "replica" `TextBox`  style from the `TimePicker` template.
* Simplifies the `TimePicker` template and "adopts" the `SmartHint` approach by leveraging a full-fledged `TextBox` (with the appropriate style being forwarded in).