### PR TITLE
[SmartHint] Bug fix - fixes bug introduced in previous PR

### DIFF
--- a/src/MaterialDesignThemes.Wpf/HintAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/HintAssist.cs
@@ -130,6 +130,17 @@ public static class HintAssist
         => obj.SetValue(HintPaddingBrushProperty, value);
     #endregion
 
+    #region AttachedProperty: ApplyHintPaddingBrush
+    public static readonly DependencyProperty ApplyHintPaddingBrushProperty =
+        DependencyProperty.RegisterAttached("ApplyHintPaddingBrush", typeof(bool), typeof(HintAssist), new PropertyMetadata(false));
+
+    public static bool GetApplyHintPaddingBrush(DependencyObject obj)
+        => (bool)obj.GetValue(ApplyHintPaddingBrushProperty);
+
+    public static void SetApplyHintPaddingBrush(DependencyObject obj, bool value)
+        => obj.SetValue(ApplyHintPaddingBrushProperty, value);
+    #endregion
+
     #region AttachedProperty : HelperTextProperty
     public static readonly DependencyProperty HelperTextProperty
         = DependencyProperty.RegisterAttached("HelperText", typeof(string), typeof(HintAssist),

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -370,6 +370,14 @@
               <Setter TargetName="Hint" Property="FloatingMargin" Value="4,0" />
               <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="{Binding ElementName=Hint, Path=ActualHeight, Converter={StaticResource DivisionConverter}, ConverterParameter=2}" />
             </Trigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Hint" Property="wpf:HintAssist.ApplyHintPaddingBrush" Value="True" />
+            </MultiTrigger>
 
             <!-- IsEnabled -->
             <MultiTrigger>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -596,6 +596,14 @@
         <Setter TargetName="Hint" Property="FloatingMargin" Value="4,0" />
         <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="{Binding ElementName=Hint, Path=ActualHeight, Converter={StaticResource DivisionConverter}, ConverterParameter=2}" />
       </Trigger>
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+          <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+          <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+        </MultiTrigger.Conditions>
+        <Setter TargetName="Hint" Property="wpf:HintAssist.ApplyHintPaddingBrush" Value="True" />
+      </MultiTrigger>
 
       <!-- Floating hint -->
       <MultiTrigger>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -362,6 +362,14 @@
               <Setter TargetName="Hint" Property="FloatingMargin" Value="4,0" />
               <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="{Binding ElementName=Hint, Path=ActualHeight, Converter={StaticResource DivisionConverter}, ConverterParameter=2}" />
             </Trigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Hint" Property="wpf:HintAssist.ApplyHintPaddingBrush" Value="True" />
+            </MultiTrigger>
 
             <!-- IsEnabled -->
             <MultiTrigger>
@@ -994,6 +1002,14 @@
               <Setter TargetName="Hint" Property="FloatingMargin" Value="4,0" />
               <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="{Binding ElementName=Hint, Path=ActualHeight, Converter={StaticResource DivisionConverter}, ConverterParameter=2}" />
             </Trigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Hint" Property="wpf:HintAssist.ApplyHintPaddingBrush" Value="True" />
+            </MultiTrigger>
 
             <!-- IsEnabled -->
             <MultiTrigger>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -229,7 +229,11 @@
                 </Grid>
               </Grid>
               <ControlTemplate.Triggers>
-                <Trigger Property="IsHintInFloatingPosition" Value="True">
+                <MultiTrigger>
+                  <MultiTrigger.Conditions>
+                    <Condition Property="IsHintInFloatingPosition" Value="True" />
+                    <Condition Property="wpf:HintAssist.ApplyHintPaddingBrush" Value="True" />
+                  </MultiTrigger.Conditions>
                   <Setter TargetName="HintBackgroundGrid" Property="Background">
                     <Setter.Value>
                       <MultiBinding Converter="{StaticResource FirstNonNullConverter}">
@@ -238,7 +242,7 @@
                       </MultiBinding>
                     </Setter.Value>
                   </Setter>
-                </Trigger>
+                </MultiTrigger>
               </ControlTemplate.Triggers>
             </ControlTemplate>
           </Setter.Value>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -386,6 +386,14 @@
               <Setter TargetName="Hint" Property="FloatingMargin" Value="4,0" />
               <Setter TargetName="Hint" Property="InitialVerticalOffset" Value="{Binding ElementName=Hint, Path=ActualHeight, Converter={StaticResource DivisionConverter}, ConverterParameter=2}" />
             </Trigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TextFieldAssist.HasOutlinedTextField" Value="True" />
+                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="Hint" Property="wpf:HintAssist.ApplyHintPaddingBrush" Value="True" />
+            </MultiTrigger>
 
             <!-- IsEnabled -->
             <MultiTrigger>


### PR DESCRIPTION
Fixes #3710

As part of PR #3701, a new way of controlling the background on the hint was introduced. While this fixed the issue for the outlined style, it broke the other styles 😢 This was my fault for not being thorough enough in my manual testing.

This PR introduces a new AP to support the AP introduced in the other PR, because it basically should only be used in the outlined scenarios. Therefore, this PR also reintroduces the style triggers previously removed, but now sets the supporting AP value instead of explicitly setting a color as they did prior to PR #3701.

Essentially, if the style is "outlined", set `HintAssist.ApplyHintPaddingBrush=True` in the relevant styles, and use that value in the `SmartHint` style trigger to modify the background only in that particular case.