### PR TITLE
Migrate brush names in MD3 Demo

### DIFF
--- a/src/MaterialDesign3.Demo.Wpf/App.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/App.xaml
@@ -68,7 +68,7 @@
                     <materialDesign:PackIcon Margin="3"
                                              Background="Transparent"
                                              Cursor="Hand"
-                                             Foreground="{DynamicResource PrimaryHueDarkBrush}"
+                                             Foreground="{DynamicResource MaterialDesign.Brush.Primary.Dark}"
                                              Kind="Xml"
                                              ToolTip="View XAML">
                       <materialDesign:PackIcon.Style>
@@ -101,7 +101,7 @@
                 <Grid>
                   <AdornerDecorator>
                     <Border Margin="-5"
-                            BorderBrush="{DynamicResource SecondaryHueMidBrush}"
+                            BorderBrush="{DynamicResource MaterialDesign.Brush.Secondary}"
                             Opacity=".4">
                       <Border.Style>
                         <Style TargetType="Border">
@@ -136,7 +136,7 @@
       <Style TargetType="Rectangle" x:Key="PageSectionSeparator">
         <Setter Property="Margin" Value="0,24" />
         <Setter Property="Height" Value="1" />
-        <Setter Property="Fill" Value="{DynamicResource MaterialDesignDivider}" />
+        <Setter Property="Fill" Value="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
       </Style>
       
     </ResourceDictionary>

--- a/src/MaterialDesign3.Demo.Wpf/Buttons.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Buttons.xaml
@@ -503,7 +503,7 @@
           </smtx:XamlDisplay>
 
           <smtx:XamlDisplay UniqueKey="buttons_254">
-            <Button Background="{DynamicResource MaterialDesignTextFieldBoxBackground}"
+            <Button Background="{DynamicResource MaterialDesign.Brush.TextBox.FilledBackground}"
                     IsEnabled="{Binding DataContext.ControlsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}"
                     Style="{StaticResource MaterialDesignIconButton}"
                     ToolTip="MaterialDesignIconButton">
@@ -518,7 +518,7 @@
     <Rectangle Grid.Row="2"
                Height="1"
                Margin="0,24,0,0"
-               Fill="{DynamicResource MaterialDesignDivider}" />
+               Fill="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
 
     <TextBlock Grid.Row="3"
                Margin="0,24"
@@ -584,7 +584,7 @@
     <Rectangle Grid.Row="5"
                Height="1"
                Margin="0,24,0,0"
-               Fill="{DynamicResource MaterialDesignDivider}" />
+               Fill="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
 
     <TextBlock Grid.Row="6"
                Margin="0,24"
@@ -786,7 +786,7 @@
     <Rectangle Grid.Row="8"
                Height="1"
                Margin="0,24,0,0"
-               Fill="{DynamicResource MaterialDesignDivider}" />
+               Fill="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
 
     <TextBlock Grid.Row="9"
                Margin="0,24"
@@ -941,7 +941,7 @@
     <Rectangle Grid.Row="11"
            Height="1"
            Margin="0,24,0,0"
-           Fill="{DynamicResource MaterialDesignDivider}" />
+           Fill="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
 
     <TextBlock Grid.Row="12"
            Margin="0,24"

--- a/src/MaterialDesign3.Demo.Wpf/Cards.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Cards.xaml
@@ -175,7 +175,7 @@
         <materialDesign:Card Width="200"
                              Padding="0"
                              Background="#03a9f4"
-                             Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}">
+                             Foreground="{DynamicResource MaterialDesign.Brush.Primary.Dark.Foreground}">
           <Grid>
             <Grid.RowDefinitions>
               <RowDefinition Height="Auto" />
@@ -222,8 +222,8 @@
                         UniqueKey="cards_4">
         <materialDesign:Card Width="200"
                              Padding="8"
-                             Background="{DynamicResource PrimaryHueLightBrush}"
-                             Foreground="{DynamicResource PrimaryHueLightForegroundBrush}">
+                             Background="{DynamicResource MaterialDesign.Brush.Primary.Light}"
+                             Foreground="{DynamicResource MaterialDesign.Brush.Primary.Light.Foreground}">
           <TextBlock FontSize="16" Text="Boring Text" />
         </materialDesign:Card>
       </smtx:XamlDisplay>
@@ -231,8 +231,8 @@
       <smtx:XamlDisplay Margin="4,4,0,16" UniqueKey="cards_5">
         <materialDesign:Card Width="200"
                              Padding="8"
-                             Background="{DynamicResource PrimaryHueDarkBrush}"
-                             Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}"
+                             Background="{DynamicResource MaterialDesign.Brush.Primary.Dark}"
+                             Foreground="{DynamicResource MaterialDesign.Brush.Primary.Dark.Foreground}"
                              UniformCornerRadius="6">
           <TextBlock Text="You can adjust the corner radius" TextWrapping="Wrap" />
         </materialDesign:Card>
@@ -244,8 +244,8 @@
                       UniqueKey="cards_6">
       <materialDesign:Card Width="200"
                            Padding="8"
-                           Background="{DynamicResource PrimaryHueDarkBrush}"
-                           Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}">
+                           Background="{DynamicResource MaterialDesign.Brush.Primary.Dark}"
+                           Foreground="{DynamicResource MaterialDesign.Brush.Primary.Dark.Foreground}">
         <StackPanel>
           <TextBlock Margin="16,16,12,8"
                      FontSize="16"

--- a/src/MaterialDesign3.Demo.Wpf/Chips.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Chips.xaml
@@ -55,8 +55,8 @@
 
         <smtx:XamlDisplay Margin="0,0,4,4" UniqueKey="chips_5">
           <materialDesign:Chip Content="Twitter"
-                               IconBackground="{DynamicResource PrimaryHueDarkBrush}"
-                               IconForeground="{DynamicResource PrimaryHueDarkForegroundBrush}">
+                               IconBackground="{DynamicResource MaterialDesign.Brush.Primary.Dark}"
+                               IconForeground="{DynamicResource MaterialDesign.Brush.Primary.Dark.Foreground}">
             <materialDesign:Chip.Icon>
               <materialDesign:PackIcon Kind="Twitter" />
             </materialDesign:Chip.Icon>
@@ -93,8 +93,8 @@
         <smtx:XamlDisplay Margin="0,0,4,4" UniqueKey="chips_9">
           <materialDesign:Chip Content="ZNA Inc"
                                Icon="Z"
-                               IconBackground="{DynamicResource PrimaryHueLightBrush}"
-                               IconForeground="{DynamicResource PrimaryHueLightForegroundBrush}"
+                               IconBackground="{DynamicResource MaterialDesign.Brush.Primary.Light}"
+                               IconForeground="{DynamicResource MaterialDesign.Brush.Primary.Light.Foreground}"
                                IsDeletable="True" />
         </smtx:XamlDisplay>
       </WrapPanel>
@@ -126,8 +126,8 @@
 
         <smtx:XamlDisplay Margin="0,0,4,4" UniqueKey="chips_38">
           <materialDesign:Chip Content="Twitter"
-                               IconBackground="{DynamicResource PrimaryHueDarkBrush}"
-                               IconForeground="{DynamicResource PrimaryHueDarkForegroundBrush}"
+                               IconBackground="{DynamicResource MaterialDesign.Brush.Primary.Dark}"
+                               IconForeground="{DynamicResource MaterialDesign.Brush.Primary.Dark.Foreground}"
                                Style="{StaticResource MaterialDesignOutlineChip}">
             <materialDesign:Chip.Icon>
               <materialDesign:PackIcon Kind="Twitter" />
@@ -140,7 +140,7 @@
     <StackPanel Grid.Row="2">
       <Rectangle Height="1"
                  Margin="0,24,0,0"
-                 Fill="{DynamicResource MaterialDesignDivider}" />
+                 Fill="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
       <TextBlock Style="{StaticResource ChipsHeadline}" Text="Filter Chips" />
     </StackPanel>
 
@@ -257,7 +257,7 @@
     <StackPanel Grid.Row="4">
       <Rectangle Height="1"
                  Margin="0,24,0,0"
-                 Fill="{DynamicResource MaterialDesignDivider}" />
+                 Fill="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
       <TextBlock Style="{StaticResource ChipsHeadline}" Text="Choice Chips" />
     </StackPanel>
 

--- a/src/MaterialDesign3.Demo.Wpf/ColorTool.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/ColorTool.xaml
@@ -128,7 +128,7 @@
             <Style x:Key="PaletteButton"
                    TargetType="Button"
                    BasedOn="{StaticResource MaterialDesignRaisedButton}">
-              <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
+              <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
               <Setter Property="BorderBrush" Value="Transparent" />
               <Setter Property="Height" Value="Auto" />
               <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -171,15 +171,15 @@
                   <RowDefinition />
                 </Grid.RowDefinitions>
 
-                <TextBlock Foreground="{DynamicResource MaterialDesignBody}"
+                <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
                            Style="{StaticResource MaterialDesignBody1TextBlock}"
                            Text="Primary" />
 
                 <!-- Primary mid section -->
-                <Border Grid.Row="1" Background="{DynamicResource PrimaryHueMidBrush}">
+                <Border Grid.Row="1" Background="{DynamicResource MaterialDesign.Brush.Primary}">
                   <Grid>
-                    <TextBlock DataContext="{DynamicResource PrimaryHueMidBrush}"
-                               Foreground="{DynamicResource PrimaryHueMidForegroundBrush}"
+                    <TextBlock DataContext="{DynamicResource MaterialDesign.Brush.Primary}"
+                               Foreground="{DynamicResource MaterialDesign.Brush.Primary.Foreground}"
                                Style="{StaticResource HexLabelTextBlock}"
                                Text="{Binding Converter={StaticResource BrushToHexConverter}}" />
 
@@ -190,7 +190,7 @@
                         <Style TargetType="Border">
                           <Style.Triggers>
                             <DataTrigger Binding="{Binding ActiveScheme}" Value="Primary">
-                              <Setter Property="Background" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
+                              <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Primary.Foreground}" />
                             </DataTrigger>
                           </Style.Triggers>
                         </Style>
@@ -202,10 +202,10 @@
                                  Text="P">
                         <TextBlock.Style>
                           <Style TargetType="TextBlock">
-                            <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary.Foreground}" />
                             <Style.Triggers>
                               <DataTrigger Binding="{Binding ActiveScheme}" Value="Primary">
-                                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
                               </DataTrigger>
                             </Style.Triggers>
                           </Style>
@@ -217,16 +217,16 @@
 
                 <UniformGrid Grid.Row="2" Rows="1">
                   <!-- Primary light -->
-                  <Border Background="{DynamicResource PrimaryHueLightBrush}">
-                    <TextBlock DataContext="{DynamicResource PrimaryHueLightBrush}"
-                               Foreground="{DynamicResource PrimaryHueLightForegroundBrush}"
+                  <Border Background="{DynamicResource MaterialDesign.Brush.Primary.Light}">
+                    <TextBlock DataContext="{DynamicResource MaterialDesign.Brush.Primary.Light}"
+                               Foreground="{DynamicResource MaterialDesign.Brush.Primary.Light.Foreground}"
                                Style="{StaticResource HexLabelTextBlock}"
                                Text="{Binding Converter={StaticResource BrushToHexConverter}}" />
                   </Border>
                   <!-- Primary dark -->
-                  <Border Background="{DynamicResource PrimaryHueDarkBrush}">
-                    <TextBlock DataContext="{DynamicResource PrimaryHueDarkBrush}"
-                               Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}"
+                  <Border Background="{DynamicResource MaterialDesign.Brush.Primary.Dark}">
+                    <TextBlock DataContext="{DynamicResource MaterialDesign.Brush.Primary.Dark}"
+                               Foreground="{DynamicResource MaterialDesign.Brush.Primary.Dark.Foreground}"
                                Style="{StaticResource HexLabelTextBlock}"
                                Text="{Binding Converter={StaticResource BrushToHexConverter}}" />
                   </Border>
@@ -257,15 +257,15 @@
                   <RowDefinition />
                 </Grid.RowDefinitions>
 
-                <TextBlock Foreground="{DynamicResource MaterialDesignBody}"
+                <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
                            Style="{StaticResource MaterialDesignBody1TextBlock}"
                            Text="Secondary" />
 
                 <!-- Secondary mid section -->
-                <Border Grid.Row="1" Background="{DynamicResource SecondaryHueMidBrush}">
+                <Border Grid.Row="1" Background="{DynamicResource MaterialDesign.Brush.Secondary}">
                   <Grid>
-                    <TextBlock DataContext="{DynamicResource SecondaryHueMidBrush}"
-                               Foreground="{DynamicResource SecondaryHueMidForegroundBrush}"
+                    <TextBlock DataContext="{DynamicResource MaterialDesign.Brush.Secondary}"
+                               Foreground="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}"
                                Style="{StaticResource HexLabelTextBlock}"
                                Text="{Binding Converter={StaticResource BrushToHexConverter}}" />
 
@@ -276,7 +276,7 @@
                         <Style TargetType="Border">
                           <Style.Triggers>
                             <DataTrigger Binding="{Binding ActiveScheme}" Value="Secondary">
-                              <Setter Property="Background" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                              <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}" />
                             </DataTrigger>
                           </Style.Triggers>
                         </Style>
@@ -288,10 +288,10 @@
                                  Text="S">
                         <TextBlock.Style>
                           <Style TargetType="TextBlock">
-                            <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}" />
                             <Style.Triggers>
                               <DataTrigger Binding="{Binding ActiveScheme}" Value="Secondary">
-                                <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidBrush}" />
+                                <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Secondary}" />
                               </DataTrigger>
                             </Style.Triggers>
                           </Style>
@@ -303,17 +303,17 @@
 
                 <UniformGrid Grid.Row="2" Rows="1">
                   <!-- Secondary light -->
-                  <Border Background="{DynamicResource SecondaryHueLightBrush}">
-                    <TextBlock DataContext="{DynamicResource SecondaryHueLightBrush}"
-                               Foreground="{DynamicResource SecondaryHueLightForegroundBrush}"
+                  <Border Background="{DynamicResource MaterialDesign.Brush.Secondary.Light}">
+                    <TextBlock DataContext="{DynamicResource MaterialDesign.Brush.Secondary.Light}"
+                               Foreground="{DynamicResource MaterialDesign.Brush.Secondary.Light.Foreground}"
                                Style="{StaticResource HexLabelTextBlock}"
                                Text="{Binding Converter={StaticResource BrushToHexConverter}}" />
                   </Border>
 
                   <!-- Secondary dark -->
-                  <Border Background="{DynamicResource SecondaryHueDarkBrush}">
-                    <TextBlock DataContext="{DynamicResource SecondaryHueDarkBrush}"
-                               Foreground="{DynamicResource SecondaryHueDarkForegroundBrush}"
+                  <Border Background="{DynamicResource MaterialDesign.Brush.Secondary.Dark}">
+                    <TextBlock DataContext="{DynamicResource MaterialDesign.Brush.Secondary.Dark}"
+                               Foreground="{DynamicResource MaterialDesign.Brush.Secondary.Dark.Foreground}"
                                Style="{StaticResource HexLabelTextBlock}"
                                Text="{Binding Converter={StaticResource BrushToHexConverter}}" />
                   </Border>
@@ -342,14 +342,14 @@
                     <RowDefinition Height="*" />
                   </Grid.RowDefinitions>
 
-                  <TextBlock Foreground="{DynamicResource MaterialDesignBody}"
+                  <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
                              Style="{StaticResource MaterialDesignBody1TextBlock}"
                              Text="Text on Primary" />
 
-                  <Border Grid.Row="1" Background="{DynamicResource PrimaryHueMidBrush}">
+                  <Border Grid.Row="1" Background="{DynamicResource MaterialDesign.Brush.Primary}">
                     <Grid>
-                      <TextBlock DataContext="{DynamicResource PrimaryHueMidForegroundBrush}"
-                                 Foreground="{DynamicResource PrimaryHueMidForegroundBrush}"
+                      <TextBlock DataContext="{DynamicResource MaterialDesign.Brush.Primary.Foreground}"
+                                 Foreground="{DynamicResource MaterialDesign.Brush.Primary.Foreground}"
                                  Style="{StaticResource HexLabelTextBlock}"
                                  Text="{Binding Converter={StaticResource BrushToHexConverter}}" />
 
@@ -360,7 +360,7 @@
                           <Style TargetType="Border">
                             <Style.Triggers>
                               <DataTrigger Binding="{Binding ActiveScheme}" Value="PrimaryForeground">
-                                <Setter Property="Background" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
+                                <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Primary.Foreground}" />
                               </DataTrigger>
                             </Style.Triggers>
                           </Style>
@@ -372,10 +372,10 @@
                                    Text="T">
                           <TextBlock.Style>
                             <Style TargetType="TextBlock">
-                              <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}" />
+                              <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary.Foreground}" />
                               <Style.Triggers>
                                 <DataTrigger Binding="{Binding ActiveScheme}" Value="PrimaryForeground">
-                                  <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+                                  <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
                                 </DataTrigger>
                               </Style.Triggers>
                             </Style>
@@ -407,14 +407,14 @@
                     <RowDefinition Height="*" />
                   </Grid.RowDefinitions>
 
-                  <TextBlock Foreground="{DynamicResource MaterialDesignBody}"
+                  <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
                              Style="{StaticResource MaterialDesignBody1TextBlock}"
                              Text="Text on Secondary" />
 
-                  <Border Grid.Row="1" Background="{DynamicResource SecondaryHueMidBrush}">
+                  <Border Grid.Row="1" Background="{DynamicResource MaterialDesign.Brush.Secondary}">
                     <Grid>
-                      <TextBlock DataContext="{DynamicResource SecondaryHueMidForegroundBrush}"
-                                 Foreground="{DynamicResource SecondaryHueMidForegroundBrush}"
+                      <TextBlock DataContext="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}"
+                                 Foreground="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}"
                                  Style="{StaticResource HexLabelTextBlock}"
                                  Text="{Binding Converter={StaticResource BrushToHexConverter}}" />
 
@@ -425,7 +425,7 @@
                           <Style TargetType="Border">
                             <Style.Triggers>
                               <DataTrigger Binding="{Binding ActiveScheme}" Value="SecondaryForeground">
-                                <Setter Property="Background" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                                <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}" />
                               </DataTrigger>
                             </Style.Triggers>
                           </Style>
@@ -437,10 +437,10 @@
                                    Text="T">
                           <TextBlock.Style>
                             <Style TargetType="TextBlock">
-                              <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                              <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}" />
                               <Style.Triggers>
                                 <DataTrigger Binding="{Binding ActiveScheme}" Value="SecondaryForeground">
-                                  <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidBrush}" />
+                                  <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Secondary}" />
                                 </DataTrigger>
                               </Style.Triggers>
                             </Style>

--- a/src/MaterialDesign3.Demo.Wpf/ColorZones.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/ColorZones.xaml
@@ -83,8 +83,8 @@
 
             <ComboBox Margin="8,0,0,0"
                       materialDesign:ColorZoneAssist.Mode="Standard"
-                      materialDesign:TextFieldAssist.UnderlineBrush="{DynamicResource MaterialDesignPaper}"
-                      BorderBrush="{DynamicResource MaterialDesignPaper}"
+                      materialDesign:TextFieldAssist.UnderlineBrush="{DynamicResource MaterialDesign.Brush.Background}"
+                      BorderBrush="{DynamicResource MaterialDesign.Brush.Background}"
                       BorderThickness="0"
                       SelectedIndex="0">
               <ComboBoxItem Content="Android" />

--- a/src/MaterialDesign3.Demo.Wpf/ComboBoxes.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/ComboBoxes.xaml
@@ -76,7 +76,7 @@
                   materialDesign:HintAssist.Hint="OS"
                   materialDesign:TextFieldAssist.HasClearButton="True"
                   materialDesign:TextFieldAssist.SuffixText="sw"
-                  materialDesign:TextFieldAssist.UnderlineBrush="{DynamicResource SecondaryHueMidBrush}"
+                  materialDesign:TextFieldAssist.UnderlineBrush="{DynamicResource MaterialDesign.Brush.Secondary}"
                   Style="{StaticResource MaterialDesignFloatingHintComboBox}">
           <ComboBoxItem Content="Android" />
           <ComboBoxItem Content="iOS" />
@@ -121,7 +121,7 @@
 
     <Rectangle Height="1"
                Margin="0,32,0,0"
-               Fill="{DynamicResource MaterialDesignDivider}" />
+               Fill="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
     <TextBlock Style="{StaticResource SectionTitle}" Text="Virtualised ComboBoxes" />
 
     <StackPanel Orientation="Horizontal">
@@ -213,7 +213,7 @@
 
     <Rectangle Height="1"
                Margin="0,32,0,0"
-               Fill="{DynamicResource MaterialDesignDivider}" />
+               Fill="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
     <TextBlock Style="{StaticResource SectionTitle}" Text="Filled ComboBox" />
 
     <StackPanel Margin="0,8,0,0" Orientation="Horizontal">

--- a/src/MaterialDesign3.Demo.Wpf/Dialogs.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Dialogs.xaml
@@ -94,7 +94,7 @@
           </materialDesign:DialogHost.DialogContent>
 
           <Border MinHeight="256"
-                  BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+                  BorderBrush="{DynamicResource MaterialDesign.Brush.Primary}"
                   BorderThickness="1"
                   ClipToBounds="True">
             <Grid>
@@ -226,11 +226,11 @@
                                    DialogContent="{Binding Sample4Content}"
                                    DialogTheme="Inherit"
                                    IsOpen="{Binding IsSample4DialogOpen}"
-                                   OverlayBackground="{DynamicResource PrimaryHueDarkBrush}">
+                                   OverlayBackground="{DynamicResource MaterialDesign.Brush.Primary.Dark}">
 
           <Border MinWidth="256"
                   MinHeight="256"
-                  BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+                  BorderBrush="{DynamicResource MaterialDesign.Brush.Primary}"
                   BorderThickness="1"
                   ClipToBounds="True">
             <Button HorizontalAlignment="Center"
@@ -291,7 +291,7 @@
           </materialDesign:DialogHost.DialogContent>
 
           <Border HorizontalAlignment="Stretch"
-                  BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+                  BorderBrush="{DynamicResource MaterialDesign.Brush.Primary}"
                   BorderThickness="1"
                   ClipToBounds="True">
             <Grid>

--- a/src/MaterialDesign3.Demo.Wpf/Domain/DocumentationLinks.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Domain/DocumentationLinks.xaml
@@ -78,6 +78,6 @@
         </ItemsControl>
       </StackPanel>
     </ScrollViewer>
-    <Border BorderBrush="{DynamicResource MaterialDesignDivider}" BorderThickness="0,0,0,1" />
+    <Border BorderBrush="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" BorderThickness="0,0,0,1" />
   </Grid>
 </UserControl>

--- a/src/MaterialDesign3.Demo.Wpf/Drawers.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Drawers.xaml
@@ -37,16 +37,16 @@
                                  Margin="32"
                                  HorizontalAlignment="Center"
                                  VerticalAlignment="Center"
-                                 BorderBrush="{DynamicResource MaterialDesignDivider}"
+                                 BorderBrush="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
                                  BorderThickness="2"
-                                 BottomDrawerBackground="{DynamicResource SecondaryHueLightBrush}"
+                                 BottomDrawerBackground="{DynamicResource MaterialDesign.Brush.Secondary.Light}"
                                  BottomDrawerCornerRadius="20 20 0 0">
 
         <materialDesign:DrawerHost.Style>
           <Style TargetType="materialDesign:DrawerHost" BasedOn="{StaticResource {x:Type materialDesign:DrawerHost}}">
             <Style.Triggers>
               <DataTrigger Binding="{Binding IsChecked, ElementName=BackgroundToggle}" Value="True">
-                <Setter Property="OverlayBackground" Value="{DynamicResource PrimaryHueMidBrush}" />
+                <Setter Property="OverlayBackground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
               </DataTrigger>
             </Style.Triggers>
           </Style>
@@ -123,7 +123,7 @@
                       Orientation="Horizontal">
             <TextBlock Margin="4"
                        VerticalAlignment="Center"
-                       Foreground="{DynamicResource SecondaryHueMidForegroundBrush}"
+                       Foreground="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}"
                        Text="BOTTOM BRACKET" />
 
             <Button Margin="4"

--- a/src/MaterialDesign3.Demo.Wpf/Expander.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Expander.xaml
@@ -23,7 +23,7 @@
     </Style>
 
     <Style x:Key="HorizontalDividerBorder" TargetType="{x:Type Border}">
-      <Setter Property="Background" Value="{DynamicResource MaterialDesignDivider}" />
+      <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}" />
       <Setter Property="Height" Value="1" />
       <Setter Property="HorizontalAlignment" Value="Stretch" />
       <Setter Property="UseLayoutRounding" Value="True" />
@@ -54,7 +54,7 @@
           <Expander HorizontalAlignment="Stretch" Header="Expander Example 1a">
             <StackPanel Margin="24,8,24,16"
                         Orientation="Vertical"
-                        TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
+                        TextBlock.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}">
               <TextBlock Text="Your Content" />
               <TextBlock Style="{StaticResource HorizontalExpanderContentTextBlock}" />
             </StackPanel>
@@ -65,7 +65,7 @@
                     Header="Expander Example 1b">
             <StackPanel Margin="24,8,24,16"
                         Orientation="Vertical"
-                        TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
+                        TextBlock.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}">
               <TextBlock Text="Your Content" />
               <TextBlock Style="{StaticResource HorizontalExpanderContentTextBlock}" />
             </StackPanel>
@@ -74,7 +74,7 @@
           <Expander HorizontalAlignment="Stretch" Header="Expander Example 1c">
             <StackPanel Margin="24,8,24,16"
                         Orientation="Vertical"
-                        TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
+                        TextBlock.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}">
               <TextBlock Text="Your Content" />
               <TextBlock Style="{StaticResource HorizontalExpanderContentTextBlock}" />
             </StackPanel>
@@ -85,7 +85,7 @@
                     Header="Custom Header Padding">
             <StackPanel Margin="24,8,24,16"
                         Orientation="Vertical"
-                        TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
+                        TextBlock.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}">
               <TextBlock Text="Your Content" />
               <TextBlock Style="{StaticResource HorizontalExpanderContentTextBlock}" />
             </StackPanel>
@@ -102,7 +102,7 @@
             <Expander HorizontalAlignment="Stretch" Header="Expander Example 2a">
               <StackPanel Margin="24,8,24,16"
                           Orientation="Vertical"
-                          TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
+                          TextBlock.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}">
                 <TextBlock Text="Your Content" />
                 <TextBlock Style="{StaticResource HorizontalExpanderContentTextBlock}" />
               </StackPanel>
@@ -113,7 +113,7 @@
             <Expander HorizontalAlignment="Stretch" Header="Expander Example 2b">
               <StackPanel Margin="24,8,24,16"
                           Orientation="Vertical"
-                          TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
+                          TextBlock.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}">
                 <TextBlock Text="Your Content" />
                 <TextBlock Style="{StaticResource HorizontalExpanderContentTextBlock}" />
               </StackPanel>
@@ -124,7 +124,7 @@
             <Expander HorizontalAlignment="Stretch" Header="Expander Example 2c">
               <StackPanel Margin="24,8,24,16"
                           Orientation="Vertical"
-                          TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
+                          TextBlock.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}">
                 <TextBlock Text="Your Content" />
                 <TextBlock Style="{StaticResource HorizontalExpanderContentTextBlock}" />
               </StackPanel>
@@ -153,7 +153,7 @@
 
             <StackPanel Margin="8,24,16,24"
                         Orientation="Vertical"
-                        TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
+                        TextBlock.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}">
               <TextBlock Text="Your Content" />
               <TextBlock Style="{StaticResource VerticalExpanderContentTextBlock}" />
             </StackPanel>
@@ -172,7 +172,7 @@
 
             <StackPanel Margin="8,24,16,24"
                         Orientation="Vertical"
-                        TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
+                        TextBlock.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}">
               <TextBlock Text="Your Content" />
               <TextBlock Style="{StaticResource VerticalExpanderContentTextBlock}" />
             </StackPanel>
@@ -191,7 +191,7 @@
 
             <StackPanel Margin="8,24,16,24"
                         Orientation="Vertical"
-                        TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
+                        TextBlock.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}">
               <TextBlock Text="Your Content" />
               <TextBlock Style="{StaticResource VerticalExpanderContentTextBlock}" />
             </StackPanel>
@@ -210,7 +210,7 @@
 
             <StackPanel Margin="8,24,16,24"
                         Orientation="Vertical"
-                        TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
+                        TextBlock.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}">
               <TextBlock Text="Your Content" />
               <TextBlock Style="{StaticResource VerticalExpanderContentTextBlock}" />
             </StackPanel>

--- a/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/FieldsLineUp.xaml
@@ -10,8 +10,8 @@
   <GroupBox Margin="10"
             HorizontalAlignment="Left"
             VerticalAlignment="Top"
-            materialDesign:ColorZoneAssist.Background="{DynamicResource PrimaryHueLightBrush}"
-            materialDesign:ColorZoneAssist.Foreground="{DynamicResource PrimaryHueLightForegroundBrush}"
+            materialDesign:ColorZoneAssist.Background="{DynamicResource MaterialDesign.Brush.Primary.Light}"
+            materialDesign:ColorZoneAssist.Foreground="{DynamicResource MaterialDesign.Brush.Primary.Light.Foreground}"
             materialDesign:ColorZoneAssist.Mode="Custom">
     <GroupBox.Header>
       <StackPanel Orientation="Horizontal">

--- a/src/MaterialDesign3.Demo.Wpf/GroupBoxes.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/GroupBoxes.xaml
@@ -54,7 +54,7 @@
     <smtx:XamlDisplay Grid.Row="0"
                       Grid.Column="2"
                       UniqueKey="groupbox_3">
-      <Border Background="{DynamicResource MaterialDesignBackground}">
+      <Border Background="{DynamicResource MaterialDesign.Brush.Card.Background}">
         <GroupBox Margin="16"
                   Header="Transparent Background"
                   Style="{StaticResource MaterialDesignGroupBox}"

--- a/src/MaterialDesign3.Demo.Wpf/Home.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Home.xaml
@@ -96,14 +96,14 @@
                          Grid.Column="1"
                          Margin="16,0,16,8"
                          VerticalAlignment="Center"
-                         Foreground="{DynamicResource MaterialDesignBodyLight}"
+                         Foreground="{DynamicResource MaterialDesign.Brush.ForegroundLight}"
                          Text="Say hello, make a feature request, or raise a bug through one of these channels:"
                          TextWrapping="Wrap" />
 
               <Border Grid.Row="2"
                       Grid.Column="1"
                       Margin="0,8,0,0"
-                      BorderBrush="{DynamicResource MaterialDesignDivider}"
+                      BorderBrush="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
                       BorderThickness="0,1,0,0">
                 <Grid Margin="8">
                   <Button x:Name="GitHubButton"
@@ -134,7 +134,7 @@
 
               <Border Grid.Row="3"
                       Grid.Column="1"
-                      BorderBrush="{DynamicResource MaterialDesignDivider}"
+                      BorderBrush="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
                       BorderThickness="0,1,0,0">
                 <Grid Margin="8">
                   <Button x:Name="ChatButton"
@@ -192,7 +192,7 @@
 
                 <TextBlock Margin="16,0,16,8"
                            VerticalAlignment="Top"
-                           Foreground="{DynamicResource MaterialDesignBodyLight}"
+                           Foreground="{DynamicResource MaterialDesign.Brush.ForegroundLight}"
                            Text="This project is completely open source. If you like it and want to say thanks you could hit the GitHub Star button, tweet or post about it, or tell your mum about it!"
                            TextWrapping="Wrap" />
               </StackPanel>
@@ -200,7 +200,7 @@
               <Border Grid.Row="1"
                       Grid.ColumnSpan="2"
                       Padding="8"
-                      BorderBrush="{DynamicResource MaterialDesignDivider}"
+                      BorderBrush="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
                       BorderThickness="0,1,0,0">
                 <DockPanel>
                   <Button x:Name="DonateButton"
@@ -217,7 +217,7 @@
 
                   <TextBlock Margin="16"
                              VerticalAlignment="Center"
-                             Foreground="{DynamicResource MaterialDesignBodyLight}"
+                             Foreground="{DynamicResource MaterialDesign.Brush.ForegroundLight}"
                              Text="Feel like you want to make a donation?  It would be gratefully received.  Click the button to donate via Open Collective."
                              TextWrapping="Wrap" />
                 </DockPanel>
@@ -243,8 +243,8 @@
                 <Button
                     ToolTip="Twitter"
                     Click="TwitterButton_OnClick"
-                    Background="{DynamicResource PrimaryHueMidBrush}"
-                    Foreground="{DynamicResource PrimaryHueMidForegroundBrush}"
+                    Background="{DynamicResource MaterialDesign.Brush.Primary}"
+                    Foreground="{DynamicResource MaterialDesign.Brush.Primary.Foreground}"
                     Content="{materialDesign:PackIcon Kind=Twitter, Size=20}"/>
 
                 <Button
@@ -266,8 +266,8 @@
                 <Button
                     ToolTip="Email"
                     Click="EmailButton_OnClick"
-                    Background="{DynamicResource SecondaryHueMidBrush}"
-                    Foreground="{DynamicResource SecondaryHueMidForegroundBrush}"
+                    Background="{DynamicResource MaterialDesign.Brush.Secondary}"
+                    Foreground="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}"
                     Content="{materialDesign:PackIcon Kind=Email, Size=20}"/>
 
                 <Button

--- a/src/MaterialDesign3.Demo.Wpf/IconPack.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/IconPack.xaml
@@ -171,7 +171,7 @@
                       Margin="0,0,20,0"
                       Padding="2"
                       HorizontalAlignment="Center"
-                      BorderBrush="{DynamicResource MaterialDesignBody}"
+                      BorderBrush="{DynamicResource MaterialDesign.Brush.Foreground}"
                       BorderThickness="1"
                       CornerRadius="4">
                 <materialDesign:PackIcon Width="40"

--- a/src/MaterialDesign3.Demo.Wpf/Lists.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Lists.xaml
@@ -122,7 +122,7 @@
             <DataTemplate DataType="{x:Type domain:SelectableViewModel}">
               <Border x:Name="Border"
                       Padding="8"
-                      BorderBrush="{DynamicResource MaterialDesignDivider}"
+                      BorderBrush="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
                       BorderThickness="0,0,0,1">
                 <Grid>
                   <Grid.ColumnDefinitions>

--- a/src/MaterialDesign3.Demo.Wpf/MainWindow.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/MainWindow.xaml
@@ -93,7 +93,7 @@
                   Margin="16,6,16,32"
                   HorizontalContentAlignment="Left"
                   materialDesign:ButtonAssist.CornerRadius="16"
-                  Background="{DynamicResource SecondaryHueMidBrush}"
+                  Background="{DynamicResource MaterialDesign.Brush.Secondary}"
                   BorderThickness="0"
                   Click="GitHubButton_OnClick"
                   DockPanel.Dock="Top"
@@ -271,7 +271,7 @@
 
           <Grid x:Name="NavRail"
                 Width="80"
-                Background="{DynamicResource MaterialDesignPaper}"
+                Background="{DynamicResource MaterialDesign.Brush.Background}"
                 Visibility="{Binding ElementName=drawer, Path=IsLeftDrawerOpen, Converter={StaticResource InverseBoolToVisConverter}}">
             <Grid.RowDefinitions>
               <RowDefinition Height="auto" />
@@ -283,7 +283,7 @@
                     Height="56"
                     Margin="0,25,0,60"
                     materialDesign:ButtonAssist.CornerRadius="16"
-                    Background="{DynamicResource SecondaryHueMidBrush}"
+                    Background="{DynamicResource MaterialDesign.Brush.Secondary}"
                     BorderThickness="0"
                     Click="GitHubButton_OnClick"
                     Foreground="{DynamicResource SecondaryHueMidBrushForeground}">
@@ -393,7 +393,7 @@
 
           <materialDesign:ColorZone Grid.Row="1"
                                     Height="80"
-                                    Background="{DynamicResource MaterialDesignCardBackground}">
+                                    Background="{DynamicResource MaterialDesign.Brush.Card.Background}">
             <ListBox ItemsSource="{Binding MainDemoItems}"
                      SelectedValue="{Binding SelectedItem}"
                      Style="{StaticResource MaterialDesign3.NavigationBarListBox}">
@@ -426,7 +426,7 @@
                 HorizontalAlignment="Right"
                 VerticalAlignment="Bottom"
                 materialDesign:ButtonAssist.CornerRadius="28"
-                Background="{DynamicResource SecondaryHueMidBrush}"
+                Background="{DynamicResource MaterialDesign.Brush.Secondary}"
                 BorderThickness="0"
                 Click="GitHubButton_OnClick"
                 Foreground="{DynamicResource SecondaryHueMidBrushForeground}">

--- a/src/MaterialDesign3.Demo.Wpf/MenusAndToolBars.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/MenusAndToolBars.xaml
@@ -201,17 +201,17 @@
           <MenuItem Header="Item 2" />
           <MenuItem Header="Item 3" />
         </MenuItem>
-        <MenuItem Background="{DynamicResource PrimaryHueMidBrush}"
-                  Foreground="{DynamicResource PrimaryHueMidForegroundBrush}"
+        <MenuItem Background="{DynamicResource MaterialDesign.Brush.Primary}"
+                  Foreground="{DynamicResource MaterialDesign.Brush.Primary.Foreground}"
                   Header="In Color">
-          <MenuItem Background="{DynamicResource SecondaryHueMidBrush}"
-                    Foreground="{DynamicResource SecondaryHueMidForegroundBrush}"
+          <MenuItem Background="{DynamicResource MaterialDesign.Brush.Secondary}"
+                    Foreground="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}"
                     Header="Item 1" />
-          <MenuItem Background="{DynamicResource SecondaryHueMidBrush}"
-                    Foreground="{DynamicResource SecondaryHueMidForegroundBrush}"
+          <MenuItem Background="{DynamicResource MaterialDesign.Brush.Secondary}"
+                    Foreground="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}"
                     Header="Item 2" />
-          <MenuItem Background="{DynamicResource SecondaryHueMidBrush}"
-                    Foreground="{DynamicResource SecondaryHueMidForegroundBrush}"
+          <MenuItem Background="{DynamicResource MaterialDesign.Brush.Secondary}"
+                    Foreground="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}"
                     Header="Item 3" />
         </MenuItem>
         <MenuItem Foreground="Crimson" Header="(1) Important">

--- a/src/MaterialDesign3.Demo.Wpf/NavigationBar.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/NavigationBar.xaml
@@ -23,7 +23,7 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Bottom"
                     materialDesign:ButtonAssist.CornerRadius="16"
-                    Background="{DynamicResource SecondaryHueMidBrush}"
+                    Background="{DynamicResource MaterialDesign.Brush.Secondary}"
                     BorderThickness="0"
                     Foreground="{DynamicResource SecondaryHueMidBrushForeground}">
               <materialDesign:PackIcon Width="24"
@@ -31,7 +31,7 @@
                                        Kind="PencilOutline" />
             </Button>
 
-            <Grid Height="80" Background="{DynamicResource MaterialDesignCardBackground}">
+            <Grid Height="80" Background="{DynamicResource MaterialDesign.Brush.Card.Background}">
               <ListBox Height="80"
                        SelectedIndex="0"
                        Style="{StaticResource MaterialDesign3.NavigationBarPrimaryListBox}">
@@ -71,7 +71,7 @@
       <StackPanel Margin="0,20,0,0">
         <TextBlock Text="MVVM" />
         <smtx:XamlDisplay UniqueKey="navbar_2">
-          <Grid Height="80" Background="{DynamicResource MaterialDesignCardBackground}">
+          <Grid Height="80" Background="{DynamicResource MaterialDesign.Brush.Card.Background}">
             <ListBox Height="80"
                      ItemsSource="{Binding SampleList}"
                      SelectedIndex="0"
@@ -96,7 +96,7 @@
       <StackPanel Margin="0,20,0,0">
         <TextBlock Text="Without Text" />
         <smtx:XamlDisplay UniqueKey="navbar_3">
-          <Grid Height="80" Background="{DynamicResource MaterialDesignCardBackground}">
+          <Grid Height="80" Background="{DynamicResource MaterialDesign.Brush.Card.Background}">
             <ListBox Height="80"
                      ItemsSource="{Binding SampleList}"
                      SelectedIndex="0"

--- a/src/MaterialDesign3.Demo.Wpf/NavigationRail.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/NavigationRail.xaml
@@ -26,7 +26,7 @@
     <StackPanel Margin="20,0">
       <TextBlock HorizontalAlignment="Center" Text="Custom Icon Size" />
       <smtx:XamlDisplay VerticalAlignment="Top" UniqueKey="navrail_1">
-        <Grid Width="80" Background="{DynamicResource MaterialDesignCardBackground}">
+        <Grid Width="80" Background="{DynamicResource MaterialDesign.Brush.Card.Background}">
           <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
@@ -36,7 +36,7 @@
                   Height="56"
                   Margin="0,40,0,80"
                   materialDesign:ButtonAssist.CornerRadius="16"
-                  Background="{DynamicResource SecondaryHueMidBrush}"
+                  Background="{DynamicResource MaterialDesign.Brush.Secondary}"
                   BorderThickness="0"
                   Foreground="{DynamicResource SecondaryHueMidBrushForeground}">
             <materialDesign:PackIcon Width="24"
@@ -86,7 +86,7 @@
     <StackPanel Margin="20,0">
       <TextBlock HorizontalAlignment="Center" Text="MVVM" />
       <smtx:XamlDisplay UniqueKey="navrail_2">
-        <Grid Width="80" Background="{DynamicResource MaterialDesignCardBackground}">
+        <Grid Width="80" Background="{DynamicResource MaterialDesign.Brush.Card.Background}">
           <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
             <RowDefinition Height="auto" />
@@ -100,7 +100,7 @@
                   Height="56"
                   Margin="0,10,0,40"
                   materialDesign:ButtonAssist.CornerRadius="16"
-                  Background="{DynamicResource SecondaryHueMidBrush}"
+                  Background="{DynamicResource MaterialDesign.Brush.Secondary}"
                   BorderThickness="0"
                   Click="Button_Click"
                   Foreground="{DynamicResource SecondaryHueMidBrushForeground}"
@@ -136,7 +136,7 @@
     <StackPanel Margin="20,0">
       <TextBlock HorizontalAlignment="Center" Text="Without Text" />
       <smtx:XamlDisplay UniqueKey="navrail_3">
-        <Grid Width="80" Background="{DynamicResource MaterialDesignCardBackground}">
+        <Grid Width="80" Background="{DynamicResource MaterialDesign.Brush.Card.Background}">
           <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
@@ -146,7 +146,7 @@
                   Height="56"
                   Margin="0,37,0,80"
                   materialDesign:ButtonAssist.CornerRadius="16"
-                  Background="{DynamicResource SecondaryHueMidBrush}"
+                  Background="{DynamicResource MaterialDesign.Brush.Secondary}"
                   BorderThickness="0"
                   Click="Button_Click_1"
                   Foreground="{DynamicResource SecondaryHueMidBrushForeground}"
@@ -316,7 +316,7 @@
       <TextBlock HorizontalAlignment="Center" Text="Custom Size" />
       <StackPanel Orientation="Horizontal">
         <smtx:XamlDisplay UniqueKey="navrail_6">
-          <Grid Width="120" Background="{DynamicResource MaterialDesignCardBackground}">
+          <Grid Width="120" Background="{DynamicResource MaterialDesign.Brush.Card.Background}">
             <Grid.RowDefinitions>
               <RowDefinition Height="auto" />
               <RowDefinition Height="*" />
@@ -326,7 +326,7 @@
                     Height="96"
                     Margin="0,60,0,120"
                     materialDesign:ButtonAssist.CornerRadius="28"
-                    Background="{DynamicResource SecondaryHueMidBrush}"
+                    Background="{DynamicResource MaterialDesign.Brush.Secondary}"
                     BorderThickness="0"
                     Foreground="{DynamicResource SecondaryHueMidBrushForeground}"
                     Style="{StaticResource MaterialDesignFlatMidBgButton}">

--- a/src/MaterialDesign3.Demo.Wpf/Palette.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Palette.xaml
@@ -28,35 +28,35 @@
       <ColumnDefinition Width="1*" />
     </Grid.ColumnDefinitions>
 
-    <Border Grid.ColumnSpan="3" Background="{DynamicResource PrimaryHueMidBrush}">
-      <TextBlock Foreground="{DynamicResource PrimaryHueMidForegroundBrush}" Text="Primary - Mid" />
+    <Border Grid.ColumnSpan="3" Background="{DynamicResource MaterialDesign.Brush.Primary}">
+      <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Primary.Foreground}" Text="Primary - Mid" />
     </Border>
 
     <Border Grid.Row="1"
             Grid.Column="0"
-            Background="{DynamicResource PrimaryHueLightBrush}">
+            Background="{DynamicResource MaterialDesign.Brush.Primary.Light}">
       <TextBlock FontWeight="Bold"
-                 Foreground="{DynamicResource PrimaryHueLightForegroundBrush}"
+                 Foreground="{DynamicResource MaterialDesign.Brush.Primary.Light.Foreground}"
                  Text="Light" />
     </Border>
 
     <Border Grid.Row="1"
             Grid.Column="1"
-            Background="{DynamicResource PrimaryHueMidBrush}">
-      <TextBlock Foreground="{DynamicResource PrimaryHueMidForegroundBrush}" Text="Mid" />
+            Background="{DynamicResource MaterialDesign.Brush.Primary}">
+      <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Primary.Foreground}" Text="Mid" />
     </Border>
 
     <Border Grid.Row="1"
             Grid.Column="2"
-            Background="{DynamicResource PrimaryHueDarkBrush}">
-      <TextBlock Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}" Text="Dark" />
+            Background="{DynamicResource MaterialDesign.Brush.Primary.Dark}">
+      <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Primary.Dark.Foreground}" Text="Dark" />
     </Border>
 
     <Border Grid.Row="2"
             Grid.Column="0"
             Grid.ColumnSpan="3"
-            Background="{DynamicResource SecondaryHueMidBrush}">
-      <TextBlock Foreground="{DynamicResource SecondaryHueMidForegroundBrush}" Text="Secondary" />
+            Background="{DynamicResource MaterialDesign.Brush.Secondary}">
+      <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}" Text="Secondary" />
     </Border>
   </Grid>
 </UserControl>

--- a/src/MaterialDesign3.Demo.Wpf/Pickers.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Pickers.xaml
@@ -393,22 +393,22 @@
                   <Style x:Key="SecondaryCalendarDayButton"
                          TargetType="CalendarDayButton"
                          BasedOn="{StaticResource MaterialDesignCalendarDayButton}">
-                    <Setter Property="materialDesign:CalendarAssist.SelectionColor" Value="{DynamicResource SecondaryHueMidBrush}" />
-                    <Setter Property="materialDesign:CalendarAssist.SelectionForegroundColor" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                    <Setter Property="materialDesign:CalendarAssist.SelectionColor" Value="{DynamicResource MaterialDesign.Brush.Secondary}" />
+                    <Setter Property="materialDesign:CalendarAssist.SelectionForegroundColor" Value="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}" />
                   </Style>
                   <Style x:Key="SecondaryCalendarButton"
                          TargetType="CalendarButton"
                          BasedOn="{StaticResource MaterialDesignCalendarButton}">
-                    <Setter Property="materialDesign:CalendarAssist.SelectionColor" Value="{DynamicResource SecondaryHueMidBrush}" />
-                    <Setter Property="materialDesign:CalendarAssist.SelectionForegroundColor" Value="{DynamicResource SecondaryHueMidForegroundBrush}" />
+                    <Setter Property="materialDesign:CalendarAssist.SelectionColor" Value="{DynamicResource MaterialDesign.Brush.Secondary}" />
+                    <Setter Property="materialDesign:CalendarAssist.SelectionForegroundColor" Value="{DynamicResource MaterialDesign.Brush.Secondary.Foreground}" />
                   </Style>
                 </Grid.Resources>
-                <Calendar materialDesign:CalendarAssist.HeaderBackground="{DynamicResource PrimaryHueDarkBrush}"
-                          materialDesign:CalendarAssist.HeaderForeground="{DynamicResource PrimaryHueDarkForegroundBrush}"
-                          Background="{DynamicResource PrimaryHueLightBrush}"
+                <Calendar materialDesign:CalendarAssist.HeaderBackground="{DynamicResource MaterialDesign.Brush.Primary.Dark}"
+                          materialDesign:CalendarAssist.HeaderForeground="{DynamicResource MaterialDesign.Brush.Primary.Dark.Foreground}"
+                          Background="{DynamicResource MaterialDesign.Brush.Primary.Light}"
                           CalendarButtonStyle="{StaticResource SecondaryCalendarButton}"
                           CalendarDayButtonStyle="{StaticResource SecondaryCalendarDayButton}"
-                          Foreground="{DynamicResource PrimaryHueLightForegroundBrush}" />
+                          Foreground="{DynamicResource MaterialDesign.Brush.Primary.Light.Foreground}" />
               </Grid>
             </smtx:XamlDisplay>
           </GroupBox>

--- a/src/MaterialDesign3.Demo.Wpf/RatingBar.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/RatingBar.xaml
@@ -39,7 +39,7 @@
                 <TextBlock HorizontalAlignment="Center"
                            VerticalAlignment="Center"
                            FontSize="8"
-                           Foreground="{DynamicResource PrimaryHueMidForegroundBrush}"
+                           Foreground="{DynamicResource MaterialDesign.Brush.Primary.Foreground}"
                            Text="{Binding}" />
               </Grid>
             </DataTemplate>

--- a/src/MaterialDesign3.Demo.Wpf/Snackbars.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Snackbars.xaml
@@ -47,7 +47,7 @@
     <Border Grid.Row="0"
             Grid.Column="1"
             Padding="8,0,8,0"
-            Background="{DynamicResource MaterialDesignPaper}">
+            Background="{DynamicResource MaterialDesign.Brush.Background}">
       <Grid>
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
           <StackPanel.Resources>
@@ -136,7 +136,7 @@
     <Border Grid.Row="0"
             Grid.Column="3"
             Padding="8,0,8,0"
-            Background="{DynamicResource MaterialDesignPaper}">
+            Background="{DynamicResource MaterialDesign.Brush.Background}">
       <Grid>
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
           <StackPanel.Resources>
@@ -186,7 +186,7 @@
     <Border Grid.Row="1"
             Grid.Column="0"
             Grid.ColumnSpan="2"
-            Background="{DynamicResource MaterialDesignChipBackground}">
+            Background="{DynamicResource MaterialDesign.Brush.Chip.Background}">
       <StackPanel VerticalAlignment="Bottom">
         <StackPanel Margin="0,0,0,32"
                     HorizontalAlignment="Center"
@@ -268,7 +268,7 @@
     <Border Grid.Row="1"
             Grid.Column="3"
             Padding="8,0,8,0"
-            Background="{DynamicResource MaterialDesignPaper}">
+            Background="{DynamicResource MaterialDesign.Brush.Background}">
       <Grid>
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
           <StackPanel.Resources>

--- a/src/MaterialDesign3.Demo.Wpf/Toggles.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Toggles.xaml
@@ -382,7 +382,7 @@
             Grid.Column="0"
             Grid.ColumnSpan="2"
             Margin="0,24,0,0"
-            BorderBrush="{DynamicResource MaterialDesignDivider}"
+            BorderBrush="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
             BorderThickness="0,1,0,0" />
 
     <TextBlock Grid.Row="7"
@@ -445,7 +445,7 @@
             Grid.Column="0"
             Grid.ColumnSpan="2"
             Margin="0,24,0,0"
-            BorderBrush="{DynamicResource MaterialDesignDivider}"
+            BorderBrush="{DynamicResource MaterialDesign.Brush.TextBox.HoverBackground}"
             BorderThickness="0,1,0,0" />
 
     <StackPanel Grid.Row="11">
@@ -498,19 +498,19 @@
           <smtx:XamlDisplay HorizontalAlignment="Left" UniqueKey="buttons_71">
             <StackPanel Margin="4" Orientation="Horizontal">
               <RadioButton Margin="4"
-                           BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+                           BorderBrush="{DynamicResource MaterialDesign.Brush.Primary}"
                            Content="FIRST"
                            IsChecked="True"
                            Style="{StaticResource MaterialDesignTabRadioButtonTop}" />
 
               <RadioButton Margin="4"
-                           BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+                           BorderBrush="{DynamicResource MaterialDesign.Brush.Primary}"
                            Content="SECOND"
                            IsChecked="False"
                            Style="{StaticResource MaterialDesignTabRadioButtonTop}" />
 
               <RadioButton Margin="4"
-                           BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+                           BorderBrush="{DynamicResource MaterialDesign.Brush.Primary}"
                            Content="THIRD"
                            IsChecked="False"
                            IsEnabled="False"
@@ -522,19 +522,19 @@
             <materialDesign:ColorZone Mode="SecondaryMid">
               <StackPanel Margin="2" Orientation="Horizontal">
                 <RadioButton Margin="4"
-                             BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+                             BorderBrush="{DynamicResource MaterialDesign.Brush.Primary}"
                              Content="FIRST"
                              IsChecked="True"
                              Style="{StaticResource MaterialDesignTabRadioButtonTop}" />
 
                 <RadioButton Margin="4"
-                             BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+                             BorderBrush="{DynamicResource MaterialDesign.Brush.Primary}"
                              Content="SECOND"
                              IsChecked="False"
                              Style="{StaticResource MaterialDesignTabRadioButtonTop}" />
 
                 <RadioButton Margin="4"
-                             BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+                             BorderBrush="{DynamicResource MaterialDesign.Brush.Primary}"
                              Content="THIRD"
                              IsChecked="False"
                              IsEnabled="False"

--- a/src/MaterialDesign3.Demo.Wpf/TransitionsDemo/Slide5_TransitioningContent.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/TransitionsDemo/Slide5_TransitioningContent.xaml
@@ -6,7 +6,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              d:DesignHeight="300"
              d:DesignWidth="300"
-             Background="{DynamicResource MaterialDesignPaper}"
+             Background="{DynamicResource MaterialDesign.Brush.Background}"
              mc:Ignorable="d">
 
   <Grid Width="418" HorizontalAlignment="Center">


### PR DESCRIPTION
The MD3 demo still uses the old brush names. This breaks the look of some examples (e.g. the `Card` page), and we probably shouldn't lead consumers to use the old brush names.

I used your `Migrate.ps1` script and had a quick glance at the UI, so the changes should all be fine.