### PR TITLE
[SmartHint] Hint placement for "readonly" controls

### DIFF
--- a/src/MainDemo.Wpf/SmartHint.xaml.cs
+++ b/src/MainDemo.Wpf/SmartHint.xaml.cs
@@ -17,10 +17,24 @@ public partial class SmartHint : UserControl
     internal static void SetRichTextBoxText(DependencyObject element, object value) => element.SetValue(RichTextBoxTextProperty, value);
     internal static object GetRichTextBoxText(DependencyObject element) => element.GetValue(RichTextBoxTextProperty);
 
+    private SmartHintViewModel ViewModel { get; }
+
     public SmartHint()
     {
-        DataContext = new SmartHintViewModel();
+        DataContext = ViewModel = new SmartHintViewModel();
         InitializeComponent();
+
+        Loaded += SmartHint_Loaded;
+    }
+
+    private void SmartHint_Loaded(object sender, RoutedEventArgs e)
+    {
+        // HACK! For some strange reason, the calculation of the left margin for the hint is initially wrong if these values are set as default in the view model directly.
+        // Setting them here is a bit hacky, but it makes the demo page work, and I don't think this would be an issue in a real world application so I can live the hack.
+        // To see the issue in action: Simply comment out the 2 lines below, open the "Smart Hint" page and toggle the "IsReadOnly" checkbox in the "TextBox styles" section;
+        // that will place the hint on top of the prefix text for unknown reasons.
+        ViewModel.PrefixText = "Pre";
+        ViewModel.SuffixText = "Suf";
     }
 
     private void HasErrors_OnToggled(object sender, RoutedEventArgs e)

--- a/src/MainDemo.Wpf/SmartHint.xaml.cs
+++ b/src/MainDemo.Wpf/SmartHint.xaml.cs
@@ -17,24 +17,10 @@ public partial class SmartHint : UserControl
     internal static void SetRichTextBoxText(DependencyObject element, object value) => element.SetValue(RichTextBoxTextProperty, value);
     internal static object GetRichTextBoxText(DependencyObject element) => element.GetValue(RichTextBoxTextProperty);
 
-    private SmartHintViewModel ViewModel { get; }
-
     public SmartHint()
     {
-        DataContext = ViewModel = new SmartHintViewModel();
+        DataContext = new SmartHintViewModel();
         InitializeComponent();
-
-        Loaded += SmartHint_Loaded;
-    }
-
-    private void SmartHint_Loaded(object sender, RoutedEventArgs e)
-    {
-        // HACK! For some strange reason, the calculation of the left margin for the hint is initially wrong if these values are set as default in the view model directly.
-        // Setting them here is a bit hacky, but it makes the demo page work, and I don't think this would be an issue in a real world application so I can live the hack.
-        // To see the issue in action: Simply comment out the 2 lines below, open the "Smart Hint" page and toggle the "IsReadOnly" checkbox in the "TextBox styles" section;
-        // that will place the hint on top of the prefix text for unknown reasons.
-        ViewModel.PrefixText = "Pre";
-        ViewModel.SuffixText = "Suf";
     }
 
     private void HasErrors_OnToggled(object sender, RoutedEventArgs e)

--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintInitialHorizontalOffsetConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintInitialHorizontalOffsetConverter.cs
@@ -19,7 +19,8 @@ public class FloatingHintInitialHorizontalOffsetConverter : IMultiValueConverter
                 PrefixSuffixVisibility suffixVisibility,
                 PrefixSuffixHintBehavior prefixHintBehavior,
                 PrefixSuffixHintBehavior suffixHintBehavior,
-                HorizontalAlignment horizontalContentAlignment
+                HorizontalAlignment horizontalContentAlignment,
+                bool isEditable,
             ])
         {
             return 0;
@@ -37,8 +38,11 @@ public class FloatingHintInitialHorizontalOffsetConverter : IMultiValueConverter
             return prefixVisibility switch
             {
                 PrefixSuffixVisibility.WhenFocusedOrNonEmpty
-                    when prefixHintBehavior == PrefixSuffixHintBehavior.AlignWithText =>
+                    when prefixHintBehavior == PrefixSuffixHintBehavior.AlignWithText && isEditable =>
                     prefixWidth + prefixMargin.Right,
+                PrefixSuffixVisibility.WhenFocusedOrNonEmpty
+                    when prefixHintBehavior == PrefixSuffixHintBehavior.AlignWithPrefixSuffix && !isEditable =>
+                    -(prefixWidth + prefixMargin.Right),
                 PrefixSuffixVisibility.Always
                     when prefixHintBehavior == PrefixSuffixHintBehavior.AlignWithPrefixSuffix =>
                     -(prefixWidth + prefixMargin.Right),
@@ -51,8 +55,11 @@ public class FloatingHintInitialHorizontalOffsetConverter : IMultiValueConverter
             return suffixVisibility switch
             {
                 PrefixSuffixVisibility.WhenFocusedOrNonEmpty
-                    when suffixHintBehavior == PrefixSuffixHintBehavior.AlignWithText =>
+                    when suffixHintBehavior == PrefixSuffixHintBehavior.AlignWithText && isEditable =>
                     -(suffixWidth + suffixMargin.Left),
+                PrefixSuffixVisibility.WhenFocusedOrNonEmpty
+                    when suffixHintBehavior == PrefixSuffixHintBehavior.AlignWithPrefixSuffix && !isEditable =>
+                    suffixWidth + suffixMargin.Left,
                 PrefixSuffixVisibility.Always
                     when suffixHintBehavior == PrefixSuffixHintBehavior.AlignWithPrefixSuffix =>
                     suffixWidth + suffixMargin.Left,

--- a/src/MaterialDesignThemes.Wpf/SmartHint.cs
+++ b/src/MaterialDesignThemes.Wpf/SmartHint.cs
@@ -258,7 +258,7 @@ public class SmartHint : Control
             string state = string.Empty;
 
             bool isEmpty = proxy.IsEmpty();
-            bool isFocused = proxy.IsFocused();
+            bool isFocused = HintHost?.IsKeyboardFocusWithin ?? proxy.IsFocused();
 
             if (UseFloating)
                 state = !isEmpty || isFocused ? HintFloatingPositionName : HintRestingPositionName;

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -174,6 +174,7 @@
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.PrefixTextHintBehavior)" />
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.SuffixTextHintBehavior)" />
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="HorizontalContentAlignment" />
+                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="IsReadOnly" Converter="{x:Static converters:InvertBooleanConverter.Instance}" />
                       </MultiBinding>
                     </wpf:SmartHint.InitialHorizontalOffset>
                     <wpf:SmartHint.Margin>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -71,29 +71,29 @@
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
             <Border HorizontalAlignment="Stretch"
-            VerticalAlignment="Stretch"
-            Background="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
-            CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
-            RenderTransformOrigin="0.5,0.5"
-            Visibility="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled, Converter={x:Static converters:BooleanToVisibilityConverter.CollapsedInstance}}">
+                    VerticalAlignment="Stretch"
+                    Background="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
+                    CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
+                    RenderTransformOrigin="0.5,0.5"
+                    Visibility="{TemplateBinding wpf:TextFieldAssist.RippleOnFocusEnabled, Converter={x:Static converters:BooleanToVisibilityConverter.CollapsedInstance}}">
               <Border.RenderTransform>
                 <ScaleTransform x:Name="RippleOnFocusScaleTransform" ScaleX="0" ScaleY="0" />
               </Border.RenderTransform>
             </Border>
             <AdornerDecorator>
               <Border x:Name="OuterBorder"
-              Padding="{TemplateBinding Padding}"
-              wpf:BottomDashedLineAdorner.Brush="{TemplateBinding BorderBrush}"
-              wpf:BottomDashedLineAdorner.Thickness="{Binding RelativeSource={RelativeSource Self}, Path=BorderThickness}"
-              Background="{TemplateBinding Background}"
-              BorderBrush="{TemplateBinding BorderBrush}"
-              BorderThickness="{TemplateBinding BorderThickness}"
-              CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
-              SnapsToDevicePixels="True">
+                      Padding="{TemplateBinding Padding}"
+                      wpf:BottomDashedLineAdorner.Brush="{TemplateBinding BorderBrush}"
+                      wpf:BottomDashedLineAdorner.Thickness="{Binding RelativeSource={RelativeSource Self}, Path=BorderThickness}"
+                      Background="{TemplateBinding Background}"
+                      BorderBrush="{TemplateBinding BorderBrush}"
+                      BorderThickness="{TemplateBinding BorderThickness}"
+                      CornerRadius="{TemplateBinding wpf:TextFieldAssist.TextFieldCornerRadius}"
+                      SnapsToDevicePixels="True">
 
                 <Grid x:Name="ContentGrid"
-              MinHeight="16"
-              VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                      MinHeight="16"
+                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
@@ -104,32 +104,14 @@
                   </Grid.ColumnDefinitions>
 
                   <wpf:PackIcon x:Name="LeadingPackIcon"
-                        Grid.Column="0"
-                        Width="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
-                        Height="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
-                        Margin="0,0,6,0"
-                        VerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
-                        Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
-                        Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                        Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={x:Static converters:BooleanToVisibilityConverter.CollapsedInstance}}" />
-
-                  <TextBlock x:Name="PrefixTextBlock"
-                     Grid.Column="1"
-                     Margin="0,0,2,0"
-                     VerticalAlignment="Center"
-                     FontSize="{TemplateBinding FontSize}"
-                     Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                     Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}">
-                    <TextBlock.Visibility>
-                      <MultiBinding Converter="{StaticResource PrefixSuffixTextVisibilityConverter}">
-                        <Binding ElementName="Hint" Path="IsHintInFloatingPosition" />
-                        <Binding Path="(wpf:TextFieldAssist.PrefixText)" RelativeSource="{RelativeSource TemplatedParent}" />
-                        <Binding Path="(wpf:TextFieldAssist.PrefixTextVisibility)" RelativeSource="{RelativeSource TemplatedParent}" />
-                        <Binding Path="IsKeyboardFocusWithin" RelativeSource="{RelativeSource TemplatedParent}" />
-                        <Binding Path="IsReadOnly" RelativeSource="{RelativeSource TemplatedParent}" Converter="{x:Static converters:InvertBooleanConverter.Instance}" />
-                      </MultiBinding>
-                    </TextBlock.Visibility>
-                  </TextBlock>
+                                Grid.Column="0"
+                                Width="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
+                                Height="{TemplateBinding wpf:TextFieldAssist.LeadingIconSize}"
+                                Margin="0,0,6,0"
+                                VerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
+                                Kind="{TemplateBinding wpf:TextFieldAssist.LeadingIcon}"
+                                Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                                Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={x:Static converters:BooleanToVisibilityConverter.CollapsedInstance}}" />
 
                   <ScrollViewer x:Name="PART_ContentHost"
                         Grid.Column="2"
@@ -192,20 +174,38 @@
                     </wpf:SmartHint.Margin>
                     <wpf:SmartHint.Hint>
                       <Border x:Name="HintBackgroundBorder"
-                      Background="{TemplateBinding wpf:HintAssist.Background}"
-                      CornerRadius="2">
+                              Background="{TemplateBinding wpf:HintAssist.Background}"
+                              CornerRadius="2">
                         <ContentPresenter x:Name="HintWrapper" Content="{TemplateBinding wpf:HintAssist.Hint}" />
                       </Border>
                     </wpf:SmartHint.Hint>
                   </wpf:SmartHint>
 
+                  <TextBlock x:Name="PrefixTextBlock"
+                             Grid.Column="1"
+                             Margin="0,0,2,0"
+                             VerticalAlignment="Center"
+                             FontSize="{TemplateBinding FontSize}"
+                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                             Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}">
+                    <TextBlock.Visibility>
+                      <MultiBinding Converter="{StaticResource PrefixSuffixTextVisibilityConverter}">
+                        <Binding ElementName="Hint" Path="IsHintInFloatingPosition" />
+                        <Binding Path="(wpf:TextFieldAssist.PrefixText)" RelativeSource="{RelativeSource TemplatedParent}" />
+                        <Binding Path="(wpf:TextFieldAssist.PrefixTextVisibility)" RelativeSource="{RelativeSource TemplatedParent}" />
+                        <Binding Path="IsKeyboardFocusWithin" RelativeSource="{RelativeSource TemplatedParent}" />
+                        <Binding Path="IsReadOnly" RelativeSource="{RelativeSource TemplatedParent}" Converter="{x:Static converters:InvertBooleanConverter.Instance}" />
+                      </MultiBinding>
+                    </TextBlock.Visibility>
+                  </TextBlock>
+
                   <TextBlock x:Name="SuffixTextBlock"
-                     Grid.Column="3"
-                     Margin="2,0,0,0"
-                     VerticalAlignment="Center"
-                     FontSize="{TemplateBinding FontSize}"
-                     Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                     Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}">
+                             Grid.Column="3"
+                             Margin="2,0,0,0"
+                             VerticalAlignment="Center"
+                             FontSize="{TemplateBinding FontSize}"
+                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                             Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}">
                     <TextBlock.Visibility>
                       <MultiBinding Converter="{StaticResource PrefixSuffixTextVisibilityConverter}">
                         <Binding ElementName="Hint" Path="IsHintInFloatingPosition" />
@@ -289,11 +289,10 @@
                    CornerRadius="{TemplateBinding wpf:TextFieldAssist.UnderlineCornerRadius}"
                    Visibility="{TemplateBinding wpf:TextFieldAssist.DecorationVisibility}" />
 
-            <Canvas VerticalAlignment="Bottom"
-            IsHitTestVisible="False">
+            <Canvas VerticalAlignment="Bottom" IsHitTestVisible="False">
               <Border Canvas.Top="2"
-              Padding="{TemplateBinding Padding, Converter={StaticResource HelperTextMarginConverter}}"
-              Width="{Binding ActualWidth, ElementName=OuterBorder}">
+                      Padding="{TemplateBinding Padding, Converter={StaticResource HelperTextMarginConverter}}"
+                      Width="{Binding ActualWidth, ElementName=OuterBorder}">
                 <Grid x:Name="FooterGrid">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -416,6 +416,7 @@
                     <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.PrefixTextHintBehavior)" />
                     <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.SuffixTextHintBehavior)" />
                     <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="HorizontalContentAlignment" />
+                    <Binding Path="IsEditable" RelativeSource="{RelativeSource TemplatedParent}" />
                   </MultiBinding>
                 </wpf:SmartHint.InitialHorizontalOffset>
                 <wpf:SmartHint.Margin>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -216,6 +216,7 @@
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.PrefixTextHintBehavior)" />
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.SuffixTextHintBehavior)" />
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="HorizontalContentAlignment" />
+                        <Binding Source="{StaticResource TrueValue}" />
                       </MultiBinding>
                     </wpf:SmartHint.InitialHorizontalOffset>
                     <wpf:SmartHint.Margin>
@@ -836,6 +837,7 @@
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.PrefixTextHintBehavior)" />
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.SuffixTextHintBehavior)" />
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="HorizontalContentAlignment" />
+                        <Binding Source="{StaticResource TrueValue}" />
                       </MultiBinding>
                     </wpf:SmartHint.InitialHorizontalOffset>
                     <wpf:SmartHint.Margin>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -212,6 +212,7 @@
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.PrefixTextHintBehavior)" />
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:TextFieldAssist.SuffixTextHintBehavior)" />
                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="HorizontalContentAlignment" />
+                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="IsReadOnly" Converter="{x:Static converters:InvertBooleanConverter.Instance}" />
                       </MultiBinding>
                     </wpf:SmartHint.InitialHorizontalOffset>
                     <wpf:SmartHint.Margin>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -151,24 +151,6 @@
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                 Visibility="{TemplateBinding wpf:TextFieldAssist.HasLeadingIcon, Converter={x:Static converters:BooleanToVisibilityConverter.CollapsedInstance}}" />
 
-                  <TextBlock x:Name="PrefixTextBlock"
-                             Grid.Column="1"
-                             Margin="0,0,2,0"
-                             VerticalAlignment="Center"
-                             FontSize="{TemplateBinding FontSize}"
-                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
-                             Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}">
-                    <TextBlock.Visibility>
-                      <MultiBinding Converter="{StaticResource PrefixSuffixTextVisibilityConverter}">
-                        <Binding ElementName="Hint" Path="IsHintInFloatingPosition" />
-                        <Binding Path="(wpf:TextFieldAssist.PrefixText)" RelativeSource="{RelativeSource TemplatedParent}" />
-                        <Binding Path="(wpf:TextFieldAssist.PrefixTextVisibility)" RelativeSource="{RelativeSource TemplatedParent}" />
-                        <Binding Path="IsKeyboardFocusWithin" RelativeSource="{RelativeSource TemplatedParent}" />
-                        <Binding Path="IsReadOnly" RelativeSource="{RelativeSource TemplatedParent}" Converter="{x:Static converters:InvertBooleanConverter.Instance}" />
-                      </MultiBinding>
-                    </TextBlock.Visibility>
-                  </TextBlock>
-
                   <ScrollViewer x:Name="PART_ContentHost"
                                 Grid.Column="2"
                                 HorizontalAlignment="Stretch"
@@ -237,6 +219,24 @@
                     </wpf:SmartHint.Hint>
                   </wpf:SmartHint>
 
+                  <TextBlock x:Name="PrefixTextBlock"
+                             Grid.Column="1"
+                             Margin="0,0,2,0"
+                             VerticalAlignment="Center"
+                             FontSize="{TemplateBinding FontSize}"
+                             Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
+                             Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}">
+                    <TextBlock.Visibility>
+                      <MultiBinding Converter="{StaticResource PrefixSuffixTextVisibilityConverter}">
+                        <Binding ElementName="Hint" Path="IsHintInFloatingPosition" />
+                        <Binding Path="(wpf:TextFieldAssist.PrefixText)" RelativeSource="{RelativeSource TemplatedParent}" />
+                        <Binding Path="(wpf:TextFieldAssist.PrefixTextVisibility)" RelativeSource="{RelativeSource TemplatedParent}" />
+                        <Binding Path="IsKeyboardFocusWithin" RelativeSource="{RelativeSource TemplatedParent}" />
+                        <Binding Path="IsReadOnly" RelativeSource="{RelativeSource TemplatedParent}" Converter="{x:Static converters:InvertBooleanConverter.Instance}" />
+                      </MultiBinding>
+                    </TextBlock.Visibility>
+                  </TextBlock>
+                  
                   <TextBlock x:Name="SuffixTextBlock"
                              Grid.Column="3"
                              Margin="2,0,0,0"


### PR DESCRIPTION
Fixes #3762 

Initially I thought this was just a fix for the `ComboBox` styles, but it turns out that it was actually a common issue when the control is "readonly" (e.g. `TextBox.IsReadOnly=true` or `ComboBox.IsEditable=False`).

While investigating the root cause, I stumpled upon 2 other issues that I fixed as well. So this PR covers:

1. Fixing a very weird issue in the `SmartHint` demo app page, where the initial calculation of hint would sit on top of the prefix text. I was not able to reproduce this outside of the `SmartHint` demo app which puzzles me quite a bit. To "fix" it, I added a hack to the demo app, where it simply overrides the prefix/suffix texts in a `Loaded` event handler on the demo app page itself; this seems to kick the calculation into gear. Another way to manually "fix" it is to simply clear the prefix text in the UI, and then set it to back to what it was (or anything non-emtpy basically).

2. The Material Design 2 spec is quite clear in the visualization of a `ComboBox` in various states. We did not follow that completely since we did not float the hint once the drop-down was visible. A small change in `SmartHint.cs` regarding `HintHost.IsKeyboardFocusWithin` fixes that issue. See the MD2 spec [here](https://m2.material.io/components/menus#exposed-dropdown-menu) (scroll down a small bit further to the "Behavior" section).

3. Fixes the actual issue reported in the linked issue above. For "readonly" controls, we have a "business rule" that the prefix/suffix texts are always visible. For editable controls, the prefix/suffix visibility depends on the value of `TextFieldAssist.PrefixTextVisibility` which defaults to `WhenFocusedOrNonEmpty`. In the "readonly" case, the fact that the prefix/suffix is always visible was not accounted for, this PR changes that.

### Before
![image](https://github.com/user-attachments/assets/35831576-4495-4eb6-9d05-3707dd5508b6)

![image](https://github.com/user-attachments/assets/ac0f502b-d613-48e7-b72f-c6f62349e30e)


### After
![image](https://github.com/user-attachments/assets/876cc219-e395-465a-82e0-4b8f3d45e134)

![image](https://github.com/user-attachments/assets/ef7e59db-e0d1-4d5c-b954-43d8d672712f)

@corvinsz @Keboo Could you guys please check out this branch and give it a short spin? Try to play around with `Smart Hint` and `Fields line up` demo pages, the former gives you a lot of control over how the hint/prefix/suffix and control behavior in general. It also showcases the different alignments, as well as all the controls supporting the `SmartHint` control.

And a small note-to-self: Think twice before undertaking a major refactoring of something as complex as the `SmartHint` and the placement-hell that lies within...