### PR TITLE
Fix 3593: Double up the space reserved for the Clip

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintClippingGridConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintClippingGridConverter.cs
@@ -13,7 +13,7 @@ public class FloatingHintClippingGridConverter : IMultiValueConverter
             return null;
         }
 
-        RectangleGeometry geometry = new(new Rect(new Point(0, 0), new Size(actualWidth, actualHeight * floatingScale)));
+        RectangleGeometry geometry = new(new Rect(new Point(0, 0), new Size(actualWidth, actualHeight * 2 * floatingScale)));
         geometry.Freeze();
         return geometry;
     }


### PR DESCRIPTION
Fixes #3593 

Not the nicest of fixes, but I can't really explain why the `ActualHeight` is not sufficient.

My initial thought was that it was DPI-scaling that needed to be taken into account, but this was also reproduceable when setting the DPI scaling to 100% (i.e. no scaling).

The poor mans solution was to simply double up the reserved space. If you have a better fix, please just abandon this PR. For now I just want the hints to not be clipped "by default" which they are right now. Basically anything below the baseline of the text is currently clipped.