### PR TITLE
Added missing AP RadioButtonAssist to Style

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
@@ -203,8 +203,8 @@
               <ColumnDefinition Width="Auto" />
               <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <Viewbox Width="18"
-                     Height="18"
+            <Viewbox Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:RadioButtonAssist.RadioButtonSize)}"
+                     Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:RadioButtonAssist.RadioButtonSize)}"
                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
               <Canvas Width="24" Height="24">
                 <Path x:Name="Graphic"


### PR DESCRIPTION
just like in #3743 there is a Style for `RadioButton`s which was missing the AP `RadioButtonAssist.RadioButtonSize`