### PR TITLE
Fix SmartHint clipping when WindowChrome is disabled

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintClippingGridConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintClippingGridConverter.cs
@@ -4,15 +4,20 @@ using System.Windows.Media;
 
 namespace MaterialDesignThemes.Wpf.Converters;
 
-public class FloatingHintClippingGridConverter : IValueConverter
+public class FloatingHintClippingGridConverter : IMultiValueConverter
 {
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        value switch
+    public object? Convert(object?[] values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values is not [double actualWidth, double actualHeight, double floatingScale])
         {
-            double actualWidth => new RectangleGeometry(new Rect(new Point(0, 0), new Size(actualWidth, double.MaxValue))),
-            _ => null
-        };
+            return null;
+        }
 
-    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        RectangleGeometry geometry = new(new Rect(new Point(0, 0), new Size(actualWidth, actualHeight * floatingScale)));
+        geometry.Freeze();
+        return geometry;
+    }
+
+    public object?[] ConvertBack(object? value, Type[] targetTypes, object? parameter, CultureInfo culture)
         => throw new NotImplementedException();
 }

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -143,7 +143,14 @@
                   </VisualStateGroup>
                 </VisualStateManager.VisualStateGroups>
                 <wpf:ScaleHost x:Name="ScaleHost" />
-                <Grid Clip="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ActualWidth, Converter={StaticResource FloatingHintClippingGridConverter}}">
+                <Grid>
+                  <Grid.Clip>
+                    <MultiBinding Converter="{StaticResource FloatingHintClippingGridConverter}">
+                      <Binding Path="ActualWidth" RelativeSource="{RelativeSource TemplatedParent}" />
+                      <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
+                      <Binding Path="FloatingScale" RelativeSource="{RelativeSource TemplatedParent}" />
+                    </MultiBinding>
+                  </Grid.Clip>
                   <Grid.RenderTransform>
                     <MultiBinding Converter="{StaticResource FloatingHintTranslateTransformConverter}">
                       <Binding ElementName="ScaleHost" Path="Scale" />


### PR DESCRIPTION
Fixes #3564 

The old implementation was using `double.MaxValue` for the height of the returned `RectangleGeometry`. This was causing the background to become black. I was unable to root cause why that is happening, but adjusting to a value smaller than double.MaxValue fixes the issue.

I tried to narrow down magic number at which point the black background appears, and it turned out to be `349_023` which is a very random number and therefore something I assume is just specific to my monitor/resolution/DPI setup.

So rather than using some magic number, I changed the converter to a `IMultiValueConverter` and I  am now also passing in the `ActualHeight` of the (non-scaled) hint, as well as the scaling factor (`HintAssist.FloatingScale`). This allows me to calculate the required vertical space rather than using `double.MaxValue`.

The old implementation was not freezing the returned `Geometry` so I added that as well for the minor perf bump.

|Before|After|
|---|---|
|![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/2efae414-b5f9-4615-b99e-e7e72f2856eb)|![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/ccda6ad4-6011-4c6f-9433-4ff864fb9ad5)|

