### PR TITLE
Fix Enhance Mouseover Visuals for TabControl

### DIFF
--- a/src/MaterialDesignThemes.Wpf/TabAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/TabAssist.cs
@@ -27,7 +27,7 @@ public static class TabAssist
         => element.SetValue(HeaderPanelMarginProperty, value);
 
     public static Thickness GetHeaderPanelMargin(DependencyObject element)
-        => (Thickness) element.GetValue(HeaderPanelMarginProperty);
+        => (Thickness)element.GetValue(HeaderPanelMarginProperty);
 
     internal static Visibility GetBindableIsItemsHost(DependencyObject obj)
         => (Visibility)obj.GetValue(BindableIsItemsHostProperty);
@@ -45,4 +45,13 @@ public static class TabAssist
             panel.IsItemsHost = (Visibility)e.NewValue == Visibility.Visible;
         }
     }
+
+    public static Cursor GetTabHeaderCursor(DependencyObject obj)
+        => (Cursor)obj.GetValue(TabHeaderCursorProperty);
+
+    public static void SetTabHeaderCursor(DependencyObject obj, Cursor value)
+        => obj.SetValue(TabHeaderCursorProperty, value);
+
+    public static readonly DependencyProperty TabHeaderCursorProperty =
+        DependencyProperty.RegisterAttached("TabHeaderCursor", typeof(Cursor), typeof(TabAssist), new PropertyMetadata(Cursors.Hand));
 }

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -291,7 +291,7 @@
                                Duration="0" />
             </Storyboard>
           </ControlTemplate.Resources>
-          <Grid x:Name="Root" Cursor="Hand">
+          <Grid x:Name="Root" Cursor="{Binding Path=(wpf:TabAssist.TabHeaderCursor), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}">
             <!-- This is the Header label ColorZone. -->
             <wpf:ColorZone x:Name="ColorZoneHeader"
                            HorizontalAlignment="Stretch"

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -291,7 +291,7 @@
                                Duration="0" />
             </Storyboard>
           </ControlTemplate.Resources>
-          <Grid x:Name="Root">
+          <Grid x:Name="Root" Cursor="Hand">
             <!-- This is the Header label ColorZone. -->
             <wpf:ColorZone x:Name="ColorZoneHeader"
                            HorizontalAlignment="Stretch"
@@ -333,6 +333,9 @@
             </Border>
           </Grid>
           <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True" SourceName="ColorZoneHeader">
+              <Setter TargetName="Root" Property="Background" Value="{Binding Foreground, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={x:Static converters:BrushOpacityConverter.Instance}, ConverterParameter=0.16}" />
+            </Trigger>
             <Trigger Property="IsEnabled" Value="False">
               <Setter Property="Opacity" Value="0.38" />
             </Trigger>


### PR DESCRIPTION
fixes #3802

- Sets the `Cursor="Hand"` when hovering over a `TabItem`
- Added the same "hover effect" to `TabItem` which any normal `Button` has

## Current behavior
![tabControlPre](https://github.com/user-attachments/assets/42558df8-bb35-4278-a320-93f73c1d5ef9)

## New behavior
![tabControlPost](https://github.com/user-attachments/assets/a2d67182-894f-4877-81f6-a6a69d08bee6)
