### PR TITLE
Fix PopupBox misalignment on mixed DPI systems

### DIFF
--- a/src/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/src/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -617,8 +617,8 @@ public class PopupBox : ContentControl
                 throw new ArgumentOutOfRangeException();
         }
 
-        double xTransformed = DpiHelper.TransformToDeviceX(x);
-        double yTransformed = DpiHelper.TransformToDeviceY(y);
+        double xTransformed = DpiHelper.TransformToDeviceX(this, x);
+        double yTransformed = DpiHelper.TransformToDeviceY(this, y);
 
         _popupPointFromLastRequest = new Point(xTransformed, yTransformed);
         return new[] { new CustomPopupPlacement(_popupPointFromLastRequest, PopupPrimaryAxis.Horizontal) };


### PR DESCRIPTION
`PopupBox` correctly transforms from device coordinates using the `PresentationSource` transform matrix, but then uses the global system DPI to transform back to device coordinates. This causes placement issues on systems with multiple DPI/scaling settings.

These examples were captured on a system with mixed scaling of 100% on the primary screen and 225% on the secondary, with the demo app placed on the latter.

Before:

![image](https://github.com/user-attachments/assets/d2921cd4-f9ff-4466-8c08-e2f2ddf03867)

After:

![image](https://github.com/user-attachments/assets/303829d8-f483-49c6-9326-853ed24f3dd1)

I chose `BottomAndAlignRightEdges` because the misalignment is particularly noticeable, but ultimately every placement mode is misaligned.