### PR TITLE
Fix default CornerRadius in FilledAutoSuggestBox style

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -612,7 +612,7 @@
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.FilledBackground}" />
     <Setter Property="Padding" Value="{x:Static wpf:Constants.FilledTextBoxDefaultPadding}" />
     <Setter Property="wpf:TextFieldAssist.HasFilledTextField" Value="True" />
-    <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4" />
+    <Setter Property="wpf:TextFieldAssist.TextFieldCornerRadius" Value="4,4,0,0" />
     <Setter Property="wpf:TextFieldAssist.UnderlineCornerRadius" Value="0" />
   </Style>
 


### PR DESCRIPTION
fixed a minor mistake with the `CornerRadius` in the default `MaterialDesignFilledAutoSuggestBox` style where the bottom left and bottom right corners have a radius applied.

## Current behavior
![image](https://github.com/user-attachments/assets/9f6ece83-ebf9-473b-99db-a1cf3a209447)

## New behavior
![image](https://github.com/user-attachments/assets/2b839221-1206-40a3-a037-c00cc809c2aa)