### PR TITLE
Fix 3357: Card double padding

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -45,7 +45,6 @@
                       Background="{TemplateBinding Background}"
                       Clip="{TemplateBinding ContentClip}">
                 <ContentPresenter x:Name="ContentPresenter"
-                                  Margin="{TemplateBinding Padding}"
                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                   Content="{TemplateBinding ContentControl.Content}"


### PR DESCRIPTION
Fix for bug explained in #3357 which was introduced in #3118

With the fix now this code works correctly:

```
<StackPanel Grid.Column="1" HorizontalAlignment="Center"  VerticalAlignment="Center">
  <materialDesign:Card  Width="100" Height="100" Padding="6">
    <Border Background="red"/>
  </materialDesign:Card>
  <Border Background="{StaticResource MaterialDesign.Brush.Card.Background}"
          Width="100" Height="100" CornerRadius="4" Margin="0 10 0 0" Padding="6"
          Effect="{StaticResource MaterialDesignElevationShadow1}">
    <Border Background="red"/>
  </Border>
</StackPanel>
```

![HAmbD1gITb](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/58171461/61dd6e61-cedc-4b49-9595-93f917268138)
