### PR TITLE
Align NumericUpDown style with other controls

### DIFF
--- a/src/MainDemo.Wpf/Domain/MainWindowViewModel.cs
+++ b/src/MainDemo.Wpf/Domain/MainWindowViewModel.cs
@@ -191,7 +191,7 @@ public class MainWindowViewModel : ViewModelBase
         };
 
         yield return new DemoItem(
-            "Field line up",
+            "Fields line up",
             typeof(FieldsLineUp),
             new[]
             {

--- a/src/MainDemo.Wpf/FieldsLineUp.xaml
+++ b/src/MainDemo.Wpf/FieldsLineUp.xaml
@@ -19,8 +19,10 @@
 
     <GroupBox HorizontalAlignment="Left"
               VerticalAlignment="Top"
-              materialDesign:ColorZoneAssist.Background="{DynamicResource PrimaryHueLightBrush}"
-              materialDesign:ColorZoneAssist.Foreground="{DynamicResource PrimaryHueLightForegroundBrush}"
+              BorderBrush="{DynamicResource MaterialDesign.Brush.Primary}"
+              BorderThickness="1"
+              materialDesign:ColorZoneAssist.Background="{DynamicResource MaterialDesign.Brush.Background}"
+              materialDesign:ColorZoneAssist.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
               materialDesign:ColorZoneAssist.Mode="Custom">
       <GroupBox.Header>
         <StackPanel Orientation="Horizontal">
@@ -81,7 +83,7 @@
               <Style TargetType="TextBox" BasedOn="{StaticResource MaterialDesignTextBox}">
                 <Setter Property="FontFamily" Value="Consolas" />
                 <Setter Property="HorizontalAlignment" Value="Left" />
-                <Setter Property="Margin" Value="10,2" />
+                <Setter Property="Margin" Value="10,6" />
                 <Setter Property="MinWidth" Value="200" />
                 <Setter Property="VerticalAlignment" Value="Center" />
                 <Setter Property="materialDesign:HintAssist.IsFloating" Value="True" />

--- a/src/MainDemo.Wpf/FieldsLineUp.xaml
+++ b/src/MainDemo.Wpf/FieldsLineUp.xaml
@@ -156,6 +156,7 @@
             <ColumnDefinition MinWidth="100" />
             <ColumnDefinition MinWidth="100" />
             <ColumnDefinition MinWidth="100" />
+            <ColumnDefinition MinWidth="100" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Row="1"
@@ -195,6 +196,10 @@
                      Grid.Column="5"
                      Style="{StaticResource FieldHeader}"
                      Text="TimePicker" />
+          <TextBlock Grid.Row="0"
+                     Grid.Column="6"
+                     Style="{StaticResource FieldHeader}"
+                     Text="NumericUpDown" />
 
           <TextBox Grid.Row="1" Grid.Column="1" />
           <TextBox Grid.Row="2"
@@ -250,6 +255,17 @@
           <materialDesign:TimePicker Grid.Row="4"
                                      Grid.Column="5"
                                      Style="{StaticResource MaterialDesignOutlinedTimePicker}" />
+
+          <materialDesign:NumericUpDown Grid.Row="1" Grid.Column="6" />
+          <materialDesign:NumericUpDown Grid.Row="2"
+                                        Grid.Column="6"
+                                        Style="{StaticResource MaterialDesignFloatingHintNumericUpDown}" />
+          <materialDesign:NumericUpDown Grid.Row="3"
+                                        Grid.Column="6"
+                                        Style="{StaticResource MaterialDesignFilledNumericUpDown}" />
+          <materialDesign:NumericUpDown Grid.Row="4"
+                                        Grid.Column="6"
+                                        Style="{StaticResource MaterialDesignOutlinedNumericUpDown}" />
 
         </Grid>
       </StackPanel>

--- a/src/MainDemo.Wpf/FieldsLineUp.xaml.cs
+++ b/src/MainDemo.Wpf/FieldsLineUp.xaml.cs
@@ -90,6 +90,9 @@ public partial class FieldsLineUp
             case TimePicker timePicker:
                 timePicker.SelectedTime = DateTime.Now;
                 break;
+            case MaterialDesignThemes.Wpf.NumericUpDown numericUpDown:
+                numericUpDown.Value = 0;
+                break;
             default:
                 throw new NotSupportedException(control.GetType().FullName);
         }

--- a/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml
@@ -247,7 +247,17 @@
                                    Grid.Column="5"
                                    Style="{StaticResource MaterialDesignOutlinedTimePicker}" />
 
-        <materialDesign:NumericUpDown Grid.Row="1" Grid.Column="6"></materialDesign:NumericUpDown>
+        <materialDesign:NumericUpDown Grid.Row="1" Grid.Column="6" />
+        <materialDesign:NumericUpDown Grid.Row="2"
+                                      Grid.Column="6"
+                                      Style="{StaticResource MaterialDesignFloatingHintNumericUpDown}" />
+        <materialDesign:NumericUpDown Grid.Row="3"
+                                      Grid.Column="6"
+                                      Style="{StaticResource MaterialDesignFilledNumericUpDown}" />
+        <materialDesign:NumericUpDown Grid.Row="4"
+                                      Grid.Column="6"
+                                      Style="{StaticResource MaterialDesignOutlinedNumericUpDown}" />
+
       </Grid>
     </StackPanel>
   </GroupBox>

--- a/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml
@@ -147,6 +147,7 @@
           <ColumnDefinition MinWidth="100" />
           <ColumnDefinition MinWidth="100" />
           <ColumnDefinition MinWidth="100" />
+          <ColumnDefinition MinWidth="100" />
         </Grid.ColumnDefinitions>
 
         <TextBlock Grid.Row="1"
@@ -186,6 +187,10 @@
                    Grid.Column="5"
                    Style="{StaticResource FieldHeader}"
                    Text="TimePicker" />
+        <TextBlock Grid.Row="0"
+                   Grid.Column="6"
+                   Style="{StaticResource FieldHeader}"
+                   Text="NumericUpDown" />
 
         <TextBox Grid.Row="1" Grid.Column="1" />
         <TextBox Grid.Row="2"
@@ -242,6 +247,7 @@
                                    Grid.Column="5"
                                    Style="{StaticResource MaterialDesignOutlinedTimePicker}" />
 
+        <materialDesign:NumericUpDown Grid.Row="1" Grid.Column="6"></materialDesign:NumericUpDown>
       </Grid>
     </StackPanel>
   </GroupBox>

--- a/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml.cs
+++ b/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml.cs
@@ -90,6 +90,9 @@ public partial class FieldsLineUp
             case TimePicker timePicker:
                 timePicker.SelectedTime = DateTime.Now;
                 break;
+            case NumericUpDown numericUpDown:
+                numericUpDown.Value = 0;
+                break;
             default:
                 throw new NotSupportedException(control.GetType().FullName);
         }

--- a/src/MaterialDesignThemes.Wpf/DatePickerAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/DatePickerAssist.cs
@@ -1,6 +1,6 @@
 ﻿namespace MaterialDesignThemes.Wpf;
 
-[Obsolete("This class is obsolete and will be removed in a future version. Please use the TextBoxAssist equivalents instead. For OutlinedBorderInactiveThickness, simply use BorderThickness property instead.")]
+[Obsolete("This class is obsolete and will be removed in a future version. Please use the TextFieldAssist equivalents instead. For OutlinedBorderInactiveThickness, simply use DatePicker.BorderThickness property instead.")]
 public static class DatePickerAssist
 {
     public static readonly DependencyProperty OutlinedBorderInactiveThicknessProperty = DependencyProperty.RegisterAttached(

--- a/src/MaterialDesignThemes.Wpf/NumericUpDown.cs
+++ b/src/MaterialDesignThemes.Wpf/NumericUpDown.cs
@@ -1,17 +1,16 @@
 using System.ComponentModel;
 using System.Globalization;
-using System.Windows.Automation.Peers;
 
 namespace MaterialDesignThemes.Wpf;
 
 [TemplatePart(Name = IncreaseButtonPartName, Type = typeof(RepeatButton))]
 [TemplatePart(Name = DecreaseButtonPartName, Type = typeof(RepeatButton))]
-[TemplatePart(Name = TextFieldBoxPartName, Type = typeof(TextBox))]
+[TemplatePart(Name = TextBoxPartName, Type = typeof(TextBox))]
 public class NumericUpDown : Control
 {
     public const string IncreaseButtonPartName = "PART_IncreaseButton";
     public const string DecreaseButtonPartName = "PART_DecreaseButton";
-    public const string TextFieldBoxPartName = "PART_TextBox";
+    public const string TextBoxPartName = "PART_TextBox";
 
     private TextBox? _textBoxField;
     private RepeatButton? _decreaseButton;
@@ -180,7 +179,7 @@ public class NumericUpDown : Control
 
         _increaseButton = GetTemplateChild(IncreaseButtonPartName) as RepeatButton;
         _decreaseButton = GetTemplateChild(DecreaseButtonPartName) as RepeatButton;
-        _textBoxField = GetTemplateChild(TextFieldBoxPartName) as TextBox;
+        _textBoxField = GetTemplateChild(TextBoxPartName) as TextBox;
 
         if (_increaseButton != null)
             _increaseButton.Click += IncreaseButtonOnClick;

--- a/src/MaterialDesignThemes.Wpf/NumericUpDown.cs
+++ b/src/MaterialDesignThemes.Wpf/NumericUpDown.cs
@@ -11,7 +11,7 @@ public class NumericUpDown : Control
 {
     public const string IncreaseButtonPartName = "PART_IncreaseButton";
     public const string DecreaseButtonPartName = "PART_DecreaseButton";
-    public const string TextFieldBoxPartName = "PART_TextBoxField";
+    public const string TextFieldBoxPartName = "PART_TextBox";
 
     private TextBox? _textBoxField;
     private RepeatButton? _decreaseButton;

--- a/src/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -4,8 +4,7 @@
                     xmlns:local="clr-namespace:MaterialDesignThemes.Wpf"
                     xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:system="clr-namespace:System;assembly=mscorlib"
-                    xmlns:transitions="clr-namespace:MaterialDesignThemes.Wpf.Transitions"
-                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+                    xmlns:transitions="clr-namespace:MaterialDesignThemes.Wpf.Transitions">
 
   <ResourceDictionary.MergedDictionaries>
     <!--
@@ -13,7 +12,7 @@
       as part of Material Design in XAML Toolkit. Other themes, for existing controls
       must be selected manually by the user, so that they override default styles.
       The easiest way to do this is include:
-      
+
       MaterialDesignTheme.Defaults.xaml
       in your App.xaml
     -->
@@ -43,6 +42,7 @@
   <Style TargetType="{x:Type local:TimePicker}" BasedOn="{StaticResource MaterialDesignTimePicker}" />
   <Style TargetType="{x:Type local:AutoSuggestBox}" BasedOn="{StaticResource MaterialDesignAutoSuggestBox}" />
   <Style TargetType="{x:Type local:SplitButton}" BasedOn="{StaticResource MaterialDesignRaisedSplitButton}" />
+  <Style TargetType="{x:Type local:NumericUpDown}" BasedOn="{StaticResource MaterialDesignNumericUpDown}" />
 
   <converters:BrushToRadialGradientBrushConverter x:Key="BrushToRadialGradientBrushConverter" />
   <converters:DrawerOffsetConverter x:Key="DrawerOffsetConverter" />
@@ -332,7 +332,7 @@
               <Setter TargetName="ComponentOneTwoWrapper" Property="Opacity" Value=".56" />
               <Setter TargetName="ComponentThreeTextBlock" Property="Opacity" Value="1" />
             </Trigger>
-            <Trigger Property="wpf:CalendarAssist.Orientation" Value="Horizontal">
+            <Trigger Property="local:CalendarAssist.Orientation" Value="Horizontal">
               <Setter TargetName="ComponentOneTwoWrapper" Property="Orientation" Value="Vertical" />
             </Trigger>
           </ControlTemplate.Triggers>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign2.Defaults.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign2.Defaults.xaml
@@ -23,6 +23,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Listbox.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ListView.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Menu.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.NumericUpDown.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.PasswordBox.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ProgressBar.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.RadioButton.xaml" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Defaults.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Defaults.xaml
@@ -31,6 +31,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Listbox.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ListView.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Menu.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.NumericUpDown.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.PasswordBox.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ProgressBar.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.RadioButton.xaml" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.NumericUpDown.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.NumericUpDown.xaml
@@ -43,7 +43,7 @@
             <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
           </ControlTemplate.Resources>
           <Grid>
-            <TextBox x:Name="PART_TextBoxField"
+            <TextBox x:Name="PART_TextBox"
                      Padding="{TemplateBinding Padding, Converter={StaticResource NumericUpDownPaddingConverter}}"
                      VerticalAlignment="Stretch"
                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -103,13 +103,13 @@
               <RepeatButton x:Name="PART_DecreaseButton"
                             Margin="{TemplateBinding Padding, Converter={StaticResource PartButtonMarginConverter}}"
                             Style="{DynamicResource NestedNumericUpDownButtonsStyle}"
-                            Foreground="{Binding ElementName=PART_TextBoxField, Path=Foreground}"
+                            Foreground="{Binding ElementName=PART_TextBox, Path=Foreground}"
                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                             Content="{TemplateBinding DecreaseContent}" />
               <RepeatButton x:Name="PART_IncreaseButton"
                             Margin="{TemplateBinding Padding, Converter={StaticResource PartButtonMarginConverter}}"
                             Style="{DynamicResource NestedNumericUpDownButtonsStyle}"
-                            Foreground="{Binding ElementName=PART_TextBoxField, Path=Foreground}"
+                            Foreground="{Binding ElementName=PART_TextBox, Path=Foreground}"
                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                             Content="{TemplateBinding IncreaseContent}" />
             </StackPanel>
@@ -140,8 +140,8 @@
 
             <!-- Validation.HasError -->
             <Trigger Property="Validation.HasError" Value="True">
-              <Setter TargetName="PART_TextBoxField" Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
-              <Setter TargetName="PART_TextBoxField" Property="wpf:ValidationAssist.HasError" Value="True" />
+              <Setter TargetName="PART_TextBox" Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
+              <Setter TargetName="PART_TextBox" Property="wpf:ValidationAssist.HasError" Value="True" />
             </Trigger>
           </ControlTemplate.Triggers>
 

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.NumericUpDown.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.NumericUpDown.xaml
@@ -44,6 +44,7 @@
           </ControlTemplate.Resources>
           <Grid>
             <TextBox x:Name="PART_TextBox"
+                     BorderThickness="{TemplateBinding BorderThickness}"
                      Padding="{TemplateBinding Padding, Converter={StaticResource NumericUpDownPaddingConverter}}"
                      VerticalAlignment="Stretch"
                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -68,6 +69,7 @@
                      wpf:TextFieldAssist.HasFilledTextField="{TemplateBinding wpf:TextFieldAssist.HasFilledTextField}"
                      wpf:TextFieldAssist.HasOutlinedTextField="{TemplateBinding wpf:TextFieldAssist.HasOutlinedTextField}"
                      wpf:TextFieldAssist.NewSpecHighlightingEnabled="{TemplateBinding wpf:TextFieldAssist.NewSpecHighlightingEnabled}"
+                     wpf:TextFieldAssist.OutlinedBorderActiveThickness="{TemplateBinding wpf:TextFieldAssist.OutlinedBorderActiveThickness}"
                      wpf:TextFieldAssist.PrefixText="{TemplateBinding wpf:TextFieldAssist.PrefixText}"
                      wpf:TextFieldAssist.PrefixTextVisibility="{TemplateBinding wpf:TextFieldAssist.PrefixTextVisibility}"
                      wpf:TextFieldAssist.PrefixTextHintBehavior="{TemplateBinding wpf:TextFieldAssist.PrefixTextHintBehavior}"
@@ -84,20 +86,7 @@
                      internal:InternalTextFieldAssist.IsMouseOver="{TemplateBinding IsMouseOver}"
                      BorderBrush="{TemplateBinding BorderBrush}"
                      Focusable="{TemplateBinding Focusable}"
-                     Style="{DynamicResource NestedTextBoxStyle}">
-              <TextBox.BorderThickness>
-                <PriorityBinding>
-                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TimePickerAssist.OutlinedBorderInactiveThickness)" Converter="{StaticResource OutlinedBorderInactiveThicknessConverter}" />
-                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="BorderThickness" />
-                </PriorityBinding>
-              </TextBox.BorderThickness>
-              <wpf:TextFieldAssist.OutlinedBorderActiveThickness>
-                <PriorityBinding>
-                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TimePickerAssist.OutlinedBorderActiveThickness)" Converter="{StaticResource OutlinedBorderActiveThicknessConverter}" />
-                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" />
-                </PriorityBinding>
-              </wpf:TextFieldAssist.OutlinedBorderActiveThickness>
-            </TextBox>
+                     Style="{DynamicResource NestedTextBoxStyle}" />
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
               <RepeatButton x:Name="PART_DecreaseButton"

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.NumericUpDown.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.NumericUpDown.xaml
@@ -1,58 +1,212 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:local="clr-namespace:MaterialDesignThemes.Wpf"
-                    xmlns:system="clr-namespace:System;assembly=mscorlib"
-                    xmlns:transitions="clr-namespace:MaterialDesignThemes.Wpf.Transitions"
-                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
+                    xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal"
+                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
   <ResourceDictionary.MergedDictionaries>
-    <ResourceDictionary Source="MaterialDesignTheme.Button.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Button.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
   <Style x:Key="MaterialDesignNumericUpDown" TargetType="{x:Type wpf:NumericUpDown}">
+    <Style.Resources>
+      <Style x:Key="NestedTextBoxStyle" TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignTextBox}" />
+    </Style.Resources>
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
+    <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.TextBoxDefaultPadding}" />
+    <Setter Property="BorderThickness" Value="0,0,0,1" />
     <Setter Property="MinWidth" Value="100"/>
-    <Setter Property="Padding" Value="4"/>
-    <Setter Property="HorizontalContentAlignment" Value="Center" />
-    <Setter Property="VerticalContentAlignment" Value="Center" />
-    <Setter Property="IncreaseContent" Value="{local:PackIcon Kind=Plus}" />
-    <Setter Property="DecreaseContent" Value="{local:PackIcon Kind=Minus}" />
+    <!--<Setter Property="IncreaseContent" Value="{local:PackIcon Kind=Plus}" />-->
+    <!--<Setter Property="DecreaseContent" Value="{local:PackIcon Kind=Minus}" />-->
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type wpf:NumericUpDown}">
-          <Border Background="{TemplateBinding Background}"
-                  BorderBrush="{TemplateBinding BorderBrush}"
-                  BorderThickness="{TemplateBinding BorderThickness}"
-                  CornerRadius="10"
-                  ClipToBounds="True">
-            <Grid>
-              <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
-              </Grid.ColumnDefinitions>
+          <ControlTemplate.Resources>
+            <converters:ThicknessCloneConverter x:Key="NumericUpDownPaddingConverter"
+                                                AdditionalOffsetRight="55"
+                                                CloneEdges="All" />
+            <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverter"
+                                                CloneEdges="Top,Right,Bottom"
+                                                FixedLeft="0" />
+            <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderInactiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderInactiveThickness}" />
+            <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderActiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderActiveThickness}" />
+            <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
 
-              <TextBox x:Name="PART_TextBoxField"
-                       Margin="4 0"
-                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
+            <ControlTemplate x:Key="NumericUpButtonTemplate" TargetType="{x:Type RepeatButton}">
+              <wpf:PackIcon VerticalAlignment="Center"
+                            Background="Transparent"
+                            Foreground="{TemplateBinding Foreground}"
+                            Kind="Plus" />
+            </ControlTemplate>
 
+            <ControlTemplate x:Key="NumericDownButtonTemplate" TargetType="{x:Type RepeatButton}">
+              <wpf:PackIcon VerticalAlignment="Center"
+                            Background="Transparent"
+                            Foreground="{TemplateBinding Foreground}"
+                            Kind="Minus" />
+            </ControlTemplate>
+          </ControlTemplate.Resources>
+          <Grid>
+            <TextBox x:Name="PART_TextBoxField"
+                       Padding="{TemplateBinding Padding, Converter={StaticResource NumericUpDownPaddingConverter}}"
+                       VerticalAlignment="Stretch"
+                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                       wpf:HintAssist.FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
+                       wpf:HintAssist.FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
+                       wpf:HintAssist.FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
+                       wpf:HintAssist.Foreground="{TemplateBinding wpf:HintAssist.Foreground}"
+                       wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
+                       wpf:HintAssist.HelperTextStyle="{TemplateBinding wpf:HintAssist.HelperTextStyle}"
+                       wpf:HintAssist.Hint="{TemplateBinding wpf:HintAssist.Hint}"
+                       wpf:HintAssist.HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                       wpf:HintAssist.IsFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                       wpf:TextFieldAssist.HasLeadingIcon="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon}"
+                       wpf:TextFieldAssist.LeadingIcon="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
+                       wpf:TextFieldAssist.LeadingIconSize="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
+                       wpf:TextFieldAssist.HasTrailingIcon="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon}"
+                       wpf:TextFieldAssist.TrailingIcon="{TemplateBinding wpf:TextFieldAssist.TrailingIcon}"
+                       wpf:TextFieldAssist.TrailingIconSize="{TemplateBinding wpf:TextFieldAssist.TrailingIconSize}"
+                       wpf:TextFieldAssist.DecorationVisibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}"
+                       wpf:TextFieldAssist.HasClearButton="{TemplateBinding wpf:TextFieldAssist.HasClearButton}"
+                       wpf:TextFieldAssist.HasFilledTextField="{TemplateBinding wpf:TextFieldAssist.HasFilledTextField}"
+                       wpf:TextFieldAssist.HasOutlinedTextField="{TemplateBinding wpf:TextFieldAssist.HasOutlinedTextField}"
+                       wpf:TextFieldAssist.NewSpecHighlightingEnabled="{TemplateBinding wpf:TextFieldAssist.NewSpecHighlightingEnabled}"
+                       wpf:TextFieldAssist.PrefixText="{TemplateBinding wpf:TextFieldAssist.PrefixText}"
+                       wpf:TextFieldAssist.PrefixTextVisibility="{TemplateBinding wpf:TextFieldAssist.PrefixTextVisibility}"
+                       wpf:TextFieldAssist.PrefixTextHintBehavior="{TemplateBinding wpf:TextFieldAssist.PrefixTextHintBehavior}"
+                       wpf:TextFieldAssist.RippleOnFocusEnabled="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled}"
+                       wpf:TextFieldAssist.SuffixText="{TemplateBinding wpf:TextFieldAssist.SuffixText}"
+                       wpf:TextFieldAssist.SuffixTextVisibility="{TemplateBinding wpf:TextFieldAssist.SuffixTextVisibility}"
+                       wpf:TextFieldAssist.SuffixTextHintBehavior="{TemplateBinding wpf:TextFieldAssist.SuffixTextHintBehavior}"
+                       wpf:TextFieldAssist.IconVerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
+                       wpf:TextFieldAssist.TextBoxViewVerticalAlignment="{TemplateBinding wpf:TextFieldAssist.TextBoxViewVerticalAlignment}"
+                       wpf:TextFieldAssist.TextBoxViewMargin="{TemplateBinding wpf:TextFieldAssist.TextBoxViewMargin}"
+                       wpf:TextFieldAssist.TextFieldCornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
+                       wpf:TextFieldAssist.UnderlineBrush="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
+                       wpf:TextFieldAssist.UnderlineCornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
+                       internal:InternalTextFieldAssist.IsMouseOver="{TemplateBinding IsMouseOver}"
+                       BorderBrush="{TemplateBinding BorderBrush}"
+                       Focusable="{TemplateBinding Focusable}"
+                       Style="{DynamicResource NestedTextBoxStyle}">
+              <TextBox.BorderThickness>
+                <PriorityBinding>
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TimePickerAssist.OutlinedBorderInactiveThickness)" Converter="{StaticResource OutlinedBorderInactiveThicknessConverter}" />
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="BorderThickness" />
+                </PriorityBinding>
+              </TextBox.BorderThickness>
+              <wpf:TextFieldAssist.OutlinedBorderActiveThickness>
+                <PriorityBinding>
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TimePickerAssist.OutlinedBorderActiveThickness)" Converter="{StaticResource OutlinedBorderActiveThicknessConverter}" />
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" />
+                </PriorityBinding>
+              </wpf:TextFieldAssist.OutlinedBorderActiveThickness>
+            </TextBox>
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
               <RepeatButton x:Name="PART_DecreaseButton"
-                            Content="{TemplateBinding DecreaseContent}"
-                            Style="{StaticResource MaterialDesignFlatButton}"
-                            Padding="8,4"
-                            Grid.Column="1"/>
+                              Height="16"
+                              Width="16"
+                              Margin="{TemplateBinding Padding, Converter={StaticResource PartButtonMarginConverter}}"
+                              HorizontalAlignment="Right"
+                              VerticalAlignment="Center"
+                              Focusable="False"
+                              Foreground="{Binding ElementName=PART_TextBoxField, Path=Foreground}"
+                              Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                              Template="{StaticResource NumericDownButtonTemplate}" />
               <RepeatButton x:Name="PART_IncreaseButton"
-                            Content="{TemplateBinding IncreaseContent}"
-                            Style="{StaticResource MaterialDesignFlatButton}"
-                            Padding="8,4"
-                            Grid.Column="2" />
-            </Grid>
-          </Border>
+                              Height="16"
+                              Width="16"
+                              Margin="{TemplateBinding Padding, Converter={StaticResource PartButtonMarginConverter}}"
+                              HorizontalAlignment="Right"
+                              VerticalAlignment="Center"
+                              Focusable="False"
+                              Foreground="{Binding ElementName=PART_TextBoxField, Path=Foreground}"
+                              Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                              Template="{StaticResource NumericUpButtonTemplate}" />
+            </StackPanel>
+          </Grid>
+          <ControlTemplate.Triggers>
+             <!-- PART_Button hovering -->
+            <MultiTrigger> 
+              <MultiTrigger.Conditions> 
+                <Condition Property="IsEnabled" Value="True" />
+                <Condition SourceName="PART_DecreaseButton" Property="IsMouseOver" Value="True" /> 
+              </MultiTrigger.Conditions>
+                <Setter TargetName="PART_DecreaseButton" Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" /> 
+              </MultiTrigger> 
+              <Trigger Property="IsEnabled" Value="False">
+                <Setter TargetName="PART_DecreaseButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" /> 
+              </Trigger>
+
+              <MultiTrigger> 
+              <MultiTrigger.Conditions> 
+                <Condition Property="IsEnabled" Value="True" />
+                <Condition SourceName="PART_IncreaseButton" Property="IsMouseOver" Value="True" /> 
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_IncreaseButton" Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" /> 
+            </MultiTrigger> 
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="PART_IncreaseButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" /> 
+            </Trigger> 
+
+            <!-- Validation.HasError -->
+            <Trigger Property="Validation.HasError" Value="True">
+              <Setter TargetName="PART_TextBoxField" Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ValidationError}" />
+              <Setter TargetName="PART_TextBoxField" Property="wpf:ValidationAssist.HasError" Value="True" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+
         </ControlTemplate>
       </Setter.Value>
     </Setter>
+
+    <Setter Property="Validation.ErrorTemplate" Value="{StaticResource MaterialDesignValidationErrorTemplate}" />
+    <Setter Property="VerticalContentAlignment" Value="Stretch" />
+    <Setter Property="wpf:HintAssist.HelperTextStyle" Value="{StaticResource MaterialDesignHelperTextBlock}" />
+    <Setter Property="internal:ClearText.HandlesClearCommand" Value="True" />
+    <Setter Property="wpf:HintAssist.Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
+    <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="{x:Static wpf:Constants.DefaultTextBoxViewMargin}" />
+    <Setter Property="wpf:TextFieldAssist.UnderlineBrush" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
   </Style>
 
-  <Style TargetType="wpf:NumericUpDown" BasedOn="{StaticResource MaterialDesignNumericUpDown}" />
+  <Style x:Key="MaterialDesignFloatingHintNumericUpDown"
+         TargetType="{x:Type wpf:NumericUpDown}"
+         BasedOn="{StaticResource MaterialDesignNumericUpDown}">
+     <Style.Resources> 
+       <Style x:Key="NestedTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}" /> 
+     </Style.Resources> 
+    <Setter Property="wpf:HintAssist.IsFloating" Value="True" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.FloatingTextBoxDefaultPadding}" />
+  </Style>
+
+  <Style x:Key="MaterialDesignFilledNumericUpDown"
+         TargetType="{x:Type wpf:NumericUpDown}"
+         BasedOn="{StaticResource MaterialDesignFloatingHintNumericUpDown}">
+     <Style.Resources> 
+       <Style x:Key="NestedTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource MaterialDesignFilledTextBox}" /> 
+     </Style.Resources> 
+    <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.FilledBackground}" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.FilledTextBoxDefaultPadding}" />
+    <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
+    <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />
+    <Setter Property="wpf:TextFieldAssist.UnderlineCornerRadius" Value="0" />
+  </Style>
+
+  <Style x:Key="MaterialDesignOutlinedNumericUpDown"
+         TargetType="{x:Type wpf:NumericUpDown}"
+         BasedOn="{StaticResource MaterialDesignFloatingHintNumericUpDown}">
+     <Style.Resources> 
+       <Style x:Key="NestedTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource MaterialDesignOutlinedTextBox}" /> 
+     </Style.Resources> 
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.OutlineBorder}" />
+    <Setter Property="BorderThickness" Value="{x:Static wpf:Constants.DefaultOutlinedBorderInactiveThickness}" />
+    <Setter Property="Padding" Value="{x:Static wpf:Constants.OutlinedTextBoxDefaultPadding}" />
+    <Setter Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+    <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />
+  </Style>
+
 </ResourceDictionary>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.NumericUpDown.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.NumericUpDown.xaml
@@ -1,6 +1,5 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="clr-namespace:MaterialDesignThemes.Wpf"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
                     xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
@@ -9,89 +8,83 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
+
+  <Style x:Key="MaterialDesignNumericUpDownButtonsStyle" TargetType="{x:Type ButtonBase}" BasedOn="{StaticResource MaterialDesignFlatButton}">
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="Height" Value="18" />
+  </Style>
+
+  <wpf:PackIcon x:Key="ContentIncrease" Kind="Plus" x:Shared="False" />
+  <wpf:PackIcon x:Key="ContentDecrease" Kind="Minus" x:Shared="False" />
+
   <Style x:Key="MaterialDesignNumericUpDown" TargetType="{x:Type wpf:NumericUpDown}">
     <Style.Resources>
       <Style x:Key="NestedTextBoxStyle" TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignTextBox}" />
+      <Style x:Key="NestedNumericUpDownButtonsStyle" TargetType="{x:Type ButtonBase}" BasedOn="{StaticResource MaterialDesignNumericUpDownButtonsStyle}" />
     </Style.Resources>
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
     <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
     <Setter Property="Padding" Value="{x:Static wpf:Constants.TextBoxDefaultPadding}" />
     <Setter Property="BorderThickness" Value="0,0,0,1" />
-    <Setter Property="MinWidth" Value="100"/>
-    <!--<Setter Property="IncreaseContent" Value="{local:PackIcon Kind=Plus}" />-->
-    <!--<Setter Property="DecreaseContent" Value="{local:PackIcon Kind=Minus}" />-->
+    <Setter Property="MinWidth" Value="100" />
+    <Setter Property="IncreaseContent" Value="{StaticResource ContentIncrease}" />
+    <Setter Property="DecreaseContent" Value="{StaticResource ContentDecrease}" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type wpf:NumericUpDown}">
           <ControlTemplate.Resources>
-            <converters:ThicknessCloneConverter x:Key="NumericUpDownPaddingConverter"
-                                                AdditionalOffsetRight="55"
-                                                CloneEdges="All" />
-            <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverter"
-                                                CloneEdges="Top,Right,Bottom"
-                                                FixedLeft="0" />
+            <converters:ThicknessCloneConverter x:Key="NumericUpDownPaddingConverter" AdditionalOffsetRight="55" CloneEdges="All" />
+            <converters:ThicknessCloneConverter x:Key="PartButtonMarginConverter" CloneEdges="Top,Right,Bottom" FixedLeft="0" />
             <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderInactiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderInactiveThickness}" />
             <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderActiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderActiveThickness}" />
             <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
-
-            <ControlTemplate x:Key="NumericUpButtonTemplate" TargetType="{x:Type RepeatButton}">
-              <wpf:PackIcon VerticalAlignment="Center"
-                            Background="Transparent"
-                            Foreground="{TemplateBinding Foreground}"
-                            Kind="Plus" />
-            </ControlTemplate>
-
-            <ControlTemplate x:Key="NumericDownButtonTemplate" TargetType="{x:Type RepeatButton}">
-              <wpf:PackIcon VerticalAlignment="Center"
-                            Background="Transparent"
-                            Foreground="{TemplateBinding Foreground}"
-                            Kind="Minus" />
-            </ControlTemplate>
           </ControlTemplate.Resources>
           <Grid>
             <TextBox x:Name="PART_TextBoxField"
-                       Padding="{TemplateBinding Padding, Converter={StaticResource NumericUpDownPaddingConverter}}"
-                       VerticalAlignment="Stretch"
-                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                       wpf:HintAssist.FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
-                       wpf:HintAssist.FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
-                       wpf:HintAssist.FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
-                       wpf:HintAssist.Foreground="{TemplateBinding wpf:HintAssist.Foreground}"
-                       wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
-                       wpf:HintAssist.HelperTextStyle="{TemplateBinding wpf:HintAssist.HelperTextStyle}"
-                       wpf:HintAssist.Hint="{TemplateBinding wpf:HintAssist.Hint}"
-                       wpf:HintAssist.HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                       wpf:HintAssist.IsFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
-                       wpf:TextFieldAssist.HasLeadingIcon="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon}"
-                       wpf:TextFieldAssist.LeadingIcon="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
-                       wpf:TextFieldAssist.LeadingIconSize="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
-                       wpf:TextFieldAssist.HasTrailingIcon="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon}"
-                       wpf:TextFieldAssist.TrailingIcon="{TemplateBinding wpf:TextFieldAssist.TrailingIcon}"
-                       wpf:TextFieldAssist.TrailingIconSize="{TemplateBinding wpf:TextFieldAssist.TrailingIconSize}"
-                       wpf:TextFieldAssist.DecorationVisibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}"
-                       wpf:TextFieldAssist.HasClearButton="{TemplateBinding wpf:TextFieldAssist.HasClearButton}"
-                       wpf:TextFieldAssist.HasFilledTextField="{TemplateBinding wpf:TextFieldAssist.HasFilledTextField}"
-                       wpf:TextFieldAssist.HasOutlinedTextField="{TemplateBinding wpf:TextFieldAssist.HasOutlinedTextField}"
-                       wpf:TextFieldAssist.NewSpecHighlightingEnabled="{TemplateBinding wpf:TextFieldAssist.NewSpecHighlightingEnabled}"
-                       wpf:TextFieldAssist.PrefixText="{TemplateBinding wpf:TextFieldAssist.PrefixText}"
-                       wpf:TextFieldAssist.PrefixTextVisibility="{TemplateBinding wpf:TextFieldAssist.PrefixTextVisibility}"
-                       wpf:TextFieldAssist.PrefixTextHintBehavior="{TemplateBinding wpf:TextFieldAssist.PrefixTextHintBehavior}"
-                       wpf:TextFieldAssist.RippleOnFocusEnabled="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled}"
-                       wpf:TextFieldAssist.SuffixText="{TemplateBinding wpf:TextFieldAssist.SuffixText}"
-                       wpf:TextFieldAssist.SuffixTextVisibility="{TemplateBinding wpf:TextFieldAssist.SuffixTextVisibility}"
-                       wpf:TextFieldAssist.SuffixTextHintBehavior="{TemplateBinding wpf:TextFieldAssist.SuffixTextHintBehavior}"
-                       wpf:TextFieldAssist.IconVerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
-                       wpf:TextFieldAssist.TextBoxViewVerticalAlignment="{TemplateBinding wpf:TextFieldAssist.TextBoxViewVerticalAlignment}"
-                       wpf:TextFieldAssist.TextBoxViewMargin="{TemplateBinding wpf:TextFieldAssist.TextBoxViewMargin}"
-                       wpf:TextFieldAssist.TextFieldCornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
-                       wpf:TextFieldAssist.UnderlineBrush="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
-                       wpf:TextFieldAssist.UnderlineCornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
-                       internal:InternalTextFieldAssist.IsMouseOver="{TemplateBinding IsMouseOver}"
-                       BorderBrush="{TemplateBinding BorderBrush}"
-                       Focusable="{TemplateBinding Focusable}"
-                       Style="{DynamicResource NestedTextBoxStyle}">
+                     Padding="{TemplateBinding Padding, Converter={StaticResource NumericUpDownPaddingConverter}}"
+                     VerticalAlignment="Stretch"
+                     HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                     VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                     wpf:HintAssist.FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
+                     wpf:HintAssist.FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
+                     wpf:HintAssist.FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
+                     wpf:HintAssist.Foreground="{TemplateBinding wpf:HintAssist.Foreground}"
+                     wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
+                     wpf:HintAssist.HelperTextStyle="{TemplateBinding wpf:HintAssist.HelperTextStyle}"
+                     wpf:HintAssist.Hint="{TemplateBinding wpf:HintAssist.Hint}"
+                     wpf:HintAssist.HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                     wpf:HintAssist.IsFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                     wpf:TextFieldAssist.HasLeadingIcon="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon}"
+                     wpf:TextFieldAssist.LeadingIcon="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
+                     wpf:TextFieldAssist.LeadingIconSize="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
+                     wpf:TextFieldAssist.HasTrailingIcon="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon}"
+                     wpf:TextFieldAssist.TrailingIcon="{TemplateBinding wpf:TextFieldAssist.TrailingIcon}"
+                     wpf:TextFieldAssist.TrailingIconSize="{TemplateBinding wpf:TextFieldAssist.TrailingIconSize}"
+                     wpf:TextFieldAssist.DecorationVisibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}"
+                     wpf:TextFieldAssist.HasClearButton="{TemplateBinding wpf:TextFieldAssist.HasClearButton}"
+                     wpf:TextFieldAssist.HasFilledTextField="{TemplateBinding wpf:TextFieldAssist.HasFilledTextField}"
+                     wpf:TextFieldAssist.HasOutlinedTextField="{TemplateBinding wpf:TextFieldAssist.HasOutlinedTextField}"
+                     wpf:TextFieldAssist.NewSpecHighlightingEnabled="{TemplateBinding wpf:TextFieldAssist.NewSpecHighlightingEnabled}"
+                     wpf:TextFieldAssist.PrefixText="{TemplateBinding wpf:TextFieldAssist.PrefixText}"
+                     wpf:TextFieldAssist.PrefixTextVisibility="{TemplateBinding wpf:TextFieldAssist.PrefixTextVisibility}"
+                     wpf:TextFieldAssist.PrefixTextHintBehavior="{TemplateBinding wpf:TextFieldAssist.PrefixTextHintBehavior}"
+                     wpf:TextFieldAssist.RippleOnFocusEnabled="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled}"
+                     wpf:TextFieldAssist.SuffixText="{TemplateBinding wpf:TextFieldAssist.SuffixText}"
+                     wpf:TextFieldAssist.SuffixTextVisibility="{TemplateBinding wpf:TextFieldAssist.SuffixTextVisibility}"
+                     wpf:TextFieldAssist.SuffixTextHintBehavior="{TemplateBinding wpf:TextFieldAssist.SuffixTextHintBehavior}"
+                     wpf:TextFieldAssist.IconVerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
+                     wpf:TextFieldAssist.TextBoxViewVerticalAlignment="{TemplateBinding wpf:TextFieldAssist.TextBoxViewVerticalAlignment}"
+                     wpf:TextFieldAssist.TextBoxViewMargin="{TemplateBinding wpf:TextFieldAssist.TextBoxViewMargin}"
+                     wpf:TextFieldAssist.TextFieldCornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
+                     wpf:TextFieldAssist.UnderlineBrush="{TemplateBinding wpf:TextFieldAssist.UnderlineBrush}"
+                     wpf:TextFieldAssist.UnderlineCornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
+                     internal:InternalTextFieldAssist.IsMouseOver="{TemplateBinding IsMouseOver}"
+                     BorderBrush="{TemplateBinding BorderBrush}"
+                     Focusable="{TemplateBinding Focusable}"
+                     Style="{DynamicResource NestedTextBoxStyle}">
               <TextBox.BorderThickness>
                 <PriorityBinding>
                   <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TimePickerAssist.OutlinedBorderInactiveThickness)" Converter="{StaticResource OutlinedBorderInactiveThicknessConverter}" />
@@ -108,50 +101,42 @@
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
               <RepeatButton x:Name="PART_DecreaseButton"
-                              Height="16"
-                              Width="16"
-                              Margin="{TemplateBinding Padding, Converter={StaticResource PartButtonMarginConverter}}"
-                              HorizontalAlignment="Right"
-                              VerticalAlignment="Center"
-                              Focusable="False"
-                              Foreground="{Binding ElementName=PART_TextBoxField, Path=Foreground}"
-                              Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                              Template="{StaticResource NumericDownButtonTemplate}" />
+                            Margin="{TemplateBinding Padding, Converter={StaticResource PartButtonMarginConverter}}"
+                            Style="{DynamicResource NestedNumericUpDownButtonsStyle}"
+                            Foreground="{Binding ElementName=PART_TextBoxField, Path=Foreground}"
+                            Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                            Content="{TemplateBinding DecreaseContent}" />
               <RepeatButton x:Name="PART_IncreaseButton"
-                              Height="16"
-                              Width="16"
-                              Margin="{TemplateBinding Padding, Converter={StaticResource PartButtonMarginConverter}}"
-                              HorizontalAlignment="Right"
-                              VerticalAlignment="Center"
-                              Focusable="False"
-                              Foreground="{Binding ElementName=PART_TextBoxField, Path=Foreground}"
-                              Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                              Template="{StaticResource NumericUpButtonTemplate}" />
+                            Margin="{TemplateBinding Padding, Converter={StaticResource PartButtonMarginConverter}}"
+                            Style="{DynamicResource NestedNumericUpDownButtonsStyle}"
+                            Foreground="{Binding ElementName=PART_TextBoxField, Path=Foreground}"
+                            Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                            Content="{TemplateBinding IncreaseContent}" />
             </StackPanel>
           </Grid>
           <ControlTemplate.Triggers>
-             <!-- PART_Button hovering -->
-            <MultiTrigger> 
-              <MultiTrigger.Conditions> 
+            <!-- PART_Button hovering -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
                 <Condition Property="IsEnabled" Value="True" />
-                <Condition SourceName="PART_DecreaseButton" Property="IsMouseOver" Value="True" /> 
+                <Condition SourceName="PART_DecreaseButton" Property="IsMouseOver" Value="True" />
               </MultiTrigger.Conditions>
-                <Setter TargetName="PART_DecreaseButton" Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" /> 
-              </MultiTrigger> 
-              <Trigger Property="IsEnabled" Value="False">
-                <Setter TargetName="PART_DecreaseButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" /> 
-              </Trigger>
-
-              <MultiTrigger> 
-              <MultiTrigger.Conditions> 
-                <Condition Property="IsEnabled" Value="True" />
-                <Condition SourceName="PART_IncreaseButton" Property="IsMouseOver" Value="True" /> 
-              </MultiTrigger.Conditions>
-              <Setter TargetName="PART_IncreaseButton" Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" /> 
-            </MultiTrigger> 
+              <Setter TargetName="PART_DecreaseButton" Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
+            </MultiTrigger>
             <Trigger Property="IsEnabled" Value="False">
-              <Setter TargetName="PART_IncreaseButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" /> 
-            </Trigger> 
+              <Setter TargetName="PART_DecreaseButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+            </Trigger>
+
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="IsEnabled" Value="True" />
+                <Condition SourceName="PART_IncreaseButton" Property="IsMouseOver" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PART_IncreaseButton" Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
+            </MultiTrigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter TargetName="PART_IncreaseButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+            </Trigger>
 
             <!-- Validation.HasError -->
             <Trigger Property="Validation.HasError" Value="True">
@@ -176,9 +161,10 @@
   <Style x:Key="MaterialDesignFloatingHintNumericUpDown"
          TargetType="{x:Type wpf:NumericUpDown}"
          BasedOn="{StaticResource MaterialDesignNumericUpDown}">
-     <Style.Resources> 
-       <Style x:Key="NestedTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}" /> 
-     </Style.Resources> 
+    <Style.Resources>
+      <Style x:Key="NestedTextBoxStyle" TargetType="TextBox"
+             BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}" />
+    </Style.Resources>
     <Setter Property="wpf:HintAssist.IsFloating" Value="True" />
     <Setter Property="Padding" Value="{x:Static wpf:Constants.FloatingTextBoxDefaultPadding}" />
   </Style>
@@ -186,9 +172,9 @@
   <Style x:Key="MaterialDesignFilledNumericUpDown"
          TargetType="{x:Type wpf:NumericUpDown}"
          BasedOn="{StaticResource MaterialDesignFloatingHintNumericUpDown}">
-     <Style.Resources> 
-       <Style x:Key="NestedTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource MaterialDesignFilledTextBox}" /> 
-     </Style.Resources> 
+    <Style.Resources>
+      <Style x:Key="NestedTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource MaterialDesignFilledTextBox}" />
+    </Style.Resources>
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.FilledBackground}" />
     <Setter Property="Padding" Value="{x:Static wpf:Constants.FilledTextBoxDefaultPadding}" />
     <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
@@ -199,9 +185,9 @@
   <Style x:Key="MaterialDesignOutlinedNumericUpDown"
          TargetType="{x:Type wpf:NumericUpDown}"
          BasedOn="{StaticResource MaterialDesignFloatingHintNumericUpDown}">
-     <Style.Resources> 
-       <Style x:Key="NestedTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource MaterialDesignOutlinedTextBox}" /> 
-     </Style.Resources> 
+    <Style.Resources>
+      <Style x:Key="NestedTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource MaterialDesignOutlinedTextBox}" />
+    </Style.Resources>
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.OutlineBorder}" />
     <Setter Property="BorderThickness" Value="{x:Static wpf:Constants.DefaultOutlinedBorderInactiveThickness}" />
     <Setter Property="Padding" Value="{x:Static wpf:Constants.OutlinedTextBoxDefaultPadding}" />

--- a/src/MaterialDesignThemes.Wpf/TimePickerAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/TimePickerAssist.cs
@@ -1,6 +1,6 @@
 ﻿namespace MaterialDesignThemes.Wpf;
 
-[Obsolete("This class is obsolete and will be removed in a future version. Please use the TextBoxAssist equivalents instead. For OutlinedBorderInactiveThickness, simply use BorderThickness property instead.")]
+[Obsolete("This class is obsolete and will be removed in a future version. Please use the TextFieldAssist equivalents instead. For OutlinedBorderInactiveThickness, simply use TimePicker.BorderThickness property instead.")]
 public static class TimePickerAssist
 {
     public static readonly DependencyProperty OutlinedBorderInactiveThicknessProperty = DependencyProperty.RegisterAttached(

--- a/tests/MaterialDesignThemes.UITests/WPF/NumericUpDowns/NumericUpDownTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/NumericUpDowns/NumericUpDownTests.cs
@@ -12,7 +12,7 @@ public class NumericUpDownTests(ITestOutputHelper output) : TestBase(output)
         """);
         var plusButton = await numericUpDown.GetElement<RepeatButton>("PART_IncreaseButton");
         var minusButton = await numericUpDown.GetElement<RepeatButton>("PART_DecreaseButton");
-        var textBox = await numericUpDown.GetElement<TextBox>("PART_TextBoxField");
+        var textBox = await numericUpDown.GetElement<TextBox>("PART_TextBox");
 
         Assert.Equal("1", await textBox.GetText());
         Assert.Equal(1, await numericUpDown.GetValue());
@@ -42,7 +42,7 @@ public class NumericUpDownTests(ITestOutputHelper output) : TestBase(output)
         """);
         var plusButton = await numericUpDown.GetElement<RepeatButton>("PART_IncreaseButton");
         var minusButton = await numericUpDown.GetElement<RepeatButton>("PART_DecreaseButton");
-        var textBox = await numericUpDown.GetElement<TextBox>("PART_TextBoxField");
+        var textBox = await numericUpDown.GetElement<TextBox>("PART_TextBox");
 
         await plusButton.LeftClick();
         await Wait.For(async () =>
@@ -73,7 +73,7 @@ public class NumericUpDownTests(ITestOutputHelper output) : TestBase(output)
         """);
         var plusButton = await numericUpDown.GetElement<RepeatButton>("PART_IncreaseButton");
         var minusButton = await numericUpDown.GetElement<RepeatButton>("PART_DecreaseButton");
-        var textBox = await numericUpDown.GetElement<TextBox>("PART_TextBoxField");
+        var textBox = await numericUpDown.GetElement<TextBox>("PART_TextBox");
 
         await minusButton.LeftClick();
         await Wait.For(async () =>


### PR DESCRIPTION
This PR aligns the NumericUpDown style to the one of other controls (closes #3614)

# Tasks

- [x] Add to fields line up
- [x] Validation Style
- [x] Floating Hint
- [x] Helper Text
- [x] Suffix
- [x] Prefix

# Breaking

Currently IncreaseContent and DecreaseContent are ignored since this two values should be the same as in TimePicker, not changable.

> Should we use IncreaseContent and DecreaseContent or remove it. I would prefer to remove it and use it predefined as in TimePicker. If we ignore both properties, then we have to remove it from code before merging

|old|new|
|---|---|
|![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/4341039/961a6183-0eec-419c-afa5-25bcab331de2)|![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/4341039/29900a37-b126-4239-92ff-36d73f3c3beb)|
||![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/4341039/bf4a98eb-a38f-43ec-85b6-29170f0dede7)|
||![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/4341039/9bf1fbf4-176c-44ac-90ca-9243ee7219eb)|
||![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/4341039/2b434f35-8c5f-4a7b-8b61-14d3acc8fa96)|
||![image](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/4341039/c8f4331e-bdfa-4e35-81f0-e443475cc605)|





