### PR TITLE
UpDownBase: Fix event subscription mismatch

### DIFF
--- a/src/MaterialDesignThemes.Wpf/UpDownBase.cs
+++ b/src/MaterialDesignThemes.Wpf/UpDownBase.cs
@@ -201,7 +201,7 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
         if (_decreaseButton != null)
             _decreaseButton.Click -= DecreaseButtonOnClick;
         if (_textBoxField != null)
-            _textBoxField.TextChanged -= OnTextBoxFocusLost;
+            _textBoxField.TextChanged -= OnTextBoxTextChanged;
 
         base.OnApplyTemplate();
 
@@ -219,13 +219,13 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
 
         if (_textBoxField != null)
         {
-            _textBoxField.LostFocus += OnTextBoxFocusLost;
+            _textBoxField.TextChanged += OnTextBoxTextChanged;
             _textBoxField.Text = Value?.ToString();
         }
 
     }
 
-    private void OnTextBoxFocusLost(object sender, EventArgs e)
+    private void OnTextBoxTextChanged(object sender, EventArgs e)
     {
         if (_textBoxField is { } textBoxField)
         {

--- a/src/MaterialDesignThemes.Wpf/UpDownBase.cs
+++ b/src/MaterialDesignThemes.Wpf/UpDownBase.cs
@@ -201,7 +201,10 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
         if (_decreaseButton != null)
             _decreaseButton.Click -= DecreaseButtonOnClick;
         if (_textBoxField != null)
+        {
             _textBoxField.TextChanged -= OnTextBoxTextChanged;
+            _textBoxField.LostFocus -= OnTextBoxLostFocus;
+        }
 
         base.OnApplyTemplate();
 
@@ -220,9 +223,18 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
         if (_textBoxField != null)
         {
             _textBoxField.TextChanged += OnTextBoxTextChanged;
+            _textBoxField.LostFocus += OnTextBoxLostFocus;
             _textBoxField.Text = Value?.ToString();
         }
 
+    }
+
+    private void OnTextBoxLostFocus(object sender, EventArgs e)
+    {
+        if (_textBoxField is { } textBoxField)
+        {
+            textBoxField.Text = Value?.ToString();
+        }
     }
 
     private void OnTextBoxTextChanged(object sender, EventArgs e)
@@ -233,8 +245,6 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
             {
                 SetCurrentValue(ValueProperty, ClampValue(value));
             }
-            //NB: Because setting ValueProperty will coerce the value, we re-assign back to the textbox here.
-            textBoxField.Text = Value?.ToString();
         }
     }
 

--- a/tests/MaterialDesignThemes.UITests/WPF/UpDownControls/DecimalUpDownTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/UpDownControls/DecimalUpDownTests.cs
@@ -187,10 +187,10 @@ public class DecimalUpDownTests(ITestOutputHelper output) : TestBase(output)
 
     [Theory]
     [Description("Issue 3781")]
-    [InlineData("30")]
-    [InlineData("abc")]
-    [InlineData("2a")]
-    public async Task LostFocusWhenTextIsInvalid_RevertsToOriginalValue(string inputText)
+    [InlineData("30", 2.5)]
+    [InlineData("abc", 2.5)]
+    [InlineData("2a", 2)]
+    public async Task LostFocusWhenTextIsInvalid_RevertsToOriginalValue(string inputText, decimal expectedValue)
     {
         await using var recorder = new TestRecorder(App);
 
@@ -209,8 +209,8 @@ public class DecimalUpDownTests(ITestOutputHelper output) : TestBase(output)
         await textBox.SendKeyboardInput($"{ModifierKeys.Control}{Key.A}{ModifierKeys.None}{inputText}");
         await button.MoveKeyboardFocus();
 
-        Assert.Equal("2.5", await textBox.GetText());
-        Assert.Equal(2.5m, await decimalUpDown.GetValue());
+        Assert.Equal(expectedValue.ToString(), await textBox.GetText());
+        Assert.Equal(expectedValue, await decimalUpDown.GetValue());
 
         recorder.Success();
     }


### PR DESCRIPTION
Fixes #3827 

### UPDATE
Ooh, a failing test! It seems there is a requirement to revert back to original value on `LostFocus` if the entered value is invalid...
Not entirely sure how to handle that use-case, while still supporting `UpdateSourceTrigger=PropertyChanged` 🤔 

---

The `UpDownBase` was only subscribing to the `LostFocus` event, but the unsubscribing the `TextChanged` event. This is a potential event-handler leak, but also the root cause of the reported issue.

This PR ensures only the `TextChanged` event is subscribed/unsubscribed, and then let's the internal binding system handle when to notify a bound view model property. As long as we call `SetCurrentValue()` for the "most frequent update source trigger", the built-in system will handle the rest for us (I am quite sure of).