### PR TITLE
Removed global converter resources

### DIFF
--- a/src/MainDemo.Wpf/Buttons.xaml
+++ b/src/MainDemo.Wpf/Buttons.xaml
@@ -25,9 +25,6 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ToggleButton.xaml" />
       </ResourceDictionary.MergedDictionaries>
       <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-      <materialDesignConverters:BooleanToVisibilityConverter x:Key="InvertedBooleanToVisibilityConverter"
-                                                             FalseValue="Visible"
-                                                             TrueValue="Collapsed" />
     </ResourceDictionary>
   </UserControl.Resources>
   <StackPanel>
@@ -573,7 +570,7 @@
                     Command="{Binding DismissCommand}"
                     IsEnabled="{Binding DataContext.ControlsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}"
                     Style="{StaticResource MaterialDesignRaisedButton}"
-                    Visibility="{Binding ShowDismissButton, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Visibility="{Binding ShowDismissButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}">
               <StackPanel Orientation="Horizontal">
                 <TextBlock Text="DISMISS" />
                 <materialDesign:PackIcon Margin="4,.5,0,0" Kind="Close" />
@@ -582,7 +579,7 @@
 
             <TextBlock VerticalAlignment="Center"
                        Text="{Binding DemoRestartCountdownText}"
-                       Visibility="{Binding ShowDismissButton, Converter={StaticResource InvertedBooleanToVisibilityConverter}}" />
+                       Visibility="{Binding ShowDismissButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.InverseInstance}}" />
           </Grid>
         </smtx:XamlDisplay>
 
@@ -607,7 +604,7 @@
                     Command="{Binding DismissCommand}"
                     IsEnabled="{Binding DataContext.ControlsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}"
                     Style="{StaticResource MaterialDesignOutlinedButton}"
-                    Visibility="{Binding ShowDismissButton, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Visibility="{Binding ShowDismissButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}">
               <StackPanel Orientation="Horizontal">
                 <TextBlock Text="DISMISS" />
                 <materialDesign:PackIcon Margin="4,.5,0,0" Kind="Close" />
@@ -616,7 +613,7 @@
 
             <TextBlock VerticalAlignment="Center"
                        Text="{Binding DemoRestartCountdownText}"
-                       Visibility="{Binding ShowDismissButton, Converter={StaticResource InvertedBooleanToVisibilityConverter}}" />
+                       Visibility="{Binding ShowDismissButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.InverseInstance}}" />
           </Grid>
         </smtx:XamlDisplay>
 
@@ -641,7 +638,7 @@
                     Command="{Binding DismissCommand}"
                     IsEnabled="{Binding DataContext.ControlsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}"
                     Style="{StaticResource MaterialDesignFlatButton}"
-                    Visibility="{Binding ShowDismissButton, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Visibility="{Binding ShowDismissButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}">
               <StackPanel Orientation="Horizontal">
                 <TextBlock Text="DISMISS" />
                 <materialDesign:PackIcon Margin="4,.5,0,0" Kind="Close" />
@@ -650,7 +647,7 @@
 
             <TextBlock VerticalAlignment="Center"
                        Text="{Binding DemoRestartCountdownText}"
-                       Visibility="{Binding ShowDismissButton, Converter={StaticResource InvertedBooleanToVisibilityConverter}}" />
+                       Visibility="{Binding ShowDismissButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.InverseInstance}}" />
           </Grid>
         </smtx:XamlDisplay>
 

--- a/src/MainDemo.Wpf/ColorTool.xaml
+++ b/src/MainDemo.Wpf/ColorTool.xaml
@@ -7,6 +7,7 @@
              xmlns:local="clr-namespace:MaterialDesignDemo"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:materialDesignColors="clr-namespace:MaterialDesignColors;assembly=MaterialDesignColors"
+             xmlns:materialDesignConverters="clr-namespace:MaterialDesignThemes.Wpf.Converters;assembly=MaterialDesignThemes.Wpf"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              d:DataContext="{d:DesignInstance Type=domain:ColorToolViewModel}"
              d:DesignHeight="600"
@@ -480,7 +481,7 @@
         </UniformGrid>
 
         <Grid DockPanel.Dock="Left">
-          <Grid Visibility="{Binding IsChecked, ElementName=CustomPaletteButton, Converter={StaticResource BooleanToVisibilityConverter}}">
+          <Grid Visibility="{Binding IsChecked, ElementName=CustomPaletteButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}">
             <Grid.ColumnDefinitions>
               <ColumnDefinition Width="160" />
               <ColumnDefinition />
@@ -500,7 +501,7 @@
                                         Color="{Binding SelectedColor, Delay=25}" />
           </Grid>
 
-          <StackPanel Visibility="{Binding IsChecked, ElementName=MdPaletteButton, Converter={StaticResource BooleanToVisibilityConverter}}">
+          <StackPanel Visibility="{Binding IsChecked, ElementName=MdPaletteButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}">
             <StackPanel Orientation="Horizontal">
               <StackPanel.Resources>
                 <Style TargetType="TextBlock">

--- a/src/MainDemo.Wpf/Fields.xaml
+++ b/src/MainDemo.Wpf/Fields.xaml
@@ -6,6 +6,7 @@
              xmlns:domain="clr-namespace:MaterialDesignDemo.Domain"
              xmlns:domain1="clr-namespace:MaterialDesignDemo.Domain"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:materialDesignConverters="clr-namespace:MaterialDesignThemes.Wpf.Converters;assembly=MaterialDesignThemes.Wpf"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
@@ -258,7 +259,7 @@
 
           <TextBox VerticalAlignment="Top"
                    materialDesign:HintAssist.Hint="This is a limited text area"
-                   materialDesign:TextFieldAssist.CharacterCounterVisibility="{Binding Path=IsChecked, ElementName=MaterialDesignFilledTextBoxTextCountComboBox, Converter={StaticResource BooleanToVisibilityConverter}}"
+                   materialDesign:TextFieldAssist.CharacterCounterVisibility="{Binding Path=IsChecked, ElementName=MaterialDesignFilledTextBoxTextCountComboBox, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}"
                    MaxLength="40"
                    Style="{StaticResource MaterialDesignFilledTextBox}"
                    TextWrapping="Wrap" />
@@ -282,7 +283,7 @@
 
           <PasswordBox materialDesign:HintAssist.HelperText="Helper text"
                        materialDesign:HintAssist.Hint="Password"
-                       materialDesign:TextFieldAssist.CharacterCounterVisibility="{Binding Path=IsChecked, ElementName=MaterialDesignFilledPasswordBoxTextCountComboBox, Converter={StaticResource BooleanToVisibilityConverter}}"
+                       materialDesign:TextFieldAssist.CharacterCounterVisibility="{Binding Path=IsChecked, ElementName=MaterialDesignFilledPasswordBoxTextCountComboBox, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}"
                        Style="{StaticResource MaterialDesignFilledPasswordBox}" />
         </StackPanel>
       </smtx:XamlDisplay>
@@ -355,7 +356,7 @@
           <TextBox Height="100"
                    VerticalAlignment="Top"
                    materialDesign:HintAssist.Hint="This is a limited text area"
-                   materialDesign:TextFieldAssist.CharacterCounterVisibility="{Binding Path=IsChecked, ElementName=MaterialDesignOutlinedTextBoxTextCountComboBox, Converter={StaticResource BooleanToVisibilityConverter}}"
+                   materialDesign:TextFieldAssist.CharacterCounterVisibility="{Binding Path=IsChecked, ElementName=MaterialDesignOutlinedTextBoxTextCountComboBox, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}"
                    MaxLength="40"
                    Style="{StaticResource MaterialDesignOutlinedTextBox}"
                    TextWrapping="Wrap"

--- a/src/MainDemo.Wpf/IconPack.xaml
+++ b/src/MainDemo.Wpf/IconPack.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:domain="clr-namespace:MaterialDesignDemo.Domain"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:materialDesignConverters="clr-namespace:MaterialDesignThemes.Wpf.Converters;assembly=MaterialDesignThemes.Wpf"
              xmlns:materialDesignDemo="clr-namespace:MaterialDesignDemo"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
@@ -191,7 +192,7 @@
             </Grid>
 
             <materialDesign:ColorPicker MinHeight="100" Margin="0,10"
-                                        IsEnabled="{Binding IsChecked, ElementName=UseTransparent, Converter={StaticResource InvertBooleanConverter}}">
+                                        IsEnabled="{Binding IsChecked, ElementName=UseTransparent, Converter={x:Static materialDesignConverters:InvertBooleanConverter.Instance}}">
               <materialDesign:ColorPicker.Style>
                 <Style TargetType="materialDesign:ColorPicker" BasedOn="{StaticResource {x:Type materialDesign:ColorPicker}}">
                   <Setter Property="Color" Value="{Binding GeneratedIconBackground, Delay=25}" />

--- a/src/MainDemo.Wpf/MainWindow.xaml
+++ b/src/MainDemo.Wpf/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:domain="clr-namespace:MaterialDesignDemo.Domain"
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        xmlns:materialDesignConverters="clr-namespace:MaterialDesignThemes.Wpf.Converters;assembly=MaterialDesignThemes.Wpf"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:system="clr-namespace:System;assembly=mscorlib"
         Title="Material Design in XAML"
@@ -101,7 +102,7 @@
                             Style="{StaticResource MaterialDesignHamburgerToggleButton}" />
 
               <Button Margin="24,0,0,0"
-                      materialDesign:RippleAssist.Feedback="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Converter={StaticResource BrushRoundConverter}}"
+                      materialDesign:RippleAssist.Feedback="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Converter={x:Static materialDesignConverters:BrushRoundConverter.Instance}}"
                       Command="{Binding MovePrevCommand}"
                       Content="{materialDesign:PackIcon Kind=ArrowLeft,
                                                         Size=24}"
@@ -110,7 +111,7 @@
                       ToolTip="Previous Item" />
 
               <Button Margin="16,0,0,0"
-                      materialDesign:RippleAssist.Feedback="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Converter={StaticResource BrushRoundConverter}}"
+                      materialDesign:RippleAssist.Feedback="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Converter={x:Static materialDesignConverters:BrushRoundConverter.Instance}}"
                       Command="{Binding MoveNextCommand}"
                       Content="{materialDesign:PackIcon Kind=ArrowRight,
                                                         Size=24}"
@@ -119,7 +120,7 @@
                       ToolTip="Next Item" />
 
               <Button Margin="16,0,0,0"
-                      materialDesign:RippleAssist.Feedback="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Converter={StaticResource BrushRoundConverter}}"
+                      materialDesign:RippleAssist.Feedback="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Converter={x:Static materialDesignConverters:BrushRoundConverter.Instance}}"
                       Command="{Binding HomeCommand}"
                       Content="{materialDesign:PackIcon Kind=Home,
                                                         Size=24}"

--- a/src/MainDemo.Wpf/Pickers.xaml
+++ b/src/MainDemo.Wpf/Pickers.xaml
@@ -4,6 +4,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:domain="clr-namespace:MaterialDesignDemo.Domain"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:materialDesignConverters="clr-namespace:MaterialDesignThemes.Wpf.Converters;assembly=MaterialDesignThemes.Wpf"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
              d:DataContext="{d:DesignInstance domain:PickersViewModel}"
@@ -228,7 +229,7 @@
                   HorizontalAlignment="Left"
                   VerticalAlignment="Top"
                   UniqueKey="pickers_15">
-          <materialDesign:TimePicker ClockButtonVisibility="{Binding IsChecked, ElementName=IsClockButtonVisible, Converter={StaticResource BooleanToVisibilityConverter}}"
+          <materialDesign:TimePicker ClockButtonVisibility="{Binding IsChecked, ElementName=IsClockButtonVisible, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}"
                              Width="100"
                              Is24Hours="True" />
         </smtx:XamlDisplay>

--- a/src/MainDemo.Wpf/SmartHint.xaml
+++ b/src/MainDemo.Wpf/SmartHint.xaml
@@ -5,6 +5,7 @@
              xmlns:domain="clr-namespace:MaterialDesignDemo.Domain"
              xmlns:local="clr-namespace:MaterialDesignDemo"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:materialDesignConverters="clr-namespace:MaterialDesignThemes.Wpf.Converters;assembly=MaterialDesignThemes.Wpf"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:system="clr-namespace:System;assembly=System.Runtime"
              x:Name="_root"
@@ -1035,7 +1036,7 @@
               <Setter Property="materialDesign:TextFieldAssist.SuffixTextHintBehavior" Value="{Binding SelectedSuffixHintBehavior}" />
               <Setter Property="materialDesign:TextFieldAssist.NewSpecHighlightingEnabled" Value="{Binding NewSpecHighlightingEnabled}" />
               <Setter Property="MaxLength" Value="{Binding MaxLength}" />
-              <Setter Property="materialDesign:TextFieldAssist.CharacterCounterVisibility" Value="{Binding ShowCharacterCounter, Converter={StaticResource BooleanToVisibilityConverter}}" />
+              <Setter Property="materialDesign:TextFieldAssist.CharacterCounterVisibility" Value="{Binding ShowCharacterCounter, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -1095,7 +1096,7 @@
               <Setter Property="materialDesign:TextFieldAssist.SuffixTextHintBehavior" Value="{Binding SelectedSuffixHintBehavior}" />
               <Setter Property="materialDesign:TextFieldAssist.NewSpecHighlightingEnabled" Value="{Binding NewSpecHighlightingEnabled}" />
               <Setter Property="MaxLength" Value="{Binding MaxLength}" />
-              <Setter Property="materialDesign:TextFieldAssist.CharacterCounterVisibility" Value="{Binding ShowCharacterCounter, Converter={StaticResource BooleanToVisibilityConverter}}" />
+              <Setter Property="materialDesign:TextFieldAssist.CharacterCounterVisibility" Value="{Binding ShowCharacterCounter, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -1156,7 +1157,7 @@
               <Setter Property="materialDesign:TextFieldAssist.SuffixTextHintBehavior" Value="{Binding SelectedSuffixHintBehavior}" />
               <Setter Property="materialDesign:TextFieldAssist.NewSpecHighlightingEnabled" Value="{Binding NewSpecHighlightingEnabled}" />
               <Setter Property="MaxLength" Value="{Binding MaxLength}" />
-              <Setter Property="materialDesign:TextFieldAssist.CharacterCounterVisibility" Value="{Binding ShowCharacterCounter, Converter={StaticResource BooleanToVisibilityConverter}}" />
+              <Setter Property="materialDesign:TextFieldAssist.CharacterCounterVisibility" Value="{Binding ShowCharacterCounter, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -1226,7 +1227,7 @@
               <Setter Property="materialDesign:TextFieldAssist.SuffixTextHintBehavior" Value="{Binding SelectedSuffixHintBehavior}" />
               <Setter Property="materialDesign:TextFieldAssist.NewSpecHighlightingEnabled" Value="{Binding NewSpecHighlightingEnabled}" />
               <Setter Property="MaxLength" Value="{Binding MaxLength}" />
-              <Setter Property="materialDesign:TextFieldAssist.CharacterCounterVisibility" Value="{Binding ShowCharacterCounter, Converter={StaticResource BooleanToVisibilityConverter}}" />
+              <Setter Property="materialDesign:TextFieldAssist.CharacterCounterVisibility" Value="{Binding ShowCharacterCounter, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -1287,7 +1288,7 @@
               <Setter Property="materialDesign:TextFieldAssist.SuffixTextHintBehavior" Value="{Binding SelectedSuffixHintBehavior}" />
               <Setter Property="materialDesign:TextFieldAssist.NewSpecHighlightingEnabled" Value="{Binding NewSpecHighlightingEnabled}" />
               <Setter Property="MaxLength" Value="{Binding MaxLength}" />
-              <Setter Property="materialDesign:TextFieldAssist.CharacterCounterVisibility" Value="{Binding ShowCharacterCounter, Converter={StaticResource BooleanToVisibilityConverter}}" />
+              <Setter Property="materialDesign:TextFieldAssist.CharacterCounterVisibility" Value="{Binding ShowCharacterCounter, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>
@@ -1349,7 +1350,7 @@
               <Setter Property="materialDesign:TextFieldAssist.SuffixTextHintBehavior" Value="{Binding SelectedSuffixHintBehavior}" />
               <Setter Property="materialDesign:TextFieldAssist.NewSpecHighlightingEnabled" Value="{Binding NewSpecHighlightingEnabled}" />
               <Setter Property="MaxLength" Value="{Binding MaxLength}" />
-              <Setter Property="materialDesign:TextFieldAssist.CharacterCounterVisibility" Value="{Binding ShowCharacterCounter, Converter={StaticResource BooleanToVisibilityConverter}}" />
+              <Setter Property="materialDesign:TextFieldAssist.CharacterCounterVisibility" Value="{Binding ShowCharacterCounter, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}" />
             </Style>
           </Grid.Resources>
           <Grid.ColumnDefinitions>

--- a/src/MaterialDesign3.Demo.Wpf/Buttons.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Buttons.xaml
@@ -25,9 +25,6 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ToggleButton.xaml" />
       </ResourceDictionary.MergedDictionaries>
       <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-      <materialDesignConverters:BooleanToVisibilityConverter x:Key="InvertedBooleanToVisibilityConverter"
-                                                             FalseValue="Visible"
-                                                             TrueValue="Collapsed" />
     </ResourceDictionary>
   </UserControl.Resources>
   <Grid VerticalAlignment="Top">
@@ -605,7 +602,7 @@
                     Command="{Binding DismissCommand}"
                     IsEnabled="{Binding DataContext.ControlsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}"
                     Style="{StaticResource MaterialDesignRaisedButton}"
-                    Visibility="{Binding ShowDismissButton, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Visibility="{Binding ShowDismissButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}">
               <StackPanel Orientation="Horizontal">
                 <TextBlock Text="DISMISS" />
                 <materialDesign:PackIcon Margin="4,.5,0,0" Kind="Close" />
@@ -614,7 +611,7 @@
 
             <TextBlock VerticalAlignment="Center"
                        Text="{Binding DemoRestartCountdownText}"
-                       Visibility="{Binding ShowDismissButton, Converter={StaticResource InvertedBooleanToVisibilityConverter}}" />
+                       Visibility="{Binding ShowDismissButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.InverseInstance}}" />
           </Grid>
         </smtx:XamlDisplay>
 
@@ -639,7 +636,7 @@
                     Command="{Binding DismissCommand}"
                     IsEnabled="{Binding DataContext.ControlsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}"
                     Style="{StaticResource MaterialDesignOutlinedButton}"
-                    Visibility="{Binding ShowDismissButton, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Visibility="{Binding ShowDismissButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}">
               <StackPanel Orientation="Horizontal">
                 <TextBlock Text="DISMISS" />
                 <materialDesign:PackIcon Margin="4,.5,0,0" Kind="Close" />
@@ -648,7 +645,7 @@
 
             <TextBlock VerticalAlignment="Center"
                        Text="{Binding DemoRestartCountdownText}"
-                       Visibility="{Binding ShowDismissButton, Converter={StaticResource InvertedBooleanToVisibilityConverter}}" />
+                       Visibility="{Binding ShowDismissButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.InverseInstance}}" />
           </Grid>
         </smtx:XamlDisplay>
 
@@ -673,7 +670,7 @@
                     Command="{Binding DismissCommand}"
                     IsEnabled="{Binding DataContext.ControlsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}"
                     Style="{StaticResource MaterialDesignFlatButton}"
-                    Visibility="{Binding ShowDismissButton, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Visibility="{Binding ShowDismissButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}">
               <StackPanel Orientation="Horizontal">
                 <TextBlock Text="DISMISS" />
                 <materialDesign:PackIcon Margin="4,.5,0,0" Kind="Close" />
@@ -682,7 +679,7 @@
 
             <TextBlock VerticalAlignment="Center"
                        Text="{Binding DemoRestartCountdownText}"
-                       Visibility="{Binding ShowDismissButton, Converter={StaticResource InvertedBooleanToVisibilityConverter}}" />
+                       Visibility="{Binding ShowDismissButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.InverseInstance}}" />
           </Grid>
         </smtx:XamlDisplay>
 

--- a/src/MaterialDesign3.Demo.Wpf/ColorTool.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/ColorTool.xaml
@@ -7,6 +7,7 @@
              xmlns:local="clr-namespace:MaterialDesign3Demo"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:materialDesignColors="clr-namespace:MaterialDesignColors;assembly=MaterialDesignColors"
+             xmlns:materialDesignConverters="clr-namespace:MaterialDesignThemes.Wpf.Converters;assembly=MaterialDesignThemes.Wpf"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              d:DataContext="{d:DesignInstance Type=domain:ColorToolViewModel}"
              d:DesignHeight="600"
@@ -479,7 +480,7 @@
         </UniformGrid>
 
         <Grid DockPanel.Dock="Left">
-          <Grid Visibility="{Binding IsChecked, ElementName=CustomPaletteButton, Converter={StaticResource BooleanToVisibilityConverter}}">
+          <Grid Visibility="{Binding IsChecked, ElementName=CustomPaletteButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}">
             <Grid.ColumnDefinitions>
               <ColumnDefinition Width="160" />
               <ColumnDefinition />
@@ -500,7 +501,7 @@
                                         Color="{Binding SelectedColor, Delay=25}" />
           </Grid>
 
-          <StackPanel Visibility="{Binding IsChecked, ElementName=MdPaletteButton, Converter={StaticResource BooleanToVisibilityConverter}}">
+          <StackPanel Visibility="{Binding IsChecked, ElementName=MdPaletteButton, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}">
             <StackPanel Orientation="Horizontal">
               <StackPanel.Resources>
                 <Style TargetType="TextBlock">

--- a/src/MaterialDesign3.Demo.Wpf/Fields.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Fields.xaml
@@ -5,6 +5,7 @@
              xmlns:domain="clr-namespace:MaterialDesign3Demo.Domain"
              xmlns:domain1="clr-namespace:MaterialDesign3Demo.Domain"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:materialDesignConverters="clr-namespace:MaterialDesignThemes.Wpf.Converters;assembly=MaterialDesignThemes.Wpf"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
              d:DataContext="{d:DesignInstance domain:FieldsViewModel,
@@ -353,7 +354,7 @@
           <TextBox Height="100"
                    VerticalAlignment="Top"
                    materialDesign:HintAssist.Hint="This is a limited text area"
-                   materialDesign:TextFieldAssist.CharacterCounterVisibility="{Binding Path=IsChecked, ElementName=MaterialDesignOutlinedPasswordFieldTextCountComboBox, Converter={StaticResource BooleanToVisibilityConverter}}"
+                   materialDesign:TextFieldAssist.CharacterCounterVisibility="{Binding Path=IsChecked, ElementName=MaterialDesignOutlinedPasswordFieldTextCountComboBox, Converter={x:Static materialDesignConverters:BooleanToVisibilityConverter.Instance}}"
                    MaxLength="40"
                    Style="{StaticResource MaterialDesignOutlinedTextBox}"
                    TextWrapping="Wrap"

--- a/src/MaterialDesign3.Demo.Wpf/MainWindow.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:domain="clr-namespace:MaterialDesign3Demo.Domain"
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        xmlns:materialDesignConverters="clr-namespace:MaterialDesignThemes.Wpf.Converters;assembly=MaterialDesignThemes.Wpf"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:system="clr-namespace:System;assembly=mscorlib"
         Title="Material Design in XAML"
@@ -169,7 +170,7 @@
                             Style="{StaticResource MaterialDesignHamburgerToggleButton}" />
 
               <Button Margin="0,0,0,0"
-                      materialDesign:RippleAssist.Feedback="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Converter={StaticResource BrushRoundConverter}}"
+                      materialDesign:RippleAssist.Feedback="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Converter={x:Static materialDesignConverters:BrushRoundConverter.Instance}}"
                       Command="{Binding MovePrevCommand}"
                       Content="{materialDesign:PackIcon Kind=ArrowLeft,
                                                         Size=24}"
@@ -178,7 +179,7 @@
                       ToolTip="Previous Item" />
 
               <Button Margin="16,0,0,0"
-                      materialDesign:RippleAssist.Feedback="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Converter={StaticResource BrushRoundConverter}}"
+                      materialDesign:RippleAssist.Feedback="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Converter={x:Static materialDesignConverters:BrushRoundConverter.Instance}}"
                       Command="{Binding MoveNextCommand}"
                       Content="{materialDesign:PackIcon Kind=ArrowRight,
                                                         Size=24}"

--- a/src/MaterialDesignThemes.Wpf/Converters/BooleanAllConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/BooleanAllConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 internal class BooleanAllConverter : IMultiValueConverter
 {
+    public static readonly BooleanAllConverter Instance = new();
+
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         => values.OfType<bool>().All(b => b);
 

--- a/src/MaterialDesignThemes.Wpf/Converters/BooleanToVisibilityConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/BooleanToVisibilityConverter.cs
@@ -2,6 +2,9 @@
 
 public sealed class BooleanToVisibilityConverter : BooleanConverter<Visibility>
 {
+    public static readonly BooleanToVisibilityConverter Instance = new();
+    public static readonly BooleanToVisibilityConverter InverseInstance = new() { FalseValue = Visibility.Visible, TrueValue = Visibility.Hidden };
+
     public BooleanToVisibilityConverter() :
         base(Visibility.Visible, Visibility.Collapsed)
     { }

--- a/src/MaterialDesignThemes.Wpf/Converters/BorderClipConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/BorderClipConverter.cs
@@ -6,6 +6,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 internal class BorderClipConverter : IMultiValueConverter
 {
+    public static readonly BorderClipConverter Instance = new();
     public object Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
         if (values is [double width, double height, ..])

--- a/src/MaterialDesignThemes.Wpf/Converters/BrushOpacityConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/BrushOpacityConverter.cs
@@ -6,6 +6,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class BrushOpacityConverter : IValueConverter
 {
+    public static readonly BrushOpacityConverter Instance = new();
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is SolidColorBrush brush)

--- a/src/MaterialDesignThemes.Wpf/Converters/BrushRoundConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/BrushRoundConverter.cs
@@ -7,6 +7,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class BrushRoundConverter : IValueConverter
 {
+    public static readonly BrushRoundConverter Instance = new();
     public Brush? HighValue { get; set; } = Brushes.White;
 
     public Brush? LowValue { get; set; } = Brushes.Black;

--- a/src/MaterialDesignThemes.Wpf/Converters/BrushToRadialGradientBrushConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/BrushToRadialGradientBrushConverter.cs
@@ -6,6 +6,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class BrushToRadialGradientBrushConverter : IValueConverter
 {
+    public static readonly BrushToRadialGradientBrushConverter Instance = new();
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         if (value is not SolidColorBrush solidColorBrush) return Binding.DoNothing;

--- a/src/MaterialDesignThemes.Wpf/Converters/CalendarDateCoalesceConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/CalendarDateCoalesceConverter.cs
@@ -13,6 +13,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 /// </remarks>
 public class CalendarDateCoalesceConverter : IMultiValueConverter
 {
+    public static readonly CalendarDateCoalesceConverter Instance = new();
+
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
         if (values?.Length != 2) throw new ArgumentException("Must specify two values", nameof(values));

--- a/src/MaterialDesignThemes.Wpf/Converters/CalendarYearMonthConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/CalendarYearMonthConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public sealed class CalendarYearMonthConverter : IMultiValueConverter
 {
+    public static readonly CalendarYearMonthConverter Instance = new();
+
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
         long ticks = long.MaxValue;

--- a/src/MaterialDesignThemes.Wpf/Converters/CircularProgressBar/ArcEndPointConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/CircularProgressBar/ArcEndPointConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters.CircularProgressBar;
 
 public class ArcEndPointConverter : IMultiValueConverter
 {
+    public static readonly ArcEndPointConverter Instance = new();
+
     /// <summary>
     /// CircularProgressBar draws two arcs to support a full circle at 100 %.
     /// With one arc at 100 % the start point is identical the end point, so nothing is drawn.

--- a/src/MaterialDesignThemes.Wpf/Converters/CircularProgressBar/ArcSizeConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/CircularProgressBar/ArcSizeConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters.CircularProgressBar;
 
 public class ArcSizeConverter : IValueConverter
 {
+    public static readonly ArcSizeConverter Instance = new();
+
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         => value is double v && (v > 0.0) ? new Size(v / 2, v / 2) : new Point();
 

--- a/src/MaterialDesignThemes.Wpf/Converters/CircularProgressBar/RotateTransformCentreConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/CircularProgressBar/RotateTransformCentreConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters.CircularProgressBar;
 
 public class RotateTransformCentreConverter : IValueConverter
 {
+    public static readonly RotateTransformCentreConverter Instance = new();
+
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>        
         (double)value / 2; //value == actual width
 

--- a/src/MaterialDesignThemes.Wpf/Converters/CircularProgressBar/StartPointConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/CircularProgressBar/StartPointConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters.CircularProgressBar;
 
 public class StartPointConverter : IValueConverter
 {
+    public static readonly StartPointConverter Instance = new();
+
     [Obsolete]
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {

--- a/src/MaterialDesignThemes.Wpf/Converters/ClockLineConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/ClockLineConverter.cs
@@ -5,6 +5,10 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class ClockLineConverter : MarkupExtension, IValueConverter
 {
+    public static readonly ClockLineConverter HoursInstance = new() { DisplayMode = ClockDisplayMode.Hours };
+    public static readonly ClockLineConverter MinutesInstance = new() { DisplayMode = ClockDisplayMode.Minutes };
+    public static readonly ClockLineConverter SecondsInstance = new() { DisplayMode = ClockDisplayMode.Seconds };
+
     public ClockDisplayMode DisplayMode { get; set; }
 
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/MaterialDesignThemes.Wpf/Converters/CursorConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/CursorConverter.cs
@@ -9,6 +9,9 @@ namespace MaterialDesignThemes.Wpf.Converters;
 /// </summary>
 public sealed class CursorConverter : IValueConverter
 {
+    public static readonly CursorConverter ArrowInstance = new() { FallbackCursor = Cursors.Arrow };
+    public static readonly CursorConverter IBeamInstance = new() { FallbackCursor = Cursors.IBeam };
+
     public Cursor FallbackCursor { get; set; } = Cursors.Arrow;
 
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => value as Cursor ?? FallbackCursor;

--- a/src/MaterialDesignThemes.Wpf/Converters/DrawerOffsetConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/DrawerOffsetConverter.cs
@@ -5,6 +5,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class DrawerOffsetConverter : IValueConverter
 {
+    public static readonly DrawerOffsetConverter Instance = new();
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         double d = value as double? ?? 0;

--- a/src/MaterialDesignThemes.Wpf/Converters/ElevationMarginConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/ElevationMarginConverter.cs
@@ -1,19 +1,18 @@
 ﻿using System.Globalization;
 using System.Windows.Data;
-using System.Windows.Media;
-using MaterialDesignColors.ColorManipulation;
 
 namespace MaterialDesignThemes.Wpf.Converters;
 
-public class HsbLinearGradientConverter : IValueConverter
+public class ElevationMarginConverter : IValueConverter
 {
-    public static readonly HsbLinearGradientConverter Instance = new();
-
+    public static readonly ElevationMarginConverter Instance = new();
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        if (value is not double hue) return Binding.DoNothing;
-
-        return new LinearGradientBrush(Colors.White, new Hsb(hue, 1, 1).ToColor(), 0);
+        if (value is Elevation elevation && elevation != Elevation.Dp0)
+        {
+            return new Thickness(ElevationInfo.GetDropShadow(elevation)!.BlurRadius);
+        }
+        return new Thickness(0);
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/MaterialDesignThemes.Wpf/Converters/ElevationRadiusConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/ElevationRadiusConverter.cs
@@ -3,18 +3,21 @@ using System.Windows.Data;
 
 namespace MaterialDesignThemes.Wpf.Converters;
 
-internal class StringLengthValueConverter : IValueConverter
+public class ElevationRadiusConverter : IValueConverter
 {
-    public static readonly StringLengthValueConverter Instance = new();
+    public static readonly ElevationRadiusConverter Instance = new();
+
+    public double Multiplier { get; set; } = 1.0;
 
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        if (value is string stringValue)
+        if (value is Elevation elevation && elevation != Elevation.Dp0)
         {
-            return stringValue.Length;
+            return ElevationInfo.GetDropShadow(elevation)!.BlurRadius * Multiplier;
         }
         return 0;
     }
+
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         => throw new NotImplementedException();
 }

--- a/src/MaterialDesignThemes.Wpf/Converters/EqualityToVisibilityConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/EqualityToVisibilityConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class EqualityToVisibilityConverter : IValueConverter
 {
+    public static readonly EqualityToVisibilityConverter Instance = new();
+
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         if (value != null && value.Equals(parameter)) return Visibility.Visible;

--- a/src/MaterialDesignThemes.Wpf/Converters/ExpanderRotateAngleConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/ExpanderRotateAngleConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 internal class ExpanderRotateAngleConverter : IValueConverter
 {
+    public static readonly ExpanderRotateAngleConverter Instance = new();
+
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         double factor = 1.0;

--- a/src/MaterialDesignThemes.Wpf/Converters/FallbackBrushConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FallbackBrushConverter.cs
@@ -6,6 +6,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 internal class FallbackBrushConverter : IMultiValueConverter
 {
+    public static readonly FallbackBrushConverter Instance = new();
+
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
         return values?.OfType<SolidColorBrush>()

--- a/src/MaterialDesignThemes.Wpf/Converters/FirstNonNullConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FirstNonNullConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class FirstNonNullConverter : IMultiValueConverter
 {
+    public static readonly FirstNonNullConverter Instance = new();
+
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
         => values?.FirstOrDefault(v => v is not null);
 

--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintClippingGridConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintClippingGridConverter.cs
@@ -6,6 +6,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class FloatingHintClippingGridConverter : IMultiValueConverter
 {
+    public static readonly FloatingHintClippingGridConverter Instance = new();
     public object? Convert(object?[] values, Type targetType, object? parameter, CultureInfo culture)
     {
         if (values is not [double actualWidth, double actualHeight, double floatingScale]) return null;        

--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintContainerMarginConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintContainerMarginConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class FloatingHintContainerMarginConverter : IMultiValueConverter
 {
+    public static readonly FloatingHintContainerMarginConverter Instance = new();
+
     private static readonly object EmptyThickness = new Thickness(0);
 
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)

--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintInitialHorizontalOffsetConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintInitialHorizontalOffsetConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class FloatingHintInitialHorizontalOffsetConverter : IMultiValueConverter
 {
+    public static readonly FloatingHintInitialHorizontalOffsetConverter Instance = new();
+
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
         if (values is not

--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintInitialVerticalOffsetConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintInitialVerticalOffsetConverter.cs
@@ -16,6 +16,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 /// </summary>
 public class FloatingHintInitialVerticalOffsetConverter : IMultiValueConverter
 {
+    public static readonly FloatingHintInitialVerticalOffsetConverter Instance = new();
+
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
         if (values is [double contentHostHeight, double hintHeight, int lineCount])

--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintMarginConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintMarginConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class FloatingHintMarginConverter : IMultiValueConverter
 {
+    public static readonly FloatingHintMarginConverter Instance = new();
+
     private static readonly object EmptyThickness = new Thickness(0);
 
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)

--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintScaleTransformConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintScaleTransformConverter.cs
@@ -6,6 +6,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class FloatingHintScaleTransformConverter : IMultiValueConverter
 {
+    public static readonly FloatingHintScaleTransformConverter Instance = new();
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
         if (values is not [double scale, double lower, double upper]) return Transform.Identity;        

--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintTextBlockMarginConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintTextBlockMarginConverter.cs
@@ -6,6 +6,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 internal class FloatingHintTextBlockMarginConverter : IMultiValueConverter
 {
+    public static readonly FloatingHintTextBlockMarginConverter Instance = new();
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
         if (values is not

--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintTranslateTransformConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintTranslateTransformConverter.cs
@@ -6,6 +6,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class FloatingHintTranslateTransformConverter : IMultiValueConverter
 {
+    public static readonly FloatingHintTranslateTransformConverter Instance = new();
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
         if (values is not [double scale, double lower, double upper, SmartHint hint, Point floatingOffset, double yOffset, ..])

--- a/src/MaterialDesignThemes.Wpf/Converters/GridLinesVisibilityBorderToThicknessConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/GridLinesVisibilityBorderToThicknessConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 internal class GridLinesVisibilityBorderToThicknessConverter : IValueConverter
 {
+    public static readonly GridLinesVisibilityBorderToThicknessConverter Instance = new();
+
     private const double GridLinesThickness = 1;
 
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/MaterialDesignThemes.Wpf/Converters/HorizontalThicknessConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/HorizontalThicknessConverter.cs
@@ -5,6 +5,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 internal class HorizontalThicknessConverter : IValueConverter
 {
+    public static readonly HorizontalThicknessConverter Instance = new();
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         if (value is not Thickness thickness) return Binding.DoNothing;

--- a/src/MaterialDesignThemes.Wpf/Converters/HsbToColorConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/HsbToColorConverter.cs
@@ -7,6 +7,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class HsbToColorConverter : IValueConverter, IMultiValueConverter
 {
+    public static readonly HsbToColorConverter Instance = new();
+
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         if (value is not Hsb hsb) return Binding.DoNothing;

--- a/src/MaterialDesignThemes.Wpf/Converters/InvertBooleanConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/InvertBooleanConverter.cs
@@ -1,7 +1,8 @@
 ﻿namespace MaterialDesignThemes.Wpf.Converters;
 
-internal class InvertBooleanConverter : BooleanConverter<bool>
+public class InvertBooleanConverter : BooleanConverter<bool>
 {
+    public static readonly InvertBooleanConverter Instance = new();
     public InvertBooleanConverter()
         : base(false, true)
     {

--- a/src/MaterialDesignThemes.Wpf/Converters/IsDarkConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/IsDarkConverter.cs
@@ -7,6 +7,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 internal class IsDarkConverter : IValueConverter
 {
+    public static readonly IsDarkConverter Instance = new();
+
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         return value switch

--- a/src/MaterialDesignThemes.Wpf/Converters/IsTransparentBrushConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/IsTransparentBrushConverter.cs
@@ -6,6 +6,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public sealed class IsTransparentBrushConverter : IValueConverter
 {
+    public static readonly IsTransparentBrushConverter Instance = new();
+
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         => value is null || Equals(value, Brushes.Transparent);
 

--- a/src/MaterialDesignThemes.Wpf/Converters/MathConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/MathConverter.cs
@@ -5,6 +5,12 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public sealed class MathConverter : IValueConverter
 {
+    public static readonly MathConverter AddInstance = new() { Operation = MathOperation.Add };
+    public static readonly MathConverter SubtractInstance = new() { Operation = MathOperation.Subtract };
+    public static readonly MathConverter MultiplyInstance = new() { Operation = MathOperation.Multiply };
+    public static readonly MathConverter DivideInstance = new() { Operation = MathOperation.Divide };
+    public static readonly MathConverter PowInstance = new() { Operation = MathOperation.Pow };
+
     public double Offset { get; set; }
     public MathOperation Operation { get; set; }
 

--- a/src/MaterialDesignThemes.Wpf/Converters/MathMultipleConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/MathMultipleConverter.cs
@@ -5,6 +5,12 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public sealed class MathMultipleConverter : IMultiValueConverter
 {
+    public static readonly MathMultipleConverter AddInstance = new() { Operation = MathOperation.Add };
+    public static readonly MathMultipleConverter SubtractInstance = new() { Operation = MathOperation.Subtract };
+    public static readonly MathMultipleConverter MultiplyInstance = new() { Operation = MathOperation.Multiply };
+    public static readonly MathMultipleConverter DivideInstance = new() { Operation = MathOperation.Divide };
+    public static readonly MathMultipleConverter PowInstance = new() { Operation = MathOperation.Pow };
+
     public MathOperation Operation { get; set; }
 
     public object? Convert(object?[]? value, Type? targetType, object? parameter, CultureInfo? culture)

--- a/src/MaterialDesignThemes.Wpf/Converters/NotConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/NotConverter.cs
@@ -5,6 +5,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class NotConverter : IValueConverter
 {
+    public static readonly NotConverter Instance = new();
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is null) return null;

--- a/src/MaterialDesignThemes.Wpf/Converters/NotZeroConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/NotZeroConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class NotZeroConverter : IValueConverter
 {
+    public static readonly NotZeroConverter Instance = new();
+
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (double.TryParse((value ?? "").ToString(), out double val))

--- a/src/MaterialDesignThemes.Wpf/Converters/NotZeroToVisibilityConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/NotZeroToVisibilityConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class NotZeroToVisibilityConverter : IValueConverter
 {
+    public static readonly NotZeroToVisibilityConverter Instance = new();
+
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         double val;

--- a/src/MaterialDesignThemes.Wpf/Converters/NullableToVisibilityConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/NullableToVisibilityConverter.cs
@@ -5,6 +5,9 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class NullableToVisibilityConverter : IValueConverter
 {
+    public static readonly NullableToVisibilityConverter Instance = new();
+    public static readonly NullableToVisibilityConverter InverseInstance = new() { NullValue = Visibility.Visible, NotNullValue = Visibility.Hidden };
+
     public Visibility NullValue { get; set; } = Visibility.Collapsed;
     public Visibility NotNullValue { get; set; } = Visibility.Visible;
 

--- a/src/MaterialDesignThemes.Wpf/Converters/OutlinedStyleActiveBorderMarginCompensationConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/OutlinedStyleActiveBorderMarginCompensationConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class OutlinedStyleActiveBorderMarginCompensationConverter : IMultiValueConverter
 {
+    public static readonly OutlinedStyleActiveBorderMarginCompensationConverter Instance = new();
+
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
         if (values is not [Thickness baseThickness, Thickness thicknessToSubtract])

--- a/src/MaterialDesignThemes.Wpf/Converters/PointValueConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/PointValueConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class PointValueConverter : IMultiValueConverter
 {
+    public static readonly PointValueConverter Instance = new();
+
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
     {
         if (values?.Length == 2 && values[0] != null && values[1] != null)

--- a/src/MaterialDesignThemes.Wpf/Converters/RemoveAlphaBrushConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/RemoveAlphaBrushConverter.cs
@@ -6,6 +6,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 internal class RemoveAlphaBrushConverter : IValueConverter, IMultiValueConverter
 {
+    public static readonly RemoveAlphaBrushConverter Instance = new();
+
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         => value is SolidColorBrush brush
             ? new SolidColorBrush(RgbaToRgb(brush.Color, parameter))

--- a/src/MaterialDesignThemes.Wpf/Converters/ShadowOpacityMaskConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/ShadowOpacityMaskConverter.cs
@@ -7,6 +7,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class ShadowOpacityMaskConverter : IMultiValueConverter
 {
+    public static readonly ShadowOpacityMaskConverter Instance = new();
+
     public object? Convert(object[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
         static double? GetValidSize(object? value)

--- a/src/MaterialDesignThemes.Wpf/Converters/SliderToolTipConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/SliderToolTipConverter.cs
@@ -5,6 +5,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 internal class SliderToolTipConverter : IMultiValueConverter
 {
+    public static readonly SliderToolTipConverter Instance = new();
     public object? Convert(object?[]? values, Type? targetType, object? parameter, CultureInfo? culture)
     {
         if (values?.Length >= 2 && values[1] is string format && !string.IsNullOrEmpty(format))

--- a/src/MaterialDesignThemes.Wpf/Converters/SliderValueLabelPositionConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/SliderValueLabelPositionConverter.cs
@@ -6,6 +6,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 [ValueConversion(typeof(double), typeof(double), ParameterType = typeof(Orientation))]
 internal class SliderValueLabelPositionConverter : IValueConverter
 {
+    public static readonly SliderValueLabelPositionConverter Instance = new();
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         if (parameter is Orientation orientation && value is double width)

--- a/src/MaterialDesignThemes.Wpf/Converters/SnackbarActionButtonPlacementModeConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/SnackbarActionButtonPlacementModeConverter.cs
@@ -5,6 +5,7 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class SnackbarActionButtonPlacementModeConverter : IMultiValueConverter
 {
+    public static readonly SnackbarActionButtonPlacementModeConverter Instance = new();
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
     {
         var mode = (SnackbarActionButtonPlacementMode)values[0];

--- a/src/MaterialDesignThemes.Wpf/Converters/TextFieldHintVisibilityConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/TextFieldHintVisibilityConverter.cs
@@ -5,6 +5,9 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class TextFieldHintVisibilityConverter : IValueConverter
 {
+    public static readonly TextFieldHintVisibilityConverter Instance = new();
+    public static readonly TextFieldHintVisibilityConverter StringIsEmptyInstance = new() { IsEmptyValue = Visibility.Collapsed, IsNotEmptyValue = Visibility.Visible};
+
     public Visibility IsEmptyValue { get; set; } = Visibility.Visible;
     public Visibility IsNotEmptyValue { get; set; } = Visibility.Hidden;
 

--- a/src/MaterialDesignThemes.Wpf/Converters/ToolBarOverflowButtonVisibilityConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/ToolBarOverflowButtonVisibilityConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class ToolBarOverflowButtonVisibilityConverter : IMultiValueConverter
 {
+    public static readonly ToolBarOverflowButtonVisibilityConverter Instance = new();
+
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
     {
         var overflowMode = (OverflowMode)values[0];

--- a/src/MaterialDesignThemes.Wpf/Converters/TopThicknessConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/TopThicknessConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 internal class TopThicknessConverter : IValueConverter
 {
+    public static readonly TopThicknessConverter Instance = new();
+
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         => value is Thickness thickness
             ? new Thickness(0, thickness.Top, 0, 0)

--- a/src/MaterialDesignThemes.Wpf/Converters/TreeListViewIndentConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/TreeListViewIndentConverter.cs
@@ -5,6 +5,8 @@ namespace MaterialDesignThemes.Wpf.Converters;
 
 public class TreeListViewIndentConverter : IMultiValueConverter
 {
+    public static readonly TreeListViewIndentConverter Instance = new();
+
     public object? Convert(object?[]? values, Type targetType, object? parameter, CultureInfo culture)
     {
         if (values?.Length == 2 && values[0] is double size && values[1] is int level)

--- a/src/MaterialDesignThemes.Wpf/ElevationAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/ElevationAssist.cs
@@ -63,35 +63,3 @@ public static class ElevationAssist
 
     public static DropShadowEffect? GetDropShadow(Elevation elevation) => ElevationInfo.GetDropShadow(elevation);
 }
-
-public class ElevationMarginConverter : IValueConverter
-{
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        if (value is Elevation elevation && elevation != Elevation.Dp0)
-        {
-            return new Thickness(ElevationInfo.GetDropShadow(elevation)!.BlurRadius);
-        }
-        return new Thickness(0);
-    }
-
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        => throw new NotImplementedException();
-}
-
-public class ElevationRadiusConverter : IValueConverter
-{
-    public double Multiplier { get; set; } = 1.0;
-
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        if (value is Elevation elevation && elevation != Elevation.Dp0)
-        {
-            return ElevationInfo.GetDropShadow(elevation)!.BlurRadius * Multiplier;
-        }
-        return 0;
-    }
-
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        => throw new NotImplementedException();
-}

--- a/src/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -45,9 +45,6 @@
   <Style TargetType="{x:Type local:NumericUpDown}" BasedOn="{StaticResource MaterialDesignNumericUpDown}" />
   <Style TargetType="{x:Type local:DecimalUpDown}" BasedOn="{StaticResource MaterialDesignNumericUpDown}" />
 
-  <converters:BrushToRadialGradientBrushConverter x:Key="BrushToRadialGradientBrushConverter" />
-  <converters:DrawerOffsetConverter x:Key="DrawerOffsetConverter" />
-
   <system:Boolean x:Key="True">True</system:Boolean>
 
   <Style TargetType="{x:Type local:Ripple}">
@@ -606,6 +603,9 @@
   <SolidColorBrush x:Key="BlackBackground" Color="Black" po:Freeze="True" />
 
   <Style TargetType="{x:Type local:DrawerHost}">
+    <Style.Resources>
+      <converters:DrawerOffsetConverter x:Key="DrawerOffsetConverter" />
+    </Style.Resources>
     <Setter Property="BottomDrawerBackground" Value="{DynamicResource MaterialDesign.Brush.Background}" />
     <Setter Property="ClipToBounds" Value="True" />
     <Setter Property="IsTabStop" Value="False" />
@@ -976,7 +976,7 @@
                 </Grid.Style>
               </Grid>
               <Grid x:Name="PART_LeftDrawer"
-                    Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualWidth, Converter={StaticResource DrawerOffsetConverter}, ConverterParameter={x:Static Dock.Left}}"
+                    Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualWidth, Converter={x:Static converters:DrawerOffsetConverter.Instance}, ConverterParameter={x:Static Dock.Left}}"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Stretch"
                     Panel.ZIndex="{TemplateBinding LeftDrawerZIndex}">
@@ -1019,7 +1019,7 @@
                                   IsEnabled="{TemplateBinding IsLeftDrawerOpen}" />
               </Grid>
               <Grid x:Name="PART_RightDrawer"
-                    Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualWidth, Converter={StaticResource DrawerOffsetConverter}, ConverterParameter={x:Static Dock.Right}}"
+                    Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualWidth, Converter={x:Static converters:DrawerOffsetConverter.Instance}, ConverterParameter={x:Static Dock.Right}}"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Stretch"
                     Panel.ZIndex="{TemplateBinding RightDrawerZIndex}">
@@ -1061,7 +1061,7 @@
                                   IsEnabled="{TemplateBinding IsRightDrawerOpen}" />
               </Grid>
               <Grid x:Name="PART_TopDrawer"
-                    Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualHeight, Converter={StaticResource DrawerOffsetConverter}, ConverterParameter={x:Static Dock.Top}}"
+                    Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualHeight, Converter={x:Static converters:DrawerOffsetConverter.Instance}, ConverterParameter={x:Static Dock.Top}}"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Top"
                     Panel.ZIndex="{TemplateBinding TopDrawerZIndex}">
@@ -1103,7 +1103,7 @@
                                   IsEnabled="{TemplateBinding IsTopDrawerOpen}" />
               </Grid>
               <Grid x:Name="PART_BottomDrawer"
-                    Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualHeight, Converter={StaticResource DrawerOffsetConverter}, ConverterParameter={x:Static Dock.Bottom}}"
+                    Margin="{Binding RelativeSource={RelativeSource Self}, Path=ActualHeight, Converter={x:Static converters:DrawerOffsetConverter.Instance}, ConverterParameter={x:Static Dock.Bottom}}"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Bottom"
                     Panel.ZIndex="{TemplateBinding BottomDrawerZIndex}">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.NavigationBar.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.NavigationBar.xaml
@@ -8,8 +8,6 @@
   </ResourceDictionary.MergedDictionaries>
 
 
-  <converters:BorderClipConverter x:Key="BorderClipConverter" />
-  <converters:BrushRoundConverter x:Key="BrushRoundConverter" />
 
   <Style x:Key="MaterialDesign3.NavigationBarListBoxItem" TargetType="{x:Type ListBoxItem}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
@@ -76,7 +74,7 @@
             <Grid ClipToBounds="False">
               <Grid>
                 <Grid.Clip>
-                  <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                  <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                     <Binding ElementName="border" Path="ActualWidth" />
                     <Binding ElementName="border" Path="ActualHeight" />
                     <Binding ElementName="border" Path="CornerRadius" />
@@ -84,7 +82,7 @@
                   </MultiBinding>
                 </Grid.Clip>
                 <Border x:Name="MouseOverBorder"
-                        Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                        Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                         Opacity="0" />
 
                 <Border x:Name="SelectedBorder"
@@ -102,7 +100,7 @@
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
                             ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                            Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                            Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                             Focusable="False"
                             RecognizesAccessKey="False"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.NavigationDrawer.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.NavigationDrawer.xaml
@@ -3,10 +3,6 @@
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
-  <converters:BorderClipConverter x:Key="BorderClipConverter" />
-  <converters:BrushRoundConverter x:Key="BrushRoundConverter" />
-
-
   <Style x:Key="MaterialDesign3.NavigationDrawerListBoxItem" TargetType="{x:Type ListBoxItem}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Foreground}" />
     <Setter Property="BorderThickness" Value="0" />
@@ -69,7 +65,7 @@
             </VisualStateManager.VisualStateGroups>
             <Grid>
               <Grid.Clip>
-                <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                   <Binding ElementName="border" Path="ActualWidth" />
                   <Binding ElementName="border" Path="ActualHeight" />
                   <Binding ElementName="border" Path="CornerRadius" />
@@ -77,7 +73,7 @@
                 </MultiBinding>
               </Grid.Clip>
               <Border x:Name="MouseOverBorder"
-                      Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                      Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                       Opacity="0" />
 
               <Border x:Name="SelectedBorder"
@@ -90,7 +86,7 @@
                           VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                           ContentTemplate="{TemplateBinding ContentTemplate}"
                           ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                          Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                          Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                           Focusable="False"
                           RecognizesAccessKey="False"
                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.NavigationRail.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.NavigationRail.xaml
@@ -6,9 +6,6 @@
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Badged.xaml" />
   </ResourceDictionary.MergedDictionaries>
-  <converters:BorderClipConverter x:Key="BorderClipConverter" />
-  <converters:BrushRoundConverter x:Key="BrushRoundConverter" />
-
 
   <Style x:Key="MaterialDesign3.NavigationRailListBoxItem" TargetType="{x:Type ListBoxItem}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
@@ -74,7 +71,7 @@
             <Grid ClipToBounds="False">
               <Grid>
                 <Grid.Clip>
-                  <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                  <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                     <Binding ElementName="border" Path="ActualWidth" />
                     <Binding ElementName="border" Path="ActualHeight" />
                     <Binding ElementName="border" Path="CornerRadius" />
@@ -82,7 +79,7 @@
                   </MultiBinding>
                 </Grid.Clip>
                 <Border x:Name="MouseOverBorder"
-                        Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                        Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                         Opacity="0" />
 
                 <Border x:Name="SelectedBorder"
@@ -100,7 +97,7 @@
                             ClipToBounds="False"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
                             ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                            Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                            Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                             Focusable="False"
                             RecognizesAccessKey="False"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Slider.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.Slider.xaml
@@ -7,11 +7,6 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
-  <converters:SliderValueLabelPositionConverter x:Key="SliderValueLabelPositionConverter" />
-  <converters:BooleanAllConverter x:Key="BooleanAllConverter" />
-  <converters:InvertBooleanConverter x:Key="InvertBooleanConverter" />
-  <converters:SliderToolTipConverter x:Key="SliderToolTipConverter" />
-
   <Style x:Key="MaterialDesign3.MaterialDesignRepeatButton" TargetType="{x:Type RepeatButton}">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Focusable" Value="False" />
@@ -128,9 +123,9 @@
       </Trigger>
       <DataTrigger Value="True">
         <DataTrigger.Binding>
-          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+          <MultiBinding Converter="{x:Static converters:BooleanAllConverter.Instance}">
             <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
-            <Binding Converter="{StaticResource InvertBooleanConverter}"
+            <Binding Converter="{x:Static converters:InvertBooleanConverter.Instance}"
                      Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)"
                      RelativeSource="{RelativeSource FindAncestor,
                                                      AncestorType=RangeBase}" />
@@ -145,7 +140,7 @@
       </DataTrigger>
       <DataTrigger Value="True">
         <DataTrigger.Binding>
-          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+          <MultiBinding Converter="{x:Static converters:BooleanAllConverter.Instance}">
             <Binding Path="IsDragging" RelativeSource="{RelativeSource Self}" />
             <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
           </MultiBinding>
@@ -274,7 +269,7 @@
           <Grid.RenderTransform>
             <TransformGroup>
               <ScaleTransform ScaleX="0" ScaleY="0" />
-              <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={StaticResource SliderValueLabelPositionConverter}, ConverterParameter={x:Static Orientation.Horizontal}}" Y="-40" />
+              <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={x:Static converters:SliderValueLabelPositionConverter.Instance}, ConverterParameter={x:Static Orientation.Horizontal}}" Y="-40" />
             </TransformGroup>
           </Grid.RenderTransform>
           <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
@@ -294,7 +289,7 @@
                      Foreground="{DynamicResource MaterialDesign.Brush.Background}"
                      TextAlignment="Center">
             <TextBlock.Text>
-              <MultiBinding Converter="{StaticResource SliderToolTipConverter}"
+              <MultiBinding Converter="{x:Static converters:SliderToolTipConverter.Instance}"
                             NotifyOnValidationError="True"
                             TargetNullValue=""
                             ValidatesOnDataErrors="True">
@@ -340,9 +335,9 @@
       </Trigger>
       <DataTrigger Value="True">
         <DataTrigger.Binding>
-          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+          <MultiBinding Converter="{x:Static converters:BooleanAllConverter.Instance}">
             <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
-            <Binding Converter="{StaticResource InvertBooleanConverter}"
+            <Binding Converter="{x:Static converters:InvertBooleanConverter.Instance}"
                      Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)"
                      RelativeSource="{RelativeSource FindAncestor,
                                                      AncestorType=RangeBase}" />
@@ -357,7 +352,7 @@
       </DataTrigger>
       <DataTrigger Value="True">
         <DataTrigger.Binding>
-          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+          <MultiBinding Converter="{x:Static converters:BooleanAllConverter.Instance}">
             <Binding Path="IsDragging" RelativeSource="{RelativeSource Self}" />
             <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
           </MultiBinding>
@@ -486,7 +481,7 @@
           <Grid.RenderTransform>
             <TransformGroup>
               <ScaleTransform ScaleX="0" ScaleY="0" />
-              <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={StaticResource SliderValueLabelPositionConverter}, ConverterParameter={x:Static Orientation.Vertical}}" Y="-7" />
+              <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={x:Static converters:SliderValueLabelPositionConverter.Instance}, ConverterParameter={x:Static Orientation.Vertical}}" Y="-7" />
             </TransformGroup>
           </Grid.RenderTransform>
           <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
@@ -506,7 +501,7 @@
                      Foreground="{DynamicResource MaterialDesign.Brush.Background}"
                      TextAlignment="Center">
             <TextBlock.Text>
-              <MultiBinding Converter="{StaticResource SliderToolTipConverter}"
+              <MultiBinding Converter="{x:Static converters:SliderToolTipConverter.Instance}"
                             NotifyOnValidationError="True"
                             TargetNullValue=""
                             ValidatesOnDataErrors="True">
@@ -552,9 +547,9 @@
       </Trigger>
       <DataTrigger Value="True">
         <DataTrigger.Binding>
-          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+          <MultiBinding Converter="{x:Static converters:BooleanAllConverter.Instance}">
             <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
-            <Binding Converter="{StaticResource InvertBooleanConverter}"
+            <Binding Converter="{x:Static converters:InvertBooleanConverter.Instance}"
                      Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)"
                      RelativeSource="{RelativeSource FindAncestor,
                                                      AncestorType=RangeBase}" />
@@ -569,7 +564,7 @@
       </DataTrigger>
       <DataTrigger Value="True">
         <DataTrigger.Binding>
-          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+          <MultiBinding Converter="{x:Static converters:BooleanAllConverter.Instance}">
             <Binding Path="IsDragging" RelativeSource="{RelativeSource Self}" />
             <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
           </MultiBinding>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.ToggleButton.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.ToggleButton.xaml
@@ -5,9 +5,6 @@
                     xmlns:system="clr-namespace:System;assembly=mscorlib"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
-  <converters:MathConverter x:Key="DivisionMathConverter" Operation="Divide" />
-  <converters:PointValueConverter x:Key="PointValueConverter" />
-
   <Style x:Key="FocusVisual">
     <Setter Property="Control.Template">
       <Setter.Value>
@@ -144,14 +141,14 @@
                                 ContentTemplate="{TemplateBinding ContentTemplate}"
                                 FlowDirection="LeftToRight" />
               <Grid.Clip>
-                <EllipseGeometry RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Width, Converter={StaticResource DivisionMathConverter}, ConverterParameter=2.0}" RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height, Converter={StaticResource DivisionMathConverter}, ConverterParameter=2.0}">
+                <EllipseGeometry RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Width, Converter={x:Static converters:MathConverter.DivideInstance}, ConverterParameter=2.0}" RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height, Converter={x:Static converters:MathConverter.DivideInstance}, ConverterParameter=2.0}">
                   <EllipseGeometry.Center>
-                    <MultiBinding Converter="{StaticResource PointValueConverter}">
-                      <Binding Converter="{StaticResource DivisionMathConverter}"
+                    <MultiBinding Converter="{x:Static converters:PointValueConverter.Instance}">
+                      <Binding Converter="{x:Static converters:MathConverter.DivideInstance}"
                                ConverterParameter="2.0"
                                Path="Width"
                                RelativeSource="{RelativeSource TemplatedParent}" />
-                      <Binding Converter="{StaticResource DivisionMathConverter}"
+                      <Binding Converter="{x:Static converters:MathConverter.DivideInstance}"
                                ConverterParameter="2.0"
                                Path="Height"
                                RelativeSource="{RelativeSource TemplatedParent}" />
@@ -172,14 +169,14 @@
                                 ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ToggleButtonAssist.OnContentTemplate)}"
                                 FlowDirection="LeftToRight" />
               <Grid.Clip>
-                <EllipseGeometry RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Width, Converter={StaticResource DivisionMathConverter}, ConverterParameter=2.0}" RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height, Converter={StaticResource DivisionMathConverter}, ConverterParameter=2.0}">
+                <EllipseGeometry RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Width, Converter={x:Static converters:MathConverter.DivideInstance}, ConverterParameter=2.0}" RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height, Converter={x:Static converters:MathConverter.DivideInstance}, ConverterParameter=2.0}">
                   <EllipseGeometry.Center>
-                    <MultiBinding Converter="{StaticResource PointValueConverter}">
-                      <Binding Converter="{StaticResource DivisionMathConverter}"
+                    <MultiBinding Converter="{x:Static converters:PointValueConverter.Instance}">
+                      <Binding Converter="{x:Static converters:MathConverter.DivideInstance}"
                                ConverterParameter="2.0"
                                Path="Width"
                                RelativeSource="{RelativeSource TemplatedParent}" />
-                      <Binding Converter="{StaticResource DivisionMathConverter}"
+                      <Binding Converter="{x:Static converters:MathConverter.DivideInstance}"
                                ConverterParameter="2.0"
                                Path="Height"
                                RelativeSource="{RelativeSource TemplatedParent}" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -13,30 +13,21 @@
          TargetType="{x:Type wpf:AutoSuggestBox}"
          BasedOn="{StaticResource MaterialDesignTextBoxBase}">
     <Style.Resources>
-      <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-      <converters:CursorConverter x:Key="ArrowCursorConverter" FallbackCursor="Arrow" />
-      <converters:CursorConverter x:Key="IBeamCursorConverter" FallbackCursor="IBeam" />
-      <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
       <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearButtonVisibilityConverter" ContentEmptyVisibility="Collapsed" />
       <converters:TextFieldPrefixTextVisibilityConverter x:Key="PrefixSuffixTextVisibilityConverter" HiddenState="Collapsed" />
       <converters:BooleanToDashStyleConverter x:Key="BooleanToDashStyleConverter" TrueValue="{x:Static DashStyles.Solid}" />
       <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left,Right" />
       <converters:MathConverter x:Key="DivisionConverter" Operation="Divide" Offset="1.5" />
-      <converters:FloatingHintInitialVerticalOffsetConverter x:Key="FloatingHintInitialVerticalOffsetConverter" />
-      <converters:FloatingHintInitialHorizontalOffsetConverter x:Key="FloatingHintInitialHorizontalOffsetConverter" />
-      <converters:FloatingHintMarginConverter x:Key="FloatingHintMarginConverter" />
       <converters:ThicknessCloneConverter x:Key="ThicknessCloneConverter" CloneEdges="All" AdditionalOffsetBottom="-1" />
-      <converters:InvertBooleanConverter x:Key="InvertBooleanConverter" />
       <converters:OutlinedStyleActiveBorderMarginCompensationConverter x:Key="OutlinedStyleActiveBorderMarginCompensationConverter" />
-      <wpf:ElevationMarginConverter x:Key="ElevationMarginConverter" />
-      <wpf:ElevationRadiusConverter x:Key="ElevationRadiusConverter" Multiplier="-1" />
+      <converters:ElevationRadiusConverter x:Key="ElevationRadiusConverter" Multiplier="-1" />
     </Style.Resources>
     <Setter Property="DropDownBackground" Value="{DynamicResource MaterialDesign.Brush.Card.Background}" />
     <Setter Property="DropDownElevation" Value="Dp2" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type wpf:AutoSuggestBox}">
-          <Grid Cursor="{TemplateBinding Cursor, Converter={StaticResource ArrowCursorConverter}}">
+          <Grid Cursor="{TemplateBinding Cursor, Converter={x:Static converters:CursorConverter.ArrowInstance}}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="FocusStates">
                 <VisualState x:Name="Focused">
@@ -84,7 +75,7 @@
             Background="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
             CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
             RenderTransformOrigin="0.5,0.5"
-            Visibility="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+            Visibility="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
               <Border.RenderTransform>
                 <ScaleTransform x:Name="RippleOnFocusScaleTransform" ScaleX="0" ScaleY="0" />
               </Border.RenderTransform>
@@ -120,7 +111,7 @@
                         VerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
                         Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
                         Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                        Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}" />
 
                   <TextBlock x:Name="PrefixTextBlock"
                      Grid.Column="1"
@@ -135,7 +126,7 @@
                         <Binding Path="(wpf:TextFieldAssist.PrefixText)" RelativeSource="{RelativeSource TemplatedParent}" />
                         <Binding Path="(wpf:TextFieldAssist.PrefixTextVisibility)" RelativeSource="{RelativeSource TemplatedParent}" />
                         <Binding Path="IsKeyboardFocusWithin" RelativeSource="{RelativeSource TemplatedParent}" />
-                        <Binding Path="IsReadOnly" RelativeSource="{RelativeSource TemplatedParent}" Converter="{StaticResource InvertBooleanConverter}" />
+                        <Binding Path="IsReadOnly" RelativeSource="{RelativeSource TemplatedParent}" Converter="{x:Static converters:InvertBooleanConverter.Instance}" />
                       </MultiBinding>
                     </TextBlock.Visibility>
                   </TextBlock>
@@ -148,7 +139,7 @@
                         VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                         Panel.ZIndex="1"
                         wpf:ScrollViewerAssist.IgnorePadding="True"
-                        Cursor="{TemplateBinding Cursor, Converter={StaticResource IBeamCursorConverter}}"
+                        Cursor="{TemplateBinding Cursor, Converter={x:Static converters:CursorConverter.IBeamInstance}}"
                         Focusable="False"
                         HorizontalScrollBarVisibility="Hidden"
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
@@ -173,7 +164,7 @@
                                  wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
                                  wpf:HintAssist.HintPaddingBrush="{TemplateBinding wpf:HintAssist.HintPaddingBrush}">
                     <wpf:SmartHint.InitialHorizontalOffset>
-                      <MultiBinding Converter="{StaticResource FloatingHintInitialHorizontalOffsetConverter}">
+                      <MultiBinding Converter="{x:Static converters:FloatingHintInitialHorizontalOffsetConverter.Instance}">
                         <Binding ElementName="PrefixTextBlock" Path="ActualWidth" />
                         <Binding ElementName="PrefixTextBlock" Path="Margin" />
                         <Binding ElementName="SuffixTextBlock" Path="ActualWidth" />
@@ -186,10 +177,10 @@
                       </MultiBinding>
                     </wpf:SmartHint.InitialHorizontalOffset>
                     <wpf:SmartHint.Margin>
-                      <MultiBinding Converter="{StaticResource FloatingHintMarginConverter}">
+                      <MultiBinding Converter="{x:Static converters:FloatingHintMarginConverter.Instance}">
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.IsFloating)" />
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="IsKeyboardFocusWithin" />
-                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="IsReadOnly" Converter="{StaticResource InvertBooleanConverter}" />
+                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="IsReadOnly" Converter="{x:Static converters:InvertBooleanConverter.Instance}" />
                         <Binding ElementName="PrefixTextBlock" Path="ActualWidth" />
                         <Binding ElementName="PrefixTextBlock" Path="Margin" />
                         <Binding ElementName="SuffixTextBlock" Path="ActualWidth" />
@@ -220,7 +211,7 @@
                         <Binding Path="(wpf:TextFieldAssist.SuffixText)" RelativeSource="{RelativeSource TemplatedParent}" />
                         <Binding Path="(wpf:TextFieldAssist.SuffixTextVisibility)" RelativeSource="{RelativeSource TemplatedParent}" />
                         <Binding Path="IsKeyboardFocusWithin" RelativeSource="{RelativeSource TemplatedParent}" />
-                        <Binding Path="IsReadOnly" RelativeSource="{RelativeSource TemplatedParent}" Converter="{StaticResource InvertBooleanConverter}" />
+                        <Binding Path="IsReadOnly" RelativeSource="{RelativeSource TemplatedParent}" Converter="{x:Static converters:InvertBooleanConverter.Instance}" />
                       </MultiBinding>
                     </TextBlock.Visibility>
                   </TextBlock>
@@ -233,7 +224,7 @@
                         VerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
                         Kind="{TemplateBinding wpf:TextFieldAssist.TrailingIcon}"
                         Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                        Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}" />
 
                   <Button x:Name="PART_ClearButton"
                   Grid.Column="5"
@@ -265,7 +256,7 @@
                          StaysOpen="False"
                          Visibility="Collapsed">
               <wpf:Card x:Name="PopupCard"
-                        Margin="{TemplateBinding DropDownElevation, Converter={StaticResource ElevationMarginConverter}}"
+                        Margin="{TemplateBinding DropDownElevation, Converter={x:Static converters:ElevationMarginConverter.Instance}}"
                         Background="{TemplateBinding DropDownBackground}"
                         Foreground="{DynamicResource MaterialDesignBody}"
                         RenderOptions.ClearTypeHint="Enabled"
@@ -407,7 +398,7 @@
               <Setter TargetName="OuterBorder" Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.OutlineInactiveBorder}" />
               <Setter TargetName="HintWrapper" Property="Opacity">
                 <Setter.Value>
-                  <Binding Converter="{StaticResource MathMultiplyConverter}"
+                  <Binding Converter="{x:Static converters:MathConverter.MultiplyInstance}"
                    ConverterParameter="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}"
                    Path="(wpf:HintAssist.HintOpacity)"
                    RelativeSource="{RelativeSource TemplatedParent}" />
@@ -515,7 +506,7 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="Hint" Property="InitialVerticalOffset">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource FloatingHintInitialVerticalOffsetConverter}">
+                  <MultiBinding Converter="{x:Static converters:FloatingHintInitialVerticalOffsetConverter.Instance}">
                     <Binding ElementName="PART_ContentHost" Path="ActualHeight" />
                     <Binding ElementName="Hint" Path="ActualHeight" />
                     <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.TextBoxLineCount)" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Badged.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Badged.xaml
@@ -1,8 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
-  <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
   <SineEase x:Key="BadgeEase" EasingMode="EaseOut" />
   <Storyboard x:Key="BadgeChangedStoryboard">
     <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)">
@@ -52,7 +52,7 @@
                     RenderTransformOrigin=".5,.5"
                     TextElement.FontSize="11"
                     TextElement.FontWeight="DemiBold"
-                    Visibility="{TemplateBinding IsBadgeSet, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Visibility="{TemplateBinding IsBadgeSet, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
               <Border.Resources>
                 <Style TargetType="wpf:PackIcon">
                   <Setter Property="Height" Value="12" />
@@ -178,7 +178,7 @@
                     RenderTransformOrigin=".5,.5"
                     TextElement.FontSize="11"
                     TextElement.FontWeight="DemiBold"
-                    Visibility="{TemplateBinding IsBadgeSet, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Visibility="{TemplateBinding IsBadgeSet, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
               <Border.RenderTransform>
                 <ScaleTransform ScaleX="1" ScaleY="1" />
               </Border.RenderTransform>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
@@ -7,11 +7,6 @@
 
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
-    <ResourceDictionary>
-      <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-      <converters:BorderClipConverter x:Key="BorderClipConverter" />
-      <converters:BrushOpacityConverter x:Key="BrushOpacityConverter" />
-    </ResourceDictionary>
   </ResourceDictionary.MergedDictionaries>
 
   <Style x:Key="FocusVisual">
@@ -69,10 +64,10 @@
                              Minimum="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Minimum)}"
                              Opacity="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Opacity)}"
                              Style="{DynamicResource MaterialDesignLinearProgressBar}"
-                             Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IsIndicatorVisible), Converter={StaticResource BooleanToVisibilityConverter}}"
+                             Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IsIndicatorVisible), Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}"
                              Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Value)}">
                   <ProgressBar.Clip>
-                    <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                    <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                       <Binding ElementName="border" Path="ActualWidth" />
                       <Binding ElementName="border" Path="ActualHeight" />
                       <Binding ElementName="border" Path="CornerRadius" />
@@ -91,7 +86,7 @@
                         Focusable="False"
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <wpf:Ripple.Clip>
-                <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                   <Binding ElementName="border" Path="ActualWidth" />
                   <Binding ElementName="border" Path="ActualHeight" />
                   <Binding ElementName="border" Path="CornerRadius" />
@@ -200,10 +195,10 @@
                          Minimum="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Minimum)}"
                          Opacity="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Opacity)}"
                          Style="{DynamicResource MaterialDesignLinearProgressBar}"
-                         Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IsIndicatorVisible), Converter={StaticResource BooleanToVisibilityConverter}}"
+                         Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IsIndicatorVisible), Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}"
                          Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Value)}">
               <ProgressBar.Clip>
-                <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                   <Binding ElementName="border" Path="ActualWidth" />
                   <Binding ElementName="border" Path="ActualHeight" />
                   <Binding ElementName="border" Path="CornerRadius" />
@@ -221,7 +216,7 @@
                         Focusable="False"
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <wpf:Ripple.Clip>
-                <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                   <Binding ElementName="border" Path="ActualWidth" />
                   <Binding ElementName="border" Path="ActualHeight" />
                   <Binding ElementName="border" Path="CornerRadius" />
@@ -232,7 +227,7 @@
           </Grid>
           <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-              <Setter TargetName="border" Property="Background" Value="{Binding Foreground, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource BrushOpacityConverter}, ConverterParameter=0.16}" />
+              <Setter TargetName="border" Property="Background" Value="{Binding Foreground, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={x:Static converters:BrushOpacityConverter.Instance}, ConverterParameter=0.16}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
               <Setter Property="Opacity" Value="0.38" />
@@ -358,10 +353,10 @@
                          Minimum="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Minimum)}"
                          Opacity="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Opacity)}"
                          Style="{DynamicResource MaterialDesignLinearProgressBar}"
-                         Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IsIndicatorVisible), Converter={StaticResource BooleanToVisibilityConverter}}"
+                         Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IsIndicatorVisible), Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}"
                          Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Value)}">
               <ProgressBar.Clip>
-                <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                   <Binding ElementName="border" Path="ActualWidth" />
                   <Binding ElementName="border" Path="ActualHeight" />
                   <Binding ElementName="border" Path="CornerRadius" />
@@ -379,7 +374,7 @@
                         Focusable="False"
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <wpf:Ripple.Clip>
-                <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                   <Binding ElementName="border" Path="ActualWidth" />
                   <Binding ElementName="border" Path="ActualHeight" />
                   <Binding ElementName="border" Path="CornerRadius" />
@@ -390,7 +385,7 @@
           </Grid>
           <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-              <Setter TargetName="border" Property="Background" Value="{Binding Foreground, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource BrushOpacityConverter}, ConverterParameter=0.16}" />
+              <Setter TargetName="border" Property="Background" Value="{Binding Foreground, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={x:Static converters:BrushOpacityConverter.Instance}, ConverterParameter=0.16}" />
 
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
@@ -521,7 +516,7 @@
                          Opacity="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Opacity)}"
                          RenderTransformOrigin=".5, .5"
                          Style="{DynamicResource MaterialDesignCircularProgressBar}"
-                         Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IsIndicatorVisible), Converter={StaticResource BooleanToVisibilityConverter}}"
+                         Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IsIndicatorVisible), Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}"
                          Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Value)}">
               <ProgressBar.RenderTransform>
                 <TransformGroup>
@@ -807,7 +802,7 @@
                         Focusable="False"
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <wpf:Ripple.Clip>
-                <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                   <Binding ElementName="border" Path="ActualWidth" />
                   <Binding ElementName="border" Path="ActualHeight" />
                   <Binding ElementName="border" Path="CornerRadius" />
@@ -819,7 +814,7 @@
           <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
               <Setter TargetName="background" Property="wpf:ShadowAssist.Darken" Value="True" />
-              <Setter TargetName="border" Property="Background" Value="{Binding BorderBrush, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource BrushOpacityConverter}, ConverterParameter=0.16}" />
+              <Setter TargetName="border" Property="Background" Value="{Binding BorderBrush, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={x:Static converters:BrushOpacityConverter.Instance}, ConverterParameter=0.16}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
               <Setter Property="Opacity" Value="0.38" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
@@ -4,8 +4,6 @@
                     xmlns:globalization="clr-namespace:System.Globalization;assembly=mscorlib"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
-  <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-
   <Style x:Key="MaterialDesignCalendarButton" TargetType="{x:Type CalendarButton}">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Cursor" Value="Hand" />
@@ -440,10 +438,7 @@
                                                Foreground="{TemplateBinding Foreground}"
                                                IsEnabled="{TemplateBinding IsEnabled}">
                         <wpf:MaterialDateDisplay.DisplayDate>
-                          <MultiBinding Mode="OneWay">
-                            <MultiBinding.Converter>
-                              <converters:CalendarDateCoalesceConverter />
-                            </MultiBinding.Converter>
+                          <MultiBinding Mode="OneWay" Converter="{x:Static converters:CalendarDateCoalesceConverter.Instance}">
                             <Binding Path="DisplayDate" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type Calendar}}" />
                             <Binding Path="SelectedDate" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type Calendar}}" />
                           </MultiBinding>
@@ -451,7 +446,6 @@
                       </wpf:MaterialDateDisplay>
                     </Grid>
                   </ControlTemplate>
-                  <converters:CalendarYearMonthConverter x:Key="CalendarYearMonthConverter" />
                 </Grid.Resources>
                 <Grid.ColumnDefinitions>
                   <ColumnDefinition Width="auto" />
@@ -485,7 +479,7 @@
                         FontWeight="Bold"
                         Foreground="{TemplateBinding wpf:CalendarAssist.HeaderForeground}"
                         Template="{StaticResource HeaderButtonTemplate}"
-                        Visibility="{TemplateBinding wpf:CalendarAssist.IsHeaderVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        Visibility="{TemplateBinding wpf:CalendarAssist.IsHeaderVisible, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}" />
                 <TextBlock x:Name="CurrentDateTextBlock"
                            Grid.Row="1"
                            Grid.Column="1"
@@ -497,7 +491,7 @@
                            Opacity="0.56"
                            RenderTransformOrigin="0, 0.5">
                   <TextBlock.Text>
-                    <MultiBinding Converter="{StaticResource CalendarYearMonthConverter}">
+                    <MultiBinding Converter="{x:Static converters:CalendarYearMonthConverter.Instance}">
                       <Binding Path="DisplayDate" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type Calendar}}" />
                       <Binding Path="Language" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type Calendar}}" />
                     </MultiBinding>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -16,13 +16,10 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type wpf:Card}">
-          <ControlTemplate.Resources>
-            <converters:ShadowOpacityMaskConverter x:Key="ShadowOpacityMaskConverter" />
-          </ControlTemplate.Resources>
           <Grid Background="Transparent">
             <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
               <AdornerDecorator.OpacityMask>
-                <MultiBinding Converter="{StaticResource ShadowOpacityMaskConverter}">
+                <MultiBinding Converter="{x:Static converters:ShadowOpacityMaskConverter.Instance}">
                   <Binding Path="ActualWidth" RelativeSource="{RelativeSource TemplatedParent}" />
                   <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
                   <Binding Path="(wpf:ElevationAssist.Elevation)" RelativeSource="{RelativeSource TemplatedParent}" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
@@ -8,9 +8,6 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
-  <converters:BrushRoundConverter x:Key="BrushRoundConverter" />
-  <converters:IsDarkConverter x:Key="IsDarkConverter" />
-
   <Style x:Key="FocusVisual">
     <Setter Property="Control.Template">
       <Setter.Value>
@@ -438,7 +435,7 @@
             <Border x:Name="MouseOverBorder"
                     Grid.Column="0"
                     Grid.ColumnSpan="2"
-                    Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                    Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                     CornerRadius="16"
                     Opacity="0" />
             <Border x:Name="SelectedBackgroundBorder"
@@ -627,7 +624,7 @@
             <Border x:Name="MouseOverBorder"
                     Grid.Column="0"
                     Grid.ColumnSpan="2"
-                    Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                    Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"
                     CornerRadius="16"
@@ -683,7 +680,7 @@
     <Style.Triggers>
       <MultiDataTrigger>
         <MultiDataTrigger.Conditions>
-          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={StaticResource IsDarkConverter}}" Value="True" />
+          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={x:Static converters:IsDarkConverter.Instance}}" Value="True" />
           <Condition Binding="{Binding IsChecked, RelativeSource={RelativeSource Self}}" Value="True" />
         </MultiDataTrigger.Conditions>
         <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Primary.Dark}" />
@@ -702,7 +699,7 @@
     <Style.Triggers>
       <MultiDataTrigger>
         <MultiDataTrigger.Conditions>
-          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={StaticResource IsDarkConverter}}" Value="True" />
+          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={x:Static converters:IsDarkConverter.Instance}}" Value="True" />
           <Condition Binding="{Binding IsChecked, RelativeSource={RelativeSource Self}}" Value="True" />
         </MultiDataTrigger.Conditions>
         <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Secondary.Dark}" />
@@ -722,7 +719,7 @@
     <Style.Triggers>
       <MultiDataTrigger>
         <MultiDataTrigger.Conditions>
-          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={StaticResource IsDarkConverter}}" Value="True" />
+          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={x:Static converters:IsDarkConverter.Instance}}" Value="True" />
           <Condition Binding="{Binding IsChecked, RelativeSource={RelativeSource Self}}" Value="True" />
         </MultiDataTrigger.Conditions>
         <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Primary.Dark}" />
@@ -742,7 +739,7 @@
     <Style.Triggers>
       <MultiDataTrigger>
         <MultiDataTrigger.Conditions>
-          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={StaticResource IsDarkConverter}}" Value="True" />
+          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={x:Static converters:IsDarkConverter.Instance}}" Value="True" />
           <Condition Binding="{Binding IsChecked, RelativeSource={RelativeSource Self}}" Value="True" />
         </MultiDataTrigger.Conditions>
         <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Secondary.Dark}" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Chip.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Chip.xaml
@@ -3,14 +3,6 @@
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
-  <ResourceDictionary.MergedDictionaries>
-    <ResourceDictionary>
-      <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-      <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
-      <converters:BrushRoundConverter x:Key="BrushRoundConverter" />
-    </ResourceDictionary>
-  </ResourceDictionary.MergedDictionaries>
-
   <!-- not happy with where the tool tip is going right now -->
   <!--
     <Style x:Key="MaterialDesignChipToolTip" TargetType="ToolTip">
@@ -49,7 +41,7 @@
                                             Foreground="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:Chip}, Path=IconForeground}"
                                             FontSize="17"
                                             FontWeight="Regular"
-                                            Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:Chip}, Path=Icon, Converter={StaticResource NullableToVisibilityConverter}}"
+                                            Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:Chip}, Path=Icon, Converter={x:Static converters:NullableToVisibilityConverter.Instance}}"
                                             VerticalAlignment="Center"
                                             VerticalContentAlignment="Center"
                                             HorizontalContentAlignment="Center"
@@ -113,7 +105,7 @@
                             FontWeight="Regular"
                             Foreground="{TemplateBinding IconForeground}"
                             IsTabStop="False"
-                            Visibility="{TemplateBinding Icon, Converter={StaticResource NullableToVisibilityConverter}}">
+                            Visibility="{TemplateBinding Icon, Converter={x:Static converters:NullableToVisibilityConverter.Instance}}">
               <ContentControl.Clip>
                 <EllipseGeometry Center="16,16"
                                  RadiusX="16"
@@ -145,7 +137,7 @@
                     Margin="-6,0,8,0"
                     VerticalAlignment="Center"
                     ToolTip="{TemplateBinding DeleteToolTip}"
-                    Visibility="{TemplateBinding IsDeletable, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Visibility="{TemplateBinding IsDeletable, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
               <Button.Template>
                 <ControlTemplate>
                   <Grid>
@@ -221,7 +213,7 @@
             <Border x:Name="MouseOverBorder"
                     Grid.Column="0"
                     Grid.ColumnSpan="2"
-                    Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                    Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"
                     CornerRadius="16"
@@ -238,7 +230,7 @@
                             FontWeight="Regular"
                             Foreground="{TemplateBinding IconForeground}"
                             IsTabStop="False"
-                            Visibility="{TemplateBinding Icon, Converter={StaticResource NullableToVisibilityConverter}}">
+                            Visibility="{TemplateBinding Icon, Converter={x:Static converters:NullableToVisibilityConverter.Instance}}">
               <ContentControl.Clip>
                 <EllipseGeometry Center="16,16"
                                  RadiusX="16"
@@ -270,7 +262,7 @@
                     Margin="-6,0,8,0"
                     VerticalAlignment="Center"
                     ToolTip="{TemplateBinding DeleteToolTip}"
-                    Visibility="{TemplateBinding IsDeletable, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Visibility="{TemplateBinding IsDeletable, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
               <Button.Template>
                 <ControlTemplate>
                   <Grid>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
@@ -3,18 +3,6 @@
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
-  <ResourceDictionary.MergedDictionaries>
-    <ResourceDictionary>
-      <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-      <converters:ClockLineConverter x:Key="ClockHourLineConverter" DisplayMode="Hours" />
-      <converters:ClockLineConverter x:Key="ClockMinuteLineConverter" DisplayMode="Minutes" />
-      <converters:ClockLineConverter x:Key="ClockSecondLineConverter" DisplayMode="Seconds" />
-      <converters:NotConverter x:Key="NotConverter" />
-      <converters:BorderClipConverter x:Key="BorderClipConverter" />
-    </ResourceDictionary>
-  </ResourceDictionary.MergedDictionaries>
-
-
   <Style x:Key="MaterialDesignClockItemThumb" TargetType="{x:Type Thumb}">
     <Setter Property="Template">
       <Setter.Value>
@@ -631,7 +619,7 @@
                       Margin="0,0,0,12"
                       Background="{DynamicResource MaterialDesign.Brush.Primary}"
                       CornerRadius="2 2 0 0"
-                      Visibility="{TemplateBinding IsHeaderVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                      Visibility="{TemplateBinding IsHeaderVisible, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
                 <StackPanel x:Name="TimeReadoutStackPanel"
                             Margin="24"
                             HorizontalAlignment="Right"
@@ -733,7 +721,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Primary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.HoursInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>
@@ -757,7 +745,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Primary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.MinutesInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>
@@ -781,7 +769,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Primary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.SecondsInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>
@@ -797,7 +785,7 @@
                                HorizontalAlignment="Center"
                                VerticalAlignment="Bottom"
                                Content="AM"
-                               IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}}"
+                               IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={x:Static converters:NotConverter.Instance}}"
                                Style="{StaticResource MaterialDesignCalendarMeridiemRadioButton}" />
                   <RadioButton x:Name="PMRadioButton"
                                Width="47.333"
@@ -1392,7 +1380,7 @@
 
               <Border Margin="0,0,0,36"
                       HorizontalAlignment="Center"
-                      Visibility="{TemplateBinding IsHeaderVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                      Visibility="{TemplateBinding IsHeaderVisible, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
                 <StackPanel Orientation="Horizontal">
                   <StackPanel x:Name="TimeReadoutStackPanel"
                               HorizontalAlignment="Right"
@@ -1525,7 +1513,7 @@
                           CornerRadius="{TemplateBinding CornerRadius}">
                     <StackPanel>
                       <StackPanel.Clip>
-                        <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                        <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                           <Binding ElementName="AmPmBorder" Path="ActualWidth" />
                           <Binding ElementName="AmPmBorder" Path="ActualHeight" />
                           <Binding ElementName="AmPmBorder" Path="CornerRadius" />
@@ -1536,7 +1524,7 @@
                                    Width="52"
                                    Height="40"
                                    Content="AM"
-                                   IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}}"
+                                   IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={x:Static converters:NotConverter.Instance}}"
                                    Style="{StaticResource MaterialDesignCalendarMeridiemRadioButtonDefault}" />
                       <RadioButton x:Name="PMRadioButton"
                                    Width="52"
@@ -1576,7 +1564,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Primary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.HoursInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>
@@ -1600,7 +1588,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Primary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.MinutesInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>
@@ -1624,7 +1612,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Primary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.SecondsInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>
@@ -2214,7 +2202,7 @@
 
               <Border Margin="0,0,0,36"
                       HorizontalAlignment="Center"
-                      Visibility="{TemplateBinding IsHeaderVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                      Visibility="{TemplateBinding IsHeaderVisible, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
                 <StackPanel Orientation="Horizontal">
                   <StackPanel x:Name="TimeReadoutStackPanel"
                               HorizontalAlignment="Right"
@@ -2341,7 +2329,7 @@
                           CornerRadius="{TemplateBinding CornerRadius}">
                     <StackPanel>
                       <StackPanel.Clip>
-                        <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                        <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                           <Binding ElementName="AmPmBorder" Path="ActualWidth" />
                           <Binding ElementName="AmPmBorder" Path="ActualHeight" />
                           <Binding ElementName="AmPmBorder" Path="CornerRadius" />
@@ -2352,7 +2340,7 @@
                                    Width="52"
                                    Height="40"
                                    Content="AM"
-                                   IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}}"
+                                   IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={x:Static converters:NotConverter.Instance}}"
                                    Style="{StaticResource MaterialDesignCalendarMeridiemRadioButtonThemed}" />
                       <RadioButton x:Name="PMRadioButton"
                                    Width="52"
@@ -2391,7 +2379,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Secondary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.HoursInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>
@@ -2415,7 +2403,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Secondary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.MinutesInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>
@@ -2439,7 +2427,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Secondary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.SecondsInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>
@@ -3026,7 +3014,7 @@
 
               <Border Margin="0,0,52,0"
                       VerticalAlignment="Center"
-                      Visibility="{TemplateBinding IsHeaderVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                      Visibility="{TemplateBinding IsHeaderVisible, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
                 <StackPanel>
                   <StackPanel x:Name="TimeReadoutStackPanel"
                               HorizontalAlignment="Right"
@@ -3162,7 +3150,7 @@
                         <ColumnDefinition Width="*" />
                       </Grid.ColumnDefinitions>
                       <Grid.Clip>
-                        <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                        <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                           <Binding ElementName="AmPmBorder" Path="ActualWidth" />
                           <Binding ElementName="AmPmBorder" Path="ActualHeight" />
                           <Binding ElementName="AmPmBorder" Path="CornerRadius" />
@@ -3172,7 +3160,7 @@
                       <RadioButton x:Name="AMRadioButton"
                                    Height="40"
                                    Content="AM"
-                                   IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}}"
+                                   IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={x:Static converters:NotConverter.Instance}}"
                                    Style="{StaticResource MaterialDesignCalendarMeridiemRadioButtonDefault}" />
                       <RadioButton x:Name="PMRadioButton"
                                    Grid.Column="1"
@@ -3212,7 +3200,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Primary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.HoursInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>
@@ -3236,7 +3224,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Primary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.MinutesInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>
@@ -3260,7 +3248,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Primary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.SecondsInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>
@@ -3850,7 +3838,7 @@
 
               <Border Margin="0,0,52,0"
                       VerticalAlignment="Center"
-                      Visibility="{TemplateBinding IsHeaderVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                      Visibility="{TemplateBinding IsHeaderVisible, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
                 <StackPanel>
                   <StackPanel x:Name="TimeReadoutStackPanel"
                               HorizontalAlignment="Right"
@@ -3980,7 +3968,7 @@
                         <ColumnDefinition Width="*" />
                       </Grid.ColumnDefinitions>
                       <Grid.Clip>
-                        <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                        <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                           <Binding ElementName="AmPmBorder" Path="ActualWidth" />
                           <Binding ElementName="AmPmBorder" Path="ActualHeight" />
                           <Binding ElementName="AmPmBorder" Path="CornerRadius" />
@@ -3990,7 +3978,7 @@
                       <RadioButton x:Name="AMRadioButton"
                                    Height="40"
                                    Content="AM"
-                                   IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={StaticResource NotConverter}}"
+                                   IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPostMeridiem, Converter={x:Static converters:NotConverter.Instance}}"
                                    Style="{StaticResource MaterialDesignCalendarMeridiemRadioButtonThemed}" />
                       <RadioButton x:Name="PMRadioButton"
                                    Grid.Column="1"
@@ -4029,7 +4017,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Secondary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockHourLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.HoursInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>
@@ -4053,7 +4041,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Secondary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockMinuteLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.MinutesInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>
@@ -4077,7 +4065,7 @@
                         Stretch="Fill"
                         Stroke="{DynamicResource MaterialDesign.Brush.Secondary}">
                     <Path.RenderTransform>
-                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={StaticResource ClockSecondLineConverter}}" />
+                      <RotateTransform Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Time, Converter={x:Static converters:ClockLineConverter.SecondsInstance}}" />
                     </Path.RenderTransform>
                   </Path>
                   <Canvas.RenderTransform>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ColorPicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ColorPicker.xaml
@@ -6,9 +6,6 @@
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Slider.xaml" />
   </ResourceDictionary.MergedDictionaries>
-  <converters:HsbToColorConverter x:Key="HsbToColorConverter" />
-  <converters:HsbLinearGradientConverter x:Key="HsbLinearGradientConverter" />
-  <converters:MathConverter x:Key="DivideBy360Converter" Operation="Multiply" />
 
   <ControlTemplate x:Key="MaterialDesignColorSliderThumb" TargetType="{x:Type Thumb}">
     <Grid HorizontalAlignment="Center"
@@ -176,7 +173,7 @@
                    OverridesDefaultStyle="True"
                    Template="{StaticResource MaterialDesignColorSliderThumb}">
               <Thumb.Foreground>
-                <MultiBinding Converter="{StaticResource HsbToColorConverter}">
+                <MultiBinding Converter="{x:Static converters:HsbToColorConverter.Instance}">
                   <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                   <Binding>
                     <Binding.Source>
@@ -240,7 +237,7 @@
                    OverridesDefaultStyle="True"
                    Template="{StaticResource MaterialDesignColorSliderThumb}">
               <Thumb.Foreground>
-                <MultiBinding Converter="{StaticResource HsbToColorConverter}">
+                <MultiBinding Converter="{x:Static converters:HsbToColorConverter.Instance}">
                   <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                   <Binding>
                     <Binding.Source>
@@ -287,7 +284,7 @@
               Style="{StaticResource MaterialDesignColorSlider}"
               Value="{Binding Hsb.Hue, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
       <Grid>
-        <Rectangle Fill="{Binding Hsb.Hue, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HsbLinearGradientConverter}}" />
+        <Rectangle Fill="{Binding Hsb.Hue, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HsbLinearGradientConverter.Instance}}" />
         <Rectangle Fill="Black">
           <Rectangle.OpacityMask>
             <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
@@ -330,7 +327,7 @@
               Style="{StaticResource MaterialDesignColorSlider}"
               Value="{Binding Hsb.Hue, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
       <Grid>
-        <Rectangle Fill="{Binding Hsb.Hue, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HsbLinearGradientConverter}}" />
+        <Rectangle Fill="{Binding Hsb.Hue, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static converters:HsbLinearGradientConverter.Instance}}" />
         <Rectangle Fill="Black">
           <Rectangle.OpacityMask>
             <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -72,9 +72,6 @@
   </Style>
 
   <ControlTemplate x:Key="MaterialDesignComboBoxItemTemplate" TargetType="{x:Type ComboBoxItem}">
-    <ControlTemplate.Resources>
-      <converters:BrushRoundConverter x:Key="BrushRoundConverter" />
-    </ControlTemplate.Resources>
     <Grid x:Name="GridWrapper">
       <Grid.RowDefinitions>
         <RowDefinition Height="Auto" />
@@ -135,13 +132,13 @@
               SnapsToDevicePixels="True" />
 
       <Border x:Name="MouseOverBorder"
-              Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+              Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
               BorderBrush="{TemplateBinding BorderBrush}"
               BorderThickness="{TemplateBinding BorderThickness}"
               Opacity="0"
               SnapsToDevicePixels="True" />
       <Border x:Name="SelectedBorder"
-              Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+              Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
               Opacity="0"
               RenderTransformOrigin="0.5,0.5" />
       <wpf:Ripple Padding="{TemplateBinding Padding}"
@@ -152,7 +149,7 @@
                   Content="{TemplateBinding Content}"
                   ContentTemplate="{TemplateBinding ContentTemplate}"
                   ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                  Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                  Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                   Focusable="False"
                   RecognizesAccessKey="False"
                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
@@ -289,17 +286,11 @@
 
   <ControlTemplate x:Key="MaterialDesignFloatingHintComboBoxTemplate" TargetType="{x:Type ComboBox}">
     <ControlTemplate.Resources>
-      <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
       <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearButtonVisibilityConverter" ContentEmptyVisibility="Collapsed" />
-      <converters:FallbackBrushConverter x:Key="FallbackBrushConverter" />
-      <converters:RemoveAlphaBrushConverter x:Key="RemoveAlphaBrushConverter" />
       <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left" />
       <converters:TextFieldPrefixTextVisibilityConverter x:Key="PrefixSuffixTextVisibilityConverter" HiddenState="Collapsed" />
-      <converters:FloatingHintInitialHorizontalOffsetConverter x:Key="FloatingHintInitialHorizontalOffsetConverter" />
-      <converters:FloatingHintMarginConverter x:Key="FloatingHintMarginConverter" />
       <converters:MathConverter x:Key="DivisionConverter" Operation="Divide" Offset="1.5" />
       <converters:BooleanToDashStyleConverter x:Key="BooleanToDashStyleConverter" TrueValue="{x:Static DashStyles.Solid}" />
-      <converters:OutlinedStyleActiveBorderMarginCompensationConverter x:Key="OutlinedStyleActiveBorderMarginCompensationConverter" />
     </ControlTemplate.Resources>
     <Grid>
       <AdornerDecorator>
@@ -352,7 +343,7 @@
                             VerticalAlignment="Center"
                             Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                            Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                            Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}" />
 
               <TextBlock x:Name="PrefixTextBlock"
                          Grid.Column="1"
@@ -415,7 +406,7 @@
                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                              UseLayoutRounding="{TemplateBinding UseLayoutRounding}">
                 <wpf:SmartHint.InitialHorizontalOffset>
-                  <MultiBinding Converter="{StaticResource FloatingHintInitialHorizontalOffsetConverter}">
+                  <MultiBinding Converter="{x:Static converters:FloatingHintInitialHorizontalOffsetConverter.Instance}">
                     <Binding ElementName="PrefixTextBlock" Path="ActualWidth" />
                     <Binding ElementName="PrefixTextBlock" Path="Margin" />
                     <Binding ElementName="SuffixTextBlock" Path="ActualWidth" />
@@ -428,7 +419,7 @@
                   </MultiBinding>
                 </wpf:SmartHint.InitialHorizontalOffset>
                 <wpf:SmartHint.Margin>
-                  <MultiBinding Converter="{StaticResource FloatingHintMarginConverter}">
+                  <MultiBinding Converter="{x:Static converters:FloatingHintMarginConverter.Instance}">
                     <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.IsFloating)" />
                     <Binding ElementName="PART_EditableTextBox" Path="IsKeyboardFocusWithin" />
                     <Binding Path="IsEditable" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -475,7 +466,7 @@
                             VerticalAlignment="Center"
                             Kind="{TemplateBinding wpf:TextFieldAssist.TrailingIcon}"
                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                            Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                            Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}" />
 
               <Button x:Name="PART_ClearButton"
                       Grid.Column="5"
@@ -541,7 +532,7 @@
                    UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
                    VerticalOffset="0">
         <wpf:ComboBoxPopup.Background>
-          <MultiBinding Converter="{StaticResource FallbackBrushConverter}">
+          <MultiBinding Converter="{x:Static converters:FallbackBrushConverter.Instance}">
             <Binding Path="Background" RelativeSource="{RelativeSource TemplatedParent}" />
             <Binding ElementName="PART_Popup" Path="Tag" />
           </MultiBinding>
@@ -641,7 +632,7 @@
         </MultiTrigger.Conditions>
         <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ComboBox.OutlineInactiveBorder}" />
         <Setter TargetName="HintWrapper" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-        <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+        <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={x:Static converters:MathConverter.MultiplyInstance}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
         <Setter TargetName="LeadingPackIcon" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
         <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
         <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
@@ -666,7 +657,7 @@
         <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
         <Setter TargetName="ContentGrid" Property="Margin">
           <Setter.Value>
-            <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+            <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
               <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
               <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
             </MultiBinding>
@@ -687,7 +678,7 @@
         <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
         <Setter TargetName="ContentGrid" Property="Margin">
           <Setter.Value>
-            <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+            <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
               <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
               <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
             </MultiBinding>
@@ -736,7 +727,7 @@
         <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
         <Setter TargetName="ContentGrid" Property="Margin">
           <Setter.Value>
-            <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+            <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
               <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
               <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
             </MultiBinding>
@@ -768,7 +759,7 @@
         <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
         <Setter TargetName="ContentGrid" Property="Margin">
           <Setter.Value>
-            <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+            <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
               <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
               <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
             </MultiBinding>
@@ -785,7 +776,7 @@
         <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
         <Setter TargetName="ContentGrid" Property="Margin">
           <Setter.Value>
-            <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+            <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
               <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
               <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
             </MultiBinding>
@@ -798,7 +789,7 @@
           <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Standard" />
         </MultiTrigger.Conditions>
         <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesign.Brush.Foreground}" />
-        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={x:Static converters:RemoveAlphaBrushConverter.Instance}}" />
         <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesign.Brush.Background}" />
       </MultiTrigger>
       <MultiTrigger>
@@ -807,7 +798,7 @@
           <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Inverted" />
         </MultiTrigger.Conditions>
         <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesign.Brush.Background}" />
-        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={x:Static converters:RemoveAlphaBrushConverter.Instance}}" />
         <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesign.Brush.Foreground}" />
       </MultiTrigger>
       <MultiTrigger>
@@ -816,7 +807,7 @@
           <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="PrimaryLight" />
         </MultiTrigger.Conditions>
         <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary.Light.Foreground}" />
-        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={x:Static converters:RemoveAlphaBrushConverter.Instance}}" />
         <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesign.Brush.Primary.Light}" />
       </MultiTrigger>
       <MultiTrigger>
@@ -825,7 +816,7 @@
           <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid" />
         </MultiTrigger.Conditions>
         <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary.Foreground}" />
-        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={x:Static converters:RemoveAlphaBrushConverter.Instance}}" />
         <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
       </MultiTrigger>
       <MultiTrigger>
@@ -834,7 +825,7 @@
           <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="PrimaryDark" />
         </MultiTrigger.Conditions>
         <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary.Dark.Foreground}" />
-        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={x:Static converters:RemoveAlphaBrushConverter.Instance}}" />
         <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesign.Brush.Primary.Dark}" />
       </MultiTrigger>
       <MultiTrigger>
@@ -843,7 +834,7 @@
           <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="SecondaryLight" />
         </MultiTrigger.Conditions>
         <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesign.Brush.Secondary.Light.Foreground}" />
-        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={x:Static converters:RemoveAlphaBrushConverter.Instance}}" />
         <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesign.Brush.Secondary.Light}" />
       </MultiTrigger>
       <MultiTrigger>
@@ -852,7 +843,7 @@
           <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="SecondaryMid" />
         </MultiTrigger.Conditions>
         <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}" />
-        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={x:Static converters:RemoveAlphaBrushConverter.Instance}}" />
         <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesign.Brush.Secondary}" />
       </MultiTrigger>
       <MultiTrigger>
@@ -861,7 +852,7 @@
           <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="SecondaryDark" />
         </MultiTrigger.Conditions>
         <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesign.Brush.Secondary.Dark.Foreground}" />
-        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={x:Static converters:RemoveAlphaBrushConverter.Instance}}" />
         <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesign.Brush.Secondary.Dark}" />
       </MultiTrigger>
       <MultiTrigger>
@@ -870,7 +861,7 @@
           <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Light" />
         </MultiTrigger.Conditions>
         <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesign.Brush.ComboBox.Popup.LightForeground}" />
-        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={x:Static converters:RemoveAlphaBrushConverter.Instance}}" />
         <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesign.Brush.ComboBox.Popup.LightBackground}" />
       </MultiTrigger>
       <MultiTrigger>
@@ -879,7 +870,7 @@
           <Condition SourceName="PART_Popup" Property="wpf:ColorZoneAssist.Mode" Value="Dark" />
         </MultiTrigger.Conditions>
         <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesign.Brush.ComboBox.Popup.DarkForeground}" />
-        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource RemoveAlphaBrushConverter}}" />
+        <Setter TargetName="PART_Popup" Property="Background" Value="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={x:Static converters:RemoveAlphaBrushConverter.Instance}}" />
         <Setter TargetName="PART_Popup" Property="Tag" Value="{DynamicResource MaterialDesign.Brush.ComboBox.Popup.DarkBackground}" />
       </MultiTrigger>
     </ControlTemplate.Triggers>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
@@ -3,8 +3,6 @@
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
-  <converters:TextFieldHintVisibilityConverter x:Key="TextFieldHintVisibilityConverter" />
-
   <Style x:Key="FocusVisual">
     <Setter Property="Control.Template">
       <Setter.Value>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
@@ -12,13 +12,6 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Thumb.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
-  <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-  <converters:NotZeroToVisibilityConverter x:Key="NotZeroToVisibilityConverter" />
-  <converters:TopThicknessConverter x:Key="TopThicknessConverter" />
-  <converters:RemoveAlphaBrushConverter x:Key="RemoveAlphaBrushConverter" />
-  <converters:GridLinesVisibilityBorderToThicknessConverter x:Key="GridLinesVisibilityBorderToThicknessConverter" />
-  <converters:StringLengthValueConverter x:Key="StringLengthValueConverter" />
-
   <Style x:Key="MaterialDesignDataGridCheckBoxColumnStyle"
          TargetType="{x:Type CheckBox}"
          BasedOn="{StaticResource MaterialDesignCheckBox}">
@@ -172,7 +165,7 @@
                             Grid.Column="0"
                             MaxWidth="{TemplateBinding ActualWidth}"
                             Background="{TemplateBinding wpf:ValidationAssist.Background}"
-                            Visibility="{TemplateBinding Validation.HasError, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            Visibility="{TemplateBinding Validation.HasError, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
                       <ItemsControl ItemsSource="{TemplateBinding Validation.Errors}">
                         <ItemsControl.ItemTemplate>
                           <DataTemplate DataType="ValidationError">
@@ -191,10 +184,10 @@
                                Grid.Column="1"
                                HorizontalAlignment="Right"
                                Opacity=".56"
-                               Visibility="{TemplateBinding MaxLength, Converter={StaticResource NotZeroToVisibilityConverter}}">
+                               Visibility="{TemplateBinding MaxLength, Converter={x:Static converters:NotZeroToVisibilityConverter.Instance}}">
                       <TextBlock.Text>
                         <MultiBinding StringFormat="{}{0}/{1}">
-                          <Binding Converter="{StaticResource StringLengthValueConverter}"
+                          <Binding Converter="{x:Static converters:StringLengthValueConverter.Instance}"
                                    Path="Text"
                                    RelativeSource="{RelativeSource TemplatedParent}" />
                           <Binding Path="MaxLength" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -219,7 +212,7 @@
 
   <Style x:Key="{ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}" TargetType="{x:Type Button}">
     <Setter Property="BorderBrush" Value="{Binding HorizontalGridLinesBrush, RelativeSource={RelativeSource AncestorType=DataGrid}}" />
-    <Setter Property="BorderThickness" Value="{Binding GridLinesVisibility, RelativeSource={RelativeSource AncestorType=DataGrid}, Converter={StaticResource GridLinesVisibilityBorderToThicknessConverter}}" />
+    <Setter Property="BorderThickness" Value="{Binding GridLinesVisibility, RelativeSource={RelativeSource AncestorType=DataGrid}, Converter={x:Static converters:GridLinesVisibilityBorderToThicknessConverter.Instance}}" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Button}">
@@ -291,7 +284,7 @@
 
   <Style x:Key="MaterialDesignDataGridColumnHeader" TargetType="{x:Type DataGridColumnHeader}">
     <Setter Property="BorderBrush" Value="{Binding HorizontalGridLinesBrush, RelativeSource={RelativeSource AncestorType=DataGrid}}" />
-    <Setter Property="BorderThickness" Value="{Binding GridLinesVisibility, RelativeSource={RelativeSource AncestorType=DataGrid}, Converter={StaticResource GridLinesVisibilityBorderToThicknessConverter}}" />
+    <Setter Property="BorderThickness" Value="{Binding GridLinesVisibility, RelativeSource={RelativeSource AncestorType=DataGrid}, Converter={x:Static converters:GridLinesVisibilityBorderToThicknessConverter.Instance}}" />
     <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Header.Foreground}" />
     <Setter Property="Padding" Value="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:DataGridAssist.ColumnHeaderPadding)}" />
     <Setter Property="Template">
@@ -325,7 +318,7 @@
                                                 IsTabStop="False"
                                                 ListSortDirection="{TemplateBinding SortDirection}"
                                                 Opacity="0.45"
-                                                Visibility="{Binding CanUserSortColumns, RelativeSource={RelativeSource AncestorType=DataGrid}, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                                Visibility="{Binding CanUserSortColumns, RelativeSource={RelativeSource AncestorType=DataGrid}, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}" />
                 <ContentPresenter VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                   RecognizesAccessKey="True"
                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
@@ -374,7 +367,7 @@
 
   <Style x:Key="MaterialDesignDataGridRowHeader" TargetType="{x:Type DataGridRowHeader}">
     <Setter Property="BorderBrush" Value="{Binding HorizontalGridLinesBrush, RelativeSource={RelativeSource AncestorType=DataGrid}}" />
-    <Setter Property="BorderThickness" Value="{Binding GridLinesVisibility, RelativeSource={RelativeSource AncestorType=DataGrid}, Converter={StaticResource GridLinesVisibilityBorderToThicknessConverter}}" />
+    <Setter Property="BorderThickness" Value="{Binding GridLinesVisibility, RelativeSource={RelativeSource AncestorType=DataGrid}, Converter={x:Static converters:GridLinesVisibilityBorderToThicknessConverter.Instance}}" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type DataGridRowHeader}">
@@ -389,7 +382,7 @@
                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                 <Control SnapsToDevicePixels="false"
                          Template="{Binding ValidationErrorTemplate, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}"
-                         Visibility="{Binding (Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}" />
+                         Visibility="{Binding (Validation.HasError), Converter={x:Static converters:BooleanToVisibilityConverter.Instance}, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}" />
               </StackPanel>
             </Border>
             <Thumb x:Name="PART_TopHeaderGripper"
@@ -475,7 +468,7 @@
     <Setter Property="HeadersVisibility" Value="Column" />
     <Setter Property="HorizontalGridLinesBrush">
       <Setter.Value>
-        <MultiBinding Converter="{StaticResource RemoveAlphaBrushConverter}">
+        <MultiBinding Converter="{x:Static converters:RemoveAlphaBrushConverter.Instance}">
           <Binding Path="BorderBrush" RelativeSource="{RelativeSource Self}" />
           <Binding Path="Background" RelativeSource="{RelativeSource Self}" />
         </MultiBinding>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -39,7 +39,6 @@
                                                 FixedLeft="0" />
             <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderInactiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderInactiveThickness}" />
             <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderActiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderActiveThickness}" />
-            <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
 
             <ControlTemplate x:Key="CalendarButtonTemplate" TargetType="{x:Type Button}">
               <wpf:PackIcon VerticalAlignment="Center"
@@ -134,7 +133,7 @@
               <Setter TargetName="PART_Button" Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
             </MultiTrigger>
             <Trigger Property="IsEnabled" Value="False">
-              <Setter TargetName="PART_Button" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+              <Setter TargetName="PART_Button" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={x:Static converters:MathConverter.MultiplyInstance}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
               <Setter TargetName="PART_TextBox" Property="IsReadOnly" Value="False" />
             </Trigger>
 

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -14,9 +14,6 @@
   </Style>
 
   <Style TargetType="{x:Type wpf:DialogHost}">
-    <Style.Resources>
-      <converters:FirstNonNullConverter x:Key="FirstNonNullConverter" />
-    </Style.Resources>
     <Setter Property="DialogMargin" Value="35" />
     <Setter Property="DialogTheme" Value="Inherit" />
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -211,7 +208,7 @@
               <Grid.OpacityMask>
                 <VisualBrush>
                   <VisualBrush.Visual>
-                    <MultiBinding Converter="{StaticResource FirstNonNullConverter}">
+                    <MultiBinding Converter="{x:Static converters:FirstNonNullConverter.Instance}">
                       <Binding ElementName="ContentCoverBorder" />
                       <Binding Source="{x:Static DependencyProperty.UnsetValue}" />
                     </MultiBinding>
@@ -247,9 +244,6 @@
   </Style>
 
   <Style x:Key="MaterialDesignEmbeddedDialogHost" TargetType="{x:Type wpf:DialogHost}">
-    <Style.Resources>
-      <converters:FirstNonNullConverter x:Key="FirstNonNullConverter" />
-    </Style.Resources>
     <Setter Property="DialogMargin" Value="35" />
     <Setter Property="HorizontalContentAlignment" Value="Center" />
     <Setter Property="Placement" Value="Center" />
@@ -396,7 +390,7 @@
               <Grid.OpacityMask>
                 <VisualBrush>
                   <VisualBrush.Visual>
-                    <MultiBinding Converter="{StaticResource FirstNonNullConverter}">
+                    <MultiBinding Converter="{x:Static converters:FirstNonNullConverter.Instance}">
                       <Binding ElementName="ContentCoverBorder" />
                       <Binding Source="{x:Static DependencyProperty.UnsetValue}" />
                     </MultiBinding>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
@@ -196,9 +196,6 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Expander}">
-          <ControlTemplate.Resources>
-            <converters:ExpanderRotateAngleConverter x:Key="ExpanderRotateAngleConverter" />
-          </ControlTemplate.Resources>
           <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="ExpansionStates">
@@ -312,7 +309,7 @@
                 <Border.LayoutTransform>
                   <TransformGroup>
                     <ScaleTransform x:Name="ContentSiteScaleTransform" />
-                    <RotateTransform Angle="{Binding Path=ExpandDirection, RelativeSource={RelativeSource AncestorType=Expander}, Converter={StaticResource ExpanderRotateAngleConverter}}" />
+                    <RotateTransform Angle="{Binding Path=ExpandDirection, RelativeSource={RelativeSource AncestorType=Expander}, Converter={x:Static converters:ExpanderRotateAngleConverter.Instance}}" />
                   </TransformGroup>
                 </Border.LayoutTransform>
 
@@ -321,7 +318,7 @@
                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                   <Grid.LayoutTransform>
-                    <RotateTransform Angle="{Binding Path=ExpandDirection, RelativeSource={RelativeSource AncestorType=Expander}, Converter={StaticResource ExpanderRotateAngleConverter}, ConverterParameter=-1}" />
+                    <RotateTransform Angle="{Binding Path=ExpandDirection, RelativeSource={RelativeSource AncestorType=Expander}, Converter={x:Static converters:ExpanderRotateAngleConverter.Instance}, ConverterParameter=-1}" />
                   </Grid.LayoutTransform>
 
                   <ContentPresenter Name="PART_Content"

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.GroupBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.GroupBox.xaml
@@ -3,8 +3,6 @@
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
-  <converters:IsTransparentBrushConverter x:Key="IsTransparentBrushConverter" />
-
   <Style x:Key="MaterialDesignHeaderedContentControl" TargetType="{x:Type HeaderedContentControl}">
     <Setter Property="Template">
       <Setter.Value>
@@ -60,10 +58,10 @@
             </DockPanel>
           </Grid>
           <ControlTemplate.Triggers>
-            <DataTrigger Binding="{Binding ElementName=Border, Path=Background, Converter={StaticResource IsTransparentBrushConverter}}" Value="True">
+            <DataTrigger Binding="{Binding ElementName=Border, Path=Background, Converter={x:Static converters:IsTransparentBrushConverter.Instance}}" Value="True">
               <Setter TargetName="PART_ColorZone" Property="Effect" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}" />
             </DataTrigger>
-            <DataTrigger Binding="{Binding ElementName=Border, Path=Background, Converter={StaticResource IsTransparentBrushConverter}}" Value="False">
+            <DataTrigger Binding="{Binding ElementName=Border, Path=Background, Converter={x:Static converters:IsTransparentBrushConverter.Instance}}" Value="False">
               <Setter TargetName="OuterGrid" Property="Effect" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation), Converter={x:Static converters:ShadowConverter.Instance}}" />
             </DataTrigger>
           </ControlTemplate.Triggers>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
@@ -7,15 +7,7 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.CheckBox.xaml" />
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.RadioButton.xaml" />
-    <ResourceDictionary>
-      <converters:BrushRoundConverter x:Key="BrushRoundConverter" />
-      <converters:BorderClipConverter x:Key="BorderClipConverter" />
-      <converters:IsDarkConverter x:Key="IsDarkConverter" />
-      <converters:BrushOpacityConverter x:Key="BrushOpacityConverter" />
-    </ResourceDictionary>
   </ResourceDictionary.MergedDictionaries>
-
-  <converters:EqualityToVisibilityConverter x:Key="EqualityToVisibilityConverter" />
 
   <Style x:Key="FocusVisual">
     <Setter Property="Control.Template">
@@ -122,7 +114,7 @@
             </VisualStateManager.VisualStateGroups>
             <Grid>
               <Border x:Name="MouseOverBorder"
-                      Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                      Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                       Opacity="0" />
               <Border x:Name="SelectedBackgroundBorder"
                       Background="{DynamicResource MaterialDesign.Brush.ListBoxItem.Selected}"
@@ -134,7 +126,7 @@
                           Content="{TemplateBinding Content}"
                           ContentTemplate="{TemplateBinding ContentTemplate}"
                           ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                          Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                          Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                           Focusable="False"
                           Opacity=".56"
                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
@@ -142,7 +134,7 @@
                       BorderBrush="{DynamicResource MaterialDesign.Brush.ListBoxItem.Selected}"
                       BorderThickness="0"
                       Opacity="0"
-                      Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ListBox}, Path=SelectionMode, Converter={StaticResource EqualityToVisibilityConverter}, ConverterParameter={x:Static SelectionMode.Extended}, Mode=OneWay}" />
+                      Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ListBox}, Path=SelectionMode, Converter={x:Static converters:EqualityToVisibilityConverter.Instance}, ConverterParameter={x:Static SelectionMode.Extended}, Mode=OneWay}" />
             </Grid>
           </Border>
           <ControlTemplate.Triggers>
@@ -246,9 +238,9 @@
     <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="Padding" Value="8" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
-    <Setter Property="wpf:ListBoxItemAssist.HoverBackground" Value="{Binding Foreground, RelativeSource={RelativeSource Self}, Converter={StaticResource BrushOpacityConverter}, ConverterParameter=0.1}" />
-    <Setter Property="wpf:ListBoxItemAssist.SelectedFocusedBackground" Value="{Binding Foreground, RelativeSource={RelativeSource Self}, Converter={StaticResource BrushOpacityConverter}, ConverterParameter=0.18}" />
-    <Setter Property="wpf:ListBoxItemAssist.SelectedUnfocusedBackground" Value="{Binding Foreground, RelativeSource={RelativeSource Self}, Converter={StaticResource BrushOpacityConverter}, ConverterParameter=0.09}" />
+    <Setter Property="wpf:ListBoxItemAssist.HoverBackground" Value="{Binding Foreground, RelativeSource={RelativeSource Self}, Converter={x:Static converters:BrushOpacityConverter.Instance}, ConverterParameter=0.1}" />
+    <Setter Property="wpf:ListBoxItemAssist.SelectedFocusedBackground" Value="{Binding Foreground, RelativeSource={RelativeSource Self}, Converter={x:Static converters:BrushOpacityConverter.Instance}, ConverterParameter=0.18}" />
+    <Setter Property="wpf:ListBoxItemAssist.SelectedUnfocusedBackground" Value="{Binding Foreground, RelativeSource={RelativeSource Self}, Converter={x:Static converters:BrushOpacityConverter.Instance}, ConverterParameter=0.09}" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListBoxItem}">
@@ -318,7 +310,7 @@
                           Content="{TemplateBinding Content}"
                           ContentTemplate="{TemplateBinding ContentTemplate}"
                           ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                          Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                          Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                           Focusable="False"
                           RecognizesAccessKey="False"
                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
@@ -483,7 +475,7 @@
             </VisualStateManager.VisualStateGroups>
             <Grid>
               <Grid.Clip>
-                <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                   <Binding ElementName="border" Path="ActualWidth" />
                   <Binding ElementName="border" Path="ActualHeight" />
                   <Binding ElementName="border" Path="CornerRadius" />
@@ -491,7 +483,7 @@
                 </MultiBinding>
               </Grid.Clip>
               <Border x:Name="MouseOverBorder"
-                      Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                      Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                       Opacity="0" />
 
               <Border x:Name="SelectedBorder"
@@ -505,7 +497,7 @@
                           Content="{TemplateBinding Content}"
                           ContentTemplate="{TemplateBinding ContentTemplate}"
                           ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                          Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                          Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                           Focusable="False"
                           RecognizesAccessKey="False"
                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
@@ -541,7 +533,7 @@
     <Style.Triggers>
       <MultiDataTrigger>
         <MultiDataTrigger.Conditions>
-          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={StaticResource IsDarkConverter}}" Value="True" />
+          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={x:Static converters:IsDarkConverter.Instance}}" Value="True" />
           <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
         </MultiDataTrigger.Conditions>
         <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Primary.Light}" />
@@ -562,7 +554,7 @@
     <Style.Triggers>
       <MultiDataTrigger>
         <MultiDataTrigger.Conditions>
-          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={StaticResource IsDarkConverter}}" Value="True" />
+          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={x:Static converters:IsDarkConverter.Instance}}" Value="True" />
           <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
         </MultiDataTrigger.Conditions>
         <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Secondary.Light}" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml
@@ -14,9 +14,6 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ScrollViewer}">
-          <ControlTemplate.Resources>
-            <converters:HorizontalThicknessConverter x:Key="HorizontalThicknessConverter" />
-          </ControlTemplate.Resources>
           <Grid Background="{TemplateBinding Background}">
             <Grid.ColumnDefinitions>
               <ColumnDefinition Width="*" />
@@ -47,8 +44,9 @@
                                                 Columns="{Binding Path=TemplatedParent.View.Columns, RelativeSource={RelativeSource TemplatedParent}}"
                                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     <!-- NB: Rectangle added to keep the width of the header ScrollViewer the same size as the list items -->
-                    <Rectangle Margin="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ListViewAssist.ListViewItemPadding), Converter={StaticResource HorizontalThicknessConverter}}" />
+                    <Rectangle Margin="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ListViewAssist.ListViewItemPadding), Converter={x:Static converters:HorizontalThicknessConverter.Instance}}" />
                   </StackPanel>
+                  
                 </Border>
 
               </ScrollViewer>
@@ -195,38 +193,40 @@
     </Style.Triggers>
   </Style>
 
-  <converters:ListViewGridViewConverter x:Key="MaterialDesignListViewItemContainerStyleConverter"
-                                        DefaultValue="{StaticResource MaterialDesignListBoxItem}"
-                                        ViewValue="{StaticResource MaterialDesignGridViewItem}" />
 
-  <converters:ListViewGridViewConverter x:Key="MaterialDesignListViewTemplateConverter">
-    <converters:ListViewGridViewConverter.DefaultValue>
-      <ControlTemplate TargetType="{x:Type ListView}">
-        <ScrollViewer>
-          <ItemsPresenter />
-        </ScrollViewer>
-        <ControlTemplate.Triggers>
-          <Trigger Property="IsGrouping" Value="True">
-            <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
-          </Trigger>
-        </ControlTemplate.Triggers>
-      </ControlTemplate>
-    </converters:ListViewGridViewConverter.DefaultValue>
-    <converters:ListViewGridViewConverter.ViewValue>
-      <ControlTemplate TargetType="{x:Type ListView}">
-        <ScrollViewer Style="{DynamicResource {x:Static GridView.GridViewScrollViewerStyleKey}}">
-          <ItemsPresenter />
-        </ScrollViewer>
-        <ControlTemplate.Triggers>
-          <Trigger Property="IsGrouping" Value="True">
-            <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
-          </Trigger>
-        </ControlTemplate.Triggers>
-      </ControlTemplate>
-    </converters:ListViewGridViewConverter.ViewValue>
-  </converters:ListViewGridViewConverter>
 
   <Style x:Key="MaterialDesignListView" TargetType="{x:Type ListView}">
+    <Style.Resources>
+      <converters:ListViewGridViewConverter x:Key="MaterialDesignListViewItemContainerStyleConverter"
+                                        DefaultValue="{StaticResource MaterialDesignListBoxItem}"
+                                        ViewValue="{StaticResource MaterialDesignGridViewItem}" />
+      <converters:ListViewGridViewConverter x:Key="MaterialDesignListViewTemplateConverter">
+        <converters:ListViewGridViewConverter.DefaultValue>
+          <ControlTemplate TargetType="{x:Type ListView}">
+            <ScrollViewer>
+              <ItemsPresenter />
+            </ScrollViewer>
+            <ControlTemplate.Triggers>
+              <Trigger Property="IsGrouping" Value="True">
+                <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
+              </Trigger>
+            </ControlTemplate.Triggers>
+          </ControlTemplate>
+        </converters:ListViewGridViewConverter.DefaultValue>
+        <converters:ListViewGridViewConverter.ViewValue>
+          <ControlTemplate TargetType="{x:Type ListView}">
+            <ScrollViewer Style="{DynamicResource {x:Static GridView.GridViewScrollViewerStyleKey}}">
+              <ItemsPresenter />
+            </ScrollViewer>
+            <ControlTemplate.Triggers>
+              <Trigger Property="IsGrouping" Value="True">
+                <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
+              </Trigger>
+            </ControlTemplate.Triggers>
+          </ControlTemplate>
+        </converters:ListViewGridViewConverter.ViewValue>
+      </converters:ListViewGridViewConverter>
+    </Style.Resources>
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
     <Setter Property="BorderThickness" Value="0" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
@@ -6,12 +6,6 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Font.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
-  <converters:TextFieldHintVisibilityConverter x:Key="StringIsEmptyVisibilityConverter"
-                                               IsEmptyValue="Collapsed"
-                                               IsNotEmptyValue="Visible" />
-  <converters:BrushRoundConverter x:Key="BrushRoundConverter" />
-  <converters:BrushOpacityConverter x:Key="BrushOpacityConverter" />
-
   <ContextMenu x:Key="MaterialDesignDefaultContextMenu" FontFamily="{Binding PlacementTarget.FontFamily, RelativeSource={RelativeSource Self}}">
     <MenuItem Command="Cut">
       <MenuItem.Icon>
@@ -60,7 +54,7 @@
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Padding" Value="24,0,24,0" />
-    <Setter Property="wpf:MenuItemAssist.HighlightedBackground" Value="{Binding Foreground, RelativeSource={RelativeSource Self}, Converter={StaticResource BrushOpacityConverter}, ConverterParameter=0.13}" />
+    <Setter Property="wpf:MenuItemAssist.HighlightedBackground" Value="{Binding Foreground, RelativeSource={RelativeSource Self}, Converter={x:Static converters:BrushOpacityConverter.Instance}, ConverterParameter=0.13}" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type MenuItem}">
@@ -85,7 +79,7 @@
             <wpf:Ripple HorizontalContentAlignment="Stretch"
                         VerticalContentAlignment="Stretch"
                         Background="Transparent"
-                        Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                        Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                         Focusable="False">
               <Grid Height="{TemplateBinding Height}" Background="Transparent">
                 <Grid Margin="{TemplateBinding Padding}"
@@ -156,7 +150,7 @@
                                Foreground="{TemplateBinding Foreground}"
                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                Text="{TemplateBinding InputGestureText}"
-                               Visibility="{TemplateBinding InputGestureText, Converter={StaticResource StringIsEmptyVisibilityConverter}}" />
+                               Visibility="{TemplateBinding InputGestureText, Converter={x:Static converters:TextFieldHintVisibilityConverter.StringIsEmptyInstance}}" />
                   </Grid>
                   <Grid x:Name="SubBlock"
                         Grid.Column="2"

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.NumericUpDown.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.NumericUpDown.xaml
@@ -54,7 +54,6 @@
                                                 FixedLeft="0" />
             <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderInactiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderInactiveThickness}" />
             <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderActiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderActiveThickness}" />
-            <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
           </ControlTemplate.Resources>
           <Grid>
             <TextBox x:Name="PART_TextBox"
@@ -127,7 +126,7 @@
               <Setter TargetName="PART_DecreaseButton" Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
             </MultiTrigger>
             <Trigger Property="IsEnabled" Value="False">
-              <Setter TargetName="PART_DecreaseButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+              <Setter TargetName="PART_DecreaseButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={x:Static converters:MathConverter.MultiplyInstance}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
             </Trigger>
 
             <MultiTrigger>
@@ -138,7 +137,7 @@
               <Setter TargetName="PART_IncreaseButton" Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
             </MultiTrigger>
             <Trigger Property="IsEnabled" Value="False">
-              <Setter TargetName="PART_IncreaseButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+              <Setter TargetName="PART_IncreaseButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={x:Static converters:MathConverter.MultiplyInstance}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
             </Trigger>
 
             <!-- Validation.HasError -->

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -16,21 +16,12 @@
     <Style.Resources>
       <system:Boolean x:Key="TrueValue">True</system:Boolean>
       <system:Int32 x:Key="One">1</system:Int32>
-      <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-      <converters:CursorConverter x:Key="ArrowCursorConverter" FallbackCursor="Arrow" />
-      <converters:CursorConverter x:Key="IBeamCursorConverter" FallbackCursor="IBeam" />
-      <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
-      <converters:StringLengthValueConverter x:Key="StringLengthValueConverter" />
       <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearButtonVisibilityConverter" ContentEmptyVisibility="Collapsed" />
       <converters:TextFieldPrefixTextVisibilityConverter x:Key="PrefixSuffixTextVisibilityConverter" HiddenState="Collapsed" />
       <converters:BooleanToDashStyleConverter x:Key="BooleanToDashStyleConverter" TrueValue="{x:Static DashStyles.Solid}" />
       <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left,Right" />
       <converters:MathConverter x:Key="DivisionConverter"  Operation="Divide" Offset="1.5" />
-      <converters:FloatingHintInitialVerticalOffsetConverter x:Key="FloatingHintInitialVerticalOffsetConverter" />
-      <converters:FloatingHintInitialHorizontalOffsetConverter x:Key="FloatingHintInitialHorizontalOffsetConverter" />
-      <converters:FloatingHintMarginConverter x:Key="FloatingHintMarginConverter" />
       <converters:ThicknessCloneConverter x:Key="ThicknessCloneConverter" CloneEdges="All" AdditionalOffsetBottom="-1" />
-      <converters:OutlinedStyleActiveBorderMarginCompensationConverter x:Key="OutlinedStyleActiveBorderMarginCompensationConverter" />
 
       <Style x:Key="MaterialDesignPasswordCharacterCounterTextBlock"
              TargetType="TextBlock"
@@ -78,7 +69,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type PasswordBox}">
-          <Grid Cursor="{TemplateBinding Cursor, Converter={StaticResource ArrowCursorConverter}}">
+          <Grid Cursor="{TemplateBinding Cursor, Converter={x:Static converters:CursorConverter.ArrowInstance}}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="FocusStates">
                 <VisualState x:Name="Focused">
@@ -126,7 +117,7 @@
                     Background="{DynamicResource MaterialDesign.Brush.PasswordBox.HoverBackground}"
                     CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                     RenderTransformOrigin="0.5,0.5"
-                    Visibility="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Visibility="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
               <Border.RenderTransform>
                 <ScaleTransform x:Name="RippleOnFocusScaleTransform" ScaleX="0" ScaleY="0" />
               </Border.RenderTransform>
@@ -162,7 +153,7 @@
                                 VerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
                                 Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}" />
 
                   <TextBlock x:Name="PrefixTextBlock"
                              Grid.Column="1"
@@ -190,7 +181,7 @@
                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Panel.ZIndex="1"
                                 wpf:ScrollViewerAssist.IgnorePadding="True"
-                                Cursor="{TemplateBinding Cursor, Converter={StaticResource IBeamCursorConverter}}"
+                                Cursor="{TemplateBinding Cursor, Converter={x:Static converters:CursorConverter.IBeamInstance}}"
                                 Focusable="False"
                                 HorizontalScrollBarVisibility="Hidden"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
@@ -215,7 +206,7 @@
                                  wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
                                  wpf:HintAssist.HintPaddingBrush="{TemplateBinding wpf:HintAssist.HintPaddingBrush}">
                     <wpf:SmartHint.InitialHorizontalOffset>
-                      <MultiBinding Converter="{StaticResource FloatingHintInitialHorizontalOffsetConverter}">
+                      <MultiBinding Converter="{x:Static converters:FloatingHintInitialHorizontalOffsetConverter.Instance}">
                         <Binding ElementName="PrefixTextBlock" Path="ActualWidth" />
                         <Binding ElementName="PrefixTextBlock" Path="Margin" />
                         <Binding ElementName="SuffixTextBlock" Path="ActualWidth" />
@@ -228,7 +219,7 @@
                       </MultiBinding>
                     </wpf:SmartHint.InitialHorizontalOffset>
                     <wpf:SmartHint.Margin>
-                      <MultiBinding Converter="{StaticResource FloatingHintMarginConverter}">
+                      <MultiBinding Converter="{x:Static converters:FloatingHintMarginConverter.Instance}">
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.IsFloating)" />
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="IsKeyboardFocusWithin" />
                         <Binding Source="{StaticResource TrueValue}" />
@@ -275,7 +266,7 @@
                                 VerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
                                 Kind="{TemplateBinding wpf:TextFieldAssist.TrailingIcon}"
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}" />
 
                   <Button x:Name="PART_ClearButton"
                           Foreground="{TemplateBinding Foreground}"
@@ -390,7 +381,7 @@
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.PasswordBox.OutlineInactiveBorder}" />
               <Setter TargetName="PART_ContentHost" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
               <Setter TargetName="HintWrapper" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={x:Static converters:MathConverter.MultiplyInstance}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
               <Setter TargetName="LeadingPackIcon" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
               <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
               <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
@@ -413,7 +404,7 @@
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="ContentGrid" Property="Margin">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+                  <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
                     <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
@@ -458,7 +449,7 @@
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="ContentGrid" Property="Margin">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+                  <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
                     <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
@@ -483,7 +474,7 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="Hint" Property="InitialVerticalOffset">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource FloatingHintInitialVerticalOffsetConverter}">
+                  <MultiBinding Converter="{x:Static converters:FloatingHintInitialVerticalOffsetConverter.Instance}">
                     <Binding ElementName="PART_ContentHost" Path="ActualHeight" />
                     <Binding ElementName="Hint" Path="ActualHeight" />
                     <Binding Source="{StaticResource One}" />
@@ -514,7 +505,7 @@
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="ContentGrid" Property="Margin">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+                  <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
                     <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
@@ -576,24 +567,12 @@
     <Style.Resources>
       <system:Boolean x:Key="TrueValue">True</system:Boolean>
       <system:Int32 x:Key="One">1</system:Int32>
-      <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-      <converters:BooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter"
-                                               FalseValue="Visible"
-                                               TrueValue="Hidden" />
-      <converters:CursorConverter x:Key="ArrowCursorConverter" FallbackCursor="Arrow" />
-      <converters:CursorConverter x:Key="IBeamCursorConverter" FallbackCursor="IBeam" />
-      <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
-      <converters:StringLengthValueConverter x:Key="StringLengthValueConverter" />
       <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearButtonVisibilityConverter" ContentEmptyVisibility="Collapsed" />
       <converters:TextFieldPrefixTextVisibilityConverter x:Key="PrefixSuffixTextVisibilityConverter" HiddenState="Collapsed" />
       <converters:BooleanToDashStyleConverter x:Key="BooleanToDashStyleConverter" TrueValue="{x:Static DashStyles.Solid}" />
       <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left,Right" />
       <converters:MathConverter x:Key="DivisionConverter"  Operation="Divide" Offset="1.5" />
-      <converters:FloatingHintInitialVerticalOffsetConverter x:Key="FloatingHintInitialVerticalOffsetConverter" />
-      <converters:FloatingHintInitialHorizontalOffsetConverter x:Key="FloatingHintInitialHorizontalOffsetConverter" />
-      <converters:FloatingHintMarginConverter x:Key="FloatingHintMarginConverter" />
       <converters:ThicknessCloneConverter x:Key="ThicknessCloneConverter" CloneEdges="All" AdditionalOffsetBottom="-1" />
-      <converters:OutlinedStyleActiveBorderMarginCompensationConverter x:Key="OutlinedStyleActiveBorderMarginCompensationConverter" />
 
       <Style x:Key="MaterialDesignPasswordCharacterCounterTextBlock"
              TargetType="TextBlock"
@@ -676,7 +655,7 @@
 
             </Style>
           </ControlTemplate.Resources>
-          <Grid Cursor="{TemplateBinding Cursor, Converter={StaticResource ArrowCursorConverter}}">
+          <Grid Cursor="{TemplateBinding Cursor, Converter={x:Static converters:CursorConverter.ArrowInstance}}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="FocusStates">
                 <VisualState x:Name="Focused">
@@ -724,7 +703,7 @@
                     Background="{DynamicResource MaterialDesign.Brush.PasswordBox.HoverBackground}"
                     CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                     RenderTransformOrigin="0.5,0.5"
-                    Visibility="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Visibility="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
               <Border.RenderTransform>
                 <ScaleTransform x:Name="RippleOnFocusScaleTransform" ScaleX="0" ScaleY="0" />
               </Border.RenderTransform>
@@ -761,7 +740,7 @@
                                 VerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
                                 Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}" />
 
                   <TextBlock x:Name="PrefixTextBlock"
                              Grid.Column="1"
@@ -794,13 +773,13 @@
                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                   Panel.ZIndex="1"
                                   wpf:ScrollViewerAssist.IgnorePadding="True"
-                                  Cursor="{TemplateBinding Cursor, Converter={StaticResource IBeamCursorConverter}}"
+                                  Cursor="{TemplateBinding Cursor, Converter={x:Static converters:CursorConverter.IBeamInstance}}"
                                   Focusable="False"
                                   HorizontalScrollBarVisibility="Hidden"
                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                   UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
                                   VerticalScrollBarVisibility="Hidden"
-                                  Visibility="{Binding ElementName=PasswordContentGrid, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed), Converter={StaticResource InverseBooleanToVisibilityConverter}}"
+                                  Visibility="{Binding ElementName=PasswordContentGrid, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed), Converter={x:Static converters:BooleanToVisibilityConverter.InverseInstance}}"
                                   wpf:ScrollViewerAssist.BubbleVerticalScroll="True"/>
 
                     <TextBox x:Name="RevealPasswordTextBox"
@@ -810,7 +789,7 @@
                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                              CaretBrush="{TemplateBinding CaretBrush}"
-                             Cursor="{TemplateBinding Cursor, Converter={StaticResource IBeamCursorConverter}}"
+                             Cursor="{TemplateBinding Cursor, Converter={x:Static converters:CursorConverter.IBeamInstance}}"
                              Foreground="{TemplateBinding Foreground}"
                              MaxLength="{TemplateBinding MaxLength}"
                              SelectionBrush="{TemplateBinding SelectionBrush}"
@@ -818,7 +797,7 @@
                              Style="{StaticResource MaterialDesignRawTextBox}"
                              Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:PasswordBoxAssist.Password), UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                              UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
-                             Visibility="{Binding ElementName=PasswordContentGrid, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed), Converter={StaticResource BooleanToVisibilityConverter}}">
+                             Visibility="{Binding ElementName=PasswordContentGrid, Path=(wpf:PasswordBoxAssist.IsPasswordRevealed), Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
                       <behaviors:Interaction.Behaviors>
                         <internalbehaviors:PasswordBoxRevealTextBoxBehavior PasswordBox="{Binding RelativeSource={RelativeSource TemplatedParent}}" />
                       </behaviors:Interaction.Behaviors>
@@ -842,7 +821,7 @@
                                  wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
                                  wpf:HintAssist.HintPaddingBrush="{TemplateBinding wpf:HintAssist.HintPaddingBrush}">
                     <wpf:SmartHint.InitialHorizontalOffset>
-                      <MultiBinding Converter="{StaticResource FloatingHintInitialHorizontalOffsetConverter}">
+                      <MultiBinding Converter="{x:Static converters:FloatingHintInitialHorizontalOffsetConverter.Instance}">
                         <Binding ElementName="PrefixTextBlock" Path="ActualWidth" />
                         <Binding ElementName="PrefixTextBlock" Path="Margin" />
                         <Binding ElementName="SuffixTextBlock" Path="ActualWidth" />
@@ -855,7 +834,7 @@
                       </MultiBinding>
                     </wpf:SmartHint.InitialHorizontalOffset>
                     <wpf:SmartHint.Margin>
-                      <MultiBinding Converter="{StaticResource FloatingHintMarginConverter}">
+                      <MultiBinding Converter="{x:Static converters:FloatingHintMarginConverter.Instance}">
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.IsFloating)" />
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="IsKeyboardFocusWithin" />
                         <Binding Source="{StaticResource TrueValue}" />
@@ -915,7 +894,7 @@
                                 VerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
                                 Kind="{TemplateBinding wpf:TextFieldAssist.TrailingIcon}"
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}" />
 
                   <Button x:Name="PART_ClearButton"
                           Grid.Column="6"
@@ -1030,7 +1009,7 @@
               <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.PasswordBox.OutlineInactiveBorder}" />
               <Setter TargetName="PART_ContentHost" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
               <Setter TargetName="HintWrapper" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={x:Static converters:MathConverter.MultiplyInstance}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
               <Setter TargetName="LeadingPackIcon" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
               <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
               <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
@@ -1055,7 +1034,7 @@
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="ContentGrid" Property="Margin">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+                  <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
                     <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
@@ -1100,7 +1079,7 @@
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="ContentGrid" Property="Margin">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+                  <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
                     <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
@@ -1125,7 +1104,7 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="Hint" Property="InitialVerticalOffset">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource FloatingHintInitialVerticalOffsetConverter}">
+                  <MultiBinding Converter="{x:Static converters:FloatingHintInitialVerticalOffsetConverter.Instance}">
                     <Binding ElementName="PART_ContentHost" Path="ActualHeight" />
                     <Binding ElementName="Hint" Path="ActualHeight" />
                     <Binding Source="{StaticResource One}" />
@@ -1156,7 +1135,7 @@
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="ContentGrid" Property="Margin">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+                  <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
                     <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -45,7 +45,7 @@
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
             <Border x:Name="MouseOverBorder"
-                    Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                    Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                     Opacity="0" />
             <wpf:Ripple MinHeight="48"
                         Padding="{TemplateBinding Padding}"
@@ -54,7 +54,7 @@
                         Content="{TemplateBinding Content}"
                         ContentTemplate="{TemplateBinding ContentTemplate}"
                         ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                        Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                        Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                         Focusable="False"
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
           </Grid>
@@ -63,14 +63,6 @@
     </Setter>
     <Setter Property="VerticalContentAlignment" Value="Bottom" />
   </Style>
-
-  <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-  <converters:NullableToVisibilityConverter x:Key="NullVisibilityConverter" />
-  <converters:NullableToVisibilityConverter x:Key="InvertedNullVisibilityConverter"
-                                            NotNullValue="Collapsed"
-                                            NullValue="Visible" />
-  <converters:BrushRoundConverter x:Key="BrushRoundConverter" />
-  <converters:NotConverter x:Key="NotConverter" />
 
   <wpf:PackIcon x:Key="MaterialDesignPopupBoxToggleContent"
                 Width="24"
@@ -81,9 +73,6 @@
                 Kind="DotsVertical" />
 
   <Style x:Key="MaterialDesignPopupBox" TargetType="{x:Type wpf:PopupBox}">
-    <Style.Resources>
-      <converters:FirstNonNullConverter x:Key="FirstNonNullConverter" />
-    </Style.Resources>
     <Setter Property="Focusable" Value="True" />
     <Setter Property="HorizontalAlignment" Value="Left" />
     <Setter Property="Padding" Value="0,8,0,8" />
@@ -95,9 +84,9 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type wpf:PopupBox}">
           <ControlTemplate.Resources>
-            <wpf:ElevationMarginConverter x:Key="ElevationMarginConverter" />
-            <wpf:ElevationRadiusConverter x:Key="ElevationRadiusConverter" Multiplier="-1" />
-            <wpf:ElevationRadiusConverter x:Key="RtlElevationRadiusConverter" Multiplier="1" />
+            <converters:ElevationMarginConverter x:Key="ElevationMarginConverter" />
+            <converters:ElevationRadiusConverter x:Key="ElevationRadiusConverter" Multiplier="-1" />
+            <converters:ElevationRadiusConverter x:Key="RtlElevationRadiusConverter" Multiplier="1" />
 
             <Style TargetType="Separator" BasedOn="{StaticResource MaterialDesignSeparator}" />
             <Style x:Key="ToggleButtonStyle" TargetType="ToggleButton">
@@ -140,7 +129,7 @@
                          PopupAnimation="Fade"
                          VerticalOffset="{TemplateBinding PopupElevation, Converter={StaticResource ElevationRadiusConverter}}">
               <wpf:PopupEx.PlacementTarget>
-                <MultiBinding Converter="{StaticResource FirstNonNullConverter}">
+                <MultiBinding Converter="{x:Static converters:FirstNonNullConverter.Instance}">
                   <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="PlacementTarget" />
                   <Binding ElementName="PART_Toggle" />
                 </MultiBinding>
@@ -172,7 +161,7 @@
     </Setter>
     <Setter Property="TextElement.FontWeight" Value="Normal" />
     <Setter Property="ToggleContent" Value="{StaticResource MaterialDesignPopupBoxToggleContent}" />
-    <Setter Property="ToolTipService.IsEnabled" Value="{Binding IsPopupOpen, RelativeSource={RelativeSource Self}, Converter={StaticResource NotConverter}}" />
+    <Setter Property="ToolTipService.IsEnabled" Value="{Binding IsPopupOpen, RelativeSource={RelativeSource Self}, Converter={x:Static converters:NotConverter.Instance}}" />
     <Setter Property="wpf:RippleAssist.ClipToBounds" Value="False" />
     <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesign.Brush.Button.Ripple}" />
     <Setter Property="wpf:RippleAssist.IsCentered" Value="True" />
@@ -199,9 +188,6 @@
                 Kind="Plus" />
 
   <Style x:Key="MaterialDesignMultiFloatingActionPopupBox" TargetType="{x:Type wpf:PopupBox}">
-    <Style.Resources>
-      <converters:FirstNonNullConverter x:Key="FirstNonNullConverter" />
-    </Style.Resources>
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
     <Setter Property="BorderThickness" Value="1" />
@@ -390,20 +376,20 @@
                                 ContentTemplate="{TemplateBinding ToggleContentTemplate}"
                                 ContentTemplateSelector="{TemplateBinding ToggleContentTemplateSelector}"
                                 Focusable="False"
-                                Visibility="{TemplateBinding ToggleCheckedContent, Converter={StaticResource InvertedNullVisibilityConverter}}" />
+                                Visibility="{TemplateBinding ToggleCheckedContent, Converter={x:Static converters:NullableToVisibilityConverter.InverseInstance}}" />
                 <ContentControl x:Name="ExplicitToggleContent"
                                 Content="{TemplateBinding ToggleContent}"
                                 ContentTemplate="{TemplateBinding ToggleContentTemplate}"
                                 ContentTemplateSelector="{TemplateBinding ToggleContentTemplateSelector}"
                                 Focusable="False"
-                                Visibility="{TemplateBinding ToggleCheckedContent, Converter={StaticResource NullVisibilityConverter}}" />
+                                Visibility="{TemplateBinding ToggleCheckedContent, Converter={x:Static converters:NullableToVisibilityConverter.Instance}}" />
                 <ContentControl x:Name="ExplicitToggleCheckedContent"
                                 Content="{TemplateBinding ToggleCheckedContent}"
                                 ContentTemplate="{TemplateBinding ToggleCheckedContentTemplate}"
                                 Focusable="False"
                                 Opacity="0"
                                 RenderTransformOrigin=".5,.5"
-                                Visibility="{TemplateBinding ToggleCheckedContent, Converter={StaticResource NullVisibilityConverter}}">
+                                Visibility="{TemplateBinding ToggleCheckedContent, Converter={x:Static converters:NullableToVisibilityConverter.Instance}}">
                   <ContentControl.RenderTransform>
                     <RotateTransform Angle="-45" />
                   </ContentControl.RenderTransform>
@@ -417,7 +403,7 @@
                          Placement="Custom"
                          PopupAnimation="None">
               <wpf:PopupEx.PlacementTarget>
-                <MultiBinding Converter="{StaticResource FirstNonNullConverter}">
+                <MultiBinding Converter="{x:Static converters:FirstNonNullConverter.Instance}">
                   <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="PlacementTarget" />
                   <Binding ElementName="PART_Toggle" />
                 </MultiBinding>
@@ -434,7 +420,7 @@
                                 Content="{TemplateBinding PopupContent}"
                                 ContentTemplate="{TemplateBinding PopupContentTemplate}"
                                 Opacity="0"
-                                Visibility="{TemplateBinding IsEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                Visibility="{TemplateBinding IsEnabled, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
                   <ContentControl.Resources>
                     <ResourceDictionary>
                       <Style TargetType="{x:Type ToolTip}" BasedOn="{StaticResource MaterialDesignToolTip}">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:circularProgressBar="clr-namespace:MaterialDesignThemes.Wpf.Converters.CircularProgressBar"
+                    xmlns:circularProgressBarConverters="clr-namespace:MaterialDesignThemes.Wpf.Converters.CircularProgressBar"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:transitions="clr-namespace:MaterialDesignThemes.Wpf.Transitions"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
@@ -133,12 +133,6 @@
     </Setter>
   </Style>
 
-  <circularProgressBar:StartPointConverter x:Key="StartPointConverter" />
-  <circularProgressBar:ArcSizeConverter x:Key="ArcSizeConverter" />
-  <circularProgressBar:ArcEndPointConverter x:Key="ArcEndPointConverter" />
-  <circularProgressBar:RotateTransformCentreConverter x:Key="RotateTransformCentreConverter" />
-  <converters:NotZeroConverter x:Key="NotZeroConverter" />
-
   <Style x:Key="MaterialDesignCircularProgressBar" TargetType="{x:Type ProgressBar}">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
@@ -190,10 +184,10 @@
                     StrokeThickness="3">
                 <Path.Data>
                   <PathGeometry>
-                    <PathFigure StartPoint="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource StartPointConverter}, Mode=OneWay}">
-                      <ArcSegment Size="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource ArcSizeConverter}, Mode=OneWay}" SweepDirection="Clockwise">
+                    <PathFigure StartPoint="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:StartPointConverter.Instance}, Mode=OneWay}">
+                      <ArcSegment Size="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:ArcSizeConverter.Instance}, Mode=OneWay}" SweepDirection="Clockwise">
                         <ArcSegment.Point>
-                          <MultiBinding Converter="{StaticResource ArcEndPointConverter}" ConverterParameter="{x:Static circularProgressBar:ArcEndPointConverter.ParameterMidPoint}">
+                          <MultiBinding Converter="{x:Static circularProgressBarConverters:ArcEndPointConverter.Instance}" ConverterParameter="{x:Static circularProgressBarConverters:ArcEndPointConverter.ParameterMidPoint}">
                             <Binding ElementName="PathGrid" Path="ActualWidth" />
                             <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                             <Binding Path="Minimum" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -202,9 +196,9 @@
                           </MultiBinding>
                         </ArcSegment.Point>
                       </ArcSegment>
-                      <ArcSegment Size="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource ArcSizeConverter}, Mode=OneWay}" SweepDirection="Clockwise">
+                      <ArcSegment Size="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:ArcSizeConverter.Instance}, Mode=OneWay}" SweepDirection="Clockwise">
                         <ArcSegment.Point>
-                          <MultiBinding Converter="{StaticResource ArcEndPointConverter}">
+                          <MultiBinding Converter="{x:Static circularProgressBarConverters:ArcEndPointConverter.Instance}">
                             <Binding ElementName="PathGrid" Path="ActualWidth" />
                             <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                             <Binding Path="Minimum" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -218,7 +212,7 @@
                 </Path.Data>
                 <Path.RenderTransform>
                   <TransformGroup>
-                    <RotateTransform x:Name="RotateTransform" CenterX="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource RotateTransformCentreConverter}, Mode=OneWay}" CenterY="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource RotateTransformCentreConverter}, Mode=OneWay}" />
+                    <RotateTransform x:Name="RotateTransform" CenterX="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:RotateTransformCentreConverter.Instance}, Mode=OneWay}" CenterY="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:RotateTransformCentreConverter.Instance}, Mode=OneWay}" />
                   </TransformGroup>
                 </Path.RenderTransform>
               </Path>
@@ -229,7 +223,7 @@
               <MultiDataTrigger.Conditions>
                 <Condition Binding="{Binding IsIndeterminate, RelativeSource={RelativeSource Self}}" Value="True" />
                 <Condition Binding="{Binding IsVisible, RelativeSource={RelativeSource Self}}" Value="True" />
-                <Condition Binding="{Binding Value, RelativeSource={RelativeSource Self}, Converter={StaticResource NotZeroConverter}}" Value="True" />
+                <Condition Binding="{Binding Value, RelativeSource={RelativeSource Self}, Converter={x:Static converters:NotZeroConverter.Instance}}" Value="True" />
               </MultiDataTrigger.Conditions>
               <MultiDataTrigger.EnterActions>
                 <BeginStoryboard Name="IsIndeterminateStoryboard" Storyboard="{StaticResource IsIndeterminateStoryboard}" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
@@ -4,10 +4,7 @@
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml" />
-    <ResourceDictionary>
-      <converters:BrushRoundConverter x:Key="BrushRoundConverter" />
-      <converters:IsDarkConverter x:Key="IsDarkConverter" />
-    </ResourceDictionary>
+
   </ResourceDictionary.MergedDictionaries>
 
   <Style x:Key="OptionMarkFocusVisual">
@@ -300,7 +297,7 @@
                          Minimum="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Minimum)}"
                          Opacity="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Opacity)}"
                          Style="{DynamicResource MaterialDesignLinearProgressBar}"
-                         Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IsIndicatorVisible), Converter={StaticResource BooleanToVisibilityConverter}}"
+                         Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.IsIndicatorVisible), Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}"
                          Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Value)}" />
             <Border Margin="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
               <wpf:Ripple x:Name="contentPresenter"
@@ -454,7 +451,7 @@
             </VisualStateManager.VisualStateGroups>
             <Grid>
               <Border x:Name="MouseOverBorder"
-                      Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                      Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                       Opacity="0" />
               <Border x:Name="CheckedBackgroundBorder"
                       Background="{DynamicResource MaterialDesign.Brush.RadioButton.Checked}"
@@ -466,7 +463,7 @@
                           Content="{TemplateBinding Content}"
                           ContentTemplate="{TemplateBinding ContentTemplate}"
                           ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                          Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                          Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                           Focusable="False"
                           Opacity=".56"
                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
@@ -474,7 +471,7 @@
                       BorderBrush="{DynamicResource MaterialDesign.Brush.RadioButton.Checked}"
                       BorderThickness="0"
                       Opacity="0"
-                      Visibility="{TemplateBinding IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                      Visibility="{TemplateBinding IsChecked, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}" />
             </Grid>
           </Border>
           <ControlTemplate.Triggers>
@@ -597,7 +594,7 @@
             <Border x:Name="MouseOverBorder"
                     Grid.Column="0"
                     Grid.ColumnSpan="2"
-                    Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                    Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                     CornerRadius="16"
                     Opacity="0" />
             <Border x:Name="SelectedBackgroundBorder"
@@ -754,7 +751,7 @@
             <Border x:Name="MouseOverBorder"
                     Grid.Column="0"
                     Grid.ColumnSpan="2"
-                    Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                    Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"
                     CornerRadius="16"
@@ -802,7 +799,7 @@
     <Style.Triggers>
       <MultiDataTrigger>
         <MultiDataTrigger.Conditions>
-          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={StaticResource IsDarkConverter}}" Value="True" />
+          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={x:Static converters:IsDarkConverter.Instance}}" Value="True" />
           <Condition Binding="{Binding IsChecked, RelativeSource={RelativeSource Self}}" Value="True" />
         </MultiDataTrigger.Conditions>
         <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Primary.Dark}" />
@@ -821,7 +818,7 @@
     <Style.Triggers>
       <MultiDataTrigger>
         <MultiDataTrigger.Conditions>
-          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={StaticResource IsDarkConverter}}" Value="True" />
+          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={x:Static converters:IsDarkConverter.Instance}}" Value="True" />
           <Condition Binding="{Binding IsChecked, RelativeSource={RelativeSource Self}}" Value="True" />
         </MultiDataTrigger.Conditions>
         <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Secondary.Dark}" />
@@ -841,7 +838,7 @@
     <Style.Triggers>
       <MultiDataTrigger>
         <MultiDataTrigger.Conditions>
-          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={StaticResource IsDarkConverter}}" Value="True" />
+          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={x:Static converters:IsDarkConverter.Instance}}" Value="True" />
           <Condition Binding="{Binding IsChecked, RelativeSource={RelativeSource Self}}" Value="True" />
         </MultiDataTrigger.Conditions>
         <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Primary.Dark}" />
@@ -861,7 +858,7 @@
     <Style.Triggers>
       <MultiDataTrigger>
         <MultiDataTrigger.Conditions>
-          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={StaticResource IsDarkConverter}}" Value="True" />
+          <Condition Binding="{Binding Path=(wpf:ThemeAssist.TriggerBrush), RelativeSource={RelativeSource Self}, Converter={x:Static converters:IsDarkConverter.Instance}}" Value="True" />
           <Condition Binding="{Binding IsChecked, RelativeSource={RelativeSource Self}}" Value="True" />
         </MultiDataTrigger.Conditions>
         <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Secondary.Dark}" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
@@ -7,11 +7,6 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
-  <converters:SliderValueLabelPositionConverter x:Key="SliderValueLabelPositionConverter" />
-  <converters:BooleanAllConverter x:Key="BooleanAllConverter" />
-  <converters:InvertBooleanConverter x:Key="InvertBooleanConverter" />
-  <converters:SliderToolTipConverter x:Key="SliderToolTipConverter" />
-
   <Style x:Key="MaterialDesignRepeatButton" TargetType="{x:Type RepeatButton}">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Focusable" Value="False" />
@@ -128,9 +123,9 @@
       </Trigger>
       <DataTrigger Value="True">
         <DataTrigger.Binding>
-          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+          <MultiBinding Converter="{x:Static converters:BooleanAllConverter.Instance}">
             <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
-            <Binding Converter="{StaticResource InvertBooleanConverter}"
+            <Binding Converter="{x:Static converters:InvertBooleanConverter.Instance}"
                      Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)"
                      RelativeSource="{RelativeSource FindAncestor,
                                                      AncestorType=RangeBase}" />
@@ -145,7 +140,7 @@
       </DataTrigger>
       <DataTrigger Value="True">
         <DataTrigger.Binding>
-          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+          <MultiBinding Converter="{x:Static converters:BooleanAllConverter.Instance}">
             <Binding Path="IsDragging" RelativeSource="{RelativeSource Self}" />
             <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
           </MultiBinding>
@@ -274,7 +269,7 @@
           <Grid.RenderTransform>
             <TransformGroup>
               <ScaleTransform ScaleX="0" ScaleY="0" />
-              <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={StaticResource SliderValueLabelPositionConverter}, ConverterParameter={x:Static Orientation.Horizontal}}" Y="-40" />
+              <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={x:Static converters:SliderValueLabelPositionConverter.Instance}, ConverterParameter={x:Static Orientation.Horizontal}}" Y="-40" />
             </TransformGroup>
           </Grid.RenderTransform>
           <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
@@ -294,7 +289,7 @@
                      Foreground="{DynamicResource MaterialDesign.Brush.Background}"
                      TextAlignment="Center">
             <TextBlock.Text>
-              <MultiBinding Converter="{StaticResource SliderToolTipConverter}"
+              <MultiBinding Converter="{x:Static converters:SliderToolTipConverter.Instance}"
                             NotifyOnValidationError="True"
                             TargetNullValue=""
                             ValidatesOnDataErrors="True">
@@ -340,9 +335,9 @@
       </Trigger>
       <DataTrigger Value="True">
         <DataTrigger.Binding>
-          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+          <MultiBinding Converter="{x:Static converters:BooleanAllConverter.Instance}">
             <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
-            <Binding Converter="{StaticResource InvertBooleanConverter}"
+            <Binding Converter="{x:Static converters:InvertBooleanConverter.Instance}"
                      Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)"
                      RelativeSource="{RelativeSource FindAncestor,
                                                      AncestorType=RangeBase}" />
@@ -357,7 +352,7 @@
       </DataTrigger>
       <DataTrigger Value="True">
         <DataTrigger.Binding>
-          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+          <MultiBinding Converter="{x:Static converters:BooleanAllConverter.Instance}">
             <Binding Path="IsDragging" RelativeSource="{RelativeSource Self}" />
             <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
           </MultiBinding>
@@ -486,7 +481,7 @@
           <Grid.RenderTransform>
             <TransformGroup>
               <ScaleTransform ScaleX="0" ScaleY="0" />
-              <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={StaticResource SliderValueLabelPositionConverter}, ConverterParameter={x:Static Orientation.Vertical}}" Y="-7" />
+              <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={x:Static converters:SliderValueLabelPositionConverter.Instance}, ConverterParameter={x:Static Orientation.Vertical}}" Y="-7" />
             </TransformGroup>
           </Grid.RenderTransform>
           <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
@@ -506,7 +501,7 @@
                      Foreground="{DynamicResource MaterialDesign.Brush.Background}"
                      TextAlignment="Center">
             <TextBlock.Text>
-              <MultiBinding Converter="{StaticResource SliderToolTipConverter}"
+              <MultiBinding Converter="{x:Static converters:SliderToolTipConverter.Instance}"
                             NotifyOnValidationError="True"
                             TargetNullValue=""
                             ValidatesOnDataErrors="True">
@@ -552,9 +547,9 @@
       </Trigger>
       <DataTrigger Value="True">
         <DataTrigger.Binding>
-          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+          <MultiBinding Converter="{x:Static converters:BooleanAllConverter.Instance}">
             <Binding Path="IsFocused" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
-            <Binding Converter="{StaticResource InvertBooleanConverter}"
+            <Binding Converter="{x:Static converters:InvertBooleanConverter.Instance}"
                      Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)"
                      RelativeSource="{RelativeSource FindAncestor,
                                                      AncestorType=RangeBase}" />
@@ -569,7 +564,7 @@
       </DataTrigger>
       <DataTrigger Value="True">
         <DataTrigger.Binding>
-          <MultiBinding Converter="{StaticResource BooleanAllConverter}">
+          <MultiBinding Converter="{x:Static converters:BooleanAllConverter.Instance}">
             <Binding Path="IsDragging" RelativeSource="{RelativeSource Self}" />
             <Binding Path="(wpf:SliderAssist.OnlyShowFocusVisualWhileDragging)" RelativeSource="{RelativeSource FindAncestor, AncestorType=RangeBase}" />
           </MultiBinding>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -7,18 +7,8 @@
 
   <Style TargetType="{x:Type wpf:SmartHint}">
     <Style.Resources>
-      <converters:BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
-      <converters:BooleanToVisibilityConverter x:Key="InverseBoolToVisConverter"
-                                               FalseValue="Visible"
-                                               TrueValue="Collapsed" />
       <system:Double x:Key="NoContentFloatingScale">1.0</system:Double>
       <CubicEase x:Key="AnimationEasingFunction" EasingMode="EaseInOut" />
-      <converters:FloatingHintTranslateTransformConverter x:Key="FloatingHintTranslateTransformConverter" />
-      <converters:FloatingHintScaleTransformConverter x:Key="FloatingHintScaleTransformConverter" />
-      <converters:FloatingHintContainerMarginConverter x:Key="FloatingHintContainerMarginConverter" />
-      <converters:FloatingHintTextBlockMarginConverter x:Key="FloatingHintTextBlockMarginConverter" />
-      <converters:FloatingHintClippingGridConverter x:Key="FloatingHintClippingGridConverter" />
-      <converters:FirstNonNullConverter x:Key="FirstNonNullConverter" />
     </Style.Resources>
     <Setter Property="wpf:BehaviorsAssist.Behaviors">
       <Setter.Value>
@@ -82,7 +72,7 @@
                             IsHitTestVisible="False"
                             IsTabStop="False"
                             Opacity="{TemplateBinding HintOpacity}"
-                            Visibility="{TemplateBinding UseFloating, Converter={StaticResource InverseBoolToVisConverter}}" />
+                            Visibility="{TemplateBinding UseFloating, Converter={x:Static converters:BooleanToVisibilityConverter.InverseInstance}}" />
           </Grid>
         </ControlTemplate>
       </Setter.Value>
@@ -154,14 +144,14 @@
                 <wpf:ScaleHost x:Name="ScaleHost" />
                 <Grid>
                   <Grid.Clip>
-                    <MultiBinding Converter="{StaticResource FloatingHintClippingGridConverter}">
+                    <MultiBinding Converter="{x:Static converters:FloatingHintClippingGridConverter.Instance}">
                       <Binding Path="ActualWidth" RelativeSource="{RelativeSource TemplatedParent}" />
                       <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
                       <Binding Path="FloatingScale" RelativeSource="{RelativeSource TemplatedParent}" />
                     </MultiBinding>
                   </Grid.Clip>
                   <Grid.RenderTransform>
-                    <MultiBinding Converter="{StaticResource FloatingHintTranslateTransformConverter}">
+                    <MultiBinding Converter="{x:Static converters:FloatingHintTranslateTransformConverter.Instance}">
                       <Binding ElementName="ScaleHost" Path="Scale" />
                       <Binding Path="FloatingScale" RelativeSource="{RelativeSource TemplatedParent}" />
                       <Binding Source="{StaticResource NoContentFloatingScale}" />
@@ -189,10 +179,10 @@
                                     IsTabStop="False"
                                     Opacity="{TemplateBinding HintOpacity}"
                                     RenderTransformOrigin="0,0"
-                                    Visibility="{TemplateBinding UseFloating, Converter={StaticResource BoolToVisConverter}}">
+                                    Visibility="{TemplateBinding UseFloating, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
                       
                       <ContentControl.Margin>
-                        <MultiBinding Converter="{StaticResource FloatingHintTextBlockMarginConverter}">
+                        <MultiBinding Converter="{x:Static converters:FloatingHintTextBlockMarginConverter.Instance}">
                           <Binding Path="(wpf:HintAssist.HintHorizontalAlignment)" RelativeSource="{RelativeSource TemplatedParent}" />
                           <Binding Path="(wpf:HintAssist.FloatingHintHorizontalAlignment)" RelativeSource="{RelativeSource TemplatedParent}" />
                           <Binding Path="HorizontalContentAlignment" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -207,7 +197,7 @@
                         <system:Double>0.0</system:Double>
                       </ContentControl.Tag>
                       <ContentControl.RenderTransform>
-                        <MultiBinding Converter="{StaticResource FloatingHintScaleTransformConverter}">
+                        <MultiBinding Converter="{x:Static converters:FloatingHintScaleTransformConverter.Instance}">
                           <Binding ElementName="ScaleHost" Path="Scale" />
                           <Binding Path="FloatingScale" RelativeSource="{RelativeSource TemplatedParent}" />
                           <Binding Source="{StaticResource NoContentFloatingScale}" />
@@ -216,7 +206,7 @@
                       <Grid x:Name="HintBackgroundGrid" Tag="{DynamicResource MaterialDesign.Brush.Background}" IsHitTestVisible="False">
                         <ContentControl Content="{TemplateBinding Hint}" IsTabStop="False">
                           <ContentControl.Margin>
-                            <MultiBinding Converter="{StaticResource FloatingHintContainerMarginConverter}">
+                            <MultiBinding Converter="{x:Static converters:FloatingHintContainerMarginConverter.Instance}">
                               <Binding ElementName="ScaleHost" Path="Scale" />
                               <Binding Path="FloatingMargin" RelativeSource="{RelativeSource TemplatedParent}" />
                               <Binding Path="FloatingScale" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -236,7 +226,7 @@
                   </MultiTrigger.Conditions>
                   <Setter TargetName="HintBackgroundGrid" Property="Background">
                     <Setter.Value>
-                      <MultiBinding Converter="{StaticResource FirstNonNullConverter}">
+                      <MultiBinding Converter="{x:Static converters:FirstNonNullConverter.Instance}">
                         <Binding Path="(wpf:HintAssist.HintPaddingBrush)" RelativeSource="{RelativeSource TemplatedParent}" />
                         <Binding Path="Tag" ElementName="HintBackgroundGrid" />
                       </MultiBinding>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Snackbar.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Snackbar.xaml
@@ -9,10 +9,6 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBlock.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
-  <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
-  <converters:MathMultipleConverter x:Key="MathMultipleConverter" Operation="Multiply" />
-  <converters:SnackbarActionButtonPlacementModeConverter x:Key="SnackbarActionButtonPlacementModeConverter" />
-
   <Style x:Key="MaterialDesignSnackbarActionButton" TargetType="Button">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="Transparent" />
@@ -93,9 +89,9 @@
                     ContentTemplate="{TemplateBinding ActionContentTemplate}"
                     ContentTemplateSelector="{TemplateBinding ActionContentTemplateSelector}"
                     Style="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type wpf:Snackbar}}, Path=ActionButtonStyle}"
-                    Visibility="{TemplateBinding ActionContent, Converter={StaticResource NullableToVisibilityConverter}}">
+                    Visibility="{TemplateBinding ActionContent, Converter={x:Static converters:NullableToVisibilityConverter.Instance}}">
               <DockPanel.Dock>
-                <MultiBinding Converter="{StaticResource SnackbarActionButtonPlacementModeConverter}">
+                <MultiBinding Converter="{x:Static converters:SnackbarActionButtonPlacementModeConverter.Instance}">
                   <Binding Path="ActionButtonPlacement" RelativeSource="{RelativeSource AncestorType={x:Type wpf:Snackbar}}" />
                   <Binding Path="(wpf:SnackbarMessage.InlineActionButtonMaxHeight)" RelativeSource="{RelativeSource AncestorType={x:Type wpf:Snackbar}}" />
                   <Binding Path="ActualHeight" RelativeSource="{RelativeSource AncestorType={x:Type wpf:Snackbar}}" />
@@ -186,7 +182,7 @@
               <system:Double>0.0</system:Double>
             </StackPanel.Tag>
             <StackPanel.Height>
-              <MultiBinding Converter="{StaticResource MathMultipleConverter}">
+              <MultiBinding Converter="{x:Static converters:MathMultipleConverter.AddInstance}">
                 <Binding ElementName="ContentBorder" Path="ActualHeight" />
                 <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
               </MultiBinding>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -7,9 +7,6 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBlock.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
-  <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-  <converters:BorderClipConverter x:Key="BorderClipConverter" />
-
   <Style x:Key="FocusVisual">
     <Setter Property="Control.Template">
       <Setter.Value>
@@ -519,7 +516,7 @@
                             TextOptions.TextFormattingMode="Ideal"
                             TextOptions.TextRenderingMode="Auto">
                   <wpf:Ripple.Clip>
-                    <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                    <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
                       <Binding ElementName="MouseOverBorder" Path="ActualWidth" />
                       <Binding ElementName="MouseOverBorder" Path="ActualHeight" />
                       <Binding ElementName="MouseOverBorder" Path="CornerRadius" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -21,15 +21,12 @@
   <Style x:Key="MaterialDesignCharacterCounterTextBlock"
          TargetType="TextBlock"
          BasedOn="{StaticResource {x:Type TextBlock}}">
-    <Style.Resources>
-      <converters:StringLengthValueConverter x:Key="StringLengthValueConverter" />
-    </Style.Resources>
     <Setter Property="FontSize" Value="10" />
     <Setter Property="Opacity" Value="0.56" />
     <Setter Property="Text">
       <Setter.Value>
         <MultiBinding StringFormat="{}{0} / {1}">
-          <Binding Converter="{StaticResource StringLengthValueConverter}"
+          <Binding Converter="{x:Static converters:StringLengthValueConverter.Instance}"
                    Path="Text"
                    RelativeSource="{RelativeSource FindAncestor,
                                                  AncestorType=TextBoxBase}" />
@@ -43,21 +40,12 @@
 
   <Style x:Key="MaterialDesignTextBoxBase" TargetType="{x:Type TextBoxBase}">
     <Style.Resources>
-      <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-      <converters:CursorConverter x:Key="ArrowCursorConverter" FallbackCursor="Arrow" />
-      <converters:CursorConverter x:Key="IBeamCursorConverter" FallbackCursor="IBeam" />
-      <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
       <converters:TextFieldClearButtonVisibilityConverter x:Key="ClearButtonVisibilityConverter" ContentEmptyVisibility="Collapsed" />
       <converters:TextFieldPrefixTextVisibilityConverter x:Key="PrefixSuffixTextVisibilityConverter" HiddenState="Collapsed" />
       <converters:BooleanToDashStyleConverter x:Key="BooleanToDashStyleConverter" TrueValue="{x:Static DashStyles.Solid}" />
       <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left,Right" />
       <converters:MathConverter x:Key="DivisionConverter" Operation="Divide" Offset="1.5" />
-      <converters:FloatingHintInitialVerticalOffsetConverter x:Key="FloatingHintInitialVerticalOffsetConverter" />
-      <converters:FloatingHintInitialHorizontalOffsetConverter x:Key="FloatingHintInitialHorizontalOffsetConverter" />
-      <converters:FloatingHintMarginConverter x:Key="FloatingHintMarginConverter" />
       <converters:ThicknessCloneConverter x:Key="ThicknessCloneConverter" CloneEdges="All" AdditionalOffsetBottom="-1" />
-      <converters:InvertBooleanConverter x:Key="InvertBooleanConverter" />
-      <converters:OutlinedStyleActiveBorderMarginCompensationConverter x:Key="OutlinedStyleActiveBorderMarginCompensationConverter" />
     </Style.Resources>
 
     <Setter Property="AllowDrop" Value="true" />
@@ -77,7 +65,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type TextBoxBase}">
-          <Grid Cursor="{TemplateBinding Cursor, Converter={StaticResource ArrowCursorConverter}}">
+          <Grid Cursor="{TemplateBinding Cursor, Converter={x:Static converters:CursorConverter.ArrowInstance}}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="FocusStates">
                 <VisualState x:Name="Focused">
@@ -125,7 +113,7 @@
                     Background="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
                     CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
                     RenderTransformOrigin="0.5,0.5"
-                    Visibility="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Visibility="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}">
               <Border.RenderTransform>
                 <ScaleTransform x:Name="RippleOnFocusScaleTransform" ScaleX="0" ScaleY="0" />
               </Border.RenderTransform>
@@ -161,7 +149,7 @@
                                 VerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
                                 Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}" />
 
                   <TextBlock x:Name="PrefixTextBlock"
                              Grid.Column="1"
@@ -176,7 +164,7 @@
                         <Binding Path="(wpf:TextFieldAssist.PrefixText)" RelativeSource="{RelativeSource TemplatedParent}" />
                         <Binding Path="(wpf:TextFieldAssist.PrefixTextVisibility)" RelativeSource="{RelativeSource TemplatedParent}" />
                         <Binding Path="IsKeyboardFocusWithin" RelativeSource="{RelativeSource TemplatedParent}" />
-                        <Binding Path="IsReadOnly" RelativeSource="{RelativeSource TemplatedParent}" Converter="{StaticResource InvertBooleanConverter}" />
+                        <Binding Path="IsReadOnly" RelativeSource="{RelativeSource TemplatedParent}" Converter="{x:Static converters:InvertBooleanConverter.Instance}" />
                       </MultiBinding>
                     </TextBlock.Visibility>
                   </TextBlock>
@@ -189,7 +177,7 @@
                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Panel.ZIndex="1"
                                 wpf:ScrollViewerAssist.IgnorePadding="True"
-                                Cursor="{TemplateBinding Cursor, Converter={StaticResource IBeamCursorConverter}}"
+                                Cursor="{TemplateBinding Cursor, Converter={x:Static converters:CursorConverter.IBeamInstance}}"
                                 Focusable="False"
                                 HorizontalScrollBarVisibility="Hidden"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
@@ -214,7 +202,7 @@
                                  wpf:HintAssist.Background="{TemplateBinding wpf:HintAssist.Background}"
                                  wpf:HintAssist.HintPaddingBrush="{TemplateBinding wpf:HintAssist.HintPaddingBrush}">
                     <wpf:SmartHint.InitialHorizontalOffset>
-                      <MultiBinding Converter="{StaticResource FloatingHintInitialHorizontalOffsetConverter}">
+                      <MultiBinding Converter="{x:Static converters:FloatingHintInitialHorizontalOffsetConverter.Instance}">
                         <Binding ElementName="PrefixTextBlock" Path="ActualWidth" />
                         <Binding ElementName="PrefixTextBlock" Path="Margin" />
                         <Binding ElementName="SuffixTextBlock" Path="ActualWidth" />
@@ -227,10 +215,10 @@
                       </MultiBinding>
                     </wpf:SmartHint.InitialHorizontalOffset>
                     <wpf:SmartHint.Margin>
-                      <MultiBinding Converter="{StaticResource FloatingHintMarginConverter}">
+                      <MultiBinding Converter="{x:Static converters:FloatingHintMarginConverter.Instance}">
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:HintAssist.IsFloating)" />
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="IsKeyboardFocusWithin" />
-                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="IsReadOnly" Converter="{StaticResource InvertBooleanConverter}" />
+                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="IsReadOnly" Converter="{x:Static converters:InvertBooleanConverter.Instance}" />
                         <Binding ElementName="PrefixTextBlock" Path="ActualWidth" />
                         <Binding ElementName="PrefixTextBlock" Path="Margin" />
                         <Binding ElementName="SuffixTextBlock" Path="ActualWidth" />
@@ -261,7 +249,7 @@
                         <Binding Path="(wpf:TextFieldAssist.SuffixText)" RelativeSource="{RelativeSource TemplatedParent}" />
                         <Binding Path="(wpf:TextFieldAssist.SuffixTextVisibility)" RelativeSource="{RelativeSource TemplatedParent}" />
                         <Binding Path="IsKeyboardFocusWithin" RelativeSource="{RelativeSource TemplatedParent}" />
-                        <Binding Path="IsReadOnly" RelativeSource="{RelativeSource TemplatedParent}" Converter="{StaticResource InvertBooleanConverter}" />
+                        <Binding Path="IsReadOnly" RelativeSource="{RelativeSource TemplatedParent}" Converter="{x:Static converters:InvertBooleanConverter.Instance}" />
                       </MultiBinding>
                     </TextBlock.Visibility>
                   </TextBlock>
@@ -274,7 +262,7 @@
                                 VerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
                                 Kind="{TemplateBinding wpf:TextFieldAssist.TrailingIcon}"
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasTrailingIcon, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}" />
 
                   <Button x:Name="PART_ClearButton"
                           Grid.Column="5"
@@ -414,7 +402,7 @@
               <Setter TargetName="OuterBorder" Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.OutlineInactiveBorder}" />
               <Setter TargetName="PART_ContentHost" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
               <Setter TargetName="HintWrapper" Property="Opacity" Value="{x:Static wpf:Constants.TextBoxNotEnabledOpacity}" />
-              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+              <Setter TargetName="PART_ClearButton" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={x:Static converters:MathConverter.MultiplyInstance}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
               <Setter TargetName="LeadingPackIcon" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
               <Setter TargetName="PrefixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
               <Setter TargetName="SuffixTextBlock" Property="Opacity" Value="{Binding ElementName=PART_ClearButton, Path=Opacity}" />
@@ -438,7 +426,7 @@
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="ContentGrid" Property="Margin">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+                  <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
                     <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
@@ -488,7 +476,7 @@
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="ContentGrid" Property="Margin">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+                  <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
                     <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
@@ -521,7 +509,7 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="Hint" Property="InitialVerticalOffset">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource FloatingHintInitialVerticalOffsetConverter}">
+                  <MultiBinding Converter="{x:Static converters:FloatingHintInitialVerticalOffsetConverter.Instance}">
                     <Binding ElementName="PART_ContentHost" Path="ActualHeight" />
                     <Binding ElementName="Hint" Path="ActualHeight" />
                     <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.TextBoxLineCount)" />
@@ -553,7 +541,7 @@
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="ContentGrid" Property="Margin">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+                  <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
                     <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
@@ -575,7 +563,7 @@
               <Setter TargetName="OuterBorder" Property="BorderThickness" Value="{Binding Path=(wpf:TextFieldAssist.OutlinedBorderActiveThickness), RelativeSource={RelativeSource TemplatedParent}}" />
               <Setter TargetName="ContentGrid" Property="Margin">
                 <Setter.Value>
-                  <MultiBinding Converter="{StaticResource OutlinedStyleActiveBorderMarginCompensationConverter}">
+                  <MultiBinding Converter="{x:Static converters:OutlinedStyleActiveBorderMarginCompensationConverter.Instance}">
                     <Binding Path="BorderThickness" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="(wpf:TextFieldAssist.OutlinedBorderActiveThickness)" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -52,7 +52,6 @@
                                                 FixedLeft="0" />
             <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderInactiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderInactiveThickness}" />
             <converters:NonDefaultThicknessConverter x:Key="OutlinedBorderActiveThicknessConverter" DefaultThickness="{x:Static wpf:Constants.DefaultOutlinedBorderActiveThickness}" />
-            <converters:MathConverter x:Key="MathMultiplyConverter" Operation="Multiply" />
 
             <ControlTemplate x:Key="ClockButtonTemplate" TargetType="{x:Type Button}">
               <wpf:PackIcon VerticalAlignment="Center"
@@ -147,7 +146,7 @@
               <Setter TargetName="PART_Button" Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
             </MultiTrigger>
             <Trigger Property="IsEnabled" Value="False">
-              <Setter TargetName="PART_Button" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={StaticResource MathMultiplyConverter}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
+              <Setter TargetName="PART_Button" Property="Opacity" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:HintAssist.HintOpacity), Converter={x:Static converters:MathConverter.MultiplyInstance}, ConverterParameter={x:Static wpf:Constants.TextBoxNotEnabledOpacity}}" />
             </Trigger>
 
             <!-- Validation.HasError -->

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
@@ -5,10 +5,7 @@
   <ResourceDictionary.MergedDictionaries>
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml" />
   </ResourceDictionary.MergedDictionaries>
-
-  <converters:MathConverter x:Key="DivisionMathConverter" Operation="Divide" />
-  <converters:PointValueConverter x:Key="PointValueConverter" />
-
+  
   <Style x:Key="FocusVisual">
     <Setter Property="Control.Template">
       <Setter.Value>
@@ -139,14 +136,14 @@
                                 ContentTemplate="{TemplateBinding ContentTemplate}"
                                 FlowDirection="LeftToRight" />
               <Grid.Clip>
-                <EllipseGeometry RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Width, Converter={StaticResource DivisionMathConverter}, ConverterParameter=2.0}" RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height, Converter={StaticResource DivisionMathConverter}, ConverterParameter=2.0}">
+                <EllipseGeometry RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Width, Converter={x:Static converters:MathConverter.DivideInstance}, ConverterParameter=2.0}" RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height, Converter={x:Static converters:MathConverter.DivideInstance}, ConverterParameter=2.0}">
                   <EllipseGeometry.Center>
-                    <MultiBinding Converter="{StaticResource PointValueConverter}">
-                      <Binding Converter="{StaticResource DivisionMathConverter}"
+                    <MultiBinding Converter="{x:Static converters:PointValueConverter.Instance}">
+                      <Binding Converter="{x:Static converters:MathConverter.DivideInstance}"
                                ConverterParameter="2.0"
                                Path="Width"
                                RelativeSource="{RelativeSource TemplatedParent}" />
-                      <Binding Converter="{StaticResource DivisionMathConverter}"
+                      <Binding Converter="{x:Static converters:MathConverter.DivideInstance}"
                                ConverterParameter="2.0"
                                Path="Height"
                                RelativeSource="{RelativeSource TemplatedParent}" />
@@ -167,14 +164,14 @@
                                 ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ToggleButtonAssist.OnContentTemplate)}"
                                 FlowDirection="LeftToRight" />
               <Grid.Clip>
-                <EllipseGeometry RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Width, Converter={StaticResource DivisionMathConverter}, ConverterParameter=2.0}" RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height, Converter={StaticResource DivisionMathConverter}, ConverterParameter=2.0}">
+                <EllipseGeometry RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Width, Converter={x:Static converters:MathConverter.DivideInstance}, ConverterParameter=2.0}" RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height, Converter={x:Static converters:MathConverter.DivideInstance}, ConverterParameter=2.0}">
                   <EllipseGeometry.Center>
-                    <MultiBinding Converter="{StaticResource PointValueConverter}">
-                      <Binding Converter="{StaticResource DivisionMathConverter}"
+                    <MultiBinding Converter="{x:Static converters:PointValueConverter.Instance}">
+                      <Binding Converter="{x:Static converters:MathConverter.DivideInstance}"
                                ConverterParameter="2.0"
                                Path="Width"
                                RelativeSource="{RelativeSource TemplatedParent}" />
-                      <Binding Converter="{StaticResource DivisionMathConverter}"
+                      <Binding Converter="{x:Static converters:MathConverter.DivideInstance}"
                                ConverterParameter="2.0"
                                Path="Height"
                                RelativeSource="{RelativeSource TemplatedParent}" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBar.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBar.xaml
@@ -16,9 +16,6 @@
     <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ListBox.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
-  <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-  <converters:ToolBarOverflowButtonVisibilityConverter x:Key="ToolBarOverflowButtonVisibilityConverter" />
-
   <Style x:Key="MaterialDesignToolBarVerticalOverflowButtonStyle" TargetType="{x:Type ToggleButton}">
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.ToolBar.Background}" />
     <Setter Property="MinHeight" Value="0" />
@@ -173,7 +170,7 @@
                             IsChecked="{Binding IsOverflowOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                             Style="{StaticResource MaterialDesignToolBarHorizontalOverflowButtonStyle}">
                 <ToggleButton.Visibility>
-                  <MultiBinding Converter="{StaticResource ToolBarOverflowButtonVisibilityConverter}">
+                  <MultiBinding Converter="{x:Static converters:ToolBarOverflowButtonVisibilityConverter.Instance}">
                     <Binding Path="OverflowMode" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="HasOverflowItems" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TreeListView.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TreeListView.xaml
@@ -104,15 +104,9 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type wpf:TreeListViewItem}">
-          <ControlTemplate.Resources>
-            <converters:TreeListViewIndentConverter x:Key="TreeListViewIndentConverter" />
-            <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
-            <converters:BrushRoundConverter x:Key="BrushRoundConverter" />
-            <converters:MathMultipleConverter x:Key="MathMlpMultipleConverter" Operation="Multiply" />
-          </ControlTemplate.Resources>
           <Grid>
             <Grid.Margin>
-              <MultiBinding Converter="{StaticResource TreeListViewIndentConverter}">
+              <MultiBinding Converter="{x:Static converters:TreeListViewIndentConverter.Instance}">
                 <Binding Path="LevelIndentSize" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type wpf:TreeListView}}" />
                 <Binding Path="Level" RelativeSource="{RelativeSource TemplatedParent}" />
               </MultiBinding>
@@ -183,14 +177,14 @@
             <Border x:Name="MouseOverBorder"
                     Grid.Column="1"
                     Grid.ColumnSpan="2"
-                    Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                    Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                     IsHitTestVisible="False"
                     Opacity="0" />
 
             <Border x:Name="SelectedBorder"
                     Grid.Column="1"
                     Grid.ColumnSpan="2"
-                    Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                    Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                     IsHitTestVisible="False"
                     Opacity="0" />
 
@@ -202,7 +196,7 @@
                           Padding="{TemplateBinding Padding}"
                           HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                           VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                          Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                          Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                           Focusable="False"
                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                 <internal:TreeListViewContentPresenter x:Name="PART_ContentPresenter" ContentSource="Content" />
@@ -219,10 +213,10 @@
                             Visibility="Collapsed" />
           </Grid>
           <ControlTemplate.Triggers>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:TreeViewAssist.AdditionalTemplate), Converter={StaticResource NullableToVisibilityConverter}, Mode=OneWay}" Value="Visible">
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:TreeViewAssist.AdditionalTemplate), Converter={x:Static converters:NullableToVisibilityConverter.Instance}, Mode=OneWay}" Value="Visible">
               <Setter TargetName="AdditionalContentControl" Property="Visibility" Value="Visible" />
             </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:TreeViewAssist.AdditionalTemplateSelector), Converter={StaticResource NullableToVisibilityConverter}, Mode=OneWay}" Value="Visible">
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:TreeViewAssist.AdditionalTemplateSelector), Converter={x:Static converters:NullableToVisibilityConverter.Instance}, Mode=OneWay}" Value="Visible">
               <Setter TargetName="AdditionalContentControl" Property="Visibility" Value="Visible" />
             </DataTrigger>
             <Trigger Property="HasItems" Value="false">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TreeView.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TreeView.xaml
@@ -2,16 +2,6 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
-
-  <ResourceDictionary.MergedDictionaries>
-    <ResourceDictionary>
-      <converters:BrushRoundConverter x:Key="BrushRoundConverter" />
-      <converters:MathMultipleConverter x:Key="MathMlpMultipleConverter" Operation="Multiply" />
-      <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
-    </ResourceDictionary>
-  </ResourceDictionary.MergedDictionaries>
-
-
   <Style x:Key="MaterialDesignTreeView" TargetType="{x:Type TreeView}">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="{x:Null}" />
@@ -315,14 +305,14 @@
             <Border x:Name="MouseOverBorder"
                     Grid.Column="1"
                     Grid.ColumnSpan="2"
-                    Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                    Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                     IsHitTestVisible="False"
                     Opacity="0" />
 
             <Border x:Name="SelectedBorder"
                     Grid.Column="1"
                     Grid.ColumnSpan="2"
-                    Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                    Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                     IsHitTestVisible="False"
                     Opacity="0" />
 
@@ -334,7 +324,7 @@
                           Padding="{TemplateBinding Padding}"
                           HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                           VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                          Feedback="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"
+                          Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                           Focusable="False"
                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                 <ContentPresenter x:Name="PART_Header" ContentSource="Header" />
@@ -356,7 +346,7 @@
                         Grid.ColumnSpan="2"
                         Margin="-16,0,0,0">
               <StackPanel.Height>
-                <MultiBinding Converter="{StaticResource MathMlpMultipleConverter}">
+                <MultiBinding Converter="{x:Static converters:MathMultipleConverter.MultiplyInstance}">
                   <Binding ElementName="ItemsHost" Path="ActualHeight" />
                   <Binding ElementName="ScaleHost" Path="Scale" />
                 </MultiBinding>
@@ -368,10 +358,10 @@
             </StackPanel>
           </Grid>
           <ControlTemplate.Triggers>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:TreeViewAssist.AdditionalTemplate), Converter={StaticResource NullableToVisibilityConverter}, Mode=OneWay}" Value="Visible">
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:TreeViewAssist.AdditionalTemplate), Converter={x:Static converters:NullableToVisibilityConverter.Instance}, Mode=OneWay}" Value="Visible">
               <Setter TargetName="AdditionalContentControl" Property="Visibility" Value="Visible" />
             </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:TreeViewAssist.AdditionalTemplateSelector), Converter={StaticResource NullableToVisibilityConverter}, Mode=OneWay}" Value="Visible">
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:TreeViewAssist.AdditionalTemplateSelector), Converter={x:Static converters:NullableToVisibilityConverter.Instance}, Mode=OneWay}" Value="Visible">
               <Setter TargetName="AdditionalContentControl" Property="Visibility" Value="Visible" />
             </DataTrigger>
             <Trigger Property="HasItems" Value="false">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
@@ -2,8 +2,6 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
-  <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-
   <ControlTemplate x:Key="MaterialDesignValidationErrorTemplate">
     <ControlTemplate.Resources>
       <converters:ThicknessCloneConverter x:Key="FloatingHintValidationErrorTextMarginConverter" CloneEdges="Left" />
@@ -96,7 +94,7 @@
           <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.UsePopup)}" Value="False" />
         </MultiDataTrigger.Conditions>
         <MultiDataTrigger.Setters>
-          <Setter TargetName="DefaultErrorViewer" Property="Visibility" Value="{Binding ElementName=Placeholder, Path=AdornedElement.IsKeyboardFocusWithin, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+          <Setter TargetName="DefaultErrorViewer" Property="Visibility" Value="{Binding ElementName=Placeholder, Path=AdornedElement.IsKeyboardFocusWithin, Mode=OneWay, Converter={x:Static converters:BooleanToVisibilityConverter.Instance}}" />
         </MultiDataTrigger.Setters>
       </MultiDataTrigger>
 

--- a/src/MaterialDesignThemes.Wpf/Themes/ObsoleteConverters.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/ObsoleteConverters.xaml
@@ -1,0 +1,59 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:circularProgressBarConverters="clr-namespace:MaterialDesignThemes.Wpf.Converters.CircularProgressBar"
+                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
+                    xmlns:local="clr-namespace:MaterialDesignThemes.Wpf"
+                    xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib"
+                    xmlns:transitions="clr-namespace:MaterialDesignThemes.Wpf.Transitions">
+  <!--
+    Previously we exposed converters publicly in the style xaml files.
+    Now that we use the static instance converters this file is available
+    as a backwards compatibility file to include when the converters were
+    used by consumer projects.
+  -->
+  <converters:BooleanAllConverter x:Key="BooleanAllConverter" />
+  <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+  <converters:BooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter"
+                                               FalseValue="Visible"
+                                               TrueValue="Hidden" />
+  <converters:BorderClipConverter x:Key="BorderClipConverter" />
+  <converters:BrushOpacityConverter x:Key="BrushOpacityConverter" />
+  <converters:BrushRoundConverter x:Key="BrushRoundConverter" />
+  <converters:BrushToRadialGradientBrushConverter x:Key="BrushToRadialGradientBrushConverter" />
+  <converters:ClockLineConverter x:Key="ClockHourLineConverter" DisplayMode="Hours" />
+  <converters:ClockLineConverter x:Key="ClockMinuteLineConverter" DisplayMode="Minutes" />
+  <converters:ClockLineConverter x:Key="ClockSecondLineConverter" DisplayMode="Seconds" />
+  <converters:DrawerOffsetConverter x:Key="DrawerOffsetConverter" />
+  <converters:EqualityToVisibilityConverter x:Key="EqualityToVisibilityConverter" />
+  <converters:GridLinesVisibilityBorderToThicknessConverter x:Key="GridLinesVisibilityBorderToThicknessConverter" />
+  <converters:HsbToColorConverter x:Key="HsbToColorConverter" />
+  <converters:HsbLinearGradientConverter x:Key="HsbLinearGradientConverter" />
+  <converters:InvertBooleanConverter x:Key="InvertBooleanConverter" />
+  <converters:IsDarkConverter x:Key="IsDarkConverter" />
+  <converters:IsTransparentBrushConverter x:Key="IsTransparentBrushConverter" />
+  <converters:MathConverter x:Key="DivisionMathConverter" Operation="Divide" />
+  <converters:MathMultipleConverter x:Key="MathMultipleConverter" Operation="Multiply" />
+  <converters:NotConverter x:Key="NotConverter" />
+  <converters:NotZeroConverter x:Key="NotZeroConverter" />
+  <converters:NotZeroToVisibilityConverter x:Key="NotZeroToVisibilityConverter" />
+  <converters:NullableToVisibilityConverter x:Key="NullableToVisibilityConverter" />
+  <converters:NullableToVisibilityConverter x:Key="InvertedNullVisibilityConverter"
+                                            NotNullValue="Collapsed"
+                                            NullValue="Visible" />
+  <converters:PointValueConverter x:Key="PointValueConverter" />
+  <converters:RemoveAlphaBrushConverter x:Key="RemoveAlphaBrushConverter" />
+  <converters:SnackbarActionButtonPlacementModeConverter x:Key="SnackbarActionButtonPlacementModeConverter" />
+  <converters:SliderToolTipConverter x:Key="SliderToolTipConverter" />
+  <converters:SliderValueLabelPositionConverter x:Key="SliderValueLabelPositionConverter" />
+  <converters:StringLengthValueConverter x:Key="StringLengthValueConverter" />
+  <converters:TextFieldHintVisibilityConverter x:Key="TextFieldHintVisibilityConverter" />
+  <converters:ToolBarOverflowButtonVisibilityConverter x:Key="ToolBarOverflowButtonVisibilityConverter" />
+  <converters:TopThicknessConverter x:Key="TopThicknessConverter" />
+
+
+  <circularProgressBarConverters:StartPointConverter x:Key="StartPointConverter" />
+  <circularProgressBarConverters:ArcSizeConverter x:Key="ArcSizeConverter" />
+  <circularProgressBarConverters:ArcEndPointConverter x:Key="ArcEndPointConverter" />
+  <circularProgressBarConverters:RotateTransformCentreConverter x:Key="RotateTransformCentreConverter" />
+</ResourceDictionary>


### PR DESCRIPTION
- Removed the global converter resources
- Introduced Instance static readonly field(s) on converters whenever possible
  - Used the Instance field whenever applicable because it is better for the overall performance
- Introduced ObsoleteConverters.xaml to easily include these deprecated converter keys in consumer projects