### PR TITLE
Badged: ArrangeOverride Infinate loop fix

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Badged.cs
+++ b/src/MaterialDesignThemes.Wpf/Badged.cs
@@ -161,7 +161,6 @@ public class Badged : ContentControl
 
         var h = 0 - containerDesiredSize.Width / 2;
         var v = 0 - containerDesiredSize.Height / 2;
-        _badgeContainer.Margin = new Thickness(0);
         _badgeContainer.Margin = new Thickness(h, v, h, v);
 
         return result;


### PR DESCRIPTION
We had issues with infinate loops in our application. We eventually found that the ArrangeOverride method of Badged caused this issue. In the code we found that the _badgeContainer.Margin is set twice. Removing this the first set solves our issue and also seems not necessary.