### PR TITLE
Fix3688 - Size content of Calendar dynamically

### DIFF
--- a/src/MainDemo.Wpf/App.xaml
+++ b/src/MainDemo.Wpf/App.xaml
@@ -143,6 +143,11 @@
         <Setter Property="Height" Value="1" />
         <Setter Property="Fill" Value="{DynamicResource MaterialDesignDivider}" />
       </Style>
+
+      <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="30"/>
+      </Style>
+
     </ResourceDictionary>
   </Application.Resources>
 </Application>

--- a/src/MainDemo.Wpf/Properties/launchSettings.json
+++ b/src/MainDemo.Wpf/Properties/launchSettings.json
@@ -2,7 +2,7 @@
     "profiles": {
         "Demo App": {
             "commandName": "Project",
-            "commandLineArgs": "-p Home -t Inherit -f LeftToRight"
+            "commandLineArgs": "-p Picker -t Inherit -f LeftToRight"
         }
     }
 }

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
@@ -154,7 +154,7 @@
       </Setter.Value>
     </Setter>
     <Setter Property="VerticalContentAlignment" Value="Center" />
-    <Setter Property="Width" Value="48" />
+    <Setter Property="MinWidth" Value="48" />
     <Setter Property="wpf:CalendarAssist.SelectionColor" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
     <Setter Property="wpf:CalendarAssist.SelectionForegroundColor" Value="{DynamicResource MaterialDesign.Brush.Primary.Foreground}" />
   </Style>
@@ -162,7 +162,6 @@
   <Style x:Key="MaterialDesignCalendarDayButton" TargetType="{x:Type CalendarDayButton}">
     <Setter Property="Cursor" Value="Hand" />
     <Setter Property="FontSize" Value="12" />
-    <Setter Property="Height" Value="28" />
     <Setter Property="HorizontalContentAlignment" Value="Center" />
     <Setter Property="Margin" Value="2" />
     <Setter Property="MinHeight" Value="5" />
@@ -317,7 +316,8 @@
       </Setter.Value>
     </Setter>
     <Setter Property="VerticalContentAlignment" Value="Center" />
-    <Setter Property="Width" Value="28" />
+    <Setter Property="MinWidth" Value="28" />
+    <Setter Property="MinHeight" Value="{Binding ActualWidth, RelativeSource={RelativeSource Self}}"/>
     <Setter Property="wpf:CalendarAssist.SelectionColor" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
     <Setter Property="wpf:CalendarAssist.SelectionForegroundColor" Value="{DynamicResource MaterialDesign.Brush.Primary.Foreground}" />
     <Style.Triggers>


### PR DESCRIPTION
When having a default style for `TextBlock` which increases the `FontSize` to something large, the days, months and years in the `Calendar` are cut off.
This is due to the hardcoded Widths in the styles.

With this default style in the `App.xaml`:
```xaml
<Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
  <Setter Property="FontSize" Value="30"/>
</Style>
```
We get this result:
![image](https://github.com/user-attachments/assets/1d8ff343-23be-4202-ac0f-af292e112d84)


With the changes proposed in this PR the calendar looks like this:
![image](https://github.com/user-attachments/assets/48ef3a1c-1565-41e6-bd8d-b8de4e78abae)


Please don't mind the german abbreviation of the months.
This should fix #3688
Any thoughts on adding an attached property (maybe in the `CalendarAssist` class) so the fontsize of the calendar can be set independently of the rest of the apps fontsize?