### PR TITLE
MD3 ToggleButton - Add fallback value to binding to avoid division by NaN

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.ToggleButton.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.ToggleButton.xaml
@@ -377,7 +377,7 @@
                 </DoubleAnimation>
                 <DoubleAnimation Storyboard.TargetName="Thumb"
                                  Storyboard.TargetProperty="Width"
-                                 To="{Binding Tag, ElementName=SwitchGrid}"
+                                 To="{Binding Tag, ElementName=SwitchGrid, FallbackValue=0}"
                                  Duration="0:0:0.2">
                   <DoubleAnimation.EasingFunction>
                     <QuadraticEase EasingMode="EaseOut" />
@@ -385,7 +385,7 @@
                 </DoubleAnimation>
                 <DoubleAnimation Storyboard.TargetName="Thumb"
                                  Storyboard.TargetProperty="Height"
-                                 To="{Binding Tag, ElementName=SwitchGrid}"
+                                 To="{Binding Tag, ElementName=SwitchGrid, FallbackValue=0}"
                                  Duration="0:0:0.16">
                   <DoubleAnimation.EasingFunction>
                     <QuadraticEase EasingMode="EaseOut" />
@@ -399,11 +399,11 @@
                                  Duration="0" />
                 <DoubleAnimation Storyboard.TargetName="Thumb"
                                  Storyboard.TargetProperty="Width"
-                                 To="{Binding Tag, ElementName=SwitchGrid}"
+                                 To="{Binding Tag, ElementName=SwitchGrid, FallbackValue=0}"
                                  Duration="0" />
                 <DoubleAnimation Storyboard.TargetName="Thumb"
                                  Storyboard.TargetProperty="Height"
-                                 To="{Binding Tag, ElementName=SwitchGrid}"
+                                 To="{Binding Tag, ElementName=SwitchGrid, FallbackValue=0}"
                                  Duration="0" />
               </Storyboard>
             </Grid.Resources>


### PR DESCRIPTION
Fixes #3740 

The bindings changed in this PR are bound to a `Tag` property which becomes `null` when the control is unloaded. This results in an exception being thrown from the `DoubleAnimation` presumably because `DoubleAnimation.To` (of type `double`) being bound to `null` results in `double.NaN`.

To avoid the exception, this PR simply applies a fallback value of 0 to the binding, which effectively mitigates the issue.

I don't believe this should affect the visual appearance of the `ToggleButton` since the `Tag` binding will have a valid value as long as the element is loaded/visible.

Using Snoop, it is also possible to observe the `Tag` value changing from 16 to '' (null I suppose).