### PR TITLE
Enhance Mouseover Visuals for ListBoxItem

### DIFF
--- a/src/MaterialDesignThemes.Wpf/ListBoxItemAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/ListBoxItemAssist.cs
@@ -61,4 +61,15 @@ public static class ListBoxItemAssist
     public static readonly DependencyProperty ShowSelectionProperty =
         DependencyProperty.RegisterAttached("ShowSelection", typeof(bool), typeof(ListBoxItemAssist), new PropertyMetadata(true));
     #endregion
+
+    #region Cursor
+    public static Cursor GetCursor(DependencyObject obj)
+        => (Cursor)obj.GetValue(CursorProperty);
+
+    public static void SetCursor(DependencyObject obj, Cursor value)
+        => obj.SetValue(CursorProperty, value);
+
+    public static readonly DependencyProperty CursorProperty =
+        DependencyProperty.RegisterAttached("Cursor", typeof(Cursor), typeof(ListBoxItemAssist), new PropertyMetadata(Cursors.Hand));
+    #endregion
 }

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
@@ -241,6 +241,7 @@
     <Setter Property="wpf:ListBoxItemAssist.HoverBackground" Value="{Binding Foreground, RelativeSource={RelativeSource Self}, Converter={x:Static converters:BrushOpacityConverter.Instance}, ConverterParameter=0.1}" />
     <Setter Property="wpf:ListBoxItemAssist.SelectedFocusedBackground" Value="{Binding Foreground, RelativeSource={RelativeSource Self}, Converter={x:Static converters:BrushOpacityConverter.Instance}, ConverterParameter=0.18}" />
     <Setter Property="wpf:ListBoxItemAssist.SelectedUnfocusedBackground" Value="{Binding Foreground, RelativeSource={RelativeSource Self}, Converter={x:Static converters:BrushOpacityConverter.Instance}, ConverterParameter=0.09}" />
+    <Setter Property="Cursor" Value="{Binding Path=(wpf:ListBoxItemAssist.Cursor), RelativeSource={RelativeSource AncestorType=ListBox}}"/>
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListBoxItem}">
@@ -423,6 +424,7 @@
     <Setter Property="Margin" Value="4,2,4,2" />
     <Setter Property="Padding" Value="8" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
+    <Setter Property="Cursor" Value="{Binding Path=(wpf:ListBoxItemAssist.Cursor), RelativeSource={RelativeSource AncestorType=ListBox}}"/>
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListBoxItem}">


### PR DESCRIPTION
same as #3803 but for `ListBoxItem`

The MD [specs](https://m3.material.io/components/lists/accessibility#1a70715d-c84d-4ae7-8053-a4881b3e8653) and [interactive demo](https://m2.material.io/components/lists#interactive-demo) suggest that the `Cursor` should be the `Hand` when hovering over a ListBoxItem.

Just like with the above linked PR I added an AP so users can fall back to the old behavior if they want to:
`materialDesign:ListBoxItemAssist.Cursor="Arrow"`