### PR TITLE
[SmartHint] Fix minor UI jump

### DIFF
--- a/src/MainDemo.Wpf/FieldsLineUp.xaml
+++ b/src/MainDemo.Wpf/FieldsLineUp.xaml
@@ -108,6 +108,7 @@
             <CheckBox x:Name="IsEnabledCheckBox"
                       Content="IsEnabled"
                       IsChecked="True" />
+            <CheckBox x:Name="IsReadOnlyCheckBox" Content="TextBox.IsReadOnly" />
             <CheckBox x:Name="HasClearButtonCheckBox" Content="TextFieldAssist.HasClearButton" />
             <CheckBox x:Name="IsEditableCheckBox" Content="ComboBox.IsEditable" />
           </StackPanel>

--- a/src/MainDemo.Wpf/FieldsLineUp.xaml.cs
+++ b/src/MainDemo.Wpf/FieldsLineUp.xaml.cs
@@ -52,6 +52,8 @@ public partial class FieldsLineUp
             control.Margin = new Thickness(2, 10, 2, 10);
             if (control is ComboBox comboBox)
                 comboBox.SetBinding(ComboBox.IsEditableProperty, new Binding(nameof(CheckBox.IsChecked)) { ElementName = nameof(IsEditableCheckBox) });
+            if (control is TextBoxBase tb)
+                tb.SetBinding(TextBoxBase.IsReadOnlyProperty, new Binding(nameof(CheckBox.IsChecked)) { ElementName = nameof(IsReadOnlyCheckBox) });
             SetValue(control);
         }
     }

--- a/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml
@@ -97,6 +97,7 @@
           <CheckBox x:Name="IsEnabledCheckBox"
                     Content="IsEnabled"
                     IsChecked="True" />
+          <CheckBox x:Name="IsReadOnlyCheckBox" Content="TextBox.IsReadOnly" />
           <CheckBox x:Name="HasClearButtonCheckBox" Content="TextFieldAssist.HasClearButton" />
           <CheckBox x:Name="IsEditableCheckBox" Content="ComboBox.IsEditable" />
         </StackPanel>

--- a/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml.cs
+++ b/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml.cs
@@ -52,6 +52,8 @@ public partial class FieldsLineUp
             control.Margin = new Thickness(2, 10, 2, 10);
             if (control is ComboBox comboBox)
                 comboBox.SetBinding(ComboBox.IsEditableProperty, new Binding(nameof(CheckBox.IsChecked)) { ElementName = nameof(IsEditableCheckBox) });
+            if (control is TextBoxBase tb)
+                tb.SetBinding(TextBoxBase.IsReadOnlyProperty, new Binding(nameof(CheckBox.IsChecked)) { ElementName = nameof(IsReadOnlyCheckBox) });
             SetValue(control);
         }
     }

--- a/src/MaterialDesignThemes.Wpf/Converters/FloatingHintInitialHorizontalOffsetConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/FloatingHintInitialHorizontalOffsetConverter.cs
@@ -41,7 +41,7 @@ public class FloatingHintInitialHorizontalOffsetConverter : IMultiValueConverter
                     when prefixHintBehavior == PrefixSuffixHintBehavior.AlignWithText && isEditable =>
                     prefixWidth + prefixMargin.Right,
                 PrefixSuffixVisibility.WhenFocusedOrNonEmpty
-                    when prefixHintBehavior == PrefixSuffixHintBehavior.AlignWithPrefixSuffix && !isEditable =>
+                    when prefixHintBehavior == PrefixSuffixHintBehavior.AlignWithPrefixSuffix && !isEditable && prefixWidth > 0 =>
                     -(prefixWidth + prefixMargin.Right),
                 PrefixSuffixVisibility.Always
                     when prefixHintBehavior == PrefixSuffixHintBehavior.AlignWithPrefixSuffix =>
@@ -58,7 +58,7 @@ public class FloatingHintInitialHorizontalOffsetConverter : IMultiValueConverter
                     when suffixHintBehavior == PrefixSuffixHintBehavior.AlignWithText && isEditable =>
                     -(suffixWidth + suffixMargin.Left),
                 PrefixSuffixVisibility.WhenFocusedOrNonEmpty
-                    when suffixHintBehavior == PrefixSuffixHintBehavior.AlignWithPrefixSuffix && !isEditable =>
+                    when suffixHintBehavior == PrefixSuffixHintBehavior.AlignWithPrefixSuffix && !isEditable && suffixWidth > 0 =>
                     suffixWidth + suffixMargin.Left,
                 PrefixSuffixVisibility.Always
                     when suffixHintBehavior == PrefixSuffixHintBehavior.AlignWithPrefixSuffix =>


### PR DESCRIPTION
On your latest stream working on the SmartHint PR, you noticed a small UI jump on the `Fields line up` demo app page. Turns out that was actually a bug, so I fixed it.

The extra pattern matching case from the previous PR was missing a minor condition on it (namely that the width of the prefix/suffix > 0). This avoids the case you saw where the margin of the prefix/suffix was being subtracted, causing a minor jump in the UI.

The same thing happened for `TextBox` elements, so I added an checkbox controlling `TextBoxBase.IsReadOnly` on the demo page to showcase it. The before/after below shows that both had the issue before, and that it is now fixed.

### Before
![FieldsLineUp-UiJump](https://github.com/user-attachments/assets/e81b9d87-4028-44fb-8c07-c7bfcf9e3d25)

### After
![FieldsLineUp-UiJumpFixed](https://github.com/user-attachments/assets/448c4589-27a4-4aa9-8b16-c2a7d09f9fb1)
