### PR TITLE
Fix NumericUpDown Buttons not disabling

### DIFF
--- a/src/MaterialDesignThemes.Wpf/UpDownBase.cs
+++ b/src/MaterialDesignThemes.Wpf/UpDownBase.cs
@@ -121,14 +121,23 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
             textBox.Text = e.NewValue.ToString();
         }
 
-        if (upDownBase._increaseButton is { } increaseButton)
-        {
-            increaseButton.IsEnabled = Compare(upDownBase.Value, upDownBase.Maximum) < 0;
-        }
+        upDownBase.UpdateDecreaseButtonEnabled();
+        upDownBase.UpdateIncreaseButtonEnabled();
+    }
 
-        if (upDownBase._decreaseButton is { } decreaseButton)
+    private void UpdateIncreaseButtonEnabled()
+    {
+        if (_increaseButton is { } increaseButton)
         {
-            decreaseButton.IsEnabled = Compare(upDownBase.Value, upDownBase.Minimum) > 0;
+            increaseButton.IsEnabled = Compare(Value, Maximum) < 0;
+        }
+    }
+
+    private void UpdateDecreaseButtonEnabled()
+    {
+        if (_decreaseButton is { } decreaseButton)
+        {
+            decreaseButton.IsEnabled = Compare(Value, Minimum) > 0;
         }
     }
 
@@ -197,10 +206,16 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
         base.OnApplyTemplate();
 
         if (_increaseButton != null)
+        {
             _increaseButton.Click += IncreaseButtonOnClick;
+            UpdateIncreaseButtonEnabled();
+        }
 
         if (_decreaseButton != null)
+        {
             _decreaseButton.Click += DecreaseButtonOnClick;
+            UpdateDecreaseButtonEnabled();
+        }
 
         if (_textBoxField != null)
         {

--- a/tests/MaterialDesignThemes.UITests/WPF/UpDownControls/NumericUpDownTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/UpDownControls/NumericUpDownTests.cs
@@ -187,4 +187,32 @@ public class NumericUpDownTests(ITestOutputHelper output) : TestBase(output)
 
         recorder.Success();
     }
+
+    [Theory]
+    [InlineData(1, false, true)]
+    [InlineData(5, true, true)]
+    [InlineData(10, true, false)]
+    [Description("Issue 3796")]
+    public async Task NumericUpDown_WhenValueEqualsMinimum_DisableButtons(int value,
+        bool decreaseEnabled, bool increaseEnabled)
+    {
+        await using var recorder = new TestRecorder(App);
+        //Arrange
+        var numericUpDown = await LoadXaml<NumericUpDown>($"""
+        <materialDesign:NumericUpDown Value="{value}" Maximum="10" Minimum="1" />
+        """);
+        var increaseButton = await numericUpDown.GetElement<RepeatButton>("PART_IncreaseButton");
+        var decreaseButton = await numericUpDown.GetElement<RepeatButton>("PART_DecreaseButton");
+
+        //Act
+
+        bool increaseButtonEnabled = await increaseButton.GetIsEnabled();
+        bool decreaseButtonEnabled = await decreaseButton.GetIsEnabled();
+
+        //Assert
+        Assert.Equal(increaseEnabled, increaseButtonEnabled);
+        Assert.Equal(decreaseEnabled, decreaseButtonEnabled);
+
+        recorder.Success();
+    }
 }


### PR DESCRIPTION
fixes #3796 

The following example uses a `Maximum` and initial `Value` of `2.5`.

## Current behavior
![numUpDownBugMaxPrevious](https://github.com/user-attachments/assets/b642b88e-c27f-431f-9cc1-f5aa38944940)

## New behavior
![numUpDownBugMaxPost](https://github.com/user-attachments/assets/7dcde78f-2fb7-49fa-a4ac-a157321a651b)
