### PR TITLE
Set Text of ComboBox (DataGridComboBoxColumn) when IsEditing true

### DIFF
--- a/src/MaterialDesignThemes.Wpf/DataGridComboBoxColumn.cs
+++ b/src/MaterialDesignThemes.Wpf/DataGridComboBoxColumn.cs
@@ -16,10 +16,7 @@ public class DataGridComboBoxColumn : System.Windows.Controls.DataGridComboBoxCo
 
     protected override FrameworkElement GenerateElement(DataGridCell cell, object dataItem)
     {
-        var comboBox = base.GenerateElement(cell, cell);
-
-        if (ItemsSourceBinding != null)
-            comboBox.SetBinding(ItemsControl.ItemsSourceProperty, ItemsSourceBinding);
+        var comboBox = InternalGenerateElement(cell, dataItem);
         ApplyStyle(false, false, comboBox);
 
         return comboBox;
@@ -27,14 +24,7 @@ public class DataGridComboBoxColumn : System.Windows.Controls.DataGridComboBoxCo
 
     protected override FrameworkElement GenerateEditingElement(DataGridCell cell, object dataItem)
     {
-        var comboBox = (ComboBox)base.GenerateElement(cell, cell);
-        if (IsEditable is bool isEditable)
-        {
-            comboBox.IsEditable = isEditable;
-        }
-
-        if (ItemsSourceBinding is { } binding)
-            comboBox.SetBinding(ItemsControl.ItemsSourceProperty, binding);
+        var comboBox = InternalGenerateElement(cell, dataItem);
         ApplyStyle(true, false, comboBox);
 
         return comboBox;
@@ -118,4 +108,23 @@ public class DataGridComboBoxColumn : System.Windows.Controls.DataGridComboBoxCo
     }
     */
 
+    private FrameworkElement InternalGenerateElement(DataGridCell cell, object dataItem)
+    {
+        var comboBox = (ComboBox)base.GenerateElement(cell, cell);
+        if (IsEditable is bool isEditable)
+        {
+            comboBox.IsEditable = isEditable;
+        }
+
+        if (cell?.Content is ComboBox cb)
+        {
+            comboBox.Text = cb.Text;
+        }
+
+        if (ItemsSourceBinding != null)
+        {
+            comboBox.SetBinding(ItemsControl.ItemsSourceProperty, ItemsSourceBinding);
+        }
+        return comboBox;
+    }
 }

--- a/src/MaterialDesignThemes.Wpf/DataGridComboBoxColumn.cs
+++ b/src/MaterialDesignThemes.Wpf/DataGridComboBoxColumn.cs
@@ -121,7 +121,7 @@ public class DataGridComboBoxColumn : System.Windows.Controls.DataGridComboBoxCo
             comboBox.Text = cb.Text;
         }
 
-        if (ItemsSourceBinding != null)
+        if (ItemsSourceBinding is not null)
         {
             comboBox.SetBinding(ItemsControl.ItemsSourceProperty, ItemsSourceBinding);
         }


### PR DESCRIPTION
I essentially just added logic to set the `ComboBox.Text` when `GenerateElement(...)` is called:
```C#
if (cell?.Content is ComboBox cb)
{
    comboBox.Text = cb.Text;
}
```

Because `GenerateElement()` and `GenerateEditingElement()` share alot of logic I extracted some of it into a new method `InternalGenerateElement(...)`.

This should fix #3683 