### PR TITLE
Fix off-center PopupBox ripple

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -272,17 +272,18 @@
                                   Clip="{Binding ElementName=GeometryEllipse, Path=RenderedGeometry}"
                                   ClipToBounds="True"
                                   Focusable="False"
-                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <!-- additional layer so we don't rotate the ripple directly which can cause jumpyness under certain layouts -->
-                        <ContentControl Content="{TemplateBinding Content}"
-                                        ContentTemplate="{TemplateBinding ContentTemplate}"
-                                        Focusable="False"
-                                        RenderTransformOrigin=".5,.5">
-                          <ContentControl.RenderTransform>
-                            <RotateTransform x:Name="ContentRotateTransform" Angle="0" />
-                          </ContentControl.RenderTransform>
-                        </ContentControl>
-                      </wpf:Ripple>
+                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                      <!-- additional layer so we don't rotate the ripple directly which can cause jumpyness under certain layouts -->
+                      <ContentControl Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Focusable="False"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      RenderTransformOrigin=".5,.5">
+                        <ContentControl.RenderTransform>
+                          <RotateTransform x:Name="ContentRotateTransform" Angle="0" />
+                        </ContentControl.RenderTransform>
+                      </ContentControl>
                       <Ellipse x:Name="GeometryEllipse"
                                Fill="Transparent"
                                Focusable="False"


### PR DESCRIPTION
Fixes #3839 

This PR modifies the `MaterialDesignMultiFloatingActionPopupBox` and `MaterialDesignMultiFloatingActionSecondaryPopupBox` styles that are causing the issue.

The root cause of this seems more like a side-effect of using the `Ripple` in a certain way, rather than an actual bug with the `Ripple`. At least that is my assumption, based on the fact that we have special code for offsetting the ripple when there is inner content (see [here](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/806146b3bb0c3fd8fca45ca1590ad39d8189e973/src/MaterialDesignThemes.Wpf/Ripple.cs#L111-L121)).

In most cases, we don't actually put content inside the `Ripple` but place it at the same level (i.e. "on top/below content"). I believe this is a case where that is desired as well. So this PR basically lifts the `ContentControl` up so it is no longer a child of the `Ripple`, but becomes a sibling instead.

With fix:
![PopupBoxRipple](https://github.com/user-attachments/assets/2bb2e8cf-6235-4cc7-83f2-5730bd9c9034)
