### PR TITLE
GroupBoxAssist.HeaderPadding

### DIFF
--- a/src/MainDemo.Wpf/GroupBoxes.xaml
+++ b/src/MainDemo.Wpf/GroupBoxes.xaml
@@ -95,12 +95,39 @@
         </GroupBox>
       </smtx:XamlDisplay>
     </WrapPanel>
+    
+    <Rectangle Style="{StaticResource PageSectionSeparator}" />
+    <TextBlock Style="{StaticResource PageSectionTitleTextBlock}" Text="Header Padding" />
+
+    <WrapPanel>
+      <smtx:XamlDisplay UniqueKey="groupbox_7">
+        <GroupBox Width="300" Height="100" Header="Header"
+                  materialDesign:GroupBoxAssist.HeaderPadding="4" Padding="0"
+                  Style="{StaticResource MaterialDesignGroupBox}">
+          <ScrollViewer>
+            <TextBlock Margin="8" TextWrapping="Wrap"
+              Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />
+          </ScrollViewer>
+        </GroupBox>
+      </smtx:XamlDisplay>
+
+      <smtx:XamlDisplay UniqueKey="groupbox_8">
+        <GroupBox Width="300" Height="100" Header="Header"
+                  materialDesign:GroupBoxAssist.HeaderPadding="4" Padding="0"
+                  Style="{StaticResource MaterialDesignCardGroupBox}">
+          <ScrollViewer>
+            <TextBlock Margin="8" TextWrapping="Wrap"
+              Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />
+          </ScrollViewer>
+        </GroupBox>
+      </smtx:XamlDisplay>
+    </WrapPanel>
 
     <Rectangle Style="{StaticResource PageSectionSeparator}" />
     <TextBlock Style="{StaticResource PageSectionTitleTextBlock}" Text="Card" />
 
     <WrapPanel>
-      <smtx:XamlDisplay UniqueKey="groupbox_7">
+      <smtx:XamlDisplay UniqueKey="groupbox_9">
         <GroupBox Width="300"
                   Header="Card Group Box"
                   Style="{StaticResource MaterialDesignCardGroupBox}">
@@ -117,7 +144,7 @@
         </GroupBox>
       </smtx:XamlDisplay>
 
-      <smtx:XamlDisplay UniqueKey="groupbox_8">
+      <smtx:XamlDisplay UniqueKey="groupbox_10">
         <GroupBox Width="300"
                   materialDesign:ColorZoneAssist.Mode="SecondaryMid"
                   Header="Card Group Box Secondary"
@@ -144,7 +171,7 @@
         </GroupBox>
       </smtx:XamlDisplay>
 
-      <smtx:XamlDisplay UniqueKey="groupbox_9">
+      <smtx:XamlDisplay UniqueKey="groupbox_11">
         <GroupBox Width="300"
                   materialDesign:ColorZoneAssist.Mode="SecondaryMid"
                   Header="Card Group Box Accent"
@@ -171,7 +198,7 @@
         </GroupBox>
       </smtx:XamlDisplay>
 
-      <smtx:XamlDisplay UniqueKey="groupbox_10">
+      <smtx:XamlDisplay UniqueKey="groupbox_12">
         <GroupBox Width="300"
                   materialDesign:ColorZoneAssist.Background="Black"
                   materialDesign:ColorZoneAssist.Foreground="White"
@@ -202,7 +229,7 @@
 
       <smtx:XamlDisplay Grid.Row="3"
                         Grid.Column="0"
-                        UniqueKey="groupbox_11">
+                        UniqueKey="groupbox_13">
         <GroupBox Margin="16"
                   materialDesign:ElevationAssist.Elevation="Dp6"
                   Background="White"
@@ -215,7 +242,7 @@
       </smtx:XamlDisplay>
       <smtx:XamlDisplay Grid.Row="3"
                         Grid.Column="1"
-                        UniqueKey="groupbox_12">
+                        UniqueKey="groupbox_14">
         <GroupBox Margin="16"
                   materialDesign:ElevationAssist.Elevation="Dp6"
                   Background="White"
@@ -229,7 +256,7 @@
       </smtx:XamlDisplay>
       <smtx:XamlDisplay Grid.Row="3"
                         Grid.Column="2"
-                        UniqueKey="groupbox_13">
+                        UniqueKey="groupbox_15">
         <GroupBox Margin="16"
                   materialDesign:ElevationAssist.Elevation="Dp6"
                   Header="Elevation on Card"
@@ -240,6 +267,7 @@
         </GroupBox>
       </smtx:XamlDisplay>
     </WrapPanel>
+
   </StackPanel>
 </UserControl>
 

--- a/src/MaterialDesignThemes.Wpf/GroupBoxAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/GroupBoxAssist.cs
@@ -1,0 +1,14 @@
+﻿namespace MaterialDesignThemes.Wpf;
+
+public static class GroupBoxAssist
+{
+    private const double DefaultHeaderPadding = 9.0;
+
+    #region AttachedProperty : HeaderPaddingProperty
+    public static readonly DependencyProperty HeaderPaddingProperty
+            = DependencyProperty.RegisterAttached("HeaderPadding", typeof(double), typeof(GroupBoxAssist), new PropertyMetadata(DefaultHeaderPadding));
+
+    public static double GetHeaderPadding(GroupBox element) => (double)element.GetValue(HeaderPaddingProperty);
+    public static void SetHeaderPadding(GroupBox element, double headerPadding) => element.SetValue(HeaderPaddingProperty, headerPadding);
+    #endregion
+}

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.GroupBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.GroupBox.xaml
@@ -26,6 +26,7 @@
     <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
     <Setter Property="Padding" Value="9" />
+    <Setter Property="wpf:GroupBoxAssist.HeaderPadding" Value="9" />
     <Setter Property="SnapsToDevicePixels" Value="true" />
     <Setter Property="Template">
       <Setter.Value>
@@ -37,7 +38,7 @@
                     BorderThickness="{TemplateBinding BorderThickness}" />
             <DockPanel Margin="{TemplateBinding BorderThickness}">
               <wpf:ColorZone x:Name="PART_ColorZone"
-                             Padding="{TemplateBinding Padding}"
+                             Padding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:GroupBoxAssist.HeaderPadding)}"
                              wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
                              wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}"
                              DockPanel.Dock="Top"
@@ -78,6 +79,7 @@
     <Setter Property="BorderThickness" Value="0" />
     <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
     <Setter Property="Padding" Value="9" />
+    <Setter Property="wpf:GroupBoxAssist.HeaderPadding" Value="9" />
     <Setter Property="SnapsToDevicePixels" Value="true" />
     <Setter Property="Template">
       <Setter.Value>
@@ -85,7 +87,7 @@
           <wpf:Card VerticalAlignment="Stretch" wpf:ElevationAssist.Elevation="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation)}">
             <DockPanel Background="{TemplateBinding Background}">
               <wpf:ColorZone x:Name="PART_ColorZone"
-                             Padding="{TemplateBinding Padding}"
+                             Padding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:GroupBoxAssist.HeaderPadding)}"
                              wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
                              wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}"
                              DockPanel.Dock="Top"


### PR DESCRIPTION
Currently the padding of a GroupBox is applied to both the header as well as the content.
This is especially an issue when you want to add a ListBox or a ScrollViewer inside of a card.
To resolve this I introduced GroupBoxAssist.HeaderPadding.