### PR TITLE
Remove space in color palette and swatches

### DIFF
--- a/src/MaterialDesignColors.Wpf/Recommended/BlueGreySwatch.cs
+++ b/src/MaterialDesignColors.Wpf/Recommended/BlueGreySwatch.cs
@@ -14,7 +14,7 @@ public class BlueGreySwatch : ISwatch
 	public static Color BlueGrey800 { get; } = (Color)ColorConverter.ConvertFromString("#37474F");
 	public static Color BlueGrey900 { get; } = (Color)ColorConverter.ConvertFromString("#263238");
 
-	public string Name { get; } = "Blue Grey";
+	public string Name { get; } = "BlueGrey";
 
 	public IDictionary<MaterialDesignColor, Color> Lookup { get; } = new Dictionary<MaterialDesignColor, Color>
 	{

--- a/src/MaterialDesignColors.Wpf/Recommended/DeepOrangeSwatch.cs
+++ b/src/MaterialDesignColors.Wpf/Recommended/DeepOrangeSwatch.cs
@@ -18,7 +18,7 @@ public class DeepOrangeSwatch : ISwatch
 	public static Color DeepOrangeA400 { get; } = (Color)ColorConverter.ConvertFromString("#FF3D00");
 	public static Color DeepOrangeA700 { get; } = (Color)ColorConverter.ConvertFromString("#DD2C00");
 
-	public string Name { get; } = "Deep Orange";
+	public string Name { get; } = "DeepOrange";
 
 	public IDictionary<MaterialDesignColor, Color> Lookup { get; } = new Dictionary<MaterialDesignColor, Color>
 	{

--- a/src/MaterialDesignColors.Wpf/Recommended/DeepPurpleSwatch.cs
+++ b/src/MaterialDesignColors.Wpf/Recommended/DeepPurpleSwatch.cs
@@ -18,7 +18,7 @@ public class DeepPurpleSwatch : ISwatch
 	public static Color DeepPurpleA400 { get; } = (Color)ColorConverter.ConvertFromString("#651FFF");
 	public static Color DeepPurpleA700 { get; } = (Color)ColorConverter.ConvertFromString("#6200EA");
 
-	public string Name { get; } = "Deep Purple";
+	public string Name { get; } = "DeepPurple";
 
 	public IDictionary<MaterialDesignColor, Color> Lookup { get; } = new Dictionary<MaterialDesignColor, Color>
 	{

--- a/src/MaterialDesignColors.Wpf/Recommended/LightBlueSwatch.cs
+++ b/src/MaterialDesignColors.Wpf/Recommended/LightBlueSwatch.cs
@@ -18,7 +18,7 @@ public class LightBlueSwatch : ISwatch
 	public static Color LightBlueA400 { get; } = (Color)ColorConverter.ConvertFromString("#00B0FF");
 	public static Color LightBlueA700 { get; } = (Color)ColorConverter.ConvertFromString("#0091EA");
 
-	public string Name { get; } = "Light Blue";
+	public string Name { get; } = "LightBlue";
 
 	public IDictionary<MaterialDesignColor, Color> Lookup { get; } = new Dictionary<MaterialDesignColor, Color>
 	{

--- a/src/MaterialDesignColors.Wpf/Recommended/LightGreenSwatch.cs
+++ b/src/MaterialDesignColors.Wpf/Recommended/LightGreenSwatch.cs
@@ -18,7 +18,7 @@ public class LightGreenSwatch : ISwatch
 	public static Color LightGreenA400 { get; } = (Color)ColorConverter.ConvertFromString("#76FF03");
 	public static Color LightGreenA700 { get; } = (Color)ColorConverter.ConvertFromString("#64DD17");
 
-	public string Name { get; } = "Light Green";
+	public string Name { get; } = "LightGreen";
 
 	public IDictionary<MaterialDesignColor, Color> Lookup { get; } = new Dictionary<MaterialDesignColor, Color>
 	{

--- a/src/MaterialDesignToolkit.ResourceGeneration/MaterialColourSwatchesSnippet.xml
+++ b/src/MaterialDesignToolkit.ResourceGeneration/MaterialColourSwatchesSnippet.xml
@@ -203,7 +203,7 @@
   <section class="color-group">
     <ul>
       <li class="color main-color" style="background-color: #673ab7;">
-        <span class="name">Deep Purple</span>
+        <span class="name">DeepPurple</span>
         <span class="shade">500</span>
         <span class="hex">#673ab7</span>
       </li>
@@ -404,7 +404,7 @@
   <section class="color-group">
     <ul>
       <li class="color main-color" style="background-color: #03a9f4;">
-        <span class="name dark">Light Blue</span>
+        <span class="name dark">LightBlue</span>
         <span class="shade dark">500</span>
         <span class="hex dark">#03a9f4</span>
       </li>
@@ -672,7 +672,7 @@
   <section class="color-group">
     <ul>
       <li class="color main-color" style="background-color: #8bc34a;">
-        <span class="name dark">Light Green</span>
+        <span class="name dark">LightGreen</span>
         <span class="shade dark">500</span>
         <span class="hex dark">#8bc34a</span>
       </li>
@@ -1007,7 +1007,7 @@
   <section class="color-group">
     <ul>
       <li class="color main-color" style="background-color: #ff5722;">
-        <span class="name light-strong">Deep Orange</span>
+        <span class="name light-strong">DeepOrange</span>
         <span class="shade light-strong">500</span>
         <span class="hex light-strong">#ff5722</span>
       </li>
@@ -1176,7 +1176,7 @@
   <section class="color-group">
     <ul>
       <li class="color main-color" style="background-color: #607d8b;">
-        <span class="name light-strong">Blue Grey</span>
+        <span class="name light-strong">BlueGrey</span>
         <span class="shade light-strong">500</span>
         <span class="hex light-strong">#607d8b</span>
       </li>

--- a/src/MaterialDesignToolkit.ResourceGeneration/Palette.json
+++ b/src/MaterialDesignToolkit.ResourceGeneration/Palette.json
@@ -14,7 +14,7 @@
       "hexes": [ "#F3E5F5", "#E1BEE7", "#CE93D8", "#BA68C8", "#AB47BC", "#9C27B0", "#8E24AA", "#7B1FA2", "#6A1B9A", "#4A148C", "#EA80FC", "#E040FB", "#D500F9", "#AA00FF" ]
     },
     {
-      "name": "Deep Purple",
+      "name": "DeepPurple",
       "hexes": [ "#EDE7F6", "#D1C4E9", "#B39DDB", "#9575CD", "#7E57C2", "#673AB7", "#5E35B1", "#512DA8", "#4527A0", "#311B92", "#B388FF", "#7C4DFF", "#651FFF", "#6200EA" ]
     },
     {
@@ -26,7 +26,7 @@
       "hexes": [ "#E3F2FD", "#BBDEFB", "#90CAF9", "#64B5F6", "#42A5F5", "#2196F3", "#1E88E5", "#1976D2", "#1565C0", "#0D47A1", "#82B1FF", "#448AFF", "#2979FF", "#2962FF" ]
     },
     {
-      "name": "Light Blue",
+      "name": "LightBlue",
       "hexes": [ "#E1F5FE", "#B3E5FC", "#81D4FA", "#4FC3F7", "#29B6F6", "#03A9F4", "#039BE5", "#0288D1", "#0277BD", "#01579B", "#80D8FF", "#40C4FF", "#00B0FF", "#0091EA" ]
     },
     {
@@ -42,7 +42,7 @@
       "hexes": [ "#E8F5E9", "#C8E6C9", "#A5D6A7", "#81C784", "#66BB6A", "#4CAF50", "#43A047", "#388E3C", "#2E7D32", "#1B5E20", "#B9F6CA", "#69F0AE", "#00E676", "#00C853" ]
     },
     {
-      "name": "Light Green",
+      "name": "LightGreen",
       "hexes": [ "#F1F8E9", "#DCEDC8", "#C5E1A5", "#AED581", "#9CCC65", "#8BC34A", "#7CB342", "#689F38", "#558B2F", "#33691E", "#CCFF90", "#B2FF59", "#76FF03", "#64DD17" ]
     },
     {
@@ -62,7 +62,7 @@
       "hexes": [ "#FFF3E0", "#FFE0B2", "#FFCC80", "#FFB74D", "#FFA726", "#FF9800", "#FB8C00", "#F57C00", "#EF6C00", "#E65100", "#FFD180", "#FFAB40", "#FF9100", "#FF6D00" ]
     },
     {
-      "name": "Deep Orange",
+      "name": "DeepOrange",
       "hexes": [ "#FBE9E7", "#FFCCBC", "#FFAB91", "#FF8A65", "#FF7043", "#FF5722", "#F4511E", "#E64A19", "#D84315", "#BF360C", "#FF9E80", "#FF6E40", "#FF3D00", "#DD2C00" ]
     },
     {
@@ -74,7 +74,7 @@
       "hexes": [ "#FAFAFA", "#F5F5F5", "#EEEEEE", "#E0E0E0", "#BDBDBD", "#9E9E9E", "#757575", "#616161", "#424242", "#212121" ]
     },
     {
-      "name": "Blue Grey",
+      "name": "BlueGrey",
       "hexes": [ "#ECEFF1", "#CFD8DC", "#B0BEC5", "#90A4AE", "#78909C", "#607D8B", "#546E7A", "#455A64", "#37474F", "#263238" ]
     }
   ]


### PR DESCRIPTION
This commit also removes the space in the color palette and the swatches. 
By doing this all ways to use a color are without spaces.