### PR TITLE
lift IsAnyDrawerOpen method to class level in DrawerHost

### DIFF
--- a/src/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/src/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -586,7 +586,7 @@ public class DrawerHost : ContentControl
 
     private void UpdateVisualStates(bool? useTransitions = null)
     {
-        var anyOpen = IsTopDrawerOpen || IsLeftDrawerOpen || IsBottomDrawerOpen || IsRightDrawerOpen;
+        var anyOpen = IsAnyDrawerOpen();
 
         VisualStateManager.GoToState(this,
             !anyOpen ? TemplateAllDrawersAllClosedStateName : TemplateAllDrawersAnyOpenStateName, useTransitions ?? !TransitionAssist.GetDisableTransitions(this));
@@ -661,11 +661,11 @@ public class DrawerHost : ContentControl
                 drawerContent.Effect = null;
             }
         }
+    }
 
-        bool IsAnyDrawerOpen()
-        {
-            return IsLeftDrawerOpen || IsTopDrawerOpen || IsRightDrawerOpen || IsBottomDrawerOpen;
-        }
+    private bool IsAnyDrawerOpen()
+    {
+        return IsLeftDrawerOpen || IsTopDrawerOpen || IsRightDrawerOpen || IsBottomDrawerOpen;
     }
 
     private static void RaiseDrawerOpened(DrawerHost drawerHost, Dock dock)


### PR DESCRIPTION
small cleanup of https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/pull/3832

This PR lifts up the `IsAnyDrawerOpen()` method in the `DrawerHost` to the class level for better reusability.
In the PR linked above, I didn't notice we already had this logic inplace somewhere else.