### PR TITLE
Fixed PART_ClearButton in AutoSuggestBox

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -232,9 +232,11 @@
                           Grid.Column="5"
                           Height="{TemplateBinding wpf:TextFieldAssist.ClearButtonSize}"
                           Width="{TemplateBinding wpf:TextFieldAssist.ClearButtonSize}"
+                          Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                           Padding="2,0,0,0"
                           Command="{x:Static internal:ClearText.ClearCommand}"
                           Focusable="False"
+                          Foreground="{TemplateBinding Foreground}"
                           VerticalAlignment="{TemplateBinding wpf:TextFieldAssist.IconVerticalAlignment}"
                           Style="{StaticResource MaterialDesignToolButton}">
                     <Button.Visibility>


### PR DESCRIPTION
I noticed the `ClearButton` in the `AutoSuggestBox` slightly differs from the other controls:

![image](https://github.com/user-attachments/assets/64be6ae7-a25e-4b04-83e0-0ef212e0a324)

A few TemplateBindings were missing.

The `ClearButton` in the `AutoSuggestBox` is now synced with one of the `TextBox`.