### PR TITLE
fixes #3650 - TimePicker tab navigation

### DIFF
--- a/src/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/src/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -363,6 +363,13 @@ public class TimePicker : Control
 
     private bool ProcessKey(KeyEventArgs keyEventArgs)
     {
+        // Move to previous element if Shift + Tab is pressed
+        if (keyEventArgs.Key == Key.Tab && (Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift)
+        {
+            MoveFocus(new TraversalRequest(FocusNavigationDirection.Previous));
+            return true;
+        }
+
         switch (keyEventArgs.Key)
         {
             case Key.System:

--- a/tests/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
@@ -560,7 +560,7 @@ public class TimePickerTests : TestBase
         var timePickerTextBox = await timePicker.GetElement<TimePickerTextBox>("/TimePickerTextBox");
         var hintBackgroundGrid = await timePicker.GetElement<Grid>("HintBackgroundGrid");
 
-        var defaultBackground = Colors.Transparent; 
+        var defaultBackground = Colors.Transparent;
         var defaultFloatedBackground = await GetThemeColor("MaterialDesign.Brush.Background");
 
         // Assert (unfocused state)
@@ -640,6 +640,36 @@ public class TimePickerTests : TestBase
         // Assert
         Assert.Equal(expectedThickness, timePickerTextBoxHoverThickness);
         Assert.Equal(expectedThickness, timePickerTimeButtonHoverThickness);
+
+        recorder.Success();
+    }
+
+    [Fact]
+    [Description("Issue 3650")]
+    public async Task TimePicker_MovesFocusToPrevious_WhenShiftAndTabIsPressed()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // Arrange
+        var stackPanel = await LoadXaml<StackPanel>("""
+            <StackPanel>
+              <TextBox />
+              <materialDesign:TimePicker />
+            </StackPanel>
+            """);
+
+        var textBox = await stackPanel.GetElement<TextBox>("/TextBox");
+        var timePickerTextBox = await stackPanel.GetElement<TimePickerTextBox>("/TimePickerTextBox");
+
+        // Act
+        await timePickerTextBox.MoveKeyboardFocus();
+        await Task.Delay(50);
+        await timePickerTextBox.SendInput(new KeyboardInput(Key.LeftShift, Key.Tab));
+        await Task.Delay(50);
+
+        // Assert
+        Assert.True(await textBox.GetIsFocused());
+        Assert.False(await timePickerTextBox.GetIsFocused());
 
         recorder.Success();
     }


### PR DESCRIPTION
Handle pressing shift and tab to move to the previous element.

Even though it's breaking consistency, I intentionally decided against nesting the logic in multiple switch-case statements due to readability. If that is unacceptable, let me know.

I'm thankful for feedback!