### PR TITLE
Return to ElementName binding to avoid runtime exception

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
+                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Font.xaml" />
   </ResourceDictionary.MergedDictionaries>
@@ -13,6 +14,9 @@
   </Style>
 
   <Style TargetType="{x:Type wpf:DialogHost}">
+    <Style.Resources>
+      <converters:FirstNonNullConverter x:Key="FirstNonNullConverter" />
+    </Style.Resources>
     <Setter Property="DialogMargin" Value="35" />
     <Setter Property="DialogTheme" Value="Inherit" />
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -205,7 +209,14 @@
                   IsHitTestVisible="False"
                   Visibility="{Binding ElementName=ContentCoverBorder, Path=Visibility}">
               <Grid.OpacityMask>
-                <VisualBrush Visual="{x:Reference ContentCoverBorder}" />
+                <VisualBrush>
+                  <VisualBrush.Visual>
+                    <MultiBinding Converter="{StaticResource FirstNonNullConverter}">
+                      <Binding ElementName="ContentCoverBorder" />
+                      <Binding Source="{x:Static DependencyProperty.UnsetValue}" />
+                    </MultiBinding>
+                  </VisualBrush.Visual>
+                </VisualBrush>
               </Grid.OpacityMask>
               <Border x:Name="ContentCoverBorder"
                       Background="{Binding OverlayBackground, RelativeSource={RelativeSource TemplatedParent}}"
@@ -236,6 +247,9 @@
   </Style>
 
   <Style x:Key="MaterialDesignEmbeddedDialogHost" TargetType="{x:Type wpf:DialogHost}">
+    <Style.Resources>
+      <converters:FirstNonNullConverter x:Key="FirstNonNullConverter" />
+    </Style.Resources>
     <Setter Property="DialogMargin" Value="35" />
     <Setter Property="HorizontalContentAlignment" Value="Center" />
     <Setter Property="Placement" Value="Center" />
@@ -380,7 +394,14 @@
                   IsHitTestVisible="False"
                   Visibility="{Binding ElementName=ContentCoverBorder, Path=Visibility}">
               <Grid.OpacityMask>
-                <VisualBrush Visual="{x:Reference ContentCoverBorder}" />
+                <VisualBrush>
+                  <VisualBrush.Visual>
+                    <MultiBinding Converter="{StaticResource FirstNonNullConverter}">
+                      <Binding ElementName="ContentCoverBorder" />
+                      <Binding Source="{x:Static DependencyProperty.UnsetValue}" />
+                    </MultiBinding>
+                  </VisualBrush.Visual>
+                </VisualBrush>
               </Grid.OpacityMask>
               <Border x:Name="ContentCoverBorder"
                       Background="{Binding OverlayBackground, RelativeSource={RelativeSource TemplatedParent}}"


### PR DESCRIPTION
Fixes #3522 

This PR effectively reverts this commit bfe348fed9334ea36eebe97f0897ef01c96afb15. But by simply reverting the commit, we re-introduce a temporary binding error. To mitigate this, I leverage the `FirstNonNullCoverter` to simply return the value of the binding or `DependencyProperty.UnsetValue` in case the value is `null`. This is essentially the same as a `PriorityBinding`, but the priority binding will show a XAML binding error, the converter approach does not.

Inspecting the `PART_ContentCoverGrid.OpacityMask.Visual` with snoop reveals that the correct value is applied at runtime, and that no binding errors have been reported.

![image](https://github.com/user-attachments/assets/8453e439-2468-47f1-89c6-30a0ec87ac85)

![image](https://github.com/user-attachments/assets/5bb12622-8d69-4b35-bc0d-34c6ee27f221)
