### PR TITLE
[Nuget] Inject correct copyright parameter into *.nuspec files

### DIFF
--- a/build/BuildNugets.ps1
+++ b/build/BuildNugets.ps1
@@ -5,7 +5,7 @@ param(
 )
 
 $year = [System.DateTime]::Now.ToString("yyyy")
-$copywrite = "Copyright $year James Willock/Mulholland Software Ltd"
+$copyright = "Copyright $year James Willock/Mulholland Software Ltd"
 $configuration = "Release"
 
 function Update-Icon {
@@ -59,7 +59,7 @@ function New-Nuget {
 
   $NuSpecPath = Resolve-Path $NuSpecPath
   Update-Icon "$NuSpecPath" 
-  nuget pack "$NuSpecPath" -version "$Version" -Properties "Configuration=$configuration;Copywrite=$copywrite"
+  nuget pack "$NuSpecPath" -version "$Version" -Properties "Configuration=$configuration;Copyright=$copyright"
 }
 
 Push-Location "$(Join-Path $PSScriptRoot "..")"


### PR DESCRIPTION
The *.nuspec files expect a parameter named `copyright` to be injected, but this was being passed in as `copywrite` instead. This was done as part of #1538 and the Copyright on the produced nuget packages have been missing ever since.

I verified the fix locally.

### Before:
![image](https://github.com/user-attachments/assets/08359f65-05f0-445c-9e86-de51f25e3133)

### After:
![image](https://github.com/user-attachments/assets/92f01a76-b3bd-4c00-a7d7-fceb86990a07)
