### PR TITLE
Fixing out of range exception on tree view

### DIFF
--- a/src/MaterialDesignThemes.Wpf/TreeListView.cs
+++ b/src/MaterialDesignThemes.Wpf/TreeListView.cs
@@ -84,6 +84,8 @@ public class TreeListView : ListView
         if (InternalItemsSource is { } itemsSource)
         {
             int index = ItemContainerGenerator.IndexFromContainer(item);
+            //Issue 3572
+            if (index < 0) return;
             var children = item.GetChildren().ToList();
             bool isExpanded = item.IsExpanded;
             itemsSource.SetIsExpanded(index, isExpanded);


### PR DESCRIPTION
This occurs when IsExpanded is set on a virtualized container that has been removed.

Fixes #3572
