### PR TITLE
added "ClockButtonVisibility" property to TimePicker

### DIFF
--- a/src/MainDemo.Wpf/Pickers.xaml
+++ b/src/MainDemo.Wpf/Pickers.xaml
@@ -213,15 +213,31 @@
         </smtx:XamlDisplay>
       </StackPanel>
 
-      <smtx:XamlDisplay Margin="0,16,0,0"
-                        HorizontalAlignment="Left"
-                        VerticalAlignment="Top"
-                        UniqueKey="pickers_7">
-        <materialDesign:TimePicker x:Name="PresetTimePicker"
-                                   Width="100"
-                                   Is24Hours="True"
-                                   SelectedTimeChanged="PresetTimePicker_SelectedTimeChanged" />
-      </smtx:XamlDisplay>
+      <StackPanel>
+        <smtx:XamlDisplay Margin="0,16,0,0"
+                  HorizontalAlignment="Left"
+                  VerticalAlignment="Top"
+                  UniqueKey="pickers_7">
+          <materialDesign:TimePicker x:Name="PresetTimePicker"
+                             Width="100"
+                             Is24Hours="True"
+                             SelectedTimeChanged="PresetTimePicker_SelectedTimeChanged" />
+        </smtx:XamlDisplay>
+
+        <smtx:XamlDisplay Margin="0,16,0,0"
+                  HorizontalAlignment="Left"
+                  VerticalAlignment="Top"
+                  UniqueKey="pickers_15">
+          <materialDesign:TimePicker ClockButtonVisibility="{Binding IsChecked, ElementName=IsClockButtonVisible, Converter={StaticResource BooleanToVisibilityConverter}}"
+                             Width="100"
+                             Is24Hours="True" />
+        </smtx:XamlDisplay>
+        <CheckBox x:Name="IsClockButtonVisible"
+                  Margin="0,10,0,0"
+                  VerticalAlignment="Top"
+                  Content="Show clock button" />
+      </StackPanel>
+      
 
       <StackPanel HorizontalAlignment="Left"
                   VerticalAlignment="Top">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -120,6 +120,7 @@
             <!-- VerticalAlignment=Center to follow the default ComboBox style where the arrow is always vertically centered. Could be problematic to try to calculate the offset because it needs to be v-centered in relation to the content of the nested TextBox -->
             <Button x:Name="PART_Button"
                     Height="16"
+                    Visibility="{TemplateBinding ClockButtonVisibility}"
                     Margin="{TemplateBinding Padding, Converter={StaticResource PartButtonMarginConverter}}"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Center"

--- a/src/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/src/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -170,6 +170,15 @@ public class TimePicker : Control
     public static readonly DependencyProperty IsHeaderVisibleProperty = DependencyProperty.Register(
         nameof(IsHeaderVisible), typeof(bool), typeof(TimePicker), new PropertyMetadata(default(bool)));
 
+    public Visibility ClockButtonVisibility
+    {
+        get => (Visibility)GetValue(ClockButtonVisibilityProperty);
+        set => SetValue(ClockButtonVisibilityProperty, value);
+    }
+
+    public static readonly DependencyProperty ClockButtonVisibilityProperty =
+        DependencyProperty.Register(nameof(ClockButtonVisibility), typeof(Visibility), typeof(TimePicker), new PropertyMetadata(Visibility.Visible));
+
     public bool IsHeaderVisible
     {
         get => (bool)GetValue(IsHeaderVisibleProperty);


### PR DESCRIPTION
added a `ClockButtonVisibility` property to the `TimePicker` to fix #3663 

![TimePickerShowClickButton](https://github.com/user-attachments/assets/070cfe3e-6f5e-4b83-8a92-639a7be45cdb)