### PR TITLE
[SmartHint] Improvement for multi-line TextBox hint positioning

### DIFF
--- a/src/MainDemo.Wpf/Domain/SmartHintViewModel.cs
+++ b/src/MainDemo.Wpf/Domain/SmartHintViewModel.cs
@@ -63,6 +63,7 @@ internal class SmartHintViewModel : ViewModelBase
     public IEnumerable<Thickness> CustomOutlineStyleBorderThicknessOptions { get; } = [new Thickness(1), new Thickness(2), new Thickness(3), new Thickness(4), new Thickness(5), new Thickness(6) ];
     public IEnumerable<TextWrapping> TextWrappingOptions { get; } = Enum.GetValues(typeof(TextWrapping)).OfType<TextWrapping>();
     public IEnumerable<double> MaxWidthOptions { get; } = [double.NaN, 200];
+    public IEnumerable<string> AutoSuggestBoxSuggestions { get; } = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel", "india", "juliette", "kilo", "lima"];
 
     public bool FloatHint
     {

--- a/src/MainDemo.Wpf/Domain/SmartHintViewModel.cs
+++ b/src/MainDemo.Wpf/Domain/SmartHintViewModel.cs
@@ -44,6 +44,8 @@ internal class SmartHintViewModel : ViewModelBase
     private ScrollBarVisibility _selectedHorizontalScrollBarVisibility = ScrollBarVisibility.Auto;
     private Thickness _outlineStyleBorderThickness = new(1);
     private Thickness _outlineStyleActiveBorderThickness = new(2);
+    private TextWrapping _textBoxTextWrapping = TextWrapping.Wrap;
+    private double _selectedMaxWidth = 200;
 
     public IEnumerable<FloatingHintHorizontalAlignment> HorizontalAlignmentOptions { get; } = Enum.GetValues(typeof(FloatingHintHorizontalAlignment)).OfType<FloatingHintHorizontalAlignment>();
     public IEnumerable<double> FloatingScaleOptions { get; } = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
@@ -59,6 +61,8 @@ internal class SmartHintViewModel : ViewModelBase
     public IEnumerable<PrefixSuffixHintBehavior> PrefixSuffixHintBehaviorOptions { get; } = Enum.GetValues(typeof(PrefixSuffixHintBehavior)).OfType<PrefixSuffixHintBehavior>();
     public IEnumerable<ScrollBarVisibility> ScrollBarVisibilityOptions { get; } = Enum.GetValues(typeof(ScrollBarVisibility)).OfType<ScrollBarVisibility>();
     public IEnumerable<Thickness> CustomOutlineStyleBorderThicknessOptions { get; } = [new Thickness(1), new Thickness(2), new Thickness(3), new Thickness(4), new Thickness(5), new Thickness(6) ];
+    public IEnumerable<TextWrapping> TextWrappingOptions { get; } = Enum.GetValues(typeof(TextWrapping)).OfType<TextWrapping>();
+    public IEnumerable<double> MaxWidthOptions { get; } = [double.NaN, 200];
 
     public bool FloatHint
     {
@@ -280,5 +284,17 @@ internal class SmartHintViewModel : ViewModelBase
     {
         get => _outlineStyleActiveBorderThickness;
         set => SetProperty(ref _outlineStyleActiveBorderThickness, value);
+    }
+
+    public TextWrapping TextBoxTextWrapping
+    {
+        get => _textBoxTextWrapping;
+        set => SetProperty(ref _textBoxTextWrapping, value);
+    }
+
+    public double SelectedMaxWidth
+    {
+        get => _selectedMaxWidth;
+        set => SetProperty(ref _selectedMaxWidth, value);
     }
 }

--- a/src/MainDemo.Wpf/SmartHint.xaml
+++ b/src/MainDemo.Wpf/SmartHint.xaml
@@ -596,6 +596,210 @@
           </local:InputElementContentControl>
         </Grid>
 
+        <!-- AutoSuggestBox variants -->
+        <TextBlock Margin="0,40,0,0"
+                   Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                   Text="AutoSuggestBox styles (inherits TextBox specific settings!)" />
+        <Grid HorizontalAlignment="Stretch">
+          <Grid.Resources>
+            <Style TargetType="{x:Type materialDesign:AutoSuggestBox}" BasedOn="{StaticResource MaterialDesignFloatingHintAutoSuggestBox}">
+              <Setter Property="TextWrapping" Value="{Binding TextBoxTextWrapping}" />
+              <Setter Property="MaxWidth" Value="{Binding SelectedMaxWidth}" />
+              <Setter Property="AcceptsReturn" Value="{Binding TextBoxAcceptsReturn}" />
+              <Setter Property="IsReadOnly" Value="{Binding TextBoxIsReadOnly}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize, Converter={StaticResource FontSizeConverter}}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFloatingHintTextBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="VerticalScrollBarVisibility" Value="{Binding SelectedVerticalScrollBarVisibility}" />
+              <Setter Property="HorizontalScrollBarVisibility" Value="{Binding SelectedHorizontalScrollBarVisibility}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.IconVerticalAlignment" Value="{Binding SelectedIconVerticalAlignment}" />
+              <Setter Property="materialDesign:TextFieldAssist.RippleOnFocusEnabled" Value="{Binding RippleOnFocus}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixTextVisibility" Value="{Binding SelectedPrefixVisibility}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixTextHintBehavior" Value="{Binding SelectedPrefixHintBehavior}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixTextVisibility" Value="{Binding SelectedSuffixVisibility}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixTextHintBehavior" Value="{Binding SelectedSuffixHintBehavior}" />
+              <Setter Property="materialDesign:TextFieldAssist.NewSpecHighlightingEnabled" Value="{Binding NewSpecHighlightingEnabled}" />
+              <Setter Property="MaxLength" Value="{Binding MaxLength}" />
+              <Setter Property="Suggestions" Value="{Binding AutoSuggestBoxSuggestions}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFloatingHintAutoSuggestBox</TextBlock>
+          <local:InputElementContentControl Grid.Column="1">
+            <materialDesign:AutoSuggestBox HorizontalContentAlignment="Left" />
+          </local:InputElementContentControl>
+          <local:InputElementContentControl Grid.Column="2">
+            <materialDesign:AutoSuggestBox HorizontalContentAlignment="Center" />
+          </local:InputElementContentControl>
+          <local:InputElementContentControl Grid.Column="3">
+            <materialDesign:AutoSuggestBox HorizontalContentAlignment="Right" />
+          </local:InputElementContentControl>
+          <local:InputElementContentControl Grid.Column="4">
+            <materialDesign:AutoSuggestBox HorizontalContentAlignment="Stretch" />
+          </local:InputElementContentControl>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type materialDesign:AutoSuggestBox}" BasedOn="{StaticResource MaterialDesignFilledAutoSuggestBox}">
+              <Setter Property="TextWrapping" Value="{Binding TextBoxTextWrapping}" />
+              <Setter Property="MaxWidth" Value="{Binding SelectedMaxWidth}" />
+              <Setter Property="AcceptsReturn" Value="{Binding TextBoxAcceptsReturn}" />
+              <Setter Property="IsReadOnly" Value="{Binding TextBoxIsReadOnly}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize, Converter={StaticResource FontSizeConverter}}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignFilledTextBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="VerticalScrollBarVisibility" Value="{Binding SelectedVerticalScrollBarVisibility}" />
+              <Setter Property="HorizontalScrollBarVisibility" Value="{Binding SelectedHorizontalScrollBarVisibility}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.IconVerticalAlignment" Value="{Binding SelectedIconVerticalAlignment}" />
+              <Setter Property="materialDesign:TextFieldAssist.RippleOnFocusEnabled" Value="{Binding RippleOnFocus}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixTextVisibility" Value="{Binding SelectedPrefixVisibility}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixTextHintBehavior" Value="{Binding SelectedPrefixHintBehavior}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixTextVisibility" Value="{Binding SelectedSuffixVisibility}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixTextHintBehavior" Value="{Binding SelectedSuffixHintBehavior}" />
+              <Setter Property="materialDesign:TextFieldAssist.NewSpecHighlightingEnabled" Value="{Binding NewSpecHighlightingEnabled}" />
+              <Setter Property="MaxLength" Value="{Binding MaxLength}" />
+              <Setter Property="Suggestions" Value="{Binding AutoSuggestBoxSuggestions}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignFilledAutoSuggestBox</TextBlock>
+          <local:InputElementContentControl Grid.Column="1">
+            <materialDesign:AutoSuggestBox HorizontalContentAlignment="Left" />
+          </local:InputElementContentControl>
+          <local:InputElementContentControl Grid.Column="2">
+            <materialDesign:AutoSuggestBox HorizontalContentAlignment="Center" />
+          </local:InputElementContentControl>
+          <local:InputElementContentControl Grid.Column="3">
+            <materialDesign:AutoSuggestBox HorizontalContentAlignment="Right" />
+          </local:InputElementContentControl>
+          <local:InputElementContentControl Grid.Column="4">
+            <materialDesign:AutoSuggestBox HorizontalContentAlignment="Stretch" />
+          </local:InputElementContentControl>
+        </Grid>
+        <Grid>
+          <Grid.Resources>
+            <Style TargetType="{x:Type materialDesign:AutoSuggestBox}" BasedOn="{StaticResource MaterialDesignOutlinedAutoSuggestBox}">
+              <Setter Property="TextWrapping" Value="{Binding TextBoxTextWrapping}" />
+              <Setter Property="MaxWidth" Value="{Binding SelectedMaxWidth}" />
+              <Setter Property="AcceptsReturn" Value="{Binding TextBoxAcceptsReturn}" />
+              <Setter Property="BorderThickness" Value="{Binding OutlineStyleBorderThickness}" />
+              <Setter Property="IsReadOnly" Value="{Binding TextBoxIsReadOnly}" />
+              <Setter Property="FontSize" Value="{Binding SelectedFontSize, Converter={StaticResource FontSizeConverter}}" />
+              <Setter Property="Height" Value="{Binding SelectedCustomHeight}" />
+              <Setter Property="Padding">
+                <Setter.Value>
+                  <MultiBinding Converter="{StaticResource CustomPaddingConverter}">
+                    <Binding ElementName="MaterialDesignOutlinedTextBoxDefaults" Path="Padding" />
+                    <Binding Path="ApplyCustomPadding" />
+                    <Binding Path="SelectedCustomPadding" />
+                  </MultiBinding>
+                </Setter.Value>
+              </Setter>
+              <Setter Property="Text" Value="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" />
+              <Setter Property="VerticalContentAlignment" Value="{Binding SelectedVerticalAlignment}" />
+              <Setter Property="VerticalScrollBarVisibility" Value="{Binding SelectedVerticalScrollBarVisibility}" />
+              <Setter Property="HorizontalScrollBarVisibility" Value="{Binding SelectedHorizontalScrollBarVisibility}" />
+              <Setter Property="materialDesign:HintAssist.FontFamily" Value="{Binding SelectedFontFamily}" />
+              <Setter Property="materialDesign:HintAssist.IsFloating" Value="{Binding FloatHint}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasClearButton" Value="{Binding ShowClearButton}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasLeadingIcon" Value="{Binding ShowLeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.HasTrailingIcon" Value="{Binding ShowTrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIcon" Value="{StaticResource LeadingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.LeadingIconSize" Value="{Binding SelectedLeadingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixText" Value="{Binding PrefixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixText" Value="{Binding SuffixText}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIcon" Value="{StaticResource TrailingIcon}" />
+              <Setter Property="materialDesign:TextFieldAssist.TrailingIconSize" Value="{Binding SelectedTrailingIconSize}" />
+              <Setter Property="materialDesign:TextFieldAssist.IconVerticalAlignment" Value="{Binding SelectedIconVerticalAlignment}" />
+              <Setter Property="materialDesign:TextFieldAssist.RippleOnFocusEnabled" Value="{Binding RippleOnFocus}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixTextVisibility" Value="{Binding SelectedPrefixVisibility}" />
+              <Setter Property="materialDesign:TextFieldAssist.PrefixTextHintBehavior" Value="{Binding SelectedPrefixHintBehavior}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixTextVisibility" Value="{Binding SelectedSuffixVisibility}" />
+              <Setter Property="materialDesign:TextFieldAssist.SuffixTextHintBehavior" Value="{Binding SelectedSuffixHintBehavior}" />
+              <Setter Property="materialDesign:TextFieldAssist.NewSpecHighlightingEnabled" Value="{Binding NewSpecHighlightingEnabled}" />
+              <Setter Property="MaxLength" Value="{Binding MaxLength}" />
+              <Setter Property="Suggestions" Value="{Binding AutoSuggestBoxSuggestions}" />
+            </Style>
+          </Grid.Resources>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition SharedSizeGroup="SizeGroupStyleName" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Style="{StaticResource StyleNameIndicator}">MaterialDesignOutlinedAutoSuggestBox</TextBlock>
+          <local:InputElementContentControl Grid.Column="1">
+            <materialDesign:AutoSuggestBox HorizontalContentAlignment="Left" />
+          </local:InputElementContentControl>
+          <local:InputElementContentControl Grid.Column="2">
+            <materialDesign:AutoSuggestBox HorizontalContentAlignment="Center" />
+          </local:InputElementContentControl>
+          <local:InputElementContentControl Grid.Column="3">
+            <materialDesign:AutoSuggestBox HorizontalContentAlignment="Right" />
+          </local:InputElementContentControl>
+          <local:InputElementContentControl Grid.Column="4">
+            <materialDesign:AutoSuggestBox HorizontalContentAlignment="Stretch" />
+          </local:InputElementContentControl>
+        </Grid>
+
         <!-- RichTextBox variants -->
         <TextBlock Margin="0,40,0,0"
                    Style="{StaticResource MaterialDesignHeadline6TextBlock}"

--- a/src/MainDemo.Wpf/SmartHint.xaml
+++ b/src/MainDemo.Wpf/SmartHint.xaml
@@ -371,8 +371,7 @@
           <TextBlock Margin="30,0,0,0"
                      Text="H-ScrollBar visibility:"
                      VerticalAlignment="Center" />
-          <ComboBox x:Name="HorizontalScrollBarVisibilityComboBox"
-                    ItemsSource="{Binding ScrollBarVisibilityOptions}"
+          <ComboBox ItemsSource="{Binding ScrollBarVisibilityOptions}"
                     Margin="5,0,0,0"
                     SelectedItem="{Binding SelectedHorizontalScrollBarVisibility}"
                     VerticalAlignment="Center"
@@ -380,16 +379,31 @@
           <TextBlock Margin="30,0,0,0"
                      Text="V-ScrollBar visibility:"
                      VerticalAlignment="Center" />
-          <ComboBox x:Name="VerticalScrollBarVisibilityComboBox"
-                    ItemsSource="{Binding ScrollBarVisibilityOptions}"
+          <ComboBox ItemsSource="{Binding ScrollBarVisibilityOptions}"
                     Margin="5,0,0,0"
                     SelectedItem="{Binding SelectedVerticalScrollBarVisibility}"
                     VerticalAlignment="Center"
                     Width="70"/>
+          <TextBlock Margin="30,0,0,0"
+                     Text="TextWrapping:"
+                     VerticalAlignment="Center" />
+          <ComboBox ItemsSource="{Binding TextWrappingOptions}"
+                    Margin="5,0,0,0"
+                    SelectedItem="{Binding TextBoxTextWrapping}"
+                    VerticalAlignment="Center" />
+          <TextBlock Margin="30,0,0,0"
+                     Text="MaxWidth:"
+                     VerticalAlignment="Center" />
+          <ComboBox ItemsSource="{Binding MaxWidthOptions}"
+                    Margin="5,0,0,0"
+                    SelectedItem="{Binding SelectedMaxWidth}"
+                    VerticalAlignment="Center" />
         </StackPanel>
         <Grid HorizontalAlignment="Stretch">
           <Grid.Resources>
             <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFloatingHintTextBox}">
+              <Setter Property="TextWrapping" Value="{Binding TextBoxTextWrapping}" />
+              <Setter Property="MaxWidth" Value="{Binding SelectedMaxWidth}" />
               <Setter Property="AcceptsReturn" Value="{Binding TextBoxAcceptsReturn}" />
               <Setter Property="IsReadOnly" Value="{Binding TextBoxIsReadOnly}" />
               <Setter Property="FontSize" Value="{Binding SelectedFontSize, Converter={StaticResource FontSizeConverter}}" />
@@ -453,6 +467,8 @@
         <Grid>
           <Grid.Resources>
             <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignFilledTextBox}">
+              <Setter Property="TextWrapping" Value="{Binding TextBoxTextWrapping}" />
+              <Setter Property="MaxWidth" Value="{Binding SelectedMaxWidth}" />
               <Setter Property="AcceptsReturn" Value="{Binding TextBoxAcceptsReturn}" />
               <Setter Property="IsReadOnly" Value="{Binding TextBoxIsReadOnly}" />
               <Setter Property="FontSize" Value="{Binding SelectedFontSize, Converter={StaticResource FontSizeConverter}}" />
@@ -516,6 +532,8 @@
         <Grid>
           <Grid.Resources>
             <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignOutlinedTextBox}">
+              <Setter Property="TextWrapping" Value="{Binding TextBoxTextWrapping}" />
+              <Setter Property="MaxWidth" Value="{Binding SelectedMaxWidth}" />
               <Setter Property="AcceptsReturn" Value="{Binding TextBoxAcceptsReturn}" />
               <Setter Property="BorderThickness" Value="{Binding OutlineStyleBorderThickness}" />
               <Setter Property="IsReadOnly" Value="{Binding TextBoxIsReadOnly}" />

--- a/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
+++ b/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
@@ -8,7 +8,10 @@ namespace MaterialDesignThemes.Wpf.Behaviors;
 internal class TextBoxLineCountBehavior : Behavior<TextBox>
 {
     private void AssociatedObjectOnTextChanged(object sender, TextChangedEventArgs e)
-        => AssociatedObject.SetCurrentValue(TextFieldAssist.LineCountProperty, AssociatedObject.LineCount);
+    {
+        AssociatedObject.SetCurrentValue(TextFieldAssist.LineCountProperty, AssociatedObject.LineCount);
+        AssociatedObject.SetCurrentValue(TextFieldAssist.IsMultiLineProperty, AssociatedObject.LineCount > 1);
+    }
 
     protected override void OnAttached()
     {

--- a/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
+++ b/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Xaml.Behaviors;
+
+namespace MaterialDesignThemes.Wpf.Behaviors;
+
+/// <summary>
+/// Internal behavior exposing the <see cref="TextBox.LineCount"/> (non-DP) as an attached property which we can bind to
+/// </summary>
+internal class TextBoxLineCountBehavior : Behavior<TextBox>
+{
+    private void AssociatedObjectOnTextChanged(object sender, TextChangedEventArgs e)
+        => AssociatedObject.SetCurrentValue(TextFieldAssist.LineCountProperty, AssociatedObject.LineCount);
+
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        AssociatedObject.TextChanged += AssociatedObjectOnTextChanged;
+    }
+
+    protected override void OnDetaching()
+    {
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.TextChanged -= AssociatedObjectOnTextChanged;
+        }
+        base.OnDetaching();
+    }
+}

--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintInitialVerticalOffsetConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintInitialVerticalOffsetConverter.cs
@@ -32,8 +32,6 @@ public class FloatingHintInitialVerticalOffsetConverter : IMultiValueConverter
             // that are actually visible on screen) to avoid moving the hint further away than the actual viewport.
             return Math.Max(0, (contentHostHeight - hintHeight) / 2 - (offsetMultiplier * hintHeight));
         }
-
-        PasswordBox pb = new();
         return 0.0;
     }
 

--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintInitialVerticalOffsetConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintInitialVerticalOffsetConverter.cs
@@ -3,15 +3,38 @@ using System.Windows.Data;
 
 namespace MaterialDesignThemes.Wpf.Converters;
 
+/// <summary>
+/// This converter is used to apply an initial vertical offset (downwards) of the floating hint in the case where the
+/// <see cref="SmartHint.FloatingTarget"/> is taller than the <see cref="SmartHint"/> itself. This is typically the case
+/// if a fixed (large) height is applied to the host control (e.g. <see cref="TextBox"/> or similar). In these cases the
+/// hint should not float directly on top of the <see cref="SmartHint.FloatingTarget"/>, but rather be pushed down to sit
+/// on top of the text inside the <see cref="SmartHint.FloatingTarget"/>.
+///
+/// There is an edge case that need to be dealt with, which is when the host element allows for text to wrap (i.e. in
+/// <see cref="TextBox"/> based templates). In this case, we need to take the  number of text rows/line count into account
+/// in the calculation.
+/// </summary>
 public class FloatingHintInitialVerticalOffsetConverter : IMultiValueConverter
 {
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (values is [double contentHostHeight, double hintHeight])
+        if (values is [double contentHostHeight, double hintHeight, int lineCount])
         {
-            return (contentHostHeight - hintHeight) / 2;
+            double offsetMultiplier = 0;
+            if (lineCount > 1)
+            {
+                // Edge case where there are multiple rows of text so we need to calculate how far the hint should be pushed down.
+                // If there are 2 rows, we need to reduce the offset by 0.5*height, 3 rows should reduce by 1*height, 4 rows should reduce by 1.5*height, etc.
+                offsetMultiplier = lineCount / 2.0 - 0.5;
+            }
+            // Set an initial offset in order to push the hint down to where the actual text is displayed.
+            // The value is clamped to be >= 0 which is needed for TextBoxes where a vertical scrollbar is needed (i.e. more lines
+            // that are actually visible on screen) to avoid moving the hint further away than the actual viewport.
+            return Math.Max(0, (contentHostHeight - hintHeight) / 2 - (offsetMultiplier * hintHeight));
         }
-        return 0;
+
+        PasswordBox pb = new();
+        return 0.0;
     }
 
     public object?[] ConvertBack(object? value, Type[] targetTypes, object? parameter, CultureInfo culture)

--- a/src/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -356,18 +356,31 @@ public static class TextFieldAssist
 
     internal static readonly DependencyProperty PasswordBoxCharacterCountProperty = DependencyProperty.RegisterAttached(
         "PasswordBoxCharacterCount", typeof(int), typeof(TextFieldAssist), new PropertyMetadata(default(int)));
-    internal static void SetPasswordBoxCharacterCount(DependencyObject element, int value) => element.SetValue(PasswordBoxCharacterCountProperty, value);
-    internal static int GetPasswordBoxCharacterCount(DependencyObject element) => (int)element.GetValue(PasswordBoxCharacterCountProperty);
+    internal static void SetPasswordBoxCharacterCount(DependencyObject element, int value)
+        => element.SetValue(PasswordBoxCharacterCountProperty, value);
+    internal static int GetPasswordBoxCharacterCount(DependencyObject element)
+        => (int)element.GetValue(PasswordBoxCharacterCountProperty);
 
     public static readonly DependencyProperty OutlinedBorderActiveThicknessProperty = DependencyProperty.RegisterAttached(
         "OutlinedBorderActiveThickness", typeof(Thickness), typeof(TextFieldAssist), new FrameworkPropertyMetadata(Constants.DefaultOutlinedBorderActiveThickness, FrameworkPropertyMetadataOptions.Inherits));
-    public static void SetOutlinedBorderActiveThickness(DependencyObject element, Thickness value) => element.SetValue(OutlinedBorderActiveThicknessProperty, value);
-    public static Thickness GetOutlinedBorderActiveThickness(DependencyObject element) => (Thickness)element.GetValue(OutlinedBorderActiveThicknessProperty);
+    public static void SetOutlinedBorderActiveThickness(DependencyObject element, Thickness value)
+        => element.SetValue(OutlinedBorderActiveThicknessProperty, value);
+    public static Thickness GetOutlinedBorderActiveThickness(DependencyObject element)
+        => (Thickness)element.GetValue(OutlinedBorderActiveThicknessProperty);
 
     internal static readonly DependencyProperty LineCountProperty = DependencyProperty.RegisterAttached(
         "LineCount", typeof(int), typeof(TextFieldAssist), new PropertyMetadata(0));
-    internal static void SetLineCount(DependencyObject element, int value) => element.SetValue(LineCountProperty, value);
-    internal static int GetLineCount(DependencyObject element) => (int) element.GetValue(LineCountProperty);
+    internal static void SetLineCount(DependencyObject element, int value)
+        => element.SetValue(LineCountProperty, value);
+    internal static int GetLineCount(DependencyObject element)
+        => (int) element.GetValue(LineCountProperty);
+
+    internal static readonly DependencyProperty IsMultiLineProperty = DependencyProperty.RegisterAttached(
+        "IsMultiLine", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(false));
+    internal static void SetIsMultiLine(DependencyObject element, bool value)
+        => element.SetValue(IsMultiLineProperty, value);
+    internal static bool GetIsMultiLine(DependencyObject element)
+        => (bool) element.GetValue(IsMultiLineProperty);
 
     #region Methods
 

--- a/src/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -364,6 +364,11 @@ public static class TextFieldAssist
     public static void SetOutlinedBorderActiveThickness(DependencyObject element, Thickness value) => element.SetValue(OutlinedBorderActiveThicknessProperty, value);
     public static Thickness GetOutlinedBorderActiveThickness(DependencyObject element) => (Thickness)element.GetValue(OutlinedBorderActiveThicknessProperty);
 
+    internal static readonly DependencyProperty LineCountProperty = DependencyProperty.RegisterAttached(
+        "LineCount", typeof(int), typeof(TextFieldAssist), new PropertyMetadata(0));
+    internal static void SetLineCount(DependencyObject element, int value) => element.SetValue(LineCountProperty, value);
+    internal static int GetLineCount(DependencyObject element) => (int) element.GetValue(LineCountProperty);
+
     #region Methods
 
     private static void IncludeSpellingSuggestionsChanged(DependencyObject element, DependencyPropertyChangedEventArgs e)

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -324,7 +324,14 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="PrefixTextBlock" Property="VerticalAlignment" Value="Stretch" />
               <Setter TargetName="SuffixTextBlock" Property="VerticalAlignment" Value="Stretch" />
-              <Setter TargetName="Hint" Property="VerticalAlignment" Value="Top" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="VerticalContentAlignment" Value="Stretch" />
+                <Condition Property="wpf:TextFieldAssist.IsMultiLine" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PrefixTextBlock" Property="VerticalAlignment" Value="Stretch" />
+              <Setter TargetName="SuffixTextBlock" Property="VerticalAlignment" Value="Stretch" />
             </MultiTrigger>
 
             <!-- Floating hint -->

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -2,7 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal"
-                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
+                    xmlns:behaviors="clr-namespace:MaterialDesignThemes.Wpf.Behaviors">
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Card.xaml" />
@@ -508,6 +509,7 @@
                   <MultiBinding Converter="{StaticResource FloatingHintInitialVerticalOffsetConverter}">
                     <Binding ElementName="PART_ContentHost" Path="ActualHeight" />
                     <Binding ElementName="Hint" Path="ActualHeight" />
+                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.LineCount)" />
                   </MultiBinding>
                 </Setter.Value>
               </Setter>
@@ -580,6 +582,13 @@
          TargetType="{x:Type wpf:AutoSuggestBox}"
          BasedOn="{StaticResource MaterialDesignAutoSuggestBoxBase}">
     <Setter Property="Padding" Value="{x:Static wpf:Constants.TextBoxDefaultPadding}" />
+    <Setter Property="wpf:BehaviorsAssist.Behaviors">
+      <Setter.Value>
+        <wpf:BehaviorCollection>
+          <behaviors:TextBoxLineCountBehavior />
+        </wpf:BehaviorCollection>
+      </Setter.Value>
+    </Setter>
   </Style>
 
   <Style x:Key="MaterialDesignFloatingHintAutoSuggestBox"

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -15,6 +15,7 @@
   <Style x:Key="MaterialDesignPasswordBox" TargetType="{x:Type PasswordBox}">
     <Style.Resources>
       <system:Boolean x:Key="TrueValue">True</system:Boolean>
+      <system:Int32 x:Key="One">1</system:Int32>
       <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
       <converters:CursorConverter x:Key="ArrowCursorConverter" FallbackCursor="Arrow" />
       <converters:CursorConverter x:Key="IBeamCursorConverter" FallbackCursor="IBeam" />
@@ -484,6 +485,7 @@
                   <MultiBinding Converter="{StaticResource FloatingHintInitialVerticalOffsetConverter}">
                     <Binding ElementName="PART_ContentHost" Path="ActualHeight" />
                     <Binding ElementName="Hint" Path="ActualHeight" />
+                    <Binding Source="{StaticResource One}" />
                   </MultiBinding>
                 </Setter.Value>
               </Setter>
@@ -572,6 +574,7 @@
   <Style x:Key="MaterialDesignRevealPasswordBox" TargetType="{x:Type PasswordBox}">
     <Style.Resources>
       <system:Boolean x:Key="TrueValue">True</system:Boolean>
+      <system:Int32 x:Key="One">1</system:Int32>
       <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
       <converters:BooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter"
                                                FalseValue="Visible"
@@ -1123,6 +1126,7 @@
                   <MultiBinding Converter="{StaticResource FloatingHintInitialVerticalOffsetConverter}">
                     <Binding ElementName="PART_ContentHost" Path="ActualHeight" />
                     <Binding ElementName="Hint" Path="ActualHeight" />
+                    <Binding Source="{StaticResource One}" />
                   </MultiBinding>
                 </Setter.Value>
               </Setter>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RichTextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RichTextBox.xaml
@@ -11,6 +11,8 @@
     <Setter Property="wpf:TextFieldAssist.CharacterCounterStyle" Value="{x:Null}" />
     <Setter Property="wpf:TextFieldAssist.TextBoxViewMargin" Value="-4 0 1 0" />
     <Setter Property="Padding" Value="{x:Static wpf:Constants.TextBoxDefaultPadding}" />
+    <!-- VerticalContentAlignment=Center is the best default value for RichTextBox when it comes to handling floating hint placement -->
+    <Setter Property="VerticalContentAlignment" Value="Center" />
   </Style>
 
   <Style x:Key="MaterialDesignFloatingHintRichTextBox"

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -336,7 +336,14 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="PrefixTextBlock" Property="VerticalAlignment" Value="Stretch" />
               <Setter TargetName="SuffixTextBlock" Property="VerticalAlignment" Value="Stretch" />
-              <Setter TargetName="Hint" Property="VerticalAlignment" Value="Top" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="VerticalContentAlignment" Value="Stretch" />
+                <Condition Property="wpf:TextFieldAssist.IsMultiLine" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="PrefixTextBlock" Property="VerticalAlignment" Value="Stretch" />
+              <Setter TargetName="SuffixTextBlock" Property="VerticalAlignment" Value="Stretch" />
             </MultiTrigger>
 
             <!-- Floating hint -->

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -2,7 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal"
-                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
+                    xmlns:behaviors="clr-namespace:MaterialDesignThemes.Wpf.Behaviors">
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Button.xaml" />
@@ -514,6 +515,7 @@
                   <MultiBinding Converter="{StaticResource FloatingHintInitialVerticalOffsetConverter}">
                     <Binding ElementName="PART_ContentHost" Path="ActualHeight" />
                     <Binding ElementName="Hint" Path="ActualHeight" />
+                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.LineCount)" />
                   </MultiBinding>
                 </Setter.Value>
               </Setter>
@@ -591,6 +593,13 @@
          TargetType="{x:Type TextBox}"
          BasedOn="{StaticResource MaterialDesignTextBoxBase}">
     <Setter Property="Padding" Value="{x:Static wpf:Constants.TextBoxDefaultPadding}" />
+    <Setter Property="wpf:BehaviorsAssist.Behaviors">
+      <Setter.Value>
+        <wpf:BehaviorCollection>
+          <behaviors:TextBoxLineCountBehavior />
+        </wpf:BehaviorCollection>
+      </Setter.Value>
+    </Setter>
   </Style>
 
   <Style x:Key="MaterialDesignFloatingHintTextBox"


### PR DESCRIPTION
This is intended as a partial-fix for #3675. Partial, because it only concerns the `TextBox` based styles, while a similar issue is present with the `ComboBox` template; I intend to do another PR to address that issue eventually.

### Problem
When a `TextBox` has multiple lines of text, either via `AcceptsReturn=True` or `TextWrapping=Wrap/WrapWithOverflow`, the hint position (and prefix/suffix text position) is not always correctly calculated.

#### Example:
![image](https://github.com/user-attachments/assets/95bcc6d7-a1b9-44a9-94cd-684b43a4e6b9)

### Proposed solution
In order to calculate the position correctly, knowledge about the number of rows/lines of text is needed. The information is available in the BCL on the `TextBox` type (see [here](https://source.dot.net/#PresentationFramework/System/Windows/Controls/TextBox.cs,909)), but unfortunately this is not a dependency property. To make the information available via a bindable property (i.e. attached property), I have created a `TextBoxLineCountBehavior` which hooks up to `TextBox.TextChanged` and effectively updates `TextFieldAssist.LineCount` and `TextFieldAssist.IsMultiLine` accordingly.

These attached properties are then used in bindings and converters to improve the calculation of the hint position.

### Example (GIF):
![MultiLineFix](https://github.com/user-attachments/assets/d5b696ce-14e9-4594-b44a-46f49b638ed9)

### Changes
* Extends the "Smart Hint" demo page with means of reproducing the issue(s).
* Adds `TextBoxLineCountBehavior`, `TextFieldAssist.LineCount` and `TextFieldAssist.IsMultiLine` to support correct calculations.
* Modifies `FloatingHintInitialVerticalOffsetConverter` which is responsible for doing the calculation.
* Modifies relevant styles to leverage new APs.
* Changes default value for `RichTextBox.VerticalContentAlignment` to `Center` because this seems to be the best fit if/when you want a hint in a `RichTextBox`; row/line count is not really available in this control, so hint placement can be wrong depending on how you "configure" the control.

### Considerations
This effectively registers a `TextBox.TextChanged` listener on every single instance of a `TextBox`/`AutoSuggestBox` in an app using the MDIX styles.

#### Measurements
I wrote a simple WPF app simply laying out a configurable number of `TextBox` instances in a `Canvas` (to avoid the overhead of a `Grid` having to calculate row/columns sizes). I then measured the startup time and memory footprint (3 times and took an average value; not exactly empirical data, but meh!). The results are listed in the table below. I was looking for a linear increase which would indicate an issue, but the differences I see are so insignificant that I believe the changes in the PR do not introduce a perf cost. The fact that startup time was faster for the 2000-case also indicates that there is no issue.

I ran it on my laptop with the following specs:
_Intel Core Ultra 7 165H, 1400 Mhz, 16 cores, 22 logical processors, 32GB RAM_

<table>
<tr>
  <td/>
  <td colspan="3">Before</td>
  <td colspan="3">After</td>
</tr>
<tr>
  <td># TextBoxes</td>
  <td>100</td>
  <td>1000</td>
  <td>2000</td>
  <td>100</td>
  <td>1000</td>
  <td>2000</td>
</tr>
<tr>
  <td>Startup time</td>
  <td>~2 sec</td>
  <td>~8.5 sec</td>
  <td>~13.2 sec</td>
  <td>~2.2 sec</td>
  <td>~8.5 sec</td>
  <td>~12.8 sec</td>
</tr>
<tr>
  <td>Memory footprint</td>
  <td>~711 MB</td>
  <td>~1028 MB</td>
  <td>~1280 MB</td>
  <td>~711 MB</td>
  <td>~1026 MB</td>
  <td>~1285 MB</td>
</tr>