### PR TITLE
Update MaterialDesignTheme.PasswordBox.xaml

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -884,6 +884,7 @@
                   <ToggleButton x:Name="RevealPasswordButton"
                                 Grid.Column="4"
                                 Height="Auto"
+                                Focusable="False"
                                 IsTabStop="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:PasswordBoxAssist.IsRevealButtonTabStop)}"
                                 Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                                 Padding="2,0,0,0"


### PR DESCRIPTION
¿Por qué es útil?
🔹 Mejora la accesibilidad y rapidez: Para quienes usan teclado, pueden navegar directamente al siguiente campo sin detenerse en el botón de revelar contraseña. 🔹 Evita navegación innecesaria: En la mayoría de los casos, si alguien quiere ver la contraseña, usará el mouse, por lo que incluirlo en la navegación con Tab es innecesario.