### PR TITLE
Introduce AP to control IsTabStop of the reveal button in PasswordBox (reveal style)

### DIFF
--- a/src/MaterialDesignThemes.Wpf/PasswordBoxAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/PasswordBoxAssist.cs
@@ -19,6 +19,11 @@ public static class PasswordBoxAssist
     public static void SetIsPasswordRevealed(DependencyObject element, bool value) => element.SetValue(IsPasswordRevealedProperty, value);
     public static bool GetIsPasswordRevealed(DependencyObject element) => (bool)element.GetValue(IsPasswordRevealedProperty);
 
+    public static readonly DependencyProperty IsRevealButtonTabStopProperty = DependencyProperty.RegisterAttached(
+        "IsRevealButtonTabStop", typeof(bool), typeof(PasswordBoxAssist), new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.Inherits));
+    public static void SetIsRevealButtonTabStop(DependencyObject element, bool value) => element.SetValue(IsRevealButtonTabStopProperty, value);
+    public static bool GetIsRevealButtonTabStop(DependencyObject element) => (bool)element.GetValue(IsRevealButtonTabStopProperty);
+
     public static readonly DependencyProperty PasswordProperty = DependencyProperty.RegisterAttached(
         "Password", typeof(string), typeof(PasswordBoxAssist), new FrameworkPropertyMetadata(null, HandlePasswordChanged) { BindsTwoWayByDefault = true, DefaultUpdateSourceTrigger = UpdateSourceTrigger.LostFocus });
     public static void SetPassword(DependencyObject element, string value) => element.SetValue(PasswordProperty, value);

--- a/src/MaterialDesignThemes.Wpf/PasswordBoxAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/PasswordBoxAssist.cs
@@ -20,7 +20,7 @@ public static class PasswordBoxAssist
     public static bool GetIsPasswordRevealed(DependencyObject element) => (bool)element.GetValue(IsPasswordRevealedProperty);
 
     public static readonly DependencyProperty IsRevealButtonTabStopProperty = DependencyProperty.RegisterAttached(
-        "IsRevealButtonTabStop", typeof(bool), typeof(PasswordBoxAssist), new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.Inherits));
+        "IsRevealButtonTabStop", typeof(bool), typeof(PasswordBoxAssist), new PropertyMetadata(true));
     public static void SetIsRevealButtonTabStop(DependencyObject element, bool value) => element.SetValue(IsRevealButtonTabStopProperty, value);
     public static bool GetIsRevealButtonTabStop(DependencyObject element) => (bool)element.GetValue(IsRevealButtonTabStopProperty);
 

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -884,6 +884,7 @@
                   <ToggleButton x:Name="RevealPasswordButton"
                                 Grid.Column="4"
                                 Height="Auto"
+                                IsTabStop="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:PasswordBoxAssist.IsRevealButtonTabStop)}"
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                 Padding="2,0,0,0"
                                 VerticalAlignment="Center"

--- a/tests/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using MaterialDesignThemes.UITests.Samples.PasswordBox;
 using MaterialDesignThemes.UITests.WPF.TextBoxes;
 
@@ -330,6 +330,36 @@ public class PasswordBoxTests : TestBase
         Assert.True(await revealPasswordTextBox.GetIsKeyboardFocused());
         await revealPasswordTextBox.SendKeyboardInput($"{Key.Tab}{ModifierKeys.None}");
         Assert.True(await textBox1.GetIsKeyboardFocused());
+
+        recorder.Success();
+    }
+
+    [Fact]
+    [Description("Issue 3799")]
+    public async Task PasswordBox_WithRevealButtonIsTabStopSetToFalse_RespectsKeyboardTabNavigation()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        var stackPanel = await LoadXaml<StackPanel>("""
+            <StackPanel Orientation="Vertical">
+              <PasswordBox x:Name="PasswordBox" Width="200"
+                           Style="{StaticResource MaterialDesignFilledRevealPasswordBox}" />
+              <TextBox x:Name="TextBox" Width="200" />
+            </StackPanel>
+            """);
+
+        var passwordBox = await stackPanel.GetElement<PasswordBox>("PasswordBox");
+        var textBox = await stackPanel.GetElement<TextBox>("TextBox");
+
+        // Assert Tab forward
+        await passwordBox.MoveKeyboardFocus();
+        Assert.True(await passwordBox.GetIsKeyboardFocused());
+        await passwordBox.SendKeyboardInput($"{Key.Tab}");
+        Assert.True(await textBox.GetIsKeyboardFocused());
+        
+        // Assert Tab backwards
+        await textBox.SendKeyboardInput($"{ModifierKeys.Shift}{Key.Tab}{ModifierKeys.None}");
+        Assert.True(await passwordBox.GetIsKeyboardFocused());
 
         recorder.Success();
     }

--- a/tests/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/PasswordBoxes/PasswordBoxTests.cs
@@ -343,6 +343,7 @@ public class PasswordBoxTests : TestBase
         var stackPanel = await LoadXaml<StackPanel>("""
             <StackPanel Orientation="Vertical">
               <PasswordBox x:Name="PasswordBox" Width="200"
+                           materialDesign:PasswordBoxAssist.IsRevealButtonTabStop="False"
                            Style="{StaticResource MaterialDesignFilledRevealPasswordBox}" />
               <TextBox x:Name="TextBox" Width="200" />
             </StackPanel>


### PR DESCRIPTION
Fixes #3799 

As mentioned in the issue/feature request, I have been unsuccessful at trying to fix this by simply overriding a style (in particular the `MaterialDesignRawToggleButton` style). I believe this has become somewhat more difficult after we decided to move the "internal styles" out of the root-level `ResourceDictionary` and closer to where they are used.

In this particular case, the style is nested under the `<ControlTemplate.Resources>` and thus I am unsure how I can override that as a MDIX consumer without overriding the entire template. I did try to move the inner style one level out so it resides in the `<Style.Resources>` instead; however even with that in place, I still struggled to override it.

This PR introduces an AP which allows the caller to control it.

I added a UI test mainly for the purpose of playing around with various ways of getting it to work, but in the end I could only get the AP approach to work 😞 

### Without AP
![PasswordBoxFocusIssue](https://github.com/user-attachments/assets/44ee7db9-8c20-43be-93b6-5c0941939971)

### With AP (set to `False`)
![PasswordBoxFocusIssueFixed](https://github.com/user-attachments/assets/4f218a4b-23cc-4ed1-814d-abe067c5f092)
