### PR TITLE
Removed space in color foreground names

### DIFF
--- a/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.BlueGrey.Named.Primary.xaml
+++ b/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.BlueGrey.Named.Primary.xaml
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <Color x:Key="BlueGreyPrimary50">#eceff1</Color>
-  <Color x:Key="Blue GreyPrimary50Foreground">#DD000000</Color>
+  <Color x:Key="BlueGreyPrimary50Foreground">#DD000000</Color>
   <Color x:Key="BlueGreyPrimary100">#cfd8dc</Color>
-  <Color x:Key="Blue GreyPrimary100Foreground">#DD000000</Color>
+  <Color x:Key="BlueGreyPrimary100Foreground">#DD000000</Color>
   <Color x:Key="BlueGreyPrimary200">#b0bec5</Color>
-  <Color x:Key="Blue GreyPrimary200Foreground">#DD000000</Color>
+  <Color x:Key="BlueGreyPrimary200Foreground">#DD000000</Color>
   <Color x:Key="BlueGreyPrimary300">#90a4ae</Color>
-  <Color x:Key="Blue GreyPrimary300Foreground">#DD000000</Color>
+  <Color x:Key="BlueGreyPrimary300Foreground">#DD000000</Color>
   <Color x:Key="BlueGreyPrimary400">#78909c</Color>
-  <Color x:Key="Blue GreyPrimary400Foreground">#FFFFFFFF</Color>
+  <Color x:Key="BlueGreyPrimary400Foreground">#FFFFFFFF</Color>
   <Color x:Key="BlueGreyPrimary500">#607d8b</Color>
-  <Color x:Key="Blue GreyPrimary500Foreground">#DDFFFFFF</Color>
+  <Color x:Key="BlueGreyPrimary500Foreground">#DDFFFFFF</Color>
   <Color x:Key="BlueGreyPrimary600">#546e7a</Color>
-  <Color x:Key="Blue GreyPrimary600Foreground">#DDFFFFFF</Color>
+  <Color x:Key="BlueGreyPrimary600Foreground">#DDFFFFFF</Color>
   <Color x:Key="BlueGreyPrimary700">#455a64</Color>
-  <Color x:Key="Blue GreyPrimary700Foreground">#DDFFFFFF</Color>
+  <Color x:Key="BlueGreyPrimary700Foreground">#DDFFFFFF</Color>
   <Color x:Key="BlueGreyPrimary800">#37474f</Color>
-  <Color x:Key="Blue GreyPrimary800Foreground">#DDFFFFFF</Color>
+  <Color x:Key="BlueGreyPrimary800Foreground">#DDFFFFFF</Color>
   <Color x:Key="BlueGreyPrimary900">#263238</Color>
-  <Color x:Key="Blue GreyPrimary900Foreground">#DDFFFFFF</Color>
+  <Color x:Key="BlueGreyPrimary900Foreground">#DDFFFFFF</Color>
 </ResourceDictionary>

--- a/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.BlueGrey.Named.xaml
+++ b/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.BlueGrey.Named.xaml
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <Color x:Key="BlueGreyPrimary50">#eceff1</Color>
-  <Color x:Key="Blue GreyPrimary50Foreground">#DD000000</Color>
+  <Color x:Key="BlueGreyPrimary50Foreground">#DD000000</Color>
   <Color x:Key="BlueGreyPrimary100">#cfd8dc</Color>
-  <Color x:Key="Blue GreyPrimary100Foreground">#DD000000</Color>
+  <Color x:Key="BlueGreyPrimary100Foreground">#DD000000</Color>
   <Color x:Key="BlueGreyPrimary200">#b0bec5</Color>
-  <Color x:Key="Blue GreyPrimary200Foreground">#DD000000</Color>
+  <Color x:Key="BlueGreyPrimary200Foreground">#DD000000</Color>
   <Color x:Key="BlueGreyPrimary300">#90a4ae</Color>
-  <Color x:Key="Blue GreyPrimary300Foreground">#DD000000</Color>
+  <Color x:Key="BlueGreyPrimary300Foreground">#DD000000</Color>
   <Color x:Key="BlueGreyPrimary400">#78909c</Color>
-  <Color x:Key="Blue GreyPrimary400Foreground">#FFFFFFFF</Color>
+  <Color x:Key="BlueGreyPrimary400Foreground">#FFFFFFFF</Color>
   <Color x:Key="BlueGreyPrimary500">#607d8b</Color>
-  <Color x:Key="Blue GreyPrimary500Foreground">#DDFFFFFF</Color>
+  <Color x:Key="BlueGreyPrimary500Foreground">#DDFFFFFF</Color>
   <Color x:Key="BlueGreyPrimary600">#546e7a</Color>
-  <Color x:Key="Blue GreyPrimary600Foreground">#DDFFFFFF</Color>
+  <Color x:Key="BlueGreyPrimary600Foreground">#DDFFFFFF</Color>
   <Color x:Key="BlueGreyPrimary700">#455a64</Color>
-  <Color x:Key="Blue GreyPrimary700Foreground">#DDFFFFFF</Color>
+  <Color x:Key="BlueGreyPrimary700Foreground">#DDFFFFFF</Color>
   <Color x:Key="BlueGreyPrimary800">#37474f</Color>
-  <Color x:Key="Blue GreyPrimary800Foreground">#DDFFFFFF</Color>
+  <Color x:Key="BlueGreyPrimary800Foreground">#DDFFFFFF</Color>
   <Color x:Key="BlueGreyPrimary900">#263238</Color>
-  <Color x:Key="Blue GreyPrimary900Foreground">#DDFFFFFF</Color>
+  <Color x:Key="BlueGreyPrimary900Foreground">#DDFFFFFF</Color>
 </ResourceDictionary>

--- a/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.DeepOrange.Named.Primary.xaml
+++ b/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.DeepOrange.Named.Primary.xaml
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <Color x:Key="DeepOrangePrimary50">#fbe9e7</Color>
-  <Color x:Key="Deep OrangePrimary50Foreground">#DD000000</Color>
+  <Color x:Key="DeepOrangePrimary50Foreground">#DD000000</Color>
   <Color x:Key="DeepOrangePrimary100">#ffccbc</Color>
-  <Color x:Key="Deep OrangePrimary100Foreground">#DD000000</Color>
+  <Color x:Key="DeepOrangePrimary100Foreground">#DD000000</Color>
   <Color x:Key="DeepOrangePrimary200">#ffab91</Color>
-  <Color x:Key="Deep OrangePrimary200Foreground">#DD000000</Color>
+  <Color x:Key="DeepOrangePrimary200Foreground">#DD000000</Color>
   <Color x:Key="DeepOrangePrimary300">#ff8a65</Color>
-  <Color x:Key="Deep OrangePrimary300Foreground">#DD000000</Color>
+  <Color x:Key="DeepOrangePrimary300Foreground">#DD000000</Color>
   <Color x:Key="DeepOrangePrimary400">#ff7043</Color>
-  <Color x:Key="Deep OrangePrimary400Foreground">#DD000000</Color>
+  <Color x:Key="DeepOrangePrimary400Foreground">#DD000000</Color>
   <Color x:Key="DeepOrangePrimary500">#ff5722</Color>
-  <Color x:Key="Deep OrangePrimary500Foreground">#FFFFFFFF</Color>
+  <Color x:Key="DeepOrangePrimary500Foreground">#FFFFFFFF</Color>
   <Color x:Key="DeepOrangePrimary600">#f4511e</Color>
-  <Color x:Key="Deep OrangePrimary600Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepOrangePrimary600Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepOrangePrimary700">#e64a19</Color>
-  <Color x:Key="Deep OrangePrimary700Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepOrangePrimary700Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepOrangePrimary800">#d84315</Color>
-  <Color x:Key="Deep OrangePrimary800Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepOrangePrimary800Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepOrangePrimary900">#bf360c</Color>
-  <Color x:Key="Deep OrangePrimary900Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepOrangePrimary900Foreground">#DDFFFFFF</Color>
 </ResourceDictionary>

--- a/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.DeepOrange.Named.Secondary.xaml
+++ b/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.DeepOrange.Named.Secondary.xaml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <Color x:Key="DeepOrangeSecondary100">#ff9e80</Color>
-  <Color x:Key="Deep OrangeSecondary100Foreground">#DD000000</Color>
+  <Color x:Key="DeepOrangeSecondary100Foreground">#DD000000</Color>
   <Color x:Key="DeepOrangeSecondary200">#ff6e40</Color>
-  <Color x:Key="Deep OrangeSecondary200Foreground">#DD000000</Color>
+  <Color x:Key="DeepOrangeSecondary200Foreground">#DD000000</Color>
   <Color x:Key="DeepOrangeSecondary400">#ff3d00</Color>
-  <Color x:Key="Deep OrangeSecondary400Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepOrangeSecondary400Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepOrangeSecondary700">#dd2c00</Color>
-  <Color x:Key="Deep OrangeSecondary700Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepOrangeSecondary700Foreground">#DDFFFFFF</Color>
 </ResourceDictionary>

--- a/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.DeepOrange.Named.xaml
+++ b/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.DeepOrange.Named.xaml
@@ -1,31 +1,31 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <Color x:Key="DeepOrangePrimary50">#fbe9e7</Color>
-  <Color x:Key="Deep OrangePrimary50Foreground">#DD000000</Color>
+  <Color x:Key="DeepOrangePrimary50Foreground">#DD000000</Color>
   <Color x:Key="DeepOrangePrimary100">#ffccbc</Color>
-  <Color x:Key="Deep OrangePrimary100Foreground">#DD000000</Color>
+  <Color x:Key="DeepOrangePrimary100Foreground">#DD000000</Color>
   <Color x:Key="DeepOrangePrimary200">#ffab91</Color>
-  <Color x:Key="Deep OrangePrimary200Foreground">#DD000000</Color>
+  <Color x:Key="DeepOrangePrimary200Foreground">#DD000000</Color>
   <Color x:Key="DeepOrangePrimary300">#ff8a65</Color>
-  <Color x:Key="Deep OrangePrimary300Foreground">#DD000000</Color>
+  <Color x:Key="DeepOrangePrimary300Foreground">#DD000000</Color>
   <Color x:Key="DeepOrangePrimary400">#ff7043</Color>
-  <Color x:Key="Deep OrangePrimary400Foreground">#DD000000</Color>
+  <Color x:Key="DeepOrangePrimary400Foreground">#DD000000</Color>
   <Color x:Key="DeepOrangePrimary500">#ff5722</Color>
-  <Color x:Key="Deep OrangePrimary500Foreground">#FFFFFFFF</Color>
+  <Color x:Key="DeepOrangePrimary500Foreground">#FFFFFFFF</Color>
   <Color x:Key="DeepOrangePrimary600">#f4511e</Color>
-  <Color x:Key="Deep OrangePrimary600Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepOrangePrimary600Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepOrangePrimary700">#e64a19</Color>
-  <Color x:Key="Deep OrangePrimary700Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepOrangePrimary700Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepOrangePrimary800">#d84315</Color>
-  <Color x:Key="Deep OrangePrimary800Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepOrangePrimary800Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepOrangePrimary900">#bf360c</Color>
-  <Color x:Key="Deep OrangePrimary900Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepOrangePrimary900Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepOrangeSecondary100">#ff9e80</Color>
-  <Color x:Key="Deep OrangeSecondary100Foreground">#DD000000</Color>
+  <Color x:Key="DeepOrangeSecondary100Foreground">#DD000000</Color>
   <Color x:Key="DeepOrangeSecondary200">#ff6e40</Color>
-  <Color x:Key="Deep OrangeSecondary200Foreground">#DD000000</Color>
+  <Color x:Key="DeepOrangeSecondary200Foreground">#DD000000</Color>
   <Color x:Key="DeepOrangeSecondary400">#ff3d00</Color>
-  <Color x:Key="Deep OrangeSecondary400Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepOrangeSecondary400Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepOrangeSecondary700">#dd2c00</Color>
-  <Color x:Key="Deep OrangeSecondary700Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepOrangeSecondary700Foreground">#DDFFFFFF</Color>
 </ResourceDictionary>

--- a/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.DeepPurple.Named.Primary.xaml
+++ b/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.DeepPurple.Named.Primary.xaml
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <Color x:Key="DeepPurplePrimary50">#ede7f6</Color>
-  <Color x:Key="Deep PurplePrimary50Foreground">#DD000000</Color>
+  <Color x:Key="DeepPurplePrimary50Foreground">#DD000000</Color>
   <Color x:Key="DeepPurplePrimary100">#d1c4e9</Color>
-  <Color x:Key="Deep PurplePrimary100Foreground">#DD000000</Color>
+  <Color x:Key="DeepPurplePrimary100Foreground">#DD000000</Color>
   <Color x:Key="DeepPurplePrimary200">#b39ddb</Color>
-  <Color x:Key="Deep PurplePrimary200Foreground">#DD000000</Color>
+  <Color x:Key="DeepPurplePrimary200Foreground">#DD000000</Color>
   <Color x:Key="DeepPurplePrimary300">#9575cd</Color>
-  <Color x:Key="Deep PurplePrimary300Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurplePrimary300Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurplePrimary400">#7e57c2</Color>
-  <Color x:Key="Deep PurplePrimary400Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurplePrimary400Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurplePrimary500">#673ab7</Color>
-  <Color x:Key="Deep PurplePrimary500Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurplePrimary500Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurplePrimary600">#5e35b1</Color>
-  <Color x:Key="Deep PurplePrimary600Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurplePrimary600Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurplePrimary700">#512da8</Color>
-  <Color x:Key="Deep PurplePrimary700Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurplePrimary700Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurplePrimary800">#4527a0</Color>
-  <Color x:Key="Deep PurplePrimary800Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurplePrimary800Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurplePrimary900">#311b92</Color>
-  <Color x:Key="Deep PurplePrimary900Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurplePrimary900Foreground">#DDFFFFFF</Color>
 </ResourceDictionary>

--- a/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.DeepPurple.Named.Secondary.xaml
+++ b/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.DeepPurple.Named.Secondary.xaml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <Color x:Key="DeepPurpleSecondary100">#b388ff</Color>
-  <Color x:Key="Deep PurpleSecondary100Foreground">#DD000000</Color>
+  <Color x:Key="DeepPurpleSecondary100Foreground">#DD000000</Color>
   <Color x:Key="DeepPurpleSecondary200">#7c4dff</Color>
-  <Color x:Key="Deep PurpleSecondary200Foreground">#FFFFFFFF</Color>
+  <Color x:Key="DeepPurpleSecondary200Foreground">#FFFFFFFF</Color>
   <Color x:Key="DeepPurpleSecondary400">#651fff</Color>
-  <Color x:Key="Deep PurpleSecondary400Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurpleSecondary400Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurpleSecondary700">#6200ea</Color>
-  <Color x:Key="Deep PurpleSecondary700Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurpleSecondary700Foreground">#DDFFFFFF</Color>
 </ResourceDictionary>

--- a/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.DeepPurple.Named.xaml
+++ b/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.DeepPurple.Named.xaml
@@ -1,31 +1,31 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <Color x:Key="DeepPurplePrimary50">#ede7f6</Color>
-  <Color x:Key="Deep PurplePrimary50Foreground">#DD000000</Color>
+  <Color x:Key="DeepPurplePrimary50Foreground">#DD000000</Color>
   <Color x:Key="DeepPurplePrimary100">#d1c4e9</Color>
-  <Color x:Key="Deep PurplePrimary100Foreground">#DD000000</Color>
+  <Color x:Key="DeepPurplePrimary100Foreground">#DD000000</Color>
   <Color x:Key="DeepPurplePrimary200">#b39ddb</Color>
-  <Color x:Key="Deep PurplePrimary200Foreground">#DD000000</Color>
+  <Color x:Key="DeepPurplePrimary200Foreground">#DD000000</Color>
   <Color x:Key="DeepPurplePrimary300">#9575cd</Color>
-  <Color x:Key="Deep PurplePrimary300Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurplePrimary300Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurplePrimary400">#7e57c2</Color>
-  <Color x:Key="Deep PurplePrimary400Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurplePrimary400Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurplePrimary500">#673ab7</Color>
-  <Color x:Key="Deep PurplePrimary500Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurplePrimary500Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurplePrimary600">#5e35b1</Color>
-  <Color x:Key="Deep PurplePrimary600Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurplePrimary600Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurplePrimary700">#512da8</Color>
-  <Color x:Key="Deep PurplePrimary700Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurplePrimary700Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurplePrimary800">#4527a0</Color>
-  <Color x:Key="Deep PurplePrimary800Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurplePrimary800Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurplePrimary900">#311b92</Color>
-  <Color x:Key="Deep PurplePrimary900Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurplePrimary900Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurpleSecondary100">#b388ff</Color>
-  <Color x:Key="Deep PurpleSecondary100Foreground">#DD000000</Color>
+  <Color x:Key="DeepPurpleSecondary100Foreground">#DD000000</Color>
   <Color x:Key="DeepPurpleSecondary200">#7c4dff</Color>
-  <Color x:Key="Deep PurpleSecondary200Foreground">#FFFFFFFF</Color>
+  <Color x:Key="DeepPurpleSecondary200Foreground">#FFFFFFFF</Color>
   <Color x:Key="DeepPurpleSecondary400">#651fff</Color>
-  <Color x:Key="Deep PurpleSecondary400Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurpleSecondary400Foreground">#DDFFFFFF</Color>
   <Color x:Key="DeepPurpleSecondary700">#6200ea</Color>
-  <Color x:Key="Deep PurpleSecondary700Foreground">#DDFFFFFF</Color>
+  <Color x:Key="DeepPurpleSecondary700Foreground">#DDFFFFFF</Color>
 </ResourceDictionary>

--- a/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.LightBlue.Named.Primary.xaml
+++ b/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.LightBlue.Named.Primary.xaml
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <Color x:Key="LightBluePrimary50">#e1f5fe</Color>
-  <Color x:Key="Light BluePrimary50Foreground">#DD000000</Color>
+  <Color x:Key="LightBluePrimary50Foreground">#DD000000</Color>
   <Color x:Key="LightBluePrimary100">#b3e5fc</Color>
-  <Color x:Key="Light BluePrimary100Foreground">#DD000000</Color>
+  <Color x:Key="LightBluePrimary100Foreground">#DD000000</Color>
   <Color x:Key="LightBluePrimary200">#81d4fa</Color>
-  <Color x:Key="Light BluePrimary200Foreground">#DD000000</Color>
+  <Color x:Key="LightBluePrimary200Foreground">#DD000000</Color>
   <Color x:Key="LightBluePrimary300">#4fc3f7</Color>
-  <Color x:Key="Light BluePrimary300Foreground">#DD000000</Color>
+  <Color x:Key="LightBluePrimary300Foreground">#DD000000</Color>
   <Color x:Key="LightBluePrimary400">#29b6f6</Color>
-  <Color x:Key="Light BluePrimary400Foreground">#DD000000</Color>
+  <Color x:Key="LightBluePrimary400Foreground">#DD000000</Color>
   <Color x:Key="LightBluePrimary500">#03a9f4</Color>
-  <Color x:Key="Light BluePrimary500Foreground">#DD000000</Color>
+  <Color x:Key="LightBluePrimary500Foreground">#DD000000</Color>
   <Color x:Key="LightBluePrimary600">#039be5</Color>
-  <Color x:Key="Light BluePrimary600Foreground">#FFFFFFFF</Color>
+  <Color x:Key="LightBluePrimary600Foreground">#FFFFFFFF</Color>
   <Color x:Key="LightBluePrimary700">#0288d1</Color>
-  <Color x:Key="Light BluePrimary700Foreground">#DDFFFFFF</Color>
+  <Color x:Key="LightBluePrimary700Foreground">#DDFFFFFF</Color>
   <Color x:Key="LightBluePrimary800">#0277bd</Color>
-  <Color x:Key="Light BluePrimary800Foreground">#DDFFFFFF</Color>
+  <Color x:Key="LightBluePrimary800Foreground">#DDFFFFFF</Color>
   <Color x:Key="LightBluePrimary900">#01579b</Color>
-  <Color x:Key="Light BluePrimary900Foreground">#DDFFFFFF</Color>
+  <Color x:Key="LightBluePrimary900Foreground">#DDFFFFFF</Color>
 </ResourceDictionary>

--- a/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.LightBlue.Named.Secondary.xaml
+++ b/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.LightBlue.Named.Secondary.xaml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <Color x:Key="LightBlueSecondary100">#80d8ff</Color>
-  <Color x:Key="Light BlueSecondary100Foreground">#DD000000</Color>
+  <Color x:Key="LightBlueSecondary100Foreground">#DD000000</Color>
   <Color x:Key="LightBlueSecondary200">#40c4ff</Color>
-  <Color x:Key="Light BlueSecondary200Foreground">#DD000000</Color>
+  <Color x:Key="LightBlueSecondary200Foreground">#DD000000</Color>
   <Color x:Key="LightBlueSecondary400">#00b0ff</Color>
-  <Color x:Key="Light BlueSecondary400Foreground">#DD000000</Color>
+  <Color x:Key="LightBlueSecondary400Foreground">#DD000000</Color>
   <Color x:Key="LightBlueSecondary700">#0091ea</Color>
-  <Color x:Key="Light BlueSecondary700Foreground">#FFFFFFFF</Color>
+  <Color x:Key="LightBlueSecondary700Foreground">#FFFFFFFF</Color>
 </ResourceDictionary>

--- a/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.LightBlue.Named.xaml
+++ b/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.LightBlue.Named.xaml
@@ -1,31 +1,31 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <Color x:Key="LightBluePrimary50">#e1f5fe</Color>
-  <Color x:Key="Light BluePrimary50Foreground">#DD000000</Color>
+  <Color x:Key="LightBluePrimary50Foreground">#DD000000</Color>
   <Color x:Key="LightBluePrimary100">#b3e5fc</Color>
-  <Color x:Key="Light BluePrimary100Foreground">#DD000000</Color>
+  <Color x:Key="LightBluePrimary100Foreground">#DD000000</Color>
   <Color x:Key="LightBluePrimary200">#81d4fa</Color>
-  <Color x:Key="Light BluePrimary200Foreground">#DD000000</Color>
+  <Color x:Key="LightBluePrimary200Foreground">#DD000000</Color>
   <Color x:Key="LightBluePrimary300">#4fc3f7</Color>
-  <Color x:Key="Light BluePrimary300Foreground">#DD000000</Color>
+  <Color x:Key="LightBluePrimary300Foreground">#DD000000</Color>
   <Color x:Key="LightBluePrimary400">#29b6f6</Color>
-  <Color x:Key="Light BluePrimary400Foreground">#DD000000</Color>
+  <Color x:Key="LightBluePrimary400Foreground">#DD000000</Color>
   <Color x:Key="LightBluePrimary500">#03a9f4</Color>
-  <Color x:Key="Light BluePrimary500Foreground">#DD000000</Color>
+  <Color x:Key="LightBluePrimary500Foreground">#DD000000</Color>
   <Color x:Key="LightBluePrimary600">#039be5</Color>
-  <Color x:Key="Light BluePrimary600Foreground">#FFFFFFFF</Color>
+  <Color x:Key="LightBluePrimary600Foreground">#FFFFFFFF</Color>
   <Color x:Key="LightBluePrimary700">#0288d1</Color>
-  <Color x:Key="Light BluePrimary700Foreground">#DDFFFFFF</Color>
+  <Color x:Key="LightBluePrimary700Foreground">#DDFFFFFF</Color>
   <Color x:Key="LightBluePrimary800">#0277bd</Color>
-  <Color x:Key="Light BluePrimary800Foreground">#DDFFFFFF</Color>
+  <Color x:Key="LightBluePrimary800Foreground">#DDFFFFFF</Color>
   <Color x:Key="LightBluePrimary900">#01579b</Color>
-  <Color x:Key="Light BluePrimary900Foreground">#DDFFFFFF</Color>
+  <Color x:Key="LightBluePrimary900Foreground">#DDFFFFFF</Color>
   <Color x:Key="LightBlueSecondary100">#80d8ff</Color>
-  <Color x:Key="Light BlueSecondary100Foreground">#DD000000</Color>
+  <Color x:Key="LightBlueSecondary100Foreground">#DD000000</Color>
   <Color x:Key="LightBlueSecondary200">#40c4ff</Color>
-  <Color x:Key="Light BlueSecondary200Foreground">#DD000000</Color>
+  <Color x:Key="LightBlueSecondary200Foreground">#DD000000</Color>
   <Color x:Key="LightBlueSecondary400">#00b0ff</Color>
-  <Color x:Key="Light BlueSecondary400Foreground">#DD000000</Color>
+  <Color x:Key="LightBlueSecondary400Foreground">#DD000000</Color>
   <Color x:Key="LightBlueSecondary700">#0091ea</Color>
-  <Color x:Key="Light BlueSecondary700Foreground">#FFFFFFFF</Color>
+  <Color x:Key="LightBlueSecondary700Foreground">#FFFFFFFF</Color>
 </ResourceDictionary>

--- a/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.LightGreen.Named.Primary.xaml
+++ b/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.LightGreen.Named.Primary.xaml
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <Color x:Key="LightGreenPrimary50">#f1f8e9</Color>
-  <Color x:Key="Light GreenPrimary50Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenPrimary50Foreground">#DD000000</Color>
   <Color x:Key="LightGreenPrimary100">#dcedc8</Color>
-  <Color x:Key="Light GreenPrimary100Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenPrimary100Foreground">#DD000000</Color>
   <Color x:Key="LightGreenPrimary200">#c5e1a5</Color>
-  <Color x:Key="Light GreenPrimary200Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenPrimary200Foreground">#DD000000</Color>
   <Color x:Key="LightGreenPrimary300">#aed581</Color>
-  <Color x:Key="Light GreenPrimary300Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenPrimary300Foreground">#DD000000</Color>
   <Color x:Key="LightGreenPrimary400">#9ccc65</Color>
-  <Color x:Key="Light GreenPrimary400Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenPrimary400Foreground">#DD000000</Color>
   <Color x:Key="LightGreenPrimary500">#8bc34a</Color>
-  <Color x:Key="Light GreenPrimary500Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenPrimary500Foreground">#DD000000</Color>
   <Color x:Key="LightGreenPrimary600">#7cb342</Color>
-  <Color x:Key="Light GreenPrimary600Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenPrimary600Foreground">#DD000000</Color>
   <Color x:Key="LightGreenPrimary700">#689f38</Color>
-  <Color x:Key="Light GreenPrimary700Foreground">#FFFFFFFF</Color>
+  <Color x:Key="LightGreenPrimary700Foreground">#FFFFFFFF</Color>
   <Color x:Key="LightGreenPrimary800">#558b2f</Color>
-  <Color x:Key="Light GreenPrimary800Foreground">#DDFFFFFF</Color>
+  <Color x:Key="LightGreenPrimary800Foreground">#DDFFFFFF</Color>
   <Color x:Key="LightGreenPrimary900">#33691e</Color>
-  <Color x:Key="Light GreenPrimary900Foreground">#DDFFFFFF</Color>
+  <Color x:Key="LightGreenPrimary900Foreground">#DDFFFFFF</Color>
 </ResourceDictionary>

--- a/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.LightGreen.Named.Secondary.xaml
+++ b/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.LightGreen.Named.Secondary.xaml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <Color x:Key="LightGreenSecondary100">#ccff90</Color>
-  <Color x:Key="Light GreenSecondary100Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenSecondary100Foreground">#DD000000</Color>
   <Color x:Key="LightGreenSecondary200">#b2ff59</Color>
-  <Color x:Key="Light GreenSecondary200Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenSecondary200Foreground">#DD000000</Color>
   <Color x:Key="LightGreenSecondary400">#76ff03</Color>
-  <Color x:Key="Light GreenSecondary400Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenSecondary400Foreground">#DD000000</Color>
   <Color x:Key="LightGreenSecondary700">#64dd17</Color>
-  <Color x:Key="Light GreenSecondary700Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenSecondary700Foreground">#DD000000</Color>
 </ResourceDictionary>

--- a/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.LightGreen.Named.xaml
+++ b/src/MaterialDesignColors.Wpf/Themes/MaterialDesignColor.LightGreen.Named.xaml
@@ -1,31 +1,31 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <Color x:Key="LightGreenPrimary50">#f1f8e9</Color>
-  <Color x:Key="Light GreenPrimary50Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenPrimary50Foreground">#DD000000</Color>
   <Color x:Key="LightGreenPrimary100">#dcedc8</Color>
-  <Color x:Key="Light GreenPrimary100Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenPrimary100Foreground">#DD000000</Color>
   <Color x:Key="LightGreenPrimary200">#c5e1a5</Color>
-  <Color x:Key="Light GreenPrimary200Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenPrimary200Foreground">#DD000000</Color>
   <Color x:Key="LightGreenPrimary300">#aed581</Color>
-  <Color x:Key="Light GreenPrimary300Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenPrimary300Foreground">#DD000000</Color>
   <Color x:Key="LightGreenPrimary400">#9ccc65</Color>
-  <Color x:Key="Light GreenPrimary400Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenPrimary400Foreground">#DD000000</Color>
   <Color x:Key="LightGreenPrimary500">#8bc34a</Color>
-  <Color x:Key="Light GreenPrimary500Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenPrimary500Foreground">#DD000000</Color>
   <Color x:Key="LightGreenPrimary600">#7cb342</Color>
-  <Color x:Key="Light GreenPrimary600Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenPrimary600Foreground">#DD000000</Color>
   <Color x:Key="LightGreenPrimary700">#689f38</Color>
-  <Color x:Key="Light GreenPrimary700Foreground">#FFFFFFFF</Color>
+  <Color x:Key="LightGreenPrimary700Foreground">#FFFFFFFF</Color>
   <Color x:Key="LightGreenPrimary800">#558b2f</Color>
-  <Color x:Key="Light GreenPrimary800Foreground">#DDFFFFFF</Color>
+  <Color x:Key="LightGreenPrimary800Foreground">#DDFFFFFF</Color>
   <Color x:Key="LightGreenPrimary900">#33691e</Color>
-  <Color x:Key="Light GreenPrimary900Foreground">#DDFFFFFF</Color>
+  <Color x:Key="LightGreenPrimary900Foreground">#DDFFFFFF</Color>
   <Color x:Key="LightGreenSecondary100">#ccff90</Color>
-  <Color x:Key="Light GreenSecondary100Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenSecondary100Foreground">#DD000000</Color>
   <Color x:Key="LightGreenSecondary200">#b2ff59</Color>
-  <Color x:Key="Light GreenSecondary200Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenSecondary200Foreground">#DD000000</Color>
   <Color x:Key="LightGreenSecondary400">#76ff03</Color>
-  <Color x:Key="Light GreenSecondary400Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenSecondary400Foreground">#DD000000</Color>
   <Color x:Key="LightGreenSecondary700">#64dd17</Color>
-  <Color x:Key="Light GreenSecondary700Foreground">#DD000000</Color>
+  <Color x:Key="LightGreenSecondary700Foreground">#DD000000</Color>
 </ResourceDictionary>


### PR DESCRIPTION
In a previous PR all spaces are removed from the color names, but the foreground names were not adjusted.
This PR handles to make them in line with each other again.

Furthermore I was wondering if the following files should also have the space removed from the names? If so please let me know, because than I will add it to this PR.
- MaterialColourSwatchesSnippet.xml
- Palette.json
- BlueGreySwatch.cs
- DeepOrangeSwatch.cs
- DeepPurpleSwatch.cs
- LightBlueSwatch.cs
- LightGreenSwatch.cs