### PR TITLE
TabControl - Add opt-in AP to control margin on header

### DIFF
--- a/src/MainDemo.Wpf/Tabs.xaml
+++ b/src/MainDemo.Wpf/Tabs.xaml
@@ -365,6 +365,26 @@
 
     </WrapPanel>
 
+    <WrapPanel>
+      <smtx:XamlDisplay Margin="0,0,16,16"
+                        HorizontalAlignment="Left"
+                        UniqueKey="tabs_custom_7">
+        <TabControl Width="300"
+                    materialDesign:ColorZoneAssist.Mode="SecondaryDark"
+                    Style="{StaticResource MaterialDesignFilledTabControl}"
+                    materialDesign:TabAssist.HeaderPanelMargin="20,0">
+          <TabItem Header="TAB 1">
+            <TextBlock Margin="8"
+                       Text="Notice left header margin" />
+          </TabItem>
+          <TabItem Header="TAB 2">
+            <TextBlock Margin="8"
+                       Text="Notice right header margin" />
+          </TabItem>
+        </TabControl>
+      </smtx:XamlDisplay>
+    </WrapPanel>
+
     <Rectangle Style="{StaticResource PageSectionSeparator}" />
 
     <TextBlock Style="{StaticResource PageSectionTitleTextBlock}"

--- a/src/MaterialDesignThemes.Wpf/TabAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/TabAssist.cs
@@ -5,16 +5,29 @@ public static class TabAssist
     public static readonly DependencyProperty HasFilledTabProperty = DependencyProperty.RegisterAttached(
         "HasFilledTab", typeof(bool), typeof(TabAssist), new PropertyMetadata(false));
 
-    public static void SetHasFilledTab(DependencyObject element, bool value) => element.SetValue(HasFilledTabProperty, value);
+    public static void SetHasFilledTab(DependencyObject element, bool value)
+        => element.SetValue(HasFilledTabProperty, value);
 
-    public static bool GetHasFilledTab(DependencyObject element) => (bool)element.GetValue(HasFilledTabProperty);
+    public static bool GetHasFilledTab(DependencyObject element)
+        => (bool)element.GetValue(HasFilledTabProperty);
 
     public static readonly DependencyProperty HasUniformTabWidthProperty = DependencyProperty.RegisterAttached(
         "HasUniformTabWidth", typeof(bool), typeof(TabAssist), new PropertyMetadata(false));
 
-    public static void SetHasUniformTabWidth(DependencyObject element, bool value) => element.SetValue(HasUniformTabWidthProperty, value);
+    public static void SetHasUniformTabWidth(DependencyObject element, bool value)
+        => element.SetValue(HasUniformTabWidthProperty, value);
 
-    public static bool GetHasUniformTabWidth(DependencyObject element) => (bool)element.GetValue(HasUniformTabWidthProperty);
+    public static bool GetHasUniformTabWidth(DependencyObject element)
+        => (bool)element.GetValue(HasUniformTabWidthProperty);
+
+    public static readonly DependencyProperty HeaderPanelMarginProperty = DependencyProperty.RegisterAttached(
+        "HeaderPanelMargin", typeof(Thickness), typeof(TabAssist), new PropertyMetadata(default(Thickness)));
+
+    public static void SetHeaderPanelMargin(DependencyObject element, Thickness value)
+        => element.SetValue(HeaderPanelMarginProperty, value);
+
+    public static Thickness GetHeaderPanelMargin(DependencyObject element)
+        => (Thickness) element.GetValue(HeaderPanelMarginProperty);
 
     internal static Visibility GetBindableIsItemsHost(DependencyObject obj)
         => (Visibility)obj.GetValue(BindableIsItemsHostProperty);

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -47,6 +47,7 @@
                 <StackPanel>
                   <UniformGrid x:Name="CenteredHeaderPanel"
                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                               Margin="{Binding Path=(wpf:TabAssist.HeaderPanelMargin), RelativeSource={RelativeSource TemplatedParent}}"
                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                wpf:TabAssist.BindableIsItemsHost="{Binding Visibility, RelativeSource={RelativeSource Self}}"
                                Focusable="False"
@@ -54,6 +55,7 @@
                                Rows="1" />
                   <VirtualizingStackPanel x:Name="HeaderPanel"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          Margin="{Binding Path=(wpf:TabAssist.HeaderPanelMargin), RelativeSource={RelativeSource TemplatedParent}}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                           wpf:TabAssist.BindableIsItemsHost="{Binding Visibility, RelativeSource={RelativeSource Self}}"
                                           Focusable="False"


### PR DESCRIPTION
Fixes #3633 

This PR adds a new opt-in attached property `TabAssist.HeaderPanelMargin` which allows the consumer to specify a custom `Margin` on the header panel in the template.

![TabControlHeaderMargin](https://github.com/user-attachments/assets/68c866d0-1a8b-47af-8b19-3c3c221a00e1)

```xaml
<TabControl Width="300"
            materialDesign:ColorZoneAssist.Mode="SecondaryDark"
            Style="{StaticResource MaterialDesignFilledTabControl}"
            materialDesign:TabAssist.HeaderPanelMargin="20,0">
  <TabItem Header="TAB 1">
    <TextBlock Margin="8"
               Text="Notice left header margin" />
  </TabItem>
  <TabItem Header="TAB 2">
    <TextBlock Margin="8"
               Text="Notice right header margin" />
  </TabItem>
</TabControl>
```