### PR TITLE
Add missing converter in MD3 demo app MainWindow

### DIFF
--- a/MaterialDesign3.Demo.Wpf/MainWindow.xaml
+++ b/MaterialDesign3.Demo.Wpf/MainWindow.xaml
@@ -41,6 +41,10 @@
                   Style="{StaticResource MaterialDesignFlatButton}" />
         </StackPanel>
       </DataTemplate>
+
+      <materialDesign:BooleanToVisibilityConverter x:Key="InverseBoolToVisConverter"
+                                                   FalseValue="Visible"
+                                                   TrueValue="Collapsed" />
     </ResourceDictionary>
   </Window.Resources>
 


### PR DESCRIPTION
Fixes #3541 (MD3 demo app crash)

Apparently the MD3 demo app was leveraging a converter exposed in one of the MDIX resource dictionaries, and that has probably disappeared with some of the `SmartHint` refactorings.

This explicitly introduces the converter back into the `MainWindow` of the MD3 demo app, and the application now starts up again.