### PR TITLE
"fix" AutoSuggestBox has weird tab behavior

### DIFF
--- a/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
+++ b/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
@@ -167,7 +167,6 @@ public class AutoSuggestBox : TextBox
             default:
                 return;
         }
-        e.Handled = true;
     }
 
     protected override void OnLostFocus(RoutedEventArgs e)
@@ -233,6 +232,11 @@ public class AutoSuggestBox : TextBox
 
     private void CommitValueSelection(object? selectedValue)
     {
+        if (IsSuggestionOpen == false)
+        {
+            return;
+        }
+
         string oldValue = Text;
         Text = selectedValue?.ToString();
         if (Text != null)

--- a/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
+++ b/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
@@ -145,28 +145,36 @@ public class AutoSuggestBox : TextBox
 
     protected override void OnPreviewKeyDown(KeyEventArgs e)
     {
-        base.OnPreviewKeyDown(e);
         if (_autoSuggestBoxList is null) return;
         switch (e.Key)
         {
             case Key.Down:
                 IncrementSelection();
+                e.Handled = true;
                 break;
             case Key.Up:
                 DecrementSelection();
+                e.Handled = true;
                 break;
             case Key.Enter:
                 CommitValueSelection();
+                e.Handled = true;
                 break;
             case Key.Escape:
                 CloseAutoSuggestionPopUp();
+                e.Handled = true;
                 break;
             case Key.Tab:
-                CommitValueSelection();
+                bool wasItemSelected = CommitValueSelection();
+                if (wasItemSelected)
+                {
+                    e.Handled = true;
+                }
                 break;
             default:
                 return;
         }
+        base.OnPreviewKeyDown(e);
     }
 
     protected override void OnLostFocus(RoutedEventArgs e)
@@ -227,14 +235,14 @@ public class AutoSuggestBox : TextBox
         IsSuggestionOpen = false;
     }
 
-    private void CommitValueSelection()
+    private bool CommitValueSelection()
         => CommitValueSelection(_autoSuggestBoxList?.SelectedValue);
 
-    private void CommitValueSelection(object? selectedValue)
+    private bool CommitValueSelection(object? selectedValue)
     {
         if (IsSuggestionOpen == false)
         {
-            return;
+            return false;
         }
 
         string oldValue = Text;
@@ -249,6 +257,7 @@ public class AutoSuggestBox : TextBox
             RoutedEvent = SuggestionChosenEvent
         };
         RaiseEvent(args);
+        return true;
     }
 
     private void DecrementSelection()

--- a/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
+++ b/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
@@ -166,6 +166,7 @@ public class AutoSuggestBox : TextBox
                 break;
             case Key.Tab:
                 bool wasItemSelected = CommitValueSelection();
+                // Only mark the event as handled if the SuggestionList is open and therefore the Selection was successful
                 if (wasItemSelected)
                 {
                     e.Handled = true;

--- a/tests/MaterialDesignThemes.UITests/WPF/AutoSuggestBoxes/AutoSuggestTextBoxTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/AutoSuggestBoxes/AutoSuggestTextBoxTests.cs
@@ -145,14 +145,15 @@ public class AutoSuggestBoxTests : TestBase
         // Act
         await suggestBox.MoveKeyboardFocus();
         await Task.Delay(50);
-        await suggestBox.SendInput(new KeyboardInput("B"));
+        await suggestBox.SendInput(new KeyboardInput("B")); // Open the popup
         await Task.Delay(50);
         await suggestBox.SendInput(new KeyboardInput(Key.Escape)); // Close the popup
         await Task.Delay(50);
-        await suggestBox.SendInput(new KeyboardInput(Key.Tab)); // Press TAB to focus the next element (the TextBox)
+        await suggestBox.SendInput(new KeyboardInput(Key.Tab)); // Press TAB to focus the next element
         await Task.Delay(50);
 
         // Assert
+        Assert.False(await suggestBox.GetIsFocused());
         Assert.True(await nextTextBox.GetIsFocused());
 
         recorder.Success();

--- a/tests/MaterialDesignThemes.UITests/WPF/AutoSuggestBoxes/AutoSuggestTextBoxTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/AutoSuggestBoxes/AutoSuggestTextBoxTests.cs
@@ -1,4 +1,5 @@
-﻿using MaterialDesignThemes.UITests.Samples.AutoSuggestBoxes;
+﻿using System.ComponentModel;
+using MaterialDesignThemes.UITests.Samples.AutoSuggestBoxes;
 using MaterialDesignThemes.UITests.Samples.AutoSuggestTextBoxes;
 using Xunit.Sdk;
 
@@ -47,7 +48,7 @@ public class AutoSuggestBoxTests : TestBase
     public async Task CanChoiceItem_FromTheSuggestions_AssertTheTextUpdated()
     {
         await using var recorder = new TestRecorder(App);
-        
+
         //Arrange
         IVisualElement<AutoSuggestBox> suggestBox = (await LoadUserControl<AutoSuggestTextBoxWithTemplate>()).As<AutoSuggestBox>();
         IVisualElement<Popup> popup = await suggestBox.GetElement<Popup>();
@@ -118,6 +119,41 @@ public class AutoSuggestBoxTests : TestBase
         await AssertExists(suggestionListBox, "Apples", false);
         await AssertExists(suggestionListBox, "Mtn Dew", false);
         await AssertExists(suggestionListBox, "Orange", false);
+
+        recorder.Success();
+    }
+
+    [Fact]
+    [Description("Issue 3761")]
+    public async Task AutoSuggestBox_MovesFocusToNextElement_WhenPopupIsClosed()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        // Arrange
+        string xaml = """
+            <StackPanel>
+                <local:AutoSuggestTextBoxWithCollectionView x:Name="AutoSuggestBoxSample" />
+                <TextBox x:Name="NextTextBox" />
+            </StackPanel>
+        """;
+
+        IVisualElement<StackPanel> stackPanel = await LoadXaml<StackPanel>(xaml, ("local", typeof(AutoSuggestTextBoxWithCollectionView)));
+        var suggestBoxSample = await stackPanel.GetElement<AutoSuggestTextBoxWithCollectionView>("AutoSuggestBoxSample");
+        IVisualElement<AutoSuggestBox> suggestBox = await suggestBoxSample.GetElement<AutoSuggestBox>();
+        IVisualElement<TextBox> nextTextBox = await stackPanel.GetElement<TextBox>("NextTextBox");
+
+        // Act
+        await suggestBox.MoveKeyboardFocus();
+        await Task.Delay(50);
+        await suggestBox.SendInput(new KeyboardInput("B"));
+        await Task.Delay(50);
+        await suggestBox.SendInput(new KeyboardInput(Key.Escape)); // Close the popup
+        await Task.Delay(50);
+        await suggestBox.SendInput(new KeyboardInput(Key.Tab)); // Press TAB to focus the next element (the TextBox)
+        await Task.Delay(50);
+
+        // Assert
+        Assert.True(await nextTextBox.GetIsFocused());
 
         recorder.Success();
     }


### PR DESCRIPTION
potential fix for #3761 

From my manual testing this fixes both problems mentioned in the issue.

This is a first "working" version but probably not ready for prod yet.
The changes essentially only mark the `KeyEventArgs e` event as handled, if one of the `AutoSuggestBox` "specific" keys is pressed. Additionally the method `CommitValueSelection` now returns a `bool` to indicate whether an item was selected or not.

I think this is test-worthy and therefore WIP