### PR TITLE
Fixed snackbar from not always being depicted

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Snackbar.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Snackbar.xaml
@@ -182,7 +182,7 @@
               <system:Double>0.0</system:Double>
             </StackPanel.Tag>
             <StackPanel.Height>
-              <MultiBinding Converter="{x:Static converters:MathMultipleConverter.AddInstance}">
+              <MultiBinding Converter="{x:Static converters:MathMultipleConverter.MultiplyInstance}">
                 <Binding ElementName="ContentBorder" Path="ActualHeight" />
                 <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
               </MultiBinding>


### PR DESCRIPTION
Due to the converter conversion I accidentally broke the visibility behavior of the Snackbar.
This fixes that the Snackbar is not always being depicted.