### PR TITLE
Fix 3568: Replace explicit AdornerDecorator.CacheMode with AP binding

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Slider.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Slider.xaml
@@ -91,10 +91,7 @@
           <ScaleTransform ScaleX="0" ScaleY="0" />
         </Ellipse.RenderTransform>
       </Ellipse>
-      <AdornerDecorator>
-        <AdornerDecorator.CacheMode>
-          <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-        </AdornerDecorator.CacheMode>
+      <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
         <Ellipse x:Name="grip"
                  Margin="-1,0"
                  Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}"
@@ -280,10 +277,7 @@
               <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={StaticResource SliderValueLabelPositionConverter}, ConverterParameter={x:Static Orientation.Horizontal}}" Y="-40" />
             </TransformGroup>
           </Grid.RenderTransform>
-          <AdornerDecorator>
-            <AdornerDecorator.CacheMode>
-              <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-            </AdornerDecorator.CacheMode>
+          <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
             <Grid Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}">
               <Rectangle Margin="0,0,0,5"
                          Fill="{DynamicResource MaterialDesign.Brush.ToolTip.Background}"
@@ -314,10 +308,7 @@
           </TextBlock>
         </Grid>
       </Canvas>
-      <AdornerDecorator>
-        <AdornerDecorator.CacheMode>
-          <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-        </AdornerDecorator.CacheMode>
+      <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
         <Ellipse x:Name="grip"
                  Margin="-1,0"
                  Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}"
@@ -498,10 +489,7 @@
               <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={StaticResource SliderValueLabelPositionConverter}, ConverterParameter={x:Static Orientation.Vertical}}" Y="-7" />
             </TransformGroup>
           </Grid.RenderTransform>
-          <AdornerDecorator>
-            <AdornerDecorator.CacheMode>
-              <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-            </AdornerDecorator.CacheMode>
+          <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
             <Grid Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}">
               <Rectangle Margin="0,0,5,0"
                          Fill="{DynamicResource MaterialDesign.Brush.ToolTip.Background}"
@@ -532,10 +520,7 @@
           </TextBlock>
         </Grid>
       </Canvas>
-      <AdornerDecorator>
-        <AdornerDecorator.CacheMode>
-          <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-        </AdornerDecorator.CacheMode>
+      <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
         <Ellipse x:Name="grip"
                  Margin="0,-1"
                  Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}"

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RatingBar.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RatingBar.xaml
@@ -93,10 +93,7 @@
                             </TranslateTransform>
                           </TransformGroup>
                         </Grid.RenderTransform>
-                        <AdornerDecorator>
-                          <AdornerDecorator.CacheMode>
-                            <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                          </AdornerDecorator.CacheMode>
+                        <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
                           <Grid Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:RatingBar}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}">
                             <Rectangle Margin="0,0,0,5"
                                        Fill="{DynamicResource MaterialDesign.Brush.ToolTip.Background}"
@@ -149,10 +146,7 @@
                             </TranslateTransform>
                           </TransformGroup>
                         </Grid.RenderTransform>
-                        <AdornerDecorator>
-                          <AdornerDecorator.CacheMode>
-                            <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                          </AdornerDecorator.CacheMode>
+                        <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
                           <Grid Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:RatingBar}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}">
                             <Rectangle Margin="0,0,5,0"
                                        Fill="{DynamicResource MaterialDesign.Brush.ToolTip.Background}"

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
@@ -91,10 +91,7 @@
           <ScaleTransform ScaleX="0" ScaleY="0" />
         </Ellipse.RenderTransform>
       </Ellipse>
-      <AdornerDecorator>
-        <AdornerDecorator.CacheMode>
-          <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-        </AdornerDecorator.CacheMode>
+      <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
         <Ellipse x:Name="grip"
                  Margin="-1,0"
                  Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}"
@@ -280,10 +277,7 @@
               <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={StaticResource SliderValueLabelPositionConverter}, ConverterParameter={x:Static Orientation.Horizontal}}" Y="-40" />
             </TransformGroup>
           </Grid.RenderTransform>
-          <AdornerDecorator>
-            <AdornerDecorator.CacheMode>
-              <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-            </AdornerDecorator.CacheMode>
+          <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
             <Grid Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}">
               <Rectangle Margin="0,0,0,5"
                          Fill="{DynamicResource MaterialDesign.Brush.ToolTip.Background}"
@@ -314,10 +308,7 @@
           </TextBlock>
         </Grid>
       </Canvas>
-      <AdornerDecorator>
-        <AdornerDecorator.CacheMode>
-          <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-        </AdornerDecorator.CacheMode>
+      <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
         <Ellipse x:Name="grip"
                  Margin="-1,0"
                  Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}"
@@ -498,10 +489,7 @@
               <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={StaticResource SliderValueLabelPositionConverter}, ConverterParameter={x:Static Orientation.Vertical}}" Y="-7" />
             </TransformGroup>
           </Grid.RenderTransform>
-          <AdornerDecorator>
-            <AdornerDecorator.CacheMode>
-              <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-            </AdornerDecorator.CacheMode>
+          <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
             <Grid Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}">
               <Rectangle Margin="0,0,5,0"
                          Fill="{DynamicResource MaterialDesign.Brush.ToolTip.Background}"
@@ -532,10 +520,7 @@
           </TextBlock>
         </Grid>
       </Canvas>
-      <AdornerDecorator>
-        <AdornerDecorator.CacheMode>
-          <BitmapCache SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-        </AdornerDecorator.CacheMode>
+      <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
         <Ellipse x:Name="grip"
                  Margin="0,-1"
                  Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=RangeBase}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}"


### PR DESCRIPTION
Fixes #3568 

A similar change was done to all other controls (see link in issue). The changes here seems like they may have been forgotten in the last PR (or not present at the time). There is still one left in the link below which I am a bit unsure about whether it needs the same fix or not.
https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/5dd9ca96ed81cb9c6abd79a6fa76a8266ada42d7/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBar.xaml#L190-L193

I reproduced the issue by modifying the demo app, and the changes below (along with actually setting the AP at window-level; the workaround mentioned in the original issue from 2016) fixes the issue.