### PR TITLE
Inherit Windows accent color

### DIFF
--- a/src/MaterialDesignColors.Wpf/MaterialDesignColor.cs
+++ b/src/MaterialDesignColors.Wpf/MaterialDesignColor.cs
@@ -2,6 +2,7 @@
 
 public enum PrimaryColor
 {
+    Inherit,
     Red = MaterialDesignColor.Red500,
     Pink = MaterialDesignColor.Pink500,
     Purple = MaterialDesignColor.Purple500,
@@ -25,6 +26,7 @@ public enum PrimaryColor
 
 public enum SecondaryColor
 {
+    Inherit,
     Red = MaterialDesignColor.RedSecondary,
     Pink = MaterialDesignColor.PinkSecondary,
     Purple = MaterialDesignColor.PurpleSecondary,

--- a/src/MaterialDesignThemes.Wpf/Theme.cs
+++ b/src/MaterialDesignThemes.Wpf/Theme.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Media;
+﻿using System.Diagnostics;
+using System.Windows.Media;
 using MaterialDesignColors;
 using Microsoft.Win32;
 
@@ -29,6 +30,44 @@ public partial class Theme
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Get the current Windows accent color.
+    /// Based on ControlzEx
+    /// https://github.com/ControlzEx/ControlzEx/blob/48230bb023c588e1b7eb86ea83f7ddf7d25be735/src/ControlzEx/Theming/WindowsThemeHelper.cs#L53
+    /// </summary>
+    /// <returns></returns>
+    public static Color? GetSystemAccentColor()
+    {
+        Color? accentColor = null;
+
+        try
+        {
+            var registryValue = Registry.GetValue(@"HKEY_CURRENT_USER\Software\Microsoft\Windows\DWM", "ColorizationColor", null);
+
+            if (registryValue is null)
+            {
+                return null;
+            }
+
+            // We get negative values out of the registry, so we have to cast to int from object first.
+            // Casting from int to uint works afterwards and converts the number correctly.
+            var pp = (uint)(int)registryValue;
+            if (pp > 0)
+            {
+                var bytes = BitConverter.GetBytes(pp);
+                accentColor = Color.FromArgb(bytes[3], bytes[2], bytes[1], bytes[0]);
+            }
+
+            return accentColor;
+        }
+        catch (Exception exception)
+        {
+            Trace.TraceError(exception.ToString());
+        }
+
+        return accentColor;
     }
 
     public static Theme Create(BaseTheme baseTheme, Color primary, Color secondary)


### PR DESCRIPTION
fixes #3811
With this PR consumers can use the newly added `Inherit` member for the `PrimaryColor` and `SecondaryColor` enum.
Just like with `BaseTheme="Inherit"` inherit means "take the OS preferences".

This is largely based on how it is done in [ControlzEx](https://github.com/ControlzEx/ControlzEx/blob/48230bb023c588e1b7eb86ea83f7ddf7d25be735/src/ControlzEx/Theming/WindowsThemeHelper.cs#L53)

Notes:
In the case the value could not be read from the registry, or the conversion (registry value --> C# Color) is somehow failing, the code falls back to `SwatchHelper.Lookup.First().Value`. One alternative would be to throw an error instead, but I don't think such an "irrelevant" feature should throw an exception.

Example:
```diff

<materialDesign:BundledTheme BaseTheme="Inherit"
                             ColorAdjustment="{materialDesign:ColorAdjustment}"
-                            PrimaryColor="DeepPurple"
+                            PrimaryColor="Inherit"
-                            SecondaryColor="Lime" />
+                            SecondaryColor="Inherit" />
```

I also refactored the `BundledTheme` class slightly.