### PR TITLE
Fix issue #3819

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
+++ b/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
@@ -12,10 +12,10 @@ public class TextBoxLineCountBehavior : Behavior<TextBox>
 
     private void UpdateAttachedProperties()
     {
-        if (AssociatedObject != null)
+        if (AssociatedObject is { } associatedObject)
         {
-            AssociatedObject.SetCurrentValue(TextFieldAssist.TextBoxLineCountProperty, AssociatedObject.LineCount);
-            AssociatedObject.SetCurrentValue(TextFieldAssist.TextBoxIsMultiLineProperty, AssociatedObject.LineCount > 1);
+            associatedObject.SetCurrentValue(TextFieldAssist.TextBoxLineCountProperty, associatedObject.LineCount);
+            associatedObject.SetCurrentValue(TextFieldAssist.TextBoxIsMultiLineProperty, associatedObject.LineCount > 1);
         }
     }
 


### PR DESCRIPTION
Fixes #3819 

This change prevents an issue where the AssociatedObject unexpectedly changes in a non thread-safe manner. 
See #3819 for more information.