### PR TITLE
#3740 - Fix to Style MaterialDesignSwitchToggleButton 

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.ToggleButton.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesign3.ToggleButton.xaml
@@ -399,10 +399,12 @@
                                  Duration="0" />
                 <DoubleAnimation Storyboard.TargetName="Thumb"
                                  Storyboard.TargetProperty="Width"
+                                 From="0"
                                  To="{Binding Tag, ElementName=SwitchGrid}"
                                  Duration="0" />
                 <DoubleAnimation Storyboard.TargetName="Thumb"
                                  Storyboard.TargetProperty="Height"
+                                 From="0"
                                  To="{Binding Tag, ElementName=SwitchGrid}"
                                  Duration="0" />
               </Storyboard>


### PR DESCRIPTION
### Fix: Add Default From Value to UncheckedStoryboard DoubleAnimations in MaterialDesignSwitchToggleButton

This PR resolves the issue reported in [#3740](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/3740), where the `MaterialDesignSwitchToggleButton` caused a `System.InvalidOperationException` due to the `DoubleAnimation` using an undefined origin value of `NaN`.

The solution introduces a `From` value of `0` to the `Width` and `Height` animations in the `UncheckedStoryboard`, ensuring that the animations have a valid starting value even if the `Tag` binding is unavailable at runtime. This prevents the exception while preserving the intended visual behavior of the control.

---

### Changes Made
The following lines were updated in **MaterialDesign3.ToggleButton.xaml**:

```xaml
<DoubleAnimation Storyboard.TargetName="Thumb"
                 Storyboard.TargetProperty="Width"
                 From="0"
                 To="{Binding Tag, ElementName=SwitchGrid}"
                 Duration="0" />
<DoubleAnimation Storyboard.TargetName="Thumb"
                 Storyboard.TargetProperty="Height"
                 From="0"
                 To="{Binding Tag, ElementName=SwitchGrid}"
                 Duration="0" />
```

---

### Testing
The fix has been tested using the sample provided in the issue discussion. The problem is resolved without any visible differences in the animations or behavior of the control, including with both default and custom content.

---

### Additional Notes
- The `From="0"` approach was preferred over a `FallbackValue` as it directly addresses the problem at the animation level.
- The other animations in the control do not appear to require similar changes.
- Credit to @TWhidden, @corvinsz, and @nicolaihenriksen for the investigation and solution brainstorming.

---

### Checklist
- [x] Issue referenced in the PR description.
- [x] Changes tested with provided reproduction steps.
- [x] Style guidelines followed for MaterialDesignInXamlToolkit.
- [x] Unit tests not applicable (styling-related fix).
- [x] Ready for review by maintainers.
