### PR TITLE
Fix: Add null check for AutoSuggestBox selection handling

### DIFF
--- a/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
+++ b/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
@@ -192,28 +192,30 @@ public class AutoSuggestBox : TextBox
 
     private void AutoSuggestionListBox_PreviewMouseDown(object sender, MouseButtonEventArgs e)
     {
-        if (_autoSuggestBoxList is not null && e.OriginalSource is FrameworkElement element)
-        {
-            var selectedItem = element.DataContext;
-            if (!_autoSuggestBoxList.Items.Contains(selectedItem))
-                return;
-            if (!_autoSuggestBoxList.SelectedItem.Equals(selectedItem))
-            {
-                _autoSuggestBoxList.SelectionChanged += OnSelectionChanged;
-                _autoSuggestBoxList.SelectedItem = selectedItem;
-            }
-            else
-            {
-                _autoSuggestBoxList.SelectedItem = selectedItem;
-                CommitValueSelection();
-            }
+        if (_autoSuggestBoxList is null || e.OriginalSource is not FrameworkElement element)
+            return;
 
-            void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        var selectedItem = element.DataContext;
+        if (!_autoSuggestBoxList.Items.Contains(selectedItem))
+            return;
+
+        e.Handled = true;
+
+        if (!Equals(_autoSuggestBoxList.SelectedItem, selectedItem))
+        {
+            void OnSelectionChanged(object s, SelectionChangedEventArgs args)
             {
                 _autoSuggestBoxList.SelectionChanged -= OnSelectionChanged;
                 CommitValueSelection();
             }
-            e.Handled = true;
+
+            _autoSuggestBoxList.SelectionChanged += OnSelectionChanged;
+            _autoSuggestBoxList.SelectedItem = selectedItem;
+        }
+        else
+        {
+            _autoSuggestBoxList.SelectedItem = selectedItem;
+            CommitValueSelection();
         }
     }
 


### PR DESCRIPTION
This PR fixes the crash reported in #3741 where selecting an item from the AutoSuggestBox suggestions list causes a null reference exception.

Changes made:
- Added defensive null checks in AutoSuggestionListBox_PreviewMouseDown
- Improved selection handling logic to prevent null reference exceptions
- Ensures safe handling of the SelectionChanged event

The fix prevents the crash by properly checking for null values before accessing SelectedItem and during the selection change process.

To test:
1. Create an AutoSuggestBox with suggestions
2. Type to show suggestions
3. Select an item from the dropdown
4. Verify no crash occurs and selection works as expected

Related issue: #3741