### PR TITLE
Fix for wrong outline border on ComboBox

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -775,7 +775,11 @@
       </MultiTrigger>
 
       <!-- PART_Popup.IsOpen -->
-      <Trigger SourceName="PART_Popup" Property="IsOpen" Value="True">
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition SourceName="PART_Popup" Property="IsOpen" Value="True" />
+          <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+        </MultiTrigger.Conditions>
         <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
         <Setter TargetName="ContentGrid" Property="Margin">
           <Setter.Value>
@@ -785,7 +789,7 @@
             </MultiBinding>
           </Setter.Value>
         </Setter>
-      </Trigger>
+      </MultiTrigger>
       <MultiTrigger>
         <MultiTrigger.Conditions>
           <Condition SourceName="PART_Popup" Property="IsOpen" Value="True" />

--- a/tests/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
@@ -282,4 +282,31 @@ public class ComboBoxTests : TestBase
 
         recorder.Success();
     }
+
+    [Theory]
+    [InlineData("MaterialDesignFloatingHintComboBox", 0, 0, 0, 1)]
+    [InlineData("MaterialDesignFilledComboBox", 0, 0, 0, 1)]
+    [InlineData("MaterialDesignOutlinedComboBox", 2, 2, 2, 2)]
+    [Description("Issue 3623")]
+    public async Task ComboBox_BorderShouldDependOnAppliedStyle(string style, double left, double top, double right, double bottom)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        var stackPanel = await LoadXaml<StackPanel>($$"""
+             <StackPanel>
+               <ComboBox Style="{StaticResource {{style}}}">
+                 <ComboBoxItem Content="TEST" IsSelected="True" />
+               </ComboBox>
+             </StackPanel>
+             """);
+        var comboBox = await stackPanel.GetElement<ComboBox>("/ComboBox");
+        var border = await comboBox.GetElement<Border>("OuterBorder");
+
+        await comboBox.LeftClick();
+
+        Thickness thickness = await border.GetBorderThickness();
+        Assert.Equal(new Thickness(left, top, right, bottom), thickness);
+
+        recorder.Success();
+    }
 }


### PR DESCRIPTION
Fixes #3623 

Added a test to reproduce the issue, and then fixed the issue by only conditionally modifying the `OuterBorder.BorderThickness`

![ComboBoxFix](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/assets/19572699/3cca7b3b-b809-49da-a2db-0634202a4f29)