### PR TITLE
Fix hover issue on DatePicker and TimePicker

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Internal/InternalTextFieldAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/Internal/InternalTextFieldAssist.cs
@@ -1,0 +1,13 @@
+﻿namespace MaterialDesignThemes.Wpf.Internal;
+
+public static class InternalTextFieldAssist
+{
+    /// <summary>
+    /// Used by text field "wrappers" (i.e. controls hosting a text field and decorating on top of it) to signal to the text field that the mouse is over it,
+    /// when in fact it is over a sibling (i.e. something in the wrapper) which is visually placed on top of the text field.
+    /// </summary>
+    public static readonly DependencyProperty IsMouseOverProperty = DependencyProperty.RegisterAttached(
+        "IsMouseOver", typeof(bool), typeof(InternalTextFieldAssist), new PropertyMetadata(default(bool)));
+    public static void SetIsMouseOver(DependencyObject element, bool value) => element.SetValue(IsMouseOverProperty, value);
+    public static bool GetIsMouseOver(DependencyObject element) => (bool)element.GetValue(IsMouseOverProperty);
+}

--- a/src/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -9,15 +9,6 @@ namespace MaterialDesignThemes.Wpf;
 public static class TextFieldAssist
 {
     /// <summary>
-    /// Used by text field "wrappers" (i.e. controls hosting a text field and decorating on top of it) to signal to the text field that the mouse is over it,
-    /// when in fact it is over a sibling (i.e. something in the wrapper) which is visually placed on top of the text field.
-    /// </summary>
-    public static readonly DependencyProperty IsMouseOverProperty = DependencyProperty.RegisterAttached(
-        "IsMouseOver", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(default(bool)));
-    public static void SetIsMouseOver(DependencyObject element, bool value) => element.SetValue(IsMouseOverProperty, value);
-    public static bool GetIsMouseOver(DependencyObject element) => (bool) element.GetValue(IsMouseOverProperty);
-
-    /// <summary>
     /// The text box view margin property
     /// </summary>
     public static readonly DependencyProperty TextBoxViewMarginProperty = DependencyProperty.RegisterAttached(

--- a/src/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -9,6 +9,15 @@ namespace MaterialDesignThemes.Wpf;
 public static class TextFieldAssist
 {
     /// <summary>
+    /// Used by text field "wrappers" (i.e. controls hosting a text field and decorating on top of it) to signal to the text field that the mouse is over it,
+    /// when in fact it is over a sibling (i.e. something in the wrapper) which is visually placed on top of the text field.
+    /// </summary>
+    public static readonly DependencyProperty IsMouseOverProperty = DependencyProperty.RegisterAttached(
+        "IsMouseOver", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(default(bool)));
+    public static void SetIsMouseOver(DependencyObject element, bool value) => element.SetValue(IsMouseOverProperty, value);
+    public static bool GetIsMouseOver(DependencyObject element) => (bool) element.GetValue(IsMouseOverProperty);
+
+    /// <summary>
     /// The text box view margin property
     /// </summary>
     public static readonly DependencyProperty TextBoxViewMarginProperty = DependencyProperty.RegisterAttached(

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -86,6 +86,7 @@
                                wpf:TextFieldAssist.TextFieldCornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                                wpf:TextFieldAssist.UnderlineBrush="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
                                wpf:TextFieldAssist.UnderlineCornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
+                               wpf:TextFieldAssist.IsMouseOver="{TemplateBinding IsMouseOver}"
                                BorderBrush="{TemplateBinding BorderBrush}"
                                Focusable="{TemplateBinding Focusable}"
                                Style="{DynamicResource NestedTextBoxStyle}">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -86,7 +86,7 @@
                                wpf:TextFieldAssist.TextFieldCornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                                wpf:TextFieldAssist.UnderlineBrush="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
                                wpf:TextFieldAssist.UnderlineCornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
-                               wpf:TextFieldAssist.IsMouseOver="{TemplateBinding IsMouseOver}"
+                               internal:InternalTextFieldAssist.IsMouseOver="{TemplateBinding IsMouseOver}"
                                BorderBrush="{TemplateBinding BorderBrush}"
                                Focusable="{TemplateBinding Focusable}"
                                Style="{DynamicResource NestedTextBoxStyle}">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -446,11 +446,11 @@
             <!-- IsMouseOver -->
             <Trigger Property="IsMouseOver" Value="True">
               <!-- If the mouse is over the text field itself, we explicitly override the AP so the subsequent triggers will take effect --> 
-              <Setter Property="wpf:TextFieldAssist.IsMouseOver" Value="True" />
+              <Setter Property="internal:InternalTextFieldAssist.IsMouseOver" Value="True" />
             </Trigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
-                <Condition Property="wpf:TextFieldAssist.IsMouseOver" Value="True"  />
+                <Condition Property="internal:InternalTextFieldAssist.IsMouseOver" Value="True"  />
                 <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.NewSpecHighlightingEnabled" Value="False" />
@@ -459,7 +459,7 @@
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
-                <Condition Property="wpf:TextFieldAssist.IsMouseOver" Value="True" />
+                <Condition Property="internal:InternalTextFieldAssist.IsMouseOver" Value="True" />
                 <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.NewSpecHighlightingEnabled" Value="True" />
@@ -469,7 +469,7 @@
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
-                <Condition Property="wpf:TextFieldAssist.IsMouseOver" Value="True" />
+                <Condition Property="internal:InternalTextFieldAssist.IsMouseOver" Value="True" />
                 <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterBorder" Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
@@ -477,7 +477,7 @@
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
-                <Condition Property="wpf:TextFieldAssist.IsMouseOver" Value="True" />
+                <Condition Property="internal:InternalTextFieldAssist.IsMouseOver" Value="True" />
                 <Condition Property="Validation.HasError" Value="False" />
                 <Condition Property="wpf:ValidationAssist.HasError" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
@@ -494,7 +494,7 @@
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
-                <Condition Property="wpf:TextFieldAssist.IsMouseOver" Value="True" />
+                <Condition Property="internal:InternalTextFieldAssist.IsMouseOver" Value="True" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
                 <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
                 <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -444,9 +444,13 @@
             </MultiTrigger>
 
             <!-- IsMouseOver -->
+            <Trigger Property="IsMouseOver" Value="True">
+              <!-- If the mouse is over the text field itself, we explicitly override the AP so the subsequent triggers will take effect --> 
+              <Setter Property="wpf:TextFieldAssist.IsMouseOver" Value="True" />
+            </Trigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
-                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.IsMouseOver" Value="True"  />
                 <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.NewSpecHighlightingEnabled" Value="False" />
@@ -455,7 +459,7 @@
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
-                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.IsMouseOver" Value="True" />
                 <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.NewSpecHighlightingEnabled" Value="True" />
@@ -465,7 +469,7 @@
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
-                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.IsMouseOver" Value="True" />
                 <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterBorder" Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
@@ -473,7 +477,7 @@
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
-                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.IsMouseOver" Value="True" />
                 <Condition Property="Validation.HasError" Value="False" />
                 <Condition Property="wpf:ValidationAssist.HasError" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
@@ -490,7 +494,7 @@
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
-                <Condition Property="IsMouseOver" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.IsMouseOver" Value="True" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
                 <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
                 <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -98,7 +98,7 @@
                                    wpf:TextFieldAssist.TextFieldCornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                                    wpf:TextFieldAssist.UnderlineBrush="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
                                    wpf:TextFieldAssist.UnderlineCornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
-                                   wpf:TextFieldAssist.IsMouseOver="{TemplateBinding IsMouseOver}"
+                                   internal:InternalTextFieldAssist.IsMouseOver="{TemplateBinding IsMouseOver}"
                                    BorderBrush="{TemplateBinding BorderBrush}"
                                    Focusable="{TemplateBinding Focusable}"
                                    Style="{DynamicResource NestedTextBoxStyle}">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -98,6 +98,7 @@
                                    wpf:TextFieldAssist.TextFieldCornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                                    wpf:TextFieldAssist.UnderlineBrush="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
                                    wpf:TextFieldAssist.UnderlineCornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
+                                   wpf:TextFieldAssist.IsMouseOver="{TemplateBinding IsMouseOver}"
                                    BorderBrush="{TemplateBinding BorderBrush}"
                                    Focusable="{TemplateBinding Focusable}"
                                    Style="{DynamicResource NestedTextBoxStyle}">

--- a/tests/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
@@ -310,7 +310,7 @@ public class DatePickerTests : TestBase
         await using var recorder = new TestRecorder(App);
 
         // Arrange
-        Thickness expectedThickness = new(2);
+        Thickness expectedThickness = Constants.DefaultOutlinedBorderActiveThickness;
         var stackPanel = await LoadXaml<StackPanel>("""
             <StackPanel>
               <DatePicker

--- a/tests/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
@@ -302,6 +302,40 @@ public class DatePickerTests : TestBase
 
         recorder.Success();
     }
+
+    [Fact]
+    [Description("Issue 3547")]
+    public async Task DatePicker_ShouldApplyIsMouseOverTriggers_WhenHoveringCalendarButton()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // Arrange
+        Thickness expectedThickness = new(2);
+        var stackPanel = await LoadXaml<StackPanel>("""
+            <StackPanel>
+              <DatePicker
+                Style="{StaticResource MaterialDesignOutlinedDatePicker}" />
+            </StackPanel>
+            """);
+        var datePicker = await stackPanel.GetElement<DatePicker>("/DatePicker");
+        var datePickerTextBox = await datePicker.GetElement<DatePickerTextBox>("/DatePickerTextBox");
+        var datePickerTextBoxBorder = await datePickerTextBox.GetElement<Border>("OuterBorder");
+        var datePickerTimeButton = await datePicker.GetElement<Button>("PART_Button");
+
+        // Act
+        await datePickerTextBoxBorder.MoveCursorTo();
+        await Task.Delay(50);
+        var datePickerTextBoxHoverThickness = await datePickerTextBoxBorder.GetBorderThickness();
+        await datePickerTimeButton.MoveCursorTo();
+        await Task.Delay(50);
+        var datePickerCalendarButtonHoverThickness = await datePickerTextBoxBorder.GetBorderThickness();
+
+        // Assert
+        Assert.Equal(expectedThickness, datePickerTextBoxHoverThickness);
+        Assert.Equal(expectedThickness, datePickerCalendarButtonHoverThickness);
+
+        recorder.Success();
+    }
 }
 
 public class FutureDateValidationRule : ValidationRule

--- a/tests/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
@@ -617,7 +617,7 @@ public class TimePickerTests : TestBase
         await using var recorder = new TestRecorder(App);
 
         // Arrange
-        Thickness expectedThickness = new(2);
+        Thickness expectedThickness = Constants.DefaultOutlinedBorderActiveThickness;
         var stackPanel = await LoadXaml<StackPanel>("""
             <StackPanel>
               <materialDesign:TimePicker

--- a/tests/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
@@ -609,6 +609,40 @@ public class TimePickerTests : TestBase
 
         recorder.Success();
     }
+
+    [Fact]
+    [Description("Issue 3547")]
+    public async Task TimePicker_ShouldApplyIsMouseOverTriggers_WhenHoveringTimeButton()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // Arrange
+        Thickness expectedThickness = new(2);
+        var stackPanel = await LoadXaml<StackPanel>("""
+            <StackPanel>
+              <materialDesign:TimePicker
+                Style="{StaticResource MaterialDesignOutlinedTimePicker}" />
+            </StackPanel>
+            """);
+        var timePicker = await stackPanel.GetElement<TimePicker>("/TimePicker");
+        var timePickerTextBox = await timePicker.GetElement<TimePickerTextBox>("/TimePickerTextBox");
+        var timePickerTextBoxBorder = await timePickerTextBox.GetElement<Border>("OuterBorder");
+        var timePickerTimeButton = await timePicker.GetElement<Button>("PART_Button");
+
+        // Act
+        await timePickerTextBoxBorder.MoveCursorTo();
+        await Task.Delay(50);
+        var timePickerTextBoxHoverThickness = await timePickerTextBoxBorder.GetBorderThickness();
+        await timePickerTimeButton.MoveCursorTo();
+        await Task.Delay(50);
+        var timePickerTimeButtonHoverThickness = await timePickerTextBoxBorder.GetBorderThickness();
+
+        // Assert
+        Assert.Equal(expectedThickness, timePickerTextBoxHoverThickness);
+        Assert.Equal(expectedThickness, timePickerTimeButtonHoverThickness);
+
+        recorder.Success();
+    }
 }
 
 public class OnlyTenOClockValidationRule : ValidationRule


### PR DESCRIPTION
Fixes #3547 

Please double check if you feel there are any negative side-effects to this fix. It is a slight hack in my opinion, but one that I currently cannot really see how we can avoid if we want to leverage the existing `TextBox` style in other "wrapper" controls like the `DatePicker` and `TimePicker`.

The PR introduces a new attached property which the "wrapper" (i.e. `DatePicker`/`TimePicker`) can use to communicate its `IsMouseOver` state down to the nested `TextBox`. The `TextBox` in turn relies on this `TextFieldAssist.IsMouseOver` to determinne whether the mouse is over it or not. To also handle the "normal case", it first inspects its own `IsMouseOver` for a `true` value and if so, overrides the value of the AP to `true` for the subsequent triggers to take effect.

I added 2 UI tests to cover the cases; red-green approach. Currently only for the outlined style, other tests could be added for the other styles if we feel the need.

**Note:** The color of the time/calendar button when it is hovered is the primary color; whether that is what we want or not I don't know, but that is a different issue.

Before:
![TextFieldWrapperIsMouseOverIssue](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/62b125ff-1997-48ae-a0fc-5b8ea7752e6e)

After:
![TextFieldWrapperIsMouseOverIssuePotentialFix](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/373fc1b4-9870-4d05-80c8-82614fca19f7)
