### PR TITLE
TextBoxLineCountBehavior: Fixed UpdateAttachedProperties NullReferenceException

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
+++ b/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
@@ -12,8 +12,11 @@ public class TextBoxLineCountBehavior : Behavior<TextBox>
 
     private void UpdateAttachedProperties()
     {
-        AssociatedObject.SetCurrentValue(TextFieldAssist.TextBoxLineCountProperty, AssociatedObject.LineCount);
-        AssociatedObject.SetCurrentValue(TextFieldAssist.TextBoxIsMultiLineProperty, AssociatedObject.LineCount > 1);
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.SetCurrentValue(TextFieldAssist.TextBoxLineCountProperty, AssociatedObject.LineCount);
+            AssociatedObject.SetCurrentValue(TextFieldAssist.TextBoxIsMultiLineProperty, AssociatedObject.LineCount > 1);
+        }
     }
 
     protected override void OnAttached()


### PR DESCRIPTION
UpdateAttachedProperties can be called when the behavior is detached, causing NullReferenceExceptions. Added null checking.