### PR TITLE
Fix 3585: Add ValidationErrorTemplate.xaml into the merged resource dictionary set

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
@@ -2,6 +2,9 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml" />
+  </ResourceDictionary.MergedDictionaries>
 
   <converters:MathConverter x:Key="DivisionMathConverter" Operation="Divide" />
   <converters:PointValueConverter x:Key="PointValueConverter" />


### PR DESCRIPTION
Fixes #3585 

Adds the `ValidationErrorTemplate.xaml` into the merged resource dictionary collection because it is statically referenced in the `ToggleButton` style using a `{StaticResource ...}` "binding".