### PR TITLE
RatingBar: Avoid binding errors and improve perf by using more direct bindings instead of traversing the visual tree

### DIFF
--- a/src/MaterialDesignThemes.Wpf/RatingBar.cs
+++ b/src/MaterialDesignThemes.Wpf/RatingBar.cs
@@ -324,7 +324,7 @@ public class RatingBar : Control
         {
             for (int i = Max; i >= start; i--)
             {
-                var ratingBarButton = new RatingBarButton
+                var ratingBarButton = new RatingBarButton(this)
                 {
                     Content = i,
                     ContentTemplate = ValueItemTemplate,
@@ -340,7 +340,7 @@ public class RatingBar : Control
         {
             for (int i = start; i <= Max; i++)
             {
-                var ratingBarButton = new RatingBarButton
+                var ratingBarButton = new RatingBarButton(this)
                 {
                     Content = i,
                     ContentTemplate = ValueItemTemplate,

--- a/src/MaterialDesignThemes.Wpf/RatingBarButton.cs
+++ b/src/MaterialDesignThemes.Wpf/RatingBarButton.cs
@@ -20,4 +20,13 @@ public class RatingBarButton : ButtonBase
         get => (int)GetValue(ValueProperty);
         internal set => SetValue(ValuePropertyKey, value);
     }
+
+    public RatingBar RatingBar { get; } = null!;    // Null initializer added to suppress warning (for the obsoleted empty constructor)
+
+    public RatingBarButton(RatingBar ratingBar) => RatingBar = ratingBar;
+
+    // Only added the default constructor for back-compat. Ideally should not be used from MDIX consumers, but you never know.
+    [Obsolete("Should not be used. Use the constructor taking a RatingBar instance as parameter instead. This constructor will be removed in a future version.")]
+    public RatingBarButton()
+    { }
 }

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RatingBar.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RatingBar.xaml
@@ -48,9 +48,9 @@
                       <TextBlock.Foreground>
                         <MultiBinding Converter="{x:Static wpf:RatingBar+TextBlockForegroundConverter.Instance}">
                           <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
-                          <Binding Path="Orientation" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                          <Binding Path="InvertDirection" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                          <Binding Path="Value" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
+                          <Binding Path="RatingBar.Orientation" RelativeSource="{RelativeSource TemplatedParent}" />
+                          <Binding Path="RatingBar.InvertDirection" RelativeSource="{RelativeSource TemplatedParent}" />
+                          <Binding Path="RatingBar.Value" RelativeSource="{RelativeSource TemplatedParent}" />
                           <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                         </MultiBinding>
                       </TextBlock.Foreground>
@@ -70,10 +70,10 @@
                                 <MultiBinding Converter="{x:Static wpf:RatingBar+PreviewIndicatorTransformXConverter.Instance}">
                                   <Binding Path="ActualWidth" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding ElementName="previewValueHorizontal" Path="ActualWidth" />
-                                  <Binding Path="Orientation" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                                  <Binding Path="InvertDirection" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                                  <Binding Path="IsFractionalValueEnabled" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                                  <Binding Path="PreviewValue" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
+                                  <Binding Path="RatingBar.Orientation" RelativeSource="{RelativeSource TemplatedParent}" />
+                                  <Binding Path="RatingBar.InvertDirection" RelativeSource="{RelativeSource TemplatedParent}" />
+                                  <Binding Path="RatingBar.IsFractionalValueEnabled" RelativeSource="{RelativeSource TemplatedParent}" />
+                                  <Binding Path="RatingBar.PreviewValue" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding Path="IsMouseOver" RelativeSource="{RelativeSource TemplatedParent}" />
                                 </MultiBinding>
@@ -82,10 +82,10 @@
                                 <MultiBinding Converter="{x:Static wpf:RatingBar+PreviewIndicatorTransformYConverter.Instance}">
                                   <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding ElementName="previewValueHorizontal" Path="ActualHeight" />
-                                  <Binding Path="Orientation" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                                  <Binding Path="InvertDirection" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                                  <Binding Path="IsFractionalValueEnabled" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                                  <Binding Path="PreviewValue" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
+                                  <Binding Path="RatingBar.Orientation" RelativeSource="{RelativeSource TemplatedParent}" />
+                                  <Binding Path="RatingBar.InvertDirection" RelativeSource="{RelativeSource TemplatedParent}" />
+                                  <Binding Path="RatingBar.IsFractionalValueEnabled" RelativeSource="{RelativeSource TemplatedParent}" />
+                                  <Binding Path="RatingBar.PreviewValue" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding Path="IsMouseOver" RelativeSource="{RelativeSource TemplatedParent}" />
                                 </MultiBinding>
@@ -123,10 +123,10 @@
                                 <MultiBinding Converter="{x:Static wpf:RatingBar+PreviewIndicatorTransformXConverter.Instance}">
                                   <Binding Path="ActualWidth" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding ElementName="previewValueVertical" Path="ActualWidth" />
-                                  <Binding Path="Orientation" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                                  <Binding Path="InvertDirection" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                                  <Binding Path="IsFractionalValueEnabled" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                                  <Binding Path="PreviewValue" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
+                                  <Binding Path="RatingBar.Orientation" RelativeSource="{RelativeSource TemplatedParent}" />
+                                  <Binding Path="RatingBar.InvertDirection" RelativeSource="{RelativeSource TemplatedParent}" />
+                                  <Binding Path="RatingBar.IsFractionalValueEnabled" RelativeSource="{RelativeSource TemplatedParent}" />
+                                  <Binding Path="RatingBar.PreviewValue" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding Path="IsMouseOver" RelativeSource="{RelativeSource TemplatedParent}" />
                                 </MultiBinding>
@@ -135,10 +135,10 @@
                                 <MultiBinding Converter="{x:Static wpf:RatingBar+PreviewIndicatorTransformYConverter.Instance}">
                                   <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding ElementName="previewValueVertical" Path="ActualHeight" />
-                                  <Binding Path="Orientation" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                                  <Binding Path="InvertDirection" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                                  <Binding Path="IsFractionalValueEnabled" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                                  <Binding Path="PreviewValue" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
+                                  <Binding Path="RatingBar.Orientation" RelativeSource="{RelativeSource TemplatedParent}" />
+                                  <Binding Path="RatingBar.InvertDirection" RelativeSource="{RelativeSource TemplatedParent}" />
+                                  <Binding Path="RatingBar.IsFractionalValueEnabled" RelativeSource="{RelativeSource TemplatedParent}" />
+                                  <Binding Path="RatingBar.PreviewValue" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                                   <Binding Path="IsMouseOver" RelativeSource="{RelativeSource TemplatedParent}" />
                                 </MultiBinding>
@@ -243,9 +243,9 @@
                       <TextBlock.Foreground>
                         <MultiBinding Converter="{x:Static wpf:RatingBar+TextBlockForegroundConverter.Instance}">
                           <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
-                          <Binding Path="Orientation" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                          <Binding Path="InvertDirection" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
-                          <Binding Path="Value" RelativeSource="{RelativeSource FindAncestor, AncestorType=wpf:RatingBar}" />
+                          <Binding Path="RatingBar.Orientation" RelativeSource="{RelativeSource TemplatedParent}" />
+                          <Binding Path="RatingBar.InvertDirection" RelativeSource="{RelativeSource TemplatedParent}" />
+                          <Binding Path="RatingBar.Value" RelativeSource="{RelativeSource TemplatedParent}" />
                           <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                         </MultiBinding>
                       </TextBlock.Foreground>


### PR DESCRIPTION
Fixes #3243 

Although the issue above was not really the fault of the `RatingBar`, but rather a virtualization issue, I still stumbled upon some (temporary) binding failures that seemed to have a negative impact on performance.

This PR simply forwards in the `RatingBar` instance into the `RatingBarButton` instances it creates. This makes for simpler bindings in the XAML template, that do not need to traverse the visual tree looking for a parent. Since this is already a compositional-relationship (i.e. `RatingBar` "owns" the `RatingBarButton` instances), I don't foresee any complications with this. I briefly tested to be sure it does not introduce a memory-leak, and I believe I have confirmed that it does not.

I added an obsolete default constructor simply to maintain (compilation) back-compat, although I don't really foresee any MDIX consumers using that constructor.