### PR TITLE
Fix smart hint resting opacity and (input control) enabled/disabled state

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -233,7 +233,7 @@
                       HorizontalAlignment="Right"
                       VerticalAlignment="Center"
                       Data="M7,10L12,15L17,10H7Z"
-                      Fill="{TemplateBinding BorderBrush}"
+                      Fill="{TemplateBinding Foreground}"
                       RenderTransformOrigin="0.5,0.5"
                       Stretch="Uniform" />
               </Border>
@@ -318,7 +318,9 @@
               <ColumnDefinition Width="0" MinWidth="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}" />
             </Grid.ColumnDefinitions>
             <ToggleButton x:Name="toggleButton"
+                          Foreground="{TemplateBinding Foreground}"
                           Grid.ColumnSpan="2"
+                          Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                           Padding="{TemplateBinding Padding}"
                           VerticalContentAlignment="Center"
                           BorderBrush="{TemplateBinding BorderBrush}"
@@ -476,9 +478,11 @@
               <Button x:Name="PART_ClearButton"
                       Grid.Column="5"
                       Height="Auto"
+                      Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                       Padding="2,0,0,0"
                       Command="{x:Static internal:ClearText.ClearCommand}"
                       Focusable="False"
+                      Foreground="{TemplateBinding Foreground}"
                       VerticalAlignment="Center"
                       Style="{StaticResource MaterialDesignToolButton}">
                 <Button.Visibility>
@@ -576,7 +580,6 @@
 
       <!-- Outlined combo box -->
       <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
-        <Setter TargetName="HintWrapper" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
         <Setter TargetName="PART_Popup" Property="ContentMargin" Value="6,0,6,6" />
         <Setter TargetName="PART_Popup" Property="ContentMinWidth" Value="{Binding Path=ActualWidth, ElementName=OuterBorder}" />
         <Setter TargetName="PART_Popup" Property="CornerRadius" Value="{Binding Path=(wpf:TextFieldAssist.TextFieldCornerRadius), RelativeSource={RelativeSource TemplatedParent}}" />
@@ -601,14 +604,19 @@
       </MultiTrigger>
 
       <!-- Floating hint -->
-      <Trigger Property="wpf:HintAssist.IsFloating" Value="True">
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+          <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+        </MultiTrigger.Conditions>
         <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
-      </Trigger>
+      </MultiTrigger>
       <MultiTrigger>
         <MultiTrigger.Conditions>
           <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
           <Condition Property="IsKeyboardFocusWithin" Value="True" />
         </MultiTrigger.Conditions>
+        <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
         <Setter TargetName="Hint" Property="Foreground" Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
       </MultiTrigger>
 
@@ -622,6 +630,7 @@
         <Setter TargetName="OuterBorder" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
         <Setter TargetName="OuterBorder" Property="wpf:BottomDashedLineAdorner.IsAttached" Value="True" />
         <Setter TargetName="OuterBorder" Property="wpf:BottomDashedLineAdorner.DashStyle" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TextFieldAssist.HasFilledTextField), Converter={StaticResource BooleanToDashStyleConverter}}" />
+        <Setter TargetName="toggleButton" Property="Opacity" Value="1" />
       </MultiTrigger>
       <MultiTrigger>
         <MultiTrigger.Conditions>
@@ -629,19 +638,15 @@
           <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
         </MultiTrigger.Conditions>
         <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ComboBox.OutlineInactiveBorder}" />
-        <Setter TargetName="HintWrapper" Property="Opacity">
-          <Setter.Value>
-            <Binding Converter="{StaticResource MathMultiplyConverter}"
-                     ConverterParameter="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}"
-                     Path="(wpf:HintAssist.HintOpacity)"
-                     RelativeSource="{RelativeSource TemplatedParent}" />
-          </Setter.Value>
-        </Setter>
-        <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-        <Setter TargetName="PART_EditableTextBox" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-        <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-        <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+        <Setter TargetName="HintWrapper" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+        <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+        <Setter TargetName="LeadingPackIcon" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
+        <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
+        <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
+        <Setter TargetName="TrailingPackIcon" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
         <Setter TargetName="contentPresenter" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+        <Setter TargetName="PART_EditableTextBox" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+        <Setter TargetName="toggleButton" Property="Opacity" Value="1" />
       </MultiTrigger>
 
       <!-- IsKeyboardFocused -->

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -134,6 +134,7 @@
             </MultiTrigger>
             <Trigger Property="IsEnabled" Value="False">
               <Setter TargetName="PART_Button" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+              <Setter TargetName="PART_TextBox" Property="IsReadOnly" Value="False" />
             </Trigger>
 
             <!-- Validation.HasError -->

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -39,6 +39,7 @@
                                                 FixedLeft="0" />
             <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderInactiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderInactiveThickness}" />
             <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderActiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderActiveThickness}" />
+            <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
 
             <ControlTemplate x:Key="CalendarButtonTemplate" TargetType="{x:Type Button}">
               <wpf:PackIcon VerticalAlignment="Center"
@@ -111,7 +112,8 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Center"
                     Focusable="False"
-                    Foreground="{TemplateBinding BorderBrush}"
+                    Foreground="{Binding ElementName=PART_TextBox, Path=Foreground}"
+                    Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                     Template="{StaticResource CalendarButtonTemplate}" />
             <Popup x:Name="PART_Popup"
                    AllowsTransparency="True"
@@ -131,7 +133,7 @@
               <Setter TargetName="PART_Button" Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
             </MultiTrigger>
             <Trigger Property="IsEnabled" Value="False">
-              <Setter TargetName="PART_Button" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+              <Setter TargetName="PART_Button" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
             </Trigger>
 
             <!-- Validation.HasError -->

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -276,8 +276,10 @@
                                 Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                   <Button x:Name="PART_ClearButton"
+                          Foreground="{TemplateBinding Foreground}"
                           Grid.Column="5"
                           Height="Auto"
+                          Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                           Padding="2,0,0,0"
                           Command="{x:Static internal:ClearText.ClearCommand}"
                           Focusable="False"
@@ -321,14 +323,19 @@
           </Grid>
           <ControlTemplate.Triggers>
             <!-- Floating hint -->
-            <Trigger Property="wpf:HintAssist.IsFloating" Value="True">
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+              </MultiTrigger.Conditions>
               <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
-            </Trigger>
+            </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
                 <Condition Property="IsKeyboardFocusWithin" Value="True" />
               </MultiTrigger.Conditions>
+              <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
               <Setter TargetName="Hint" Property="Foreground" Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
             </MultiTrigger>
 
@@ -347,7 +354,6 @@
 
             <!-- Outlined text field -->
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
-              <Setter TargetName="HintWrapper" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
               <Setter TargetName="Hint" Property="FloatingTarget" Value="{Binding ElementName=OuterBorder}" />
               <Setter TargetName="Hint" Property="FloatingAlignment" Value="Center" />
@@ -370,7 +376,6 @@
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterBorder" Property="BorderBrush" Value="Transparent" />
-              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
               <Setter TargetName="OuterBorder" Property="wpf:BottomDashedLineAdorner.IsAttached" Value="True" />
               <Setter TargetName="OuterBorder" Property="wpf:BottomDashedLineAdorner.DashStyle" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TextFieldAssist.HasFilledTextField), Converter={StaticResource BooleanToDashStyleConverter}}" />
               <Setter TargetName="ContentGrid" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
@@ -378,29 +383,16 @@
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="IsEnabled" Value="False" />
-                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="1" />
-              <Setter TargetName="OuterBorder" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
               </MultiTrigger.Conditions>
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.PasswordBox.OutlineInactiveBorder}" />
-              <Setter TargetName="HintWrapper" Property="Opacity">
-                <Setter.Value>
-                  <Binding Converter="{StaticResource MathMultiplyConverter}"
-                           ConverterParameter="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}"
-                           Path="(wpf:HintAssist.HintOpacity)"
-                           RelativeSource="{RelativeSource TemplatedParent}" />
-                </Setter.Value>
-              </Setter>
-              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
               <Setter TargetName="PART_ContentHost" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+              <Setter TargetName="HintWrapper" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
+              <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
+              <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
+              <Setter TargetName="TrailingPackIcon" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
             </MultiTrigger>
 
             <!-- IsKeyboardFocused -->
@@ -900,6 +892,7 @@
                   <ToggleButton x:Name="RevealPasswordButton"
                                 Grid.Column="4"
                                 Height="Auto"
+                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                 Padding="2,0,0,0"
                                 VerticalAlignment="Center"
                                 IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed), Mode=TwoWay}"
@@ -922,9 +915,11 @@
                   <Button x:Name="PART_ClearButton"
                           Grid.Column="6"
                           Height="Auto"
+                          Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                           Padding="2,0,0,0"
                           Command="{x:Static internal:ClearText.ClearCommand}"
                           Focusable="False"
+                          Foreground="{TemplateBinding Foreground}"
                           VerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
                           Style="{StaticResource MaterialDesignToolButton}">
                     <Button.Visibility>
@@ -965,14 +960,19 @@
           </Grid>
           <ControlTemplate.Triggers>
             <!-- Floating hint -->
-            <Trigger Property="wpf:HintAssist.IsFloating" Value="True">
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+              </MultiTrigger.Conditions>
               <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
-            </Trigger>
+            </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
                 <Condition Property="IsKeyboardFocusWithin" Value="True" />
               </MultiTrigger.Conditions>
+              <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
               <Setter TargetName="Hint" Property="Foreground" Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
             </MultiTrigger>
 
@@ -991,7 +991,6 @@
 
             <!-- Outlined text field -->
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
-              <Setter TargetName="HintWrapper" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
               <Setter TargetName="Hint" Property="FloatingTarget" Value="{Binding ElementName=OuterBorder}" />
               <Setter TargetName="Hint" Property="FloatingAlignment" Value="Center" />
@@ -1014,7 +1013,6 @@
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterBorder" Property="BorderBrush" Value="Transparent" />
-              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
               <Setter TargetName="OuterBorder" Property="wpf:BottomDashedLineAdorner.IsAttached" Value="True" />
               <Setter TargetName="OuterBorder" Property="wpf:BottomDashedLineAdorner.DashStyle" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TextFieldAssist.HasFilledTextField), Converter={StaticResource BooleanToDashStyleConverter}}" />
               <Setter TargetName="ContentGrid" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
@@ -1022,30 +1020,18 @@
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="IsEnabled" Value="False" />
-                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="1" />
-              <Setter TargetName="OuterBorder" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
               </MultiTrigger.Conditions>
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.PasswordBox.OutlineInactiveBorder}" />
-              <Setter TargetName="HintWrapper" Property="Opacity">
-                <Setter.Value>
-                  <Binding Converter="{StaticResource MathMultiplyConverter}"
-                           ConverterParameter="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}"
-                           Path="(wpf:HintAssist.HintOpacity)"
-                           RelativeSource="{RelativeSource TemplatedParent}" />
-                </Setter.Value>
-              </Setter>
-              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
               <Setter TargetName="PART_ContentHost" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <Setter TargetName="RevealPasswordButton" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+              <Setter TargetName="HintWrapper" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
+              <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
+              <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
+              <Setter TargetName="TrailingPackIcon" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
+              <Setter TargetName="RevealPasswordButton" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
+              <Setter TargetName="RevealPasswordTextBox" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
             </MultiTrigger>
 
             <!-- IsKeyboardFocused -->

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -275,9 +275,11 @@
                   <Button x:Name="PART_ClearButton"
                           Grid.Column="5"
                           Height="Auto"
+                          Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                           Padding="2,0,0,0"
                           Command="{x:Static internal:ClearText.ClearCommand}"
                           Focusable="False"
+                          Foreground="{TemplateBinding Foreground}"
                           VerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
                           Style="{StaticResource MaterialDesignToolButton}">
                     <Button.Visibility>
@@ -336,14 +338,19 @@
             </MultiTrigger>
 
             <!-- Floating hint -->
-            <Trigger Property="wpf:HintAssist.IsFloating" Value="True">
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+              </MultiTrigger.Conditions>
               <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
-            </Trigger>
+            </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
                 <Condition Property="IsKeyboardFocused" Value="True" />
               </MultiTrigger.Conditions>
+              <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
               <Setter TargetName="Hint" Property="Foreground" Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
             </MultiTrigger>
 
@@ -362,7 +369,6 @@
 
             <!-- Outlined text field -->
             <Trigger Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True">
-              <Setter TargetName="HintWrapper" Property="Opacity" Value="{Binding Path=(wpf:HintAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
               <Setter TargetName="Hint" Property="FloatingTarget" Value="{Binding ElementName=OuterBorder}" />
               <Setter TargetName="Hint" Property="FloatingAlignment" Value="Center" />
@@ -385,7 +391,6 @@
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="False" />
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterBorder" Property="BorderBrush" Value="Transparent" />
-              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
               <Setter TargetName="OuterBorder" Property="wpf:BottomDashedLineAdorner.IsAttached" Value="True" />
               <Setter TargetName="OuterBorder" Property="wpf:BottomDashedLineAdorner.DashStyle" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:TextFieldAssist.HasFilledTextField), Converter={StaticResource BooleanToDashStyleConverter}}" />
               <Setter TargetName="ContentGrid" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
@@ -393,29 +398,16 @@
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="IsEnabled" Value="False" />
-                <Condition Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="1" />
-              <Setter TargetName="OuterBorder" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="IsEnabled" Value="False" />
                 <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterBorder" Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.OutlineInactiveBorder}" />
-              <Setter TargetName="HintWrapper" Property="Opacity">
-                <Setter.Value>
-                  <Binding Converter="{StaticResource MathMultiplyConverter}"
-                           ConverterParameter="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}"
-                           Path="(wpf:HintAssist.HintOpacity)"
-                           RelativeSource="{RelativeSource TemplatedParent}" />
-                </Setter.Value>
-              </Setter>
-              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
               <Setter TargetName="PART_ContentHost" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+              <Setter TargetName="HintWrapper" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+              <Setter TargetName="LeadingPackIcon" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
+              <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
+              <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
+              <Setter TargetName="TrailingPackIcon" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
             </MultiTrigger>
 
             <!-- IsKeyboardFocused -->

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -51,6 +51,7 @@
                                                 FixedLeft="0" />
             <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderInactiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderInactiveThickness}" />
             <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderActiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderActiveThickness}" />
+            <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
 
             <ControlTemplate x:Key="ClockButtonTemplate" TargetType="{x:Type Button}">
               <wpf:PackIcon VerticalAlignment="Center"
@@ -123,7 +124,8 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Center"
                     Focusable="False"
-                    Foreground="{TemplateBinding BorderBrush}"
+                    Foreground="{Binding ElementName=PART_TextBox, Path=Foreground}"
+                    Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                     Template="{StaticResource ClockButtonTemplate}" />
             <Popup x:Name="PART_Popup"
                    AllowsTransparency="True"
@@ -143,7 +145,7 @@
               <Setter TargetName="PART_Button" Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
             </MultiTrigger>
             <Trigger Property="IsEnabled" Value="False">
-              <Setter TargetName="PART_Button" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
+              <Setter TargetName="PART_Button" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
             </Trigger>
 
             <!-- Validation.HasError -->


### PR DESCRIPTION
Related to #3564 (only a partial fix)

The issue above mentions some discrepancies regarding the color/dimming of the hint text which this PR addresses. While looking at it, I also found a number of discrepancies in the disabled state of the styles, so I decided to align those as well.

To play around with it yourself, use the `Smart Hint` demo app page where you can toggle the `IsEnabled` state and also test the focused/unfocused states.

The (floating) hint basically has 3 states: resting-unfocused, floating-focused, and floating-unfocused. There was really only an issue in the first of these states, and the fix can be seen below (dimming the hint); aligned across all the input controls using `SmartHint`

#### Before
![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/ec32de02-2a80-42dd-9b0a-f81c4a88e72e)

#### After
![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/506aad62-6c26-412d-ac8c-92822464e4ef)

---

Regarding `IsEnabled=False` (and even some colors in enables states as well) there were a number of issues. Much of it stems from the fact that we're using `Opacity` to represent disabled state, and we often end up with multiple layers of `Opacity` causing certain elements to be more/less opaque than others. 

There is also a quirk to the new flexible theming systems where some "disabled" brushes are directly exposed. This leads the consumer to expect they can set a specific color/brush, but it some cases that color/brush may be dimmed down with one or more levels of `Opacity` being applied.

I have aligned colors and opacity levels as best as I could, and I believe it is much closer to what we want now; this has also been aligned across all the input controls using `SmartHint`.

#### Before
|Enabled|Disabled|
|---|---|
|![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/e296fa17-d595-4e67-a8a8-e01170490014)|![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/1944d910-74b5-417e-b6e1-14067aa0b45b)|

#### After
|Enabled|Disabled|
|---|---|
|![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/56a5e136-cdd4-4aca-bd26-81b8af689d51)|![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/67ae6812-4ecb-44ad-9ecf-2b2a1d3f6748)|

