### PR TITLE
[SmartHint] Avoid timing issue in hint position calculation

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Behaviors/SmartHintBehavior.cs
+++ b/src/MaterialDesignThemes.Wpf/Behaviors/SmartHintBehavior.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Xaml.Behaviors;
+
+namespace MaterialDesignThemes.Wpf.Behaviors;
+
+public class SmartHintBehavior : Behavior<SmartHint>
+{
+    public static readonly DependencyProperty YOffsetProperty =
+        DependencyProperty.RegisterAttached("YOffset", typeof(double), typeof(SmartHintBehavior), new PropertyMetadata(0.0));
+    public static double GetYOffset(DependencyObject obj)
+        => (double)obj.GetValue(YOffsetProperty);
+    public static void SetYOffset(DependencyObject obj, double value)
+        => obj.SetValue(YOffsetProperty, value);
+
+    private void UpdateSmartHintLocationRecalculationTrigger()
+    {
+        if (AssociatedObject?.FloatingTarget is null) return;
+
+        double yOffset = AssociatedObject.FloatingTarget.TranslatePoint(new Point(0, 0), AssociatedObject).Y;
+        AssociatedObject.SetCurrentValue(YOffsetProperty, yOffset);
+    }
+
+    private void HintHostOnLayoutUpdated(object? sender, EventArgs e)
+        => UpdateSmartHintLocationRecalculationTrigger();
+
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        AssociatedObject.LayoutUpdated += HintHostOnLayoutUpdated;
+    }
+
+    protected override void OnDetaching()
+    {
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.LayoutUpdated -= HintHostOnLayoutUpdated;
+        }
+        base.OnDetaching();
+    }
+}

--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintTranslateTransformConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintTranslateTransformConverter.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Media;
 
@@ -8,7 +8,7 @@ public class FloatingHintTranslateTransformConverter : IMultiValueConverter
 {
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (values is not [double scale, double lower, double upper, SmartHint hint, Point floatingOffset, ..])
+        if (values is not [double scale, double lower, double upper, SmartHint hint, Point floatingOffset, double yOffset, ..])
         {
             return Transform.Identity;
         }
@@ -43,7 +43,7 @@ public class FloatingHintTranslateTransformConverter : IMultiValueConverter
 
         double GetFloatingTargetVerticalOffset()
         {
-            double offset = hint.FloatingTarget.TranslatePoint(new Point(0, 0), hint).Y;
+            double offset = yOffset;
             offset += hint.InitialVerticalOffset;
             offset -= hint.ActualHeight;
 

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -2,7 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:system="clr-namespace:System;assembly=mscorlib"
-                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
+                    xmlns:behaviors="clr-namespace:MaterialDesignThemes.Wpf.Behaviors">
 
   <Style TargetType="{x:Type wpf:SmartHint}">
     <Style.Resources>
@@ -18,6 +19,13 @@
       <converters:FloatingHintTextBlockMarginConverter x:Key="FloatingHintTextBlockMarginConverter" />
       <converters:FloatingHintClippingGridConverter x:Key="FloatingHintClippingGridConverter" />
     </Style.Resources>
+    <Setter Property="wpf:BehaviorsAssist.Behaviors">
+      <Setter.Value>
+        <wpf:BehaviorCollection>
+          <behaviors:SmartHintBehavior />
+        </wpf:BehaviorCollection>
+      </Setter.Value>
+    </Setter>
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="IsHitTestVisible" Value="False" />
@@ -158,6 +166,7 @@
                       <Binding Source="{StaticResource NoContentFloatingScale}" />
                       <Binding Path="." RelativeSource="{RelativeSource TemplatedParent}" />
                       <Binding Path="FloatingOffset" RelativeSource="{RelativeSource TemplatedParent}" />
+                      <Binding Path="(behaviors:SmartHintBehavior.YOffset)" RelativeSource="{RelativeSource TemplatedParent}" />
                       <!-- The bindings below are only here to trigger a recalculation - needed to support AcceptsReturn=true scenario for TextBoxes for example as well as "runtime" changes to the desired hint placement -->
                       <Binding Path="InitialVerticalOffset" RelativeSource="{RelativeSource TemplatedParent}" />
                       <Binding Path="InitialHorizontalOffset" RelativeSource="{RelativeSource TemplatedParent}" />


### PR DESCRIPTION
Fixes #3695 

I was not able to track down exactly why the timing issue occurs, but it is evident in the issue mentioned above, that the same user interaction can cause different behavior which is a good indication of a timing related issue.

I tracked down the wrong calculation to this particular line of code in the converter:
https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/eb9338c720dd93fd53aef6d6499586efa63a87ca/src/MaterialDesignThemes.Wpf/Converters/FloatingHintTranslateTransformConverter.cs#L46
The result of this calculation is essential in the placement of the hint, but not one that can easily be used as a trigger for the converter to recalculate.

The fix here, which I would like your thoughts on, is to extract said calculation into a attached property which is calculated based on a change in layout, and then use the AP in the multi-binding.

This seems to do the trick, and I can no longer reproduce the issue in the provided repo sample.