### PR TITLE
[SmartHint] Follow up - make behavior and supporting APs public

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
+++ b/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
@@ -3,20 +3,24 @@
 namespace MaterialDesignThemes.Wpf.Behaviors;
 
 /// <summary>
-/// Internal behavior exposing the <see cref="TextBox.LineCount"/> (non-DP) as an attached property which we can bind to
+/// Behavior exposing the <see cref="TextBox.LineCount"/> (non-DP) as attached properties which are bindable from XAML.
 /// </summary>
-internal class TextBoxLineCountBehavior : Behavior<TextBox>
+public class TextBoxLineCountBehavior : Behavior<TextBox>
 {
-    private void AssociatedObjectOnTextChanged(object sender, TextChangedEventArgs e)
+    private void AssociatedObjectOnTextChanged(object sender, TextChangedEventArgs e) => UpdateAttachedProperties();
+    private void AssociatedObjectOnLayoutUpdated(object? sender, EventArgs e) => UpdateAttachedProperties();
+
+    private void UpdateAttachedProperties()
     {
-        AssociatedObject.SetCurrentValue(TextFieldAssist.LineCountProperty, AssociatedObject.LineCount);
-        AssociatedObject.SetCurrentValue(TextFieldAssist.IsMultiLineProperty, AssociatedObject.LineCount > 1);
+        AssociatedObject.SetCurrentValue(TextFieldAssist.TextBoxLineCountProperty, AssociatedObject.LineCount);
+        AssociatedObject.SetCurrentValue(TextFieldAssist.TextBoxIsMultiLineProperty, AssociatedObject.LineCount > 1);
     }
 
     protected override void OnAttached()
     {
         base.OnAttached();
         AssociatedObject.TextChanged += AssociatedObjectOnTextChanged;
+        AssociatedObject.LayoutUpdated += AssociatedObjectOnLayoutUpdated;
     }
 
     protected override void OnDetaching()
@@ -24,6 +28,7 @@ internal class TextBoxLineCountBehavior : Behavior<TextBox>
         if (AssociatedObject != null)
         {
             AssociatedObject.TextChanged -= AssociatedObjectOnTextChanged;
+            AssociatedObject.LayoutUpdated -= AssociatedObjectOnLayoutUpdated;
         }
         base.OnDetaching();
     }

--- a/src/MaterialDesignThemes.Wpf/TextFieldAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/TextFieldAssist.cs
@@ -368,19 +368,19 @@ public static class TextFieldAssist
     public static Thickness GetOutlinedBorderActiveThickness(DependencyObject element)
         => (Thickness)element.GetValue(OutlinedBorderActiveThicknessProperty);
 
-    internal static readonly DependencyProperty LineCountProperty = DependencyProperty.RegisterAttached(
-        "LineCount", typeof(int), typeof(TextFieldAssist), new PropertyMetadata(0));
-    internal static void SetLineCount(DependencyObject element, int value)
-        => element.SetValue(LineCountProperty, value);
-    internal static int GetLineCount(DependencyObject element)
-        => (int) element.GetValue(LineCountProperty);
+    public static readonly DependencyProperty TextBoxLineCountProperty = DependencyProperty.RegisterAttached(
+        "TextBoxLineCount", typeof(int), typeof(TextFieldAssist), new PropertyMetadata(0));
+    public static void SetTextBoxLineCount(DependencyObject element, int value)
+        => element.SetValue(TextBoxLineCountProperty, value);
+    public static int GetTextBoxLineCount(DependencyObject element)
+        => (int) element.GetValue(TextBoxLineCountProperty);
 
-    internal static readonly DependencyProperty IsMultiLineProperty = DependencyProperty.RegisterAttached(
-        "IsMultiLine", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(false));
-    internal static void SetIsMultiLine(DependencyObject element, bool value)
-        => element.SetValue(IsMultiLineProperty, value);
-    internal static bool GetIsMultiLine(DependencyObject element)
-        => (bool) element.GetValue(IsMultiLineProperty);
+    public static readonly DependencyProperty TextBoxIsMultiLineProperty = DependencyProperty.RegisterAttached(
+        "TextBoxIsMultiLine", typeof(bool), typeof(TextFieldAssist), new PropertyMetadata(false));
+    public static void SetTextBoxIsMultiLine(DependencyObject element, bool value)
+        => element.SetValue(TextBoxIsMultiLineProperty, value);
+    public static bool GetTextBoxIsMultiLine(DependencyObject element)
+        => (bool) element.GetValue(TextBoxIsMultiLineProperty);
 
     #region Methods
 

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -328,7 +328,7 @@
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="VerticalContentAlignment" Value="Stretch" />
-                <Condition Property="wpf:TextFieldAssist.IsMultiLine" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.TextBoxIsMultiLine" Value="True" />
               </MultiTrigger.Conditions>
               <Setter TargetName="PrefixTextBlock" Property="VerticalAlignment" Value="Stretch" />
               <Setter TargetName="SuffixTextBlock" Property="VerticalAlignment" Value="Stretch" />
@@ -516,7 +516,7 @@
                   <MultiBinding Converter="{StaticResource FloatingHintInitialVerticalOffsetConverter}">
                     <Binding ElementName="PART_ContentHost" Path="ActualHeight" />
                     <Binding ElementName="Hint" Path="ActualHeight" />
-                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.LineCount)" />
+                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.TextBoxLineCount)" />
                   </MultiBinding>
                 </Setter.Value>
               </Setter>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -340,7 +340,7 @@
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="VerticalContentAlignment" Value="Stretch" />
-                <Condition Property="wpf:TextFieldAssist.IsMultiLine" Value="True" />
+                <Condition Property="wpf:TextFieldAssist.TextBoxIsMultiLine" Value="True" />
               </MultiTrigger.Conditions>
               <Setter TargetName="PrefixTextBlock" Property="VerticalAlignment" Value="Stretch" />
               <Setter TargetName="SuffixTextBlock" Property="VerticalAlignment" Value="Stretch" />
@@ -522,7 +522,7 @@
                   <MultiBinding Converter="{StaticResource FloatingHintInitialVerticalOffsetConverter}">
                     <Binding ElementName="PART_ContentHost" Path="ActualHeight" />
                     <Binding ElementName="Hint" Path="ActualHeight" />
-                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.LineCount)" />
+                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.TextBoxLineCount)" />
                   </MultiBinding>
                 </Setter.Value>
               </Setter>


### PR DESCRIPTION
Another partial-fix for #3675. `ComboBox` fix to be worked on soon...
 
As discussed, making the new behavior (and supporting APs) public.

Also fixes an issue mentioned by @omllmo where the hint position was not correct if `TextBox.Text` is bound to a property with a long (i.e. multi-line) string value. Only the initial state was wrong, once the user started typing, or other changes happened, the hint position was recalculated correctly.