### PR TITLE
[SmartHint] Add opt-in AP to control hint padding brush

### DIFF
--- a/src/MainDemo.Wpf/Fields.xaml
+++ b/src/MainDemo.Wpf/Fields.xaml
@@ -672,6 +672,20 @@
     </StackPanel>
 
     <Rectangle Style="{StaticResource PageSectionSeparator}" />
+    <TextBlock Style="{StaticResource PageSectionTitleTextBlock}" Text="Custom Background" />
+
+    <WrapPanel Margin="0,0,0,32" Background="Chocolate">
+      <smtx:XamlDisplay Margin="16"
+                        UniqueKey="fields_custom_background_1">
+        <TextBox Width="200"
+                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                 materialDesign:HintAssist.Hint="Hint text"
+                 materialDesign:HintAssist.HintPaddingBrush="Chocolate" />
+        <!-- Set HintAssist.HintPaddingBrush to match the custom background to get correct coloring of the hint padding (when floated) -->
+      </smtx:XamlDisplay>
+    </WrapPanel>
+
+    <Rectangle Style="{StaticResource PageSectionSeparator}" />
     <TextBlock Style="{StaticResource PageSectionTitleTextBlock}" Text="AutoSuggestBox" />
 
     <WrapPanel>

--- a/src/MaterialDesign3.Demo.Wpf/Fields.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Fields.xaml
@@ -518,5 +518,19 @@
         </smtx:XamlDisplay>
       </StackPanel>
     </Grid>
+
+    <TextBlock Style="{StaticResource MaterialDesignSubtitle1TextBlock}" Text="Custom Background" Margin="0,20,0,0" />
+
+    <WrapPanel Margin="0,0,0,32" Background="Chocolate">
+      <smtx:XamlDisplay Margin="16"
+                        UniqueKey="fields_custom_background_1">
+        <TextBox Width="200"
+                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                 materialDesign:HintAssist.Hint="Hint text"
+                 materialDesign:HintAssist.HintPaddingBrush="Chocolate" />
+        <!-- Set HintAssist.HintPaddingBrush to match the custom background to get correct coloring of the hint padding (when floated) -->
+      </smtx:XamlDisplay>
+    </WrapPanel>
+    
   </StackPanel>
 </UserControl>

--- a/src/MaterialDesignThemes.Wpf/HintAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/HintAssist.cs
@@ -123,10 +123,10 @@ public static class HintAssist
     public static readonly DependencyProperty HintPaddingBrushProperty =
         DependencyProperty.RegisterAttached("HintPaddingBrush", typeof(Brush), typeof(HintAssist), new PropertyMetadata(null));
 
-    public static Brush GetHintPaddingBrush(DependencyObject obj)
+    public static Brush? GetHintPaddingBrush(DependencyObject obj)
         => (Brush)obj.GetValue(HintPaddingBrushProperty);
 
-    public static void SetHintPaddingBrush(DependencyObject obj, Brush value)
+    public static void SetHintPaddingBrush(DependencyObject obj, Brush? value)
         => obj.SetValue(HintPaddingBrushProperty, value);
     #endregion
 

--- a/src/MaterialDesignThemes.Wpf/HintAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/HintAssist.cs
@@ -119,6 +119,17 @@ public static class HintAssist
         => element.SetValue(BackgroundProperty, value);
     #endregion
 
+    #region AttachedProperty: HintPaddingBrush
+    public static readonly DependencyProperty HintPaddingBrushProperty =
+        DependencyProperty.RegisterAttached("HintPaddingBrush", typeof(Brush), typeof(HintAssist), new PropertyMetadata(null));
+
+    public static Brush GetHintPaddingBrush(DependencyObject obj)
+        => (Brush)obj.GetValue(HintPaddingBrushProperty);
+
+    public static void SetHintPaddingBrush(DependencyObject obj, Brush value)
+        => obj.SetValue(HintPaddingBrushProperty, value);
+    #endregion
+
     #region AttachedProperty : HelperTextProperty
     public static readonly DependencyProperty HelperTextProperty
         = DependencyProperty.RegisterAttached("HelperText", typeof(string), typeof(HintAssist),

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -156,21 +156,22 @@
                         VerticalScrollBarVisibility="Hidden" />
 
                   <wpf:SmartHint x:Name="Hint"
-                         Grid.Column="1"
-                         Grid.ColumnSpan="3"
-                         VerticalAlignment="Center"
-                         HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                         VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                         FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
-                         FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
-                         FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
-                         FontSize="{TemplateBinding FontSize}"
-                         HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                         HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
-                         UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
-                         FloatingTarget="{Binding ElementName=PART_ContentHost}"
-                         HintHost="{Binding RelativeSource={RelativeSource TemplatedParent}}"
-                         wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}">
+                                 Grid.Column="1"
+                                 Grid.ColumnSpan="3"
+                                 VerticalAlignment="Center"
+                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                 FloatingOffset="{TemplateBinding wpf:HintAssist.FloatingOffset}"
+                                 FloatingScale="{TemplateBinding wpf:HintAssist.FloatingScale}"
+                                 FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
+                                 FontSize="{TemplateBinding FontSize}"
+                                 HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                                 HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
+                                 UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
+                                 FloatingTarget="{Binding ElementName=PART_ContentHost}"
+                                 HintHost="{Binding RelativeSource={RelativeSource TemplatedParent}}"
+                                 wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
+                                 wpf:HintAssist.HintPaddingBrush="{TemplateBinding wpf:HintAssist.HintPaddingBrush}">
                     <wpf:SmartHint.InitialHorizontalOffset>
                       <MultiBinding Converter="{StaticResource FloatingHintInitialHorizontalOffsetConverter}">
                         <Binding ElementName="PrefixTextBlock" Path="ActualWidth" />
@@ -369,14 +370,6 @@
               <Setter TargetName="Hint" Property="FloatingMargin" Value="4,0" />
               <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="{Binding ElementName=Hint, Path=ActualHeight, Converter={StaticResource DivisionConverter}, ConverterParameter=2}" />
             </Trigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="Hint" Property="wpf:HintAssist.Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
-            </MultiTrigger>
 
             <!-- IsEnabled -->
             <MultiTrigger>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -411,6 +411,7 @@
                              FloatingTarget="{Binding ElementName=PART_EditableTextBox}"
                              HintHost="{Binding RelativeSource={RelativeSource TemplatedParent}}"
                              wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
+                             wpf:HintAssist.HintPaddingBrush="{TemplateBinding wpf:HintAssist.HintPaddingBrush}"
                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                              UseLayoutRounding="{TemplateBinding UseLayoutRounding}">
                 <wpf:SmartHint.InitialHorizontalOffset>
@@ -595,14 +596,6 @@
         <Setter TargetName="Hint" Property="FloatingMargin" Value="4,0" />
         <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="{Binding ElementName=Hint, Path=ActualHeight, Converter={StaticResource DivisionConverter}, ConverterParameter=2}" />
       </Trigger>
-      <MultiTrigger>
-        <MultiTrigger.Conditions>
-          <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-          <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-          <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
-        </MultiTrigger.Conditions>
-        <Setter TargetName="Hint" Property="wpf:HintAssist.Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
-      </MultiTrigger>
 
       <!-- Floating hint -->
       <MultiTrigger>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -59,6 +59,7 @@
                                wpf:HintAssist.FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
                                wpf:HintAssist.Foreground="{TemplateBinding wpf:HintAssist.Foreground}"
                                wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
+                               wpf:HintAssist.HintPaddingBrush="{TemplateBinding wpf:HintAssist.HintPaddingBrush}"
                                wpf:HintAssist.HelperTextStyle="{TemplateBinding wpf:HintAssist.HelperTextStyle}"
                                wpf:HintAssist.Hint="{TemplateBinding wpf:HintAssist.Hint}"
                                wpf:HintAssist.HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -212,7 +212,8 @@
                                  HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                  UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
                                  FloatingTarget="{Binding ElementName=PART_ContentHost}"
-                                 wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}">
+                                 wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
+                                 wpf:HintAssist.HintPaddingBrush="{TemplateBinding wpf:HintAssist.HintPaddingBrush}">
                     <wpf:SmartHint.InitialHorizontalOffset>
                       <MultiBinding Converter="{StaticResource FloatingHintInitialHorizontalOffsetConverter}">
                         <Binding ElementName="PrefixTextBlock" Path="ActualWidth" />
@@ -361,14 +362,6 @@
               <Setter TargetName="Hint" Property="FloatingMargin" Value="4,0" />
               <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="{Binding ElementName=Hint, Path=ActualHeight, Converter={StaticResource DivisionConverter}, ConverterParameter=2}" />
             </Trigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter Property="wpf:HintAssist.Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
-            </MultiTrigger>
 
             <!-- IsEnabled -->
             <MultiTrigger>
@@ -838,7 +831,8 @@
                                  HintProxy="{Binding RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HintProxyFabricConverter.Instance}}"
                                  UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
                                  FloatingTarget="{Binding ElementName=PART_ContentHost}"
-                                 wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}">
+                                 wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
+                                 wpf:HintAssist.HintPaddingBrush="{TemplateBinding wpf:HintAssist.HintPaddingBrush}">
                     <wpf:SmartHint.InitialHorizontalOffset>
                       <MultiBinding Converter="{StaticResource FloatingHintInitialHorizontalOffsetConverter}">
                         <Binding ElementName="PrefixTextBlock" Path="ActualWidth" />
@@ -1000,14 +994,6 @@
               <Setter TargetName="Hint" Property="FloatingMargin" Value="4,0" />
               <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="{Binding ElementName=Hint, Path=ActualHeight, Converter={StaticResource DivisionConverter}, ConverterParameter=2}" />
             </Trigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter Property="wpf:HintAssist.Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
-            </MultiTrigger>
 
             <!-- IsEnabled -->
             <MultiTrigger>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -17,6 +17,7 @@
       <converters:FloatingHintContainerMarginConverter x:Key="FloatingHintContainerMarginConverter" />
       <converters:FloatingHintTextBlockMarginConverter x:Key="FloatingHintTextBlockMarginConverter" />
       <converters:FloatingHintClippingGridConverter x:Key="FloatingHintClippingGridConverter" />
+      <converters:FirstNonNullConverter x:Key="FirstNonNullConverter" />
     </Style.Resources>
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -203,7 +204,7 @@
                           <Binding Source="{StaticResource NoContentFloatingScale}" />
                         </MultiBinding>
                       </ContentControl.RenderTransform>
-                      <Grid x:Name="HintBackgroundGrid" Background="{TemplateBinding wpf:HintAssist.Background}" IsHitTestVisible="False">
+                      <Grid x:Name="HintBackgroundGrid" Tag="{DynamicResource MaterialDesign.Brush.Background}" IsHitTestVisible="False">
                         <ContentControl Content="{TemplateBinding Hint}" IsTabStop="False">
                           <ContentControl.Margin>
                             <MultiBinding Converter="{StaticResource FloatingHintContainerMarginConverter}">
@@ -218,6 +219,18 @@
                   </Canvas>
                 </Grid>
               </Grid>
+              <ControlTemplate.Triggers>
+                <Trigger Property="IsHintInFloatingPosition" Value="True">
+                  <Setter TargetName="HintBackgroundGrid" Property="Background">
+                    <Setter.Value>
+                      <MultiBinding Converter="{StaticResource FirstNonNullConverter}">
+                        <Binding Path="(wpf:HintAssist.HintPaddingBrush)" RelativeSource="{RelativeSource TemplatedParent}" />
+                        <Binding Path="Tag" ElementName="HintBackgroundGrid" />
+                      </MultiBinding>
+                    </Setter.Value>
+                  </Setter>
+                </Trigger>
+              </ControlTemplate.Triggers>
             </ControlTemplate>
           </Setter.Value>
         </Setter>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -211,7 +211,8 @@
                                  UseFloating="{TemplateBinding wpf:HintAssist.IsFloating}"
                                  FloatingTarget="{Binding ElementName=PART_ContentHost}"
                                  HintHost="{Binding RelativeSource={RelativeSource TemplatedParent}}"
-                                 wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}">
+                                 wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
+                                 wpf:HintAssist.HintPaddingBrush="{TemplateBinding wpf:HintAssist.HintPaddingBrush}">
                     <wpf:SmartHint.InitialHorizontalOffset>
                       <MultiBinding Converter="{StaticResource FloatingHintInitialHorizontalOffsetConverter}">
                         <Binding ElementName="PrefixTextBlock" Path="ActualWidth" />
@@ -385,14 +386,6 @@
               <Setter TargetName="Hint" Property="FloatingMargin" Value="4,0" />
               <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="{Binding ElementName=Hint, Path=ActualHeight, Converter={StaticResource DivisionConverter}, ConverterParameter=2}" />
             </Trigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
-                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
-                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
-              </MultiTrigger.Conditions>
-              <Setter TargetName="Hint" Property="wpf:HintAssist.Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
-            </MultiTrigger>
 
             <!-- IsEnabled -->
             <MultiTrigger>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -72,6 +72,7 @@
                                    wpf:HintAssist.FontFamily="{TemplateBinding wpf:HintAssist.FontFamily}"
                                    wpf:HintAssist.Foreground="{TemplateBinding wpf:HintAssist.Foreground}"
                                    wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
+                                   wpf:HintAssist.HintPaddingBrush="{TemplateBinding wpf:HintAssist.HintPaddingBrush}"
                                    wpf:HintAssist.HelperTextStyle="{TemplateBinding wpf:HintAssist.HelperTextStyle}"
                                    wpf:HintAssist.Hint="{TemplateBinding wpf:HintAssist.Hint}"
                                    wpf:HintAssist.HintOpacity="{TemplateBinding wpf:HintAssist.HintOpacity}"

--- a/tests/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/DatePickers/DatePickerTests.cs
@@ -253,11 +253,10 @@ public class DatePickerTests : TestBase
         var datePickerTextBox = await datePicker.GetElement<DatePickerTextBox>("/DatePickerTextBox");
         var hintBackgroundGrid = await datePicker.GetElement<Grid>("HintBackgroundGrid");
 
-        var defaultBackground = Colors.Transparent;
         var defaultFloatedBackground = await GetThemeColor("MaterialDesign.Brush.Background");
 
         // Assert (unfocused state)
-        Assert.Equal(defaultBackground, await hintBackgroundGrid.GetBackgroundColor());
+        Assert.Null(await hintBackgroundGrid.GetBackgroundColor());
 
         // Act
         await datePickerTextBox.MoveKeyboardFocus();

--- a/tests/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TimePickers/TimePickerTests.cs
@@ -560,11 +560,10 @@ public class TimePickerTests : TestBase
         var timePickerTextBox = await timePicker.GetElement<TimePickerTextBox>("/TimePickerTextBox");
         var hintBackgroundGrid = await timePicker.GetElement<Grid>("HintBackgroundGrid");
 
-        var defaultBackground = Colors.Transparent;
         var defaultFloatedBackground = await GetThemeColor("MaterialDesign.Brush.Background");
 
         // Assert (unfocused state)
-        Assert.Equal(defaultBackground, await hintBackgroundGrid.GetBackgroundColor());
+        Assert.Null(await hintBackgroundGrid.GetBackgroundColor());
 
         // Act
         await timePickerTextBox.MoveKeyboardFocus();


### PR DESCRIPTION
Fixes #3700 
Fixes #3262 

If applying a custom background, the `MaterialDesignOutlinedTextBox` style by default uses the MDIX window background brushes for the "padding" on the hint (used to "erase" some of the outline border).

This PR introduces an opt-in AP which allows consumers to override this to match their custom background.

In principle, a `PriorityBinding` should suffice for this in the `SmartHint` style, but yet again I was unable to make it work 😞 Thus I went for the converter approach I have ended up with before. Apparently I am not great friends with the `PriorityBinding`.

For a more detailed explanation of the issue, see my comment here: https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/discussions/3262#discussioncomment-10905148

### Before
`HintAssist.Background` left at default value (`Transparent`):
![image](https://github.com/user-attachments/assets/9a482947-cd81-46d8-ba6d-a40da02b854d)

`HintAssist.Background` set to match background:
![image](https://github.com/user-attachments/assets/7bfcfd64-dff6-4d84-b8f4-fa42bb08e374)

### After
`HintAssist.Background` not needed unless you want a custom background on the hint (floating and non-floating)
![image](https://github.com/user-attachments/assets/534b68b4-534e-4cd4-9719-107e8cfd955d)

