### PR TITLE
Fixed issue with margin of SplitButton not being applied as margin correctly

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SplitButton.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SplitButton.xaml
@@ -37,7 +37,6 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type wpf:SplitButton}">
           <Grid x:Name="OuterGrid"
-                Margin="{TemplateBinding Margin}"
                 Height="{TemplateBinding Height}"
                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                 UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
@@ -64,6 +63,7 @@
                     FontStyle="{TemplateBinding FontStyle}"
                     FontWeight="{TemplateBinding FontWeight}"
                     Height="{TemplateBinding Height}"
+                    Margin="0"
                     HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                     Style="{TemplateBinding ButtonStyle}"
                     VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -76,6 +76,7 @@
                           wpf:RippleAssist.IsDisabled="True"
                           Height="{TemplateBinding Height}"
                           Padding="0"
+                          Margin="0"
                           PopupUniformCornerRadius="{TemplateBinding PopupUniformCornerRadius}"
                           PopupElevation="{TemplateBinding PopupElevation}"
                           PlacementMode="{TemplateBinding PopupPlacementMode}"


### PR DESCRIPTION
When applying a margin to the SplitButton I got the following unexpected result:
![image](https://github.com/user-attachments/assets/098511b9-f8f4-4915-bbcc-4ce4bccfd756)

With this PR the margins will be applied similar as they would for a normal button.