### PR TITLE
added AutoSuggestBox to MD2&3 FieldsLineUp demo

### DIFF
--- a/src/MainDemo.Wpf/FieldsLineUp.xaml
+++ b/src/MainDemo.Wpf/FieldsLineUp.xaml
@@ -159,6 +159,7 @@
             <ColumnDefinition MinWidth="100" />
             <ColumnDefinition MinWidth="100" />
             <ColumnDefinition MinWidth="100" />
+            <ColumnDefinition MinWidth="100" />
           </Grid.ColumnDefinitions>
 
           <TextBlock Grid.Row="1"
@@ -202,6 +203,10 @@
                      Grid.Column="6"
                      Style="{StaticResource FieldHeader}"
                      Text="NumericUpDown" />
+          <TextBlock Grid.Row="0"
+                     Grid.Column="7"
+                     Style="{StaticResource FieldHeader}"
+                     Text="AutoSuggestBox " />
 
           <TextBox Grid.Row="1" Grid.Column="1" />
           <TextBox Grid.Row="2"
@@ -268,6 +273,17 @@
           <materialDesign:NumericUpDown Grid.Row="4"
                                         Grid.Column="6"
                                         Style="{StaticResource MaterialDesignOutlinedNumericUpDown}" />
+
+          <materialDesign:AutoSuggestBox Grid.Row="1" Grid.Column="7" />
+          <materialDesign:AutoSuggestBox Grid.Row="2"
+                                         Grid.Column="7"
+                                         Style="{StaticResource MaterialDesignFloatingHintAutoSuggestBox}" />
+          <materialDesign:AutoSuggestBox Grid.Row="3"
+                                         Grid.Column="7"
+                                         Style="{StaticResource MaterialDesignFilledAutoSuggestBox}" />
+          <materialDesign:AutoSuggestBox Grid.Row="4"
+                                         Grid.Column="7"
+                                         Style="{StaticResource MaterialDesignOutlinedAutoSuggestBox}" />
 
         </Grid>
       </StackPanel>

--- a/src/MainDemo.Wpf/FieldsLineUp.xaml.cs
+++ b/src/MainDemo.Wpf/FieldsLineUp.xaml.cs
@@ -73,6 +73,9 @@ public partial class FieldsLineUp
     {
         switch (control)
         {
+            case MaterialDesignThemes.Wpf.AutoSuggestBox autoSuggestBox:
+                autoSuggestBox.Text = nameof(MaterialDesignThemes.Wpf.AutoSuggestBox.Text);
+                break;
             case TextBox textBox:
                 textBox.Text = nameof(TextBox.Text);
                 break;

--- a/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml
@@ -148,6 +148,7 @@
           <ColumnDefinition MinWidth="100" />
           <ColumnDefinition MinWidth="100" />
           <ColumnDefinition MinWidth="100" />
+          <ColumnDefinition MinWidth="100" />
         </Grid.ColumnDefinitions>
 
         <TextBlock Grid.Row="1"
@@ -191,6 +192,10 @@
                    Grid.Column="6"
                    Style="{StaticResource FieldHeader}"
                    Text="NumericUpDown" />
+        <TextBlock Grid.Row="0"
+                   Grid.Column="7"
+                   Style="{StaticResource FieldHeader}"
+                   Text="AutoSuggestBox " />
 
         <TextBox Grid.Row="1" Grid.Column="1" />
         <TextBox Grid.Row="2"
@@ -257,6 +262,17 @@
         <materialDesign:NumericUpDown Grid.Row="4"
                                       Grid.Column="6"
                                       Style="{StaticResource MaterialDesignOutlinedNumericUpDown}" />
+
+        <materialDesign:AutoSuggestBox Grid.Row="1" Grid.Column="7" />
+        <materialDesign:AutoSuggestBox Grid.Row="2"
+                                       Grid.Column="7"
+                                       Style="{StaticResource MaterialDesignFloatingHintAutoSuggestBox}" />
+        <materialDesign:AutoSuggestBox Grid.Row="3"
+                                       Grid.Column="7"
+                                       Style="{StaticResource MaterialDesignFilledAutoSuggestBox}" />
+        <materialDesign:AutoSuggestBox Grid.Row="4"
+                                       Grid.Column="7"
+                                       Style="{StaticResource MaterialDesignOutlinedAutoSuggestBox}" />
 
       </Grid>
     </StackPanel>

--- a/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml.cs
+++ b/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml.cs
@@ -73,6 +73,9 @@ public partial class FieldsLineUp
     {
         switch (control)
         {
+            case MaterialDesignThemes.Wpf.AutoSuggestBox autoSuggestBox:
+                autoSuggestBox.Text = nameof(MaterialDesignThemes.Wpf.AutoSuggestBox.Text);
+                break;
             case TextBox textBox:
                 textBox.Text = nameof(TextBox.Text);
                 break;


### PR DESCRIPTION
the AutoSuggestBox was missing in the FieldsLineUp page in the demo:
![image](https://github.com/user-attachments/assets/a3104ca2-f8de-447d-a600-de5210195528)
