### PR TITLE
Set ScrollViewerAssist.IgnorePadding by default to True

### DIFF
--- a/src/MaterialDesignThemes.Wpf/ScrollViewerAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/ScrollViewerAssist.cs
@@ -76,7 +76,7 @@ public static class ScrollViewerAssist
     }
 
     public static readonly DependencyProperty IgnorePaddingProperty = DependencyProperty.RegisterAttached(
-    "IgnorePadding", typeof(bool), typeof(ScrollViewerAssist), new PropertyMetadata(false));
+    "IgnorePadding", typeof(bool), typeof(ScrollViewerAssist), new PropertyMetadata(true));
 
     public static void SetIgnorePadding(DependencyObject element, bool value) => element.SetValue(IgnorePaddingProperty, value);
     public static bool GetIgnorePadding(DependencyObject element) => (bool)element.GetValue(IgnorePaddingProperty);


### PR DESCRIPTION
Fixes #3620 

The IgnorePadding accidently flipped from True to False during the previous PR :[https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/pull/3579/files](url)

This PR should flip it back to True by default.