### PR TITLE
Dropped net7.0-windows target framework due to EOL, add net8.0-window…

### DIFF
--- a/MaterialDesignToolkit.Full.sln
+++ b/MaterialDesignToolkit.Full.sln
@@ -10,11 +10,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MaterialDesignColors.Wpf", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MahAppsDragablzDemo", "src\MahMaterialDragablzMashUp\MahAppsDragablzDemo.csproj", "{803954E5-3A35-4D8B-95A7-F6E9B63EC0DF}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "web", "src\web", "{7D0AC158-FD01-4EA3-8F8A-D19C085C77DF}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "web", "web", "{7D0AC158-FD01-4EA3-8F8A-D19C085C77DF}"
 	ProjectSection(SolutionItems) = preProject
 		src\web\images\MashUp.gif = src\web\images\MashUp.gif
-		src\web\scripts\PaletteBuilder.js = src\web\scripts\PaletteBuilder.js
 		src\web\PaletteBuilder.html = src\web\PaletteBuilder.html
+		src\web\scripts\PaletteBuilder.js = src\web\scripts\PaletteBuilder.js
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Demos", "Demos", "{D34BE232-DE51-43C1-ABDC-B69003BB50FF}"
@@ -30,7 +30,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		build\BuildNugets.ps1 = build\BuildNugets.ps1
 		Directory.Build.props = Directory.Build.props
-		Directory.Build.targets = Directory.Build.targets
 		Directory.packages.props = Directory.packages.props
 		.config\dotnet-tools.json = .config\dotnet-tools.json
 		global.json = global.json

--- a/src/MahMaterialDragablzMashUp/MahAppsDragablzDemo.csproj
+++ b/src/MahMaterialDragablzMashUp/MahAppsDragablzDemo.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net472;net6.0-windows;net7.0-windows;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0-windows;net8.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/src/MainDemo.Wpf/MaterialDesignDemo.csproj
+++ b/src/MainDemo.Wpf/MaterialDesignDemo.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net472;net6.0-windows;net7.0-windows;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0-windows;net8.0-windows</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Prefer32Bit Condition="'$(TargetFramework)' == 'net472'">true</Prefer32Bit>
     <ApplicationIcon>favicon.ico</ApplicationIcon>

--- a/src/MaterialDesign3.Demo.Wpf/MaterialDesign3Demo.csproj
+++ b/src/MaterialDesign3.Demo.Wpf/MaterialDesign3Demo.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net472;net6.0-windows;net7.0-windows;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0-windows;net8.0-windows</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Prefer32Bit Condition="'$(TargetFramework)' == 'net472'">true</Prefer32Bit>
     <ApplicationIcon>favicon.ico</ApplicationIcon>

--- a/src/MaterialDesignColors.Wpf/MaterialDesignColors.Wpf.csproj
+++ b/src/MaterialDesignColors.Wpf/MaterialDesignColors.Wpf.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>MaterialDesignColors</RootNamespace>
     <AssemblyName>MaterialDesignColors</AssemblyName>
-    <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <MDIXColorsVersion Condition="$(MDIXColorsVersion) == '' Or $(MDIXColorsVersion) == '*Undefined*'">1.0.1</MDIXColorsVersion>
     <MDIXColorsVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(MDIXColorsVersion)", "-ci\d+$", ""))</MDIXColorsVersion>

--- a/src/MaterialDesignColors.Wpf/MaterialDesignColors.nuspec
+++ b/src/MaterialDesignColors.Wpf/MaterialDesignColors.nuspec
@@ -19,7 +19,7 @@
     <dependencies>
       <group targetFramework="net462" />
       <group targetFramework="net6.0" />
-      <group targetFramework="net7.0" />
+      <group targetFramework="net8.0" />
     </dependencies>
   </metadata>
   <files>
@@ -28,7 +28,7 @@
       exclude="**\*.json" />
     <file src="bin\$configuration$\net6.0-windows\MaterialDesignColors.*" target="lib\net6.0"
       exclude="**\*.json" />
-    <file src="bin\$configuration$\net7.0-windows\MaterialDesignColors.*" target="lib\net7.0"
+    <file src="bin\$configuration$\net8.0-windows\MaterialDesignColors.*" target="lib\net8.0"
       exclude="**\*.json" />
   </files>
 </package>

--- a/src/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.csproj
+++ b/src/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <MDIXMahAppsVersion Condition="$(MDIXMahAppsVersion) == '' Or $(MDIXMahAppsVersion) == '*Undefined*'">1.0.1</MDIXMahAppsVersion>
     <MDIXMahAppsVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(MDIXMahAppsVersion)", "-ci\d+$", ""))</MDIXMahAppsVersion>

--- a/src/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.nuspec
+++ b/src/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.nuspec
@@ -27,7 +27,7 @@
         <dependency id="MaterialDesignThemes" version="0.0.0" />
         <dependency id="MahApps.Metro" version="2.0.0" />
       </group>
-      <group targetFramework="net7.0">
+      <group targetFramework="net8.0">
         <dependency id="MaterialDesignColors" version="0.0.0" />
         <dependency id="MaterialDesignThemes" version="0.0.0" />
         <dependency id="MahApps.Metro" version="2.0.0" />
@@ -40,7 +40,7 @@
       exclude="**\*.json" />
     <file src="bin\$configuration$\net6.0-windows\MaterialDesignThemes.MahApps.*"
       target="lib\net6.0" exclude="**\*.json" />
-    <file src="bin\$configuration$\net7.0-windows\MaterialDesignThemes.MahApps.*"
-      target="lib\net7.0" exclude="**\*.json" />
+    <file src="bin\$configuration$\net8.0-windows\MaterialDesignThemes.MahApps.*"
+      target="lib\net8.0" exclude="**\*.json" />
   </files>
 </package>

--- a/src/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
+++ b/src/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <MDIXVersion Condition="$(MDIXVersion) == '' Or $(MDIXVersion) == '*Undefined*'">1.0.1</MDIXVersion>
     <MDIXVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(MDIXVersion)", "-ci\d+$", ""))</MDIXVersion>

--- a/src/MaterialDesignThemes.Wpf/MaterialDesignThemes.nuspec
+++ b/src/MaterialDesignThemes.Wpf/MaterialDesignThemes.nuspec
@@ -25,7 +25,7 @@
         <dependency id="MaterialDesignColors" version="0.0.0" />
         <dependency id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" />
       </group>
-      <group targetFramework="net7.0">
+      <group targetFramework="net8.0">
         <dependency id="MaterialDesignColors" version="0.0.0" />
         <dependency id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" />
       </group>
@@ -39,8 +39,8 @@
       src="bin\$configuration$\net6.0-windows\MaterialDesignThemes.Wpf.*"
       target="lib\net6.0" exclude="**\*.json" />
     <file
-      src="bin\$configuration$\net7.0-windows\MaterialDesignThemes.Wpf.*"
-      target="lib\net7.0" exclude="**\*.json" />
+      src="bin\$configuration$\net8.0-windows\MaterialDesignThemes.Wpf.*"
+      target="lib\net8.0" exclude="**\*.json" />
     <file src="Resources\Roboto\*.ttf" target="build\Resources\Roboto" />
     <file src="MaterialDesignThemes.targets" target="build" />
     <file src="VisualStudioToolsManifest.xml" target="tools" />

--- a/src/MaterialDesignToolkit.ResourceGeneration/IconDiff.cs
+++ b/src/MaterialDesignToolkit.ResourceGeneration/IconDiff.cs
@@ -112,7 +112,7 @@ internal static partial class IconDiff
         ms.Position = 0;
         return ProcessDll(ms);
 
-        //This technically puts netcore before net framework, but since we are already at net7 and only care about latest
+        //This technically puts netcore before net framework, but since we are already at net8 and only care about latest
         //that does not matter.
         static int? GetMajorTfmVersion(string entryName)
         {

--- a/src/MaterialDesignToolkit.ResourceGeneration/MaterialDesignToolkit.ResourceGeneration.csproj
+++ b/src/MaterialDesignToolkit.ResourceGeneration/MaterialDesignToolkit.ResourceGeneration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/MaterialDesignColors.Wpf.Tests/MaterialDesignColors.Wpf.Tests.csproj
+++ b/tests/MaterialDesignColors.Wpf.Tests/MaterialDesignColors.Wpf.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0-windows;net8.0-windows</TargetFrameworks>
     <AssemblyTitle>MaterialDesignColors.Wpf.Tests</AssemblyTitle>
     <Product>MaterialDesignColors.Wpf.Tests</Product>
   </PropertyGroup>

--- a/tests/MaterialDesignThemes.UITests/MaterialDesignThemes.UITests.csproj
+++ b/tests/MaterialDesignThemes.UITests/MaterialDesignThemes.UITests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows7</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>false</SignAssembly>
     <UseWPF>true</UseWPF>

--- a/tests/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
+++ b/tests/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0-windows;net8.0-windows</TargetFrameworks>
     <AssemblyTitle>MaterialDesignThemes.Wpf.Tests</AssemblyTitle>
     <Product>MaterialDesignThemes.Wpf.Tests</Product>
   </PropertyGroup>


### PR DESCRIPTION
.NET 7 has reached its end of life, [Microsoft source](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).
I replaced every occurrence with the .NET 8 LTS target framework.

I left the .NET 6 target framework as this is still under support till november 2024.