### PR TITLE
Fix typo and make ListBoxItems toggleable in Demo

### DIFF
--- a/src/MainDemo.Wpf/MenusAndToolBars.xaml
+++ b/src/MainDemo.Wpf/MenusAndToolBars.xaml
@@ -216,7 +216,7 @@
 
           <Separator />
 
-          <ListBox>
+          <ListBox materialDesign:ListBoxAssist.CanUserToggleSelectedItem="True">
             <ListBoxItem ToolTip="This is a lonely toggle with TextBlock instead of icon">
               <TextBlock Text="W" />
             </ListBoxItem>

--- a/src/MainDemo.Wpf/MenusAndToolBars.xaml
+++ b/src/MainDemo.Wpf/MenusAndToolBars.xaml
@@ -217,7 +217,7 @@
           <Separator />
 
           <ListBox>
-            <ListBoxItem ToolTip="This is a lonley toggle with TextBlock instead of icon">
+            <ListBoxItem ToolTip="This is a lonely toggle with TextBlock instead of icon">
               <TextBlock Text="W" />
             </ListBoxItem>
           </ListBox>


### PR DESCRIPTION
The ListBoxItem's ToolTip says it should behave like a toggle, but it didn't, because `materialDesign:ListBoxAssist.CanUserToggleSelectedItem="True"` was not set.