### PR TITLE
Fix new Numeric-/DecimalUpDown styles

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.NumericUpDown.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.NumericUpDown.xaml
@@ -184,7 +184,7 @@
 
   <Style x:Key="MaterialDesignFilledUpDownBase"
          TargetType="{x:Type wpf:UpDownBase}"
-         BasedOn="{StaticResource MaterialDesignFloatingHintNumericUpDown}">
+         BasedOn="{StaticResource MaterialDesignFloatingHintUpDownBase}">
     <Style.Resources>
       <Style x:Key="NestedTextBoxStyle"
              TargetType="TextBox"
@@ -208,7 +208,7 @@
   
   <Style x:Key="MaterialDesignOutlinedUpDownBase"
          TargetType="{x:Type wpf:UpDownBase}"
-         BasedOn="{StaticResource MaterialDesignFloatingHintNumericUpDown}">
+         BasedOn="{StaticResource MaterialDesignFloatingHintUpDownBase}">
     <Style.Resources>
       <Style x:Key="NestedTextBoxStyle"
              TargetType="TextBox"


### PR DESCRIPTION
I think there was a little mistake in the complex inheritance-chain of the Numeric-/DecimalUpDown styles.
This should fix #3731 and #3756 (which is actually a duplicate).

If you have time a new, hot-fix version of this library would probably be great so people can utilize the new styles 😊