### PR TITLE
Fix3687 - card border white edges

### DIFF
--- a/src/MainDemo.Wpf/Cards.xaml
+++ b/src/MainDemo.Wpf/Cards.xaml
@@ -24,6 +24,22 @@
     <TextBlock Style="{StaticResource PageTitleTextBlock}" Text="Card" />
 
     <WrapPanel>
+
+      <smtx:XamlDisplay Margin="0,0,8,8" UniqueKey="cards_11111">
+        <Grid Background="Blue">
+          <materialDesign:Card Margin="25" UniformCornerRadius="30" Padding="0" BorderThickness="0" >
+            <Grid Background="Black" Height="300" Width="300" Margin="0">
+              <TextBlock HorizontalAlignment="Center"
+                         VerticalAlignment="Center"
+                         Foreground="White"
+                         Text="The quick brown fox jumps over the lazy dog"
+                         Margin="20"
+                         TextWrapping="Wrap"/>
+            </Grid>
+          </materialDesign:Card>
+        </Grid>
+      </smtx:XamlDisplay>
+
       <smtx:XamlDisplay Margin="0,0,8,8" UniqueKey="cards_1">
         <materialDesign:Card Width="200">
           <Grid>

--- a/src/MainDemo.Wpf/Cards.xaml
+++ b/src/MainDemo.Wpf/Cards.xaml
@@ -27,7 +27,7 @@
 
       <smtx:XamlDisplay Margin="0,0,8,8" UniqueKey="cards_11111">
         <Grid Background="Blue">
-          <materialDesign:Card Margin="25" UniformCornerRadius="30" Padding="0" BorderThickness="0" >
+          <materialDesign:Card materialDesign:ElevationAssist.Elevation="Dp24" Margin="25" UniformCornerRadius="100" Padding="0" BorderThickness="0" >
             <Grid Background="Black" Height="300" Width="300" Margin="0">
               <TextBlock HorizontalAlignment="Center"
                          VerticalAlignment="Center"

--- a/src/MainDemo.Wpf/Properties/launchSettings.json
+++ b/src/MainDemo.Wpf/Properties/launchSettings.json
@@ -2,7 +2,7 @@
     "profiles": {
         "Demo App": {
             "commandName": "Project",
-            "commandLineArgs": "-p Home -t Inherit -f LeftToRight"
+            "commandLineArgs": "-p Card -t Light -f LeftToRight"
         }
     }
 }

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -33,6 +33,9 @@
                 Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}"
                 >
                 <Border Padding="{TemplateBinding Padding}"
+                        Background="{TemplateBinding Background}"
+                        Margin="1"
+                        CornerRadius="{TemplateBinding UniformCornerRadius, Converter={x:Static converters:DoubleToCornerRadiusConverter.Instance}}"
                         Clip="{TemplateBinding ContentClip}"/>
               </Border>
             </AdornerDecorator>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -33,7 +33,6 @@
                 Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}"
                 >
                 <Border Padding="{TemplateBinding Padding}"
-                        Background="{TemplateBinding Background}"
                         Clip="{TemplateBinding ContentClip}"/>
               </Border>
             </AdornerDecorator>


### PR DESCRIPTION
I added a `Card` showcasing the linked bug in the demo app (make sure to remove it if this PR gets merged).
When removing the `Background="{TemplateBinding Background}"` of the nested `Card` in the `AdornerDecorator`, the bug seems to be fixed.

Before:
![image](https://github.com/user-attachments/assets/96066522-0645-4586-a7c0-7b02f3e0d56c)


After:
![image](https://github.com/user-attachments/assets/327d1043-c781-4999-82f7-df9408c3acab)

As shown with the text, ClearType is still maintained.

I'm not sure why there are 2 Borders in the AdornerDecorator in the first place, so any input on if this is breaking something is welcome.

Edit: this possibly fixes #3687 
Display: 1080p monitor @150% scaling