### PR TITLE
Update MaterialDesignTheme.PasswordBox.xaml

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -882,6 +882,7 @@
                   </TextBlock>
 
                   <ToggleButton x:Name="RevealPasswordButton"
+                                Focusable="False"
                                 Grid.Column="4"
                                 Height="Auto"
                                 IsTabStop="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:PasswordBoxAssist.IsRevealButtonTabStop)}"


### PR DESCRIPTION
By setting Focusable="False" on the ToggleButton, you've made an important enhancement to your app's user navigation. Normally, when you hit the Tab key, the focus jumps from one interactive element to the next (e.g., from a PasswordBox to a button). But with this change, the RevealPasswordButton no longer gets in the way during this keyboard navigation.

Why? Because the Tab key now skips over the password reveal button, making it clear that it's meant to be used only with the mouse. So users who navigate with Tab will focus only on the core fields they need (like the password box), while those who want to click the eye icon to reveal the password can do so easily with their mouse.

This small tweak refines the flow and prioritizes intuitive keyboard navigation—no distractions, just the essentials.