### PR TITLE
[SmartHint] Fix hint placement when ComboBox toggles between single-line and multi-line selection

### DIFF
--- a/src/MaterialDesignThemes.Wpf/SmartHint.cs
+++ b/src/MaterialDesignThemes.Wpf/SmartHint.cs
@@ -154,6 +154,15 @@ public class SmartHint : Control
         set => SetValue(FloatingTargetProperty, value);
     }
 
+    public static readonly DependencyProperty HintHostProperty = DependencyProperty.Register(
+        nameof(HintHost), typeof(FrameworkElement), typeof(SmartHint), new PropertyMetadata(default(FrameworkElement)));
+
+    public FrameworkElement HintHost
+    {
+        get => (FrameworkElement) GetValue(HintHostProperty);
+        set => SetValue(HintHostProperty, value);
+    }
+
     public static readonly DependencyProperty FloatingAlignmentProperty = DependencyProperty.Register(
         nameof(FloatingAlignment), typeof(VerticalAlignment), typeof(SmartHint), new PropertyMetadata(System.Windows.VerticalAlignment.Bottom));
 

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -169,6 +169,7 @@
                          HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                          UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
                          FloatingTarget="{Binding ElementName=PART_ContentHost}"
+                         HintHost="{Binding RelativeSource={RelativeSource TemplatedParent}}"
                          wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}">
                     <wpf:SmartHint.InitialHorizontalOffset>
                       <MultiBinding Converter="{StaticResource FloatingHintInitialHorizontalOffsetConverter}">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -409,6 +409,7 @@
                              HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                              UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
                              FloatingTarget="{Binding ElementName=PART_EditableTextBox}"
+                             HintHost="{Binding RelativeSource={RelativeSource TemplatedParent}}"
                              wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                              UseLayoutRounding="{TemplateBinding UseLayoutRounding}">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -163,6 +163,8 @@
                       <Binding Path="InitialHorizontalOffset" RelativeSource="{RelativeSource TemplatedParent}" />
                       <Binding Path="FloatingTarget.ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" FallbackValue="{x:Static DependencyProperty.UnsetValue}" />
                       <Binding Path="FontSize" RelativeSource="{RelativeSource TemplatedParent}" />
+                      <Binding Path="HintHost.ActualWidth" RelativeSource="{RelativeSource TemplatedParent}" />
+                      <Binding Path="HintHost.ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
                     </MultiBinding>
                   </Grid.RenderTransform>
                   <Canvas Width="{Binding ElementName=FloatingHintTextBlock, Path=ActualWidth}"

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -210,6 +210,7 @@
                                  HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                  UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
                                  FloatingTarget="{Binding ElementName=PART_ContentHost}"
+                                 HintHost="{Binding RelativeSource={RelativeSource TemplatedParent}}"
                                  wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}">
                     <wpf:SmartHint.InitialHorizontalOffset>
                       <MultiBinding Converter="{StaticResource FloatingHintInitialHorizontalOffsetConverter}">


### PR DESCRIPTION
Fixes #3675 

This is the remaining fix for the issue above. This is regarding the hint in the `ComboBox` not moving accordingly when the "selected content" changes from a single line element to a multi-line element.

The fundemental issue is that the converter in the `SmartHint` needs some knowledge about when the "host element" changes is size. This is not directly available via the `SmartHint.HintProxy` abstraction, and therefore I have added a `SmartHint.HintHost` which is essentially pointing to the same element, but not hidden behind an abstraction. As we've discussed, we could phase out the use of `IHintProxy` and replace with the `SmartHint.HintHost` instead (with some supporting methods).

`HintHost.ActualWidth` and `HintHost.ActualHeight` have both been added as "trigger bindings" to the converter calculating the hint position (the values are not used; they simply re-trigger the calculation)