### PR TITLE
Change ChoiceChip and FilterChip TargetType to ToggleButton

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
@@ -310,7 +310,7 @@
     <Setter Property="VerticalContentAlignment" Value="Center" />
   </Style>
 
-  <Style x:Key="MaterialDesignFilterChipCheckBox" TargetType="CheckBox">
+  <Style x:Key="MaterialDesignFilterChipCheckBox" TargetType="ToggleButton">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Foreground}" />
     <Setter Property="BorderThickness" Value="0" />
     <Setter Property="Cursor" Value="Hand" />
@@ -323,7 +323,7 @@
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
-        <ControlTemplate TargetType="{x:Type CheckBox}">
+        <ControlTemplate TargetType="{x:Type ToggleButton}">
           <ControlTemplate.Resources>
             <Style TargetType="{x:Type wpf:PackIcon}">
               <Setter Property="FrameworkElement.Height" Value="22" />
@@ -480,7 +480,7 @@
     </Setter>
   </Style>
 
-  <Style x:Key="MaterialDesignFilterChipOutlineCheckBox" TargetType="CheckBox">
+  <Style x:Key="MaterialDesignFilterChipOutlineCheckBox" TargetType="ToggleButton">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.Foreground}" />
     <Setter Property="BorderThickness" Value="1" />
@@ -494,7 +494,7 @@
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
-        <ControlTemplate TargetType="{x:Type CheckBox}">
+        <ControlTemplate TargetType="{x:Type ToggleButton}">
           <ControlTemplate.Resources>
             <Style TargetType="{x:Type wpf:PackIcon}">
               <Setter Property="FrameworkElement.Height" Value="22" />
@@ -674,7 +674,7 @@
   </Style>
 
   <Style x:Key="MaterialDesignFilterChipPrimaryCheckBox"
-         TargetType="CheckBox"
+         TargetType="ToggleButton"
          BasedOn="{StaticResource MaterialDesignFilterChipCheckBox}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Primary.Light}" />
     <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary.Dark}" />
@@ -693,7 +693,7 @@
   </Style>
 
   <Style x:Key="MaterialDesignFilterChipSecondaryCheckBox"
-         TargetType="CheckBox"
+         TargetType="ToggleButton"
          BasedOn="{StaticResource MaterialDesignFilterChipCheckBox}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Secondary.Light}" />
     <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Secondary.Dark}" />
@@ -712,7 +712,7 @@
   </Style>
 
   <Style x:Key="MaterialDesignFilterChipPrimaryOutlineCheckBox"
-         TargetType="CheckBox"
+         TargetType="ToggleButton"
          BasedOn="{StaticResource MaterialDesignFilterChipOutlineCheckBox}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Primary.Light}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
@@ -732,7 +732,7 @@
   </Style>
 
   <Style x:Key="MaterialDesignFilterChipSecondaryOutlineCheckBox"
-         TargetType="CheckBox"
+         TargetType="ToggleButton"
          BasedOn="{StaticResource MaterialDesignFilterChipOutlineCheckBox}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Secondary.Light}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.Secondary}" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
@@ -493,7 +493,7 @@
   </Style>
 
 
-  <Style x:Key="MaterialDesignChoiceChipRadioButton" TargetType="{x:Type RadioButton}">
+  <Style x:Key="MaterialDesignChoiceChipRadioButton" TargetType="{x:Type ToggleButton}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Foreground}" />
     <Setter Property="BorderThickness" Value="0" />
     <Setter Property="Cursor" Value="Hand" />
@@ -506,7 +506,7 @@
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
-        <ControlTemplate TargetType="{x:Type RadioButton}">
+        <ControlTemplate TargetType="{x:Type ToggleButton}">
           <ControlTemplate.Resources>
             <Style TargetType="{x:Type wpf:PackIcon}">
               <Setter Property="FrameworkElement.Height" Value="22" />
@@ -631,7 +631,7 @@
     </Setter>
   </Style>
 
-  <Style x:Key="MaterialDesignChoiceChipOutlineRadioButton" TargetType="{x:Type RadioButton}">
+  <Style x:Key="MaterialDesignChoiceChipOutlineRadioButton" TargetType="{x:Type ToggleButton}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.Foreground}" />
     <Setter Property="BorderThickness" Value="1" />
@@ -645,7 +645,7 @@
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
-        <ControlTemplate TargetType="{x:Type RadioButton}">
+        <ControlTemplate TargetType="{x:Type ToggleButton}">
           <ControlTemplate.Resources>
             <Style TargetType="{x:Type wpf:PackIcon}">
               <Setter Property="FrameworkElement.Height" Value="22" />
@@ -793,7 +793,7 @@
   </Style>
 
   <Style x:Key="MaterialDesignChoiceChipPrimaryRadioButton"
-         TargetType="{x:Type RadioButton}"
+         TargetType="{x:Type ToggleButton}"
          BasedOn="{StaticResource MaterialDesignChoiceChipRadioButton}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Primary.Light}" />
     <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary.Dark}" />
@@ -812,7 +812,7 @@
   </Style>
 
   <Style x:Key="MaterialDesignChoiceChipSecondaryRadioButton"
-         TargetType="{x:Type RadioButton}"
+         TargetType="{x:Type ToggleButton}"
          BasedOn="{StaticResource MaterialDesignChoiceChipRadioButton}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Secondary.Light}" />
     <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Secondary.Dark}" />
@@ -831,7 +831,7 @@
   </Style>
 
   <Style x:Key="MaterialDesignChoiceChipPrimaryOutlineRadioButton"
-         TargetType="{x:Type RadioButton}"
+         TargetType="{x:Type ToggleButton}"
          BasedOn="{StaticResource MaterialDesignChoiceChipOutlineRadioButton}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Primary.Light}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
@@ -851,7 +851,7 @@
   </Style>
 
   <Style x:Key="MaterialDesignChoiceChipSecondaryOutlineRadioButton"
-         TargetType="{x:Type RadioButton}"
+         TargetType="{x:Type ToggleButton}"
          BasedOn="{StaticResource MaterialDesignChoiceChipOutlineRadioButton}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Secondary.Light}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.Secondary}" />


### PR DESCRIPTION
This commit changes the TargetType of the ChoiceChip and FilterChip styles to ToggleButton. This is because a request we got for our software to improve it for color blidness. Therefore the ChoiceChips unfortunately are not always explicit enough and we want to use the FilterChip style also on a RadioButton.

- This change does not change anything on the MaterialDesignInXAML toolkit itself other than that these styles are broader usable. Therefore I kept the naming of the styles etc. the same to not make any breaking changes
- All information necessary to depict the ChoiceChip or FilterChip is available in the ToggleButton, therefore the TargetType can be changed