### PR TITLE
Faulty links in MD3 demo app

### DIFF
--- a/src/MaterialDesign3.Demo.Wpf/Domain/DocumentationLink.cs
+++ b/src/MaterialDesign3.Demo.Wpf/Domain/DocumentationLink.cs
@@ -25,7 +25,7 @@ public class DocumentationLink
 
     public static DocumentationLink StyleLink(string nameChunk, bool isMd3Style = false)
     {
-        var themesUrl = $"{ConfigurationManager.AppSettings["GitHub"]}/blob/master/MaterialDesignThemes.Wpf/Themes/";
+        var themesUrl = $"{ConfigurationManager.AppSettings["GitHub"]}/blob/master/src/MaterialDesignThemes.Wpf/Themes/";
 
         return new DocumentationLink(
             DocumentationLinkType.StyleSource,
@@ -39,7 +39,7 @@ public class DocumentationLink
 
         return new DocumentationLink(
             DocumentationLinkType.ControlSource,
-            $"{ConfigurationManager.AppSettings["GitHub"]}/blob/master/MaterialDesignThemes.Wpf/{subNamespace}/{typeName}.cs",
+            $"{ConfigurationManager.AppSettings["GitHub"]}/blob/master/src/MaterialDesignThemes.Wpf/{subNamespace}/{typeName}.cs",
             typeName);
     }
 
@@ -53,7 +53,7 @@ public class DocumentationLink
 
         return new DocumentationLink(
             DocumentationLinkType.ControlSource,
-            $"{ConfigurationManager.AppSettings["GitHub"]}/blob/master/MaterialDesignThemes.Wpf/{typeName}.cs",
+            $"{ConfigurationManager.AppSettings["GitHub"]}/blob/master/src/MaterialDesignThemes.Wpf/{typeName}.cs",
             typeName);
     }
 


### PR DESCRIPTION
fixes #3835

In the MD3 demo a few links 404'd. The folder "src" was missing.