### PR TITLE
Wrap selection in the AutoSuggestBox

### DIFF
--- a/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
+++ b/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
@@ -268,7 +268,9 @@ public class AutoSuggestBox : TextBox
         if (_autoSuggestBoxList is null || Suggestions is null)
             return;
         ICollectionView collectionView = CollectionViewSource.GetDefaultView(Suggestions);
-        if (collectionView.IsCurrentBeforeFirst)
+
+        // If we're at the first item, wrap around to the last.
+        if (collectionView.CurrentPosition == 0)
             collectionView.MoveCurrentToLast();
         else
             collectionView.MoveCurrentToPrevious();
@@ -280,7 +282,10 @@ public class AutoSuggestBox : TextBox
         if (_autoSuggestBoxList is null || Suggestions is null)
             return;
         ICollectionView collectionView = CollectionViewSource.GetDefaultView(Suggestions);
-        if (collectionView.IsCurrentAfterLast)
+        int itemCount = collectionView.Cast<object>().Count();
+
+        // If we're at the last item, wrap around to the first.
+        if (collectionView.CurrentPosition == itemCount - 1)
             collectionView.MoveCurrentToFirst();
         else
             collectionView.MoveCurrentToNext();

--- a/tests/MaterialDesignThemes.UITests/WPF/AutoSuggestBoxes/AutoSuggestTextBoxTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/AutoSuggestBoxes/AutoSuggestTextBoxTests.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System.Collections;
+using System.ComponentModel;
 using MaterialDesignThemes.UITests.Samples.AutoSuggestBoxes;
 using MaterialDesignThemes.UITests.Samples.AutoSuggestTextBoxes;
 using Xunit.Sdk;
@@ -157,6 +158,67 @@ public class AutoSuggestBoxTests : TestBase
         Assert.True(await nextTextBox.GetIsFocused());
 
         recorder.Success();
+    }
+
+    [Fact]
+    [Description("Issue 3815")]
+    public async Task AutoSuggestBox_KeysUpAndDown_WrapAround()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        //Arrange
+        IVisualElement<AutoSuggestBox> suggestBox = (await LoadUserControl<AutoSuggestTextBoxWithTemplate>()).As<AutoSuggestBox>();
+        IVisualElement<Popup> popup = await suggestBox.GetElement<Popup>();
+        IVisualElement<ListBox> suggestionListBox = await popup.GetElement<ListBox>();
+
+        const int delay = 50;
+
+        //Act & Assert
+        await suggestBox.MoveKeyboardFocus();
+        await suggestBox.SendInput(new KeyboardInput("e"));
+        await Task.Delay(delay);
+
+        //var itemSource = (await suggestBox.GetSuggestions()).Cast<object>().ToList();
+
+        //var suggestions = await suggestionListBox.GetProperty<IEnumerable>(nameof(ListBox.ItemsSource));
+        //int itemCount = suggestions.Cast<object>().Count();
+
+        int itemCount = CountNonGenericEnumerable(await suggestBox.GetSuggestions());
+
+        //Assert that initially the first item is selected
+        int selectedIndex = await suggestionListBox.GetSelectedIndex();
+        Assert.Equal(0, selectedIndex);
+        await Task.Delay(delay);
+
+        //Assert that the last item is selected after pressing ArrowUp
+        await suggestBox.SendInput(new KeyboardInput(Key.Up));
+        Assert.Equal(itemCount - 1, await suggestionListBox.GetSelectedIndex());
+        await Task.Delay(delay);
+
+        //Assert that the first item is selected after pressing ArrowDown
+        await suggestBox.SendInput(new KeyboardInput(Key.Down));
+        Assert.Equal(0, await suggestionListBox.GetSelectedIndex());
+
+
+    }
+
+    internal static int CountNonGenericEnumerable(IEnumerable? source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        if (source is ICollection collection)
+        {
+            return collection.Count;
+        }
+
+        int count = 0;
+        IEnumerator e = source.GetEnumerator();
+        while (e.MoveNext())
+        {
+            count++;
+        }
+
+        return count;
     }
 
     private static async Task AssertExists(IVisualElement<ListBox> suggestionListBox, string text, bool existsOrNotCheck = true)


### PR DESCRIPTION
fixes #3815

As shown in the linked issue, currently users can null the `SelectedItem` of the internal `ListBox` using the up/down arrow keys.

@Keboo I also tried to add tests for this case, but I can't get it to work. It might be a me-problem, but I couldn't figure out how to access the ItemSource/Suggestions of the `AutoSuggestBox`. Instead of the actual suggestions, I got back a List of characters saying "(Collection)":
![image](https://github.com/user-attachments/assets/c2509538-c1b5-45e1-8646-45f0c5bda47d)

I need the ItemSource/Suggestions to assert that the "last" (Suggestions.Count - 1) item is selected. Could this be a bug with your XAML test library or am I simply using it wrong?