### PR TITLE
Transitioner: Short-circuit SelectionChanged event when not originating from Transitioner

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Transitions/Transitioner.cs
+++ b/src/MaterialDesignThemes.Wpf/Transitions/Transitioner.cs
@@ -62,6 +62,7 @@ public class Transitioner : Selector, IZIndexController
         CommandBindings.Add(new CommandBinding(MoveFirstCommand, MoveFirstHandler));
         CommandBindings.Add(new CommandBinding(MoveLastCommand, MoveLastHandler));
         AddHandler(TransitionerSlide.InTransitionFinished, new RoutedEventHandler(IsTransitionFinishedHandler));
+        AddHandler(SelectionChangedEvent, new RoutedEventHandler(SelectionChangedEventHandler));
         Loaded += (sender, args) =>
         {
             if (SelectedIndex != -1)
@@ -105,6 +106,15 @@ public class Transitioner : Selector, IZIndexController
         foreach (var slide in Items.OfType<object>().Select(GetSlide).Where(s => s.State == TransitionerSlideState.Previous))
         {
             slide.SetCurrentValue(TransitionerSlide.StateProperty, TransitionerSlideState.None);
+        }
+    }
+
+    private static void SelectionChangedEventHandler(object sender, RoutedEventArgs e)
+    {
+        if (e.OriginalSource is not Transitioner)
+        {
+            // This event is bubbling up from a child Selector element. Swallow the event to avoid confusion with the SelectionChanged event on the Transitioner itself.
+            e.Handled = true;
         }
     }
 

--- a/tests/MaterialDesignThemes.Wpf.Tests/TransitionerTests.cs
+++ b/tests/MaterialDesignThemes.Wpf.Tests/TransitionerTests.cs
@@ -1,5 +1,4 @@
 ﻿using MaterialDesignThemes.Wpf.Transitions;
-using Xunit;
 
 namespace MaterialDesignThemes.Wpf.Tests;
 
@@ -52,4 +51,41 @@ public class TransitionerTests
         //Assert
         Assert.Equal(0, transitioner.SelectedIndex);
     }
+
+    [StaFact]
+    public void ShortCircuitIssue3268()
+    {
+        //Arrange
+        Grid child1 = new();
+        TextBox tb = new()
+        {
+            Text = "test text"
+        };
+        child1.Children.Add(tb);
+
+        UserControl child2 = new();
+
+        Transitioner transitioner = new();
+        transitioner.Items.Add(child1);
+        transitioner.Items.Add(child2);
+
+        object parameter = 1;
+
+        int selectionChangedCounter = 0;
+        transitioner.SelectionChanged += (s, e) =>
+        {
+            selectionChangedCounter++;
+        };
+
+        //Act
+        Assert.True(Transitioner.MovePreviousCommand.CanExecute(parameter, transitioner));
+        Transitioner.MovePreviousCommand.Execute(parameter, transitioner);
+        tb.SelectAll();
+
+        //Assert
+        Assert.Equal(1, selectionChangedCounter);
+        Assert.Equal(0, transitioner.SelectedIndex);
+    }
+
+    private void Transitioner_SelectionChanged(object sender, SelectionChangedEventArgs e) => throw new NotImplementedException();
 }

--- a/tests/MaterialDesignThemes.Wpf.Tests/TransitionerTests.cs
+++ b/tests/MaterialDesignThemes.Wpf.Tests/TransitionerTests.cs
@@ -57,11 +57,10 @@ public class TransitionerTests
     {
         //Arrange
         Grid child1 = new();
-        TextBox tb = new()
-        {
-            Text = "test text"
-        };
-        child1.Children.Add(tb);
+        ListBox lb = new();
+        lb.Items.Add(new Label());
+        lb.Items.Add(new Label());
+        child1.Children.Add(lb);
 
         UserControl child2 = new();
 
@@ -69,23 +68,20 @@ public class TransitionerTests
         transitioner.Items.Add(child1);
         transitioner.Items.Add(child2);
 
-        object parameter = 1;
-
         int selectionChangedCounter = 0;
         transitioner.SelectionChanged += (s, e) =>
         {
             selectionChangedCounter++;
         };
+        Transitioner.MoveNextCommand.Execute(0, transitioner);
 
         //Act
-        Assert.True(Transitioner.MovePreviousCommand.CanExecute(parameter, transitioner));
-        Transitioner.MovePreviousCommand.Execute(parameter, transitioner);
-        tb.SelectAll();
+        Assert.NotNull(transitioner.SelectedItem);
+        Assert.True(transitioner.SelectedItem == child1);
+        lb.SelectedItem = lb.Items[1];
 
         //Assert
         Assert.Equal(1, selectionChangedCounter);
         Assert.Equal(0, transitioner.SelectedIndex);
     }
-
-    private void Transitioner_SelectionChanged(object sender, SelectionChangedEventArgs e) => throw new NotImplementedException();
 }


### PR DESCRIPTION
Potentially fixes #3268 

Effectively short-circuits the `SelectionChanged` event from bubbling up from the `Transitioner` when the original source of the event is not the `Transitioner` itself. Please consider if you see any negative side-effects to this; I could not really see any, but I would like your input on that as well.