### PR TITLE
Add bindable DP `TreeListView.SelectedItems`

### DIFF
--- a/src/MainDemo.Wpf/App.xaml
+++ b/src/MainDemo.Wpf/App.xaml
@@ -22,7 +22,7 @@
         If you would prefer to use your own colors, there is an option for that as well:
         PrimaryColor and SecondaryColor also support the constant string "Inherit" to specify the color should use the system theme accent color
         -->
-        <materialDesign:CustomColorTheme BaseTheme="Light" PrimaryColor="Aqua" SecondaryColor="#FF006400" />
+        <!--<materialDesign:CustomColorTheme BaseTheme="Light" PrimaryColor="Aqua" SecondaryColor="#FF006400" />-->
 
         <!-- You can also use the built-in theme dictionaries: -->
         <!--

--- a/src/MainDemo.Wpf/Domain/TreesViewModel.cs
+++ b/src/MainDemo.Wpf/Domain/TreesViewModel.cs
@@ -104,6 +104,10 @@ public sealed class TreesViewModel : ViewModelBase
 
     public AnotherCommandImplementation RemoveListTreeItemCommand { get; }
 
+    public AnotherCommandImplementation RemoveSelectedListTreeItemCommand { get; }
+
+    public ObservableCollection<TestItem?> SelectedTreeItems { get; } = [];
+
     public TestItem? SelectedTreeItem
     {
         get => _selectedTreeItem;
@@ -119,7 +123,7 @@ public sealed class TreesViewModel : ViewModelBase
     public TreesViewModel()
     {
         Random random = new();
-        for(int i = 0; i < 10; i++)
+        for (int i = 0; i < 10; i++)
         {
             TreeItems.Add(CreateTestItem(random, 1));
         }
@@ -128,8 +132,8 @@ public sealed class TreesViewModel : ViewModelBase
         {
             int numberOfChildren = depth < 5 ? random.Next(0, 6) : 0;
             var children = Enumerable.Range(0, numberOfChildren).Select(_ => CreateTestItem(random, depth + 1));
-            var rv = new TestItem(GenerateString(random.Next(4, 10)), children); 
-            foreach(var child in rv.Items)
+            var rv = new TestItem(GenerateString(random.Next(4, 10)), children);
+            foreach (var child in rv.Items)
             {
                 child.Parent = rv;
             }
@@ -154,7 +158,7 @@ public sealed class TreesViewModel : ViewModelBase
         {
             if (items is IEnumerable enumerable)
             {
-                foreach(TestItem testItem in enumerable)
+                foreach (TestItem testItem in enumerable)
                 {
                     if (testItem.Parent is { } parent)
                     {
@@ -226,6 +230,14 @@ public sealed class TreesViewModel : ViewModelBase
                 }
             },
             _ => SelectedItem != null);
+
+        RemoveSelectedListTreeItemCommand = new(item =>
+        {
+            if (item is TestItem treeItem)
+            {
+                SelectedTreeItems.Remove(treeItem);
+            }
+        });
     }
 
     private static string GenerateString(int length)

--- a/src/MainDemo.Wpf/Trees.xaml
+++ b/src/MainDemo.Wpf/Trees.xaml
@@ -209,53 +209,85 @@
                   Grid.Column="2"
                   VerticalContentAlignment="Top"
                   UniqueKey="trees_3">
-        <Grid>
-          <materialDesign:TreeListView MinWidth="220" MaxHeight="450"
-                                     ItemsSource="{Binding TreeItems}"
-                                     SelectedItem="{Binding SelectedTreeItem}">
-            <materialDesign:TreeListView.Resources>
-              <HierarchicalDataTemplate DataType="{x:Type domain:TestItem}"
-                          ItemsSource="{Binding Items, Mode=OneTime}">
-                <TextBlock Margin="3,2" Text="{Binding Name, Mode=OneTime}" />
-              </HierarchicalDataTemplate>
+        <StackPanel Orientation="Horizontal">
+          <Grid>
+            <materialDesign:TreeListView MinWidth="220"
+                                         MaxHeight="450"
+                                         ItemsSource="{Binding TreeItems}"
+                                         SelectedItem="{Binding SelectedTreeItem}"
+                                         SelectedItems="{Binding SelectedTreeItems}">
+              <materialDesign:TreeListView.Resources>
+                <HierarchicalDataTemplate DataType="{x:Type domain:TestItem}"
+                                          ItemsSource="{Binding Items, Mode=OneTime}">
+                  <TextBlock Margin="3,2" Text="{Binding Name, Mode=OneTime}" />
+                </HierarchicalDataTemplate>
 
-              <HierarchicalDataTemplate DataType="{x:Type domain:MovieCategory}"
-                                      ItemsSource="{Binding Movies, Mode=OneTime}">
-                <TextBlock Margin="3,2" Text="{Binding Name, Mode=OneTime}" />
-              </HierarchicalDataTemplate>
+                <HierarchicalDataTemplate DataType="{x:Type domain:MovieCategory}"
+                                          ItemsSource="{Binding Movies, Mode=OneTime}">
+                  <TextBlock Margin="3,2" Text="{Binding Name, Mode=OneTime}" />
+                </HierarchicalDataTemplate>
 
-              <DataTemplate DataType="{x:Type domain:Movie}">
-                <TextBlock Margin="3,2"
-                           Text="{Binding Name, Mode=OneTime}"
-                           ToolTip="{Binding Director, Mode=OneTime}" />
-              </DataTemplate>
-            </materialDesign:TreeListView.Resources>
+                <DataTemplate DataType="{x:Type domain:Movie}">
+                  <TextBlock Margin="3,2"
+                             Text="{Binding Name, Mode=OneTime}"
+                             ToolTip="{Binding Director, Mode=OneTime}" />
+                </DataTemplate>
+              </materialDesign:TreeListView.Resources>
 
-            <!--
-            Because Data Virtualization is enabled on this tree view by default, if you don't bind the IsExpanded property to something in the bound view model,
-            you can loose the expanded state of items when the TreeListViewItem is recycled.
+              <!--
+              Because Data Virtualization is enabled on this tree view by default, if you don't bind the IsExpanded property to something in the bound view model,
+              you can loose the expanded state of items when the TreeListViewItem is recycled.
+              
+              For more information:
+              https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/3640#issuecomment-2274086113
+              https://learn.microsoft.com/dotnet/desktop/wpf/advanced/optimizing-performance-controls?view=netframeworkdesktop-4.8&WT.mc_id=DT-MVP-5003472
+              -->
+              <materialDesign:TreeListView.ItemContainerStyle>
+                <Style TargetType="materialDesign:TreeListViewItem" BasedOn="{StaticResource {x:Type materialDesign:TreeListViewItem}}">
+                  <Setter Property="IsExpanded" Value="{Binding IsExpanded}" />
+                </Style>
+              </materialDesign:TreeListView.ItemContainerStyle>
+            </materialDesign:TreeListView>
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" HorizontalAlignment="Right">
+              <Button Command="{Binding AddListTreeItemCommand}"
+                      ToolTip="Add an item"
+                      Content="{materialDesign:PackIcon Kind=Add}"/>
 
-            For more information:
-            https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/3640#issuecomment-2274086113
-            https://learn.microsoft.com/dotnet/desktop/wpf/advanced/optimizing-performance-controls?view=netframeworkdesktop-4.8&WT.mc_id=DT-MVP-5003472
-            -->
-            <materialDesign:TreeListView.ItemContainerStyle>
-              <Style TargetType="materialDesign:TreeListViewItem" BasedOn="{StaticResource {x:Type materialDesign:TreeListViewItem}}">
-                <Setter Property="IsExpanded" Value="{Binding IsExpanded}" />
-              </Style>
-            </materialDesign:TreeListView.ItemContainerStyle>
-          </materialDesign:TreeListView>
-          <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" HorizontalAlignment="Right">
-            <Button Command="{Binding AddListTreeItemCommand}"
-                    ToolTip="Add an item"
-                    Content="{materialDesign:PackIcon Kind=Add}"/>
+              <Button Command="{Binding RemoveListTreeItemCommand}"
+                      ToolTip="Remove selected item(s)"
+                      Content="{materialDesign:PackIcon Kind=Remove}"/>
 
-            <Button Command="{Binding RemoveListTreeItemCommand}"
-                    ToolTip="Remove selected item(s)"
-                    Content="{materialDesign:PackIcon Kind=Remove}"/>
+            </StackPanel>
+          </Grid>
 
-          </StackPanel>
-        </Grid>
+          <GroupBox Margin="4,0,0,0" Header="TreeListView.SelectedItems">
+            <ListBox ItemsSource="{Binding SelectedTreeItems}" HorizontalContentAlignment="Stretch">
+              <ListBox.ItemTemplate>
+                <DataTemplate>
+                  <Grid>
+                    <Grid.ColumnDefinitions>
+                      <ColumnDefinition Width="*" />
+                      <ColumnDefinition Width="auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding Name}"
+                               VerticalAlignment="Center" />
+                    <Button Grid.Column="1"
+                            Padding="4"
+                            Width="{Binding Path=ActualHeight, RelativeSource={RelativeSource Mode=Self}}"
+                            Command="{Binding DataContext.RemoveSelectedListTreeItemCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                            CommandParameter="{Binding .}"
+                            Content="{materialDesign:PackIcon Kind=Bin}"
+                            Foreground="Red"
+                            Style="{StaticResource MaterialDesignFlatButton}" />
+                  </Grid>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+          </GroupBox>
+
+        </StackPanel>
+        
       </smtx:XamlDisplay>
 
       <TextBlock Grid.Row="2"

--- a/src/MaterialDesign3.Demo.Wpf/Domain/TreesViewModel.cs
+++ b/src/MaterialDesign3.Demo.Wpf/Domain/TreesViewModel.cs
@@ -90,6 +90,10 @@ public sealed class TreesViewModel : ViewModelBase
 
     public AnotherCommandImplementation RemoveListTreeItemCommand { get; }
 
+    public AnotherCommandImplementation RemoveSelectedListTreeItemCommand { get; }
+
+    public ObservableCollection<TestItem?> SelectedTreeItems { get; } = [];
+
     public TestItem? SelectedTreeItem
     {
         get => _selectedTreeItem;
@@ -210,6 +214,14 @@ public sealed class TreesViewModel : ViewModelBase
                 }
             },
             _ => SelectedItem != null);
+
+        RemoveSelectedListTreeItemCommand = new(item =>
+        {
+            if (item is TestItem treeItem)
+            {
+                SelectedTreeItems.Remove(treeItem);
+            }
+        });
     }
 
     private static string GenerateString(int length)

--- a/src/MaterialDesign3.Demo.Wpf/Trees.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Trees.xaml
@@ -175,35 +175,69 @@
         </Grid>
       </smtx:XamlDisplay>
 
-      <TextBlock Style="{StaticResource MaterialDesignHeadline6TextBlock}" Text="Multi-Select Tree View:"
-                 Grid.Column="2"/>
+      <TextBlock Grid.Column="2"
+                 Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                 Text="Multi-Select Tree View:" />
       <smtx:XamlDisplay Grid.Row="1"
                         Grid.Column="2"
                         VerticalContentAlignment="Top"
                         UniqueKey="trees_3">
-        <Grid>
-          <materialDesign:TreeListView MinWidth="220" MaxHeight="450"
-                                       ItemsSource="{Binding TreeItems}"
-                                       SelectedItem="{Binding SelectedTreeItem}">
-            <materialDesign:TreeListView.ItemTemplate>
-              <HierarchicalDataTemplate DataType="{x:Type domain:TestItem}"
-                                        ItemsSource="{Binding Items, Mode=OneWay}">
-                <TextBlock Margin="3,2" Text="{Binding Name, Mode=OneWay}" />
-              </HierarchicalDataTemplate>
-            </materialDesign:TreeListView.ItemTemplate>
+        <StackPanel Orientation="Horizontal">
+          <Grid>
+            <materialDesign:TreeListView MinWidth="220"
+                                         MaxHeight="450"
+                                         ItemsSource="{Binding TreeItems}"
+                                         SelectedItem="{Binding SelectedTreeItem}"
+                                         SelectedItems="{Binding SelectedTreeItems}">
+              <materialDesign:TreeListView.ItemTemplate>
+                <HierarchicalDataTemplate DataType="{x:Type domain:TestItem}" ItemsSource="{Binding Items, Mode=OneWay}">
+                  <TextBlock Margin="3,2" Text="{Binding Name, Mode=OneWay}" />
+                </HierarchicalDataTemplate>
+              </materialDesign:TreeListView.ItemTemplate>
 
-          </materialDesign:TreeListView>
-          <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" HorizontalAlignment="Right">
-            <Button Command="{Binding AddListTreeItemCommand}"
-                    ToolTip="Add an item"
-                    Content="{materialDesign:PackIcon Kind=Add}"/>
+            </materialDesign:TreeListView>
+            <StackPanel HorizontalAlignment="Right"
+                        VerticalAlignment="Bottom"
+                        Orientation="Horizontal">
+              <Button Command="{Binding AddListTreeItemCommand}"
+                      Content="{materialDesign:PackIcon Kind=Add}"
+                      ToolTip="Add an item" />
 
-            <Button Command="{Binding RemoveListTreeItemCommand}"
-                    ToolTip="Remove selected item(s)"
-                    Content="{materialDesign:PackIcon Kind=Remove}"/>
+              <Button Command="{Binding RemoveListTreeItemCommand}"
+                      Content="{materialDesign:PackIcon Kind=Remove}"
+                      ToolTip="Remove selected item(s)" />
 
-          </StackPanel>
-        </Grid>
+            </StackPanel>
+          </Grid>
+
+          <GroupBox Margin="4,0,0,0" Header="TreeListView.SelectedItems">
+            <ListBox HorizontalContentAlignment="Stretch" ItemsSource="{Binding SelectedTreeItems}">
+              <ListBox.ItemTemplate>
+                <DataTemplate>
+                  <Grid>
+                    <Grid.ColumnDefinitions>
+                      <ColumnDefinition Width="*" />
+                      <ColumnDefinition Width="auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0"
+                               VerticalAlignment="Center"
+                               Text="{Binding Name}" />
+                    <Button Grid.Column="1"
+                            Width="{Binding Path=ActualHeight, RelativeSource={RelativeSource Mode=Self}}"
+                            Padding="4"
+                            Command="{Binding DataContext.RemoveSelectedListTreeItemCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                            CommandParameter="{Binding .}"
+                            Content="{materialDesign:PackIcon Kind=Bin}"
+                            Foreground="Red"
+                            Style="{StaticResource MaterialDesignFlatButton}" />
+                  </Grid>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+          </GroupBox>
+
+        </StackPanel>
+
       </smtx:XamlDisplay>
 
       <TextBlock Grid.Row="2"

--- a/src/MaterialDesignThemes.Wpf/TreeListView.cs
+++ b/src/MaterialDesignThemes.Wpf/TreeListView.cs
@@ -76,10 +76,21 @@ public class TreeListView : ListView
             return;
         }
 
-        // Remove unselected
-        foreach (var item in e.RemovedItems)
+        bool isSingleSelection = Keyboard.Modifiers == ModifierKeys.None && e.AddedItems.Count == 1;
+        // If no modifier keys, treat as single selection (like normal ListView)
+        if (isSingleSelection)
         {
-            if (!IsCollapsingItem)
+            // Remove all except the newly selected item
+            var selected = e.AddedItems[0];
+            SelectedItems.Clear();
+            SelectedItems.Add(selected);
+            return;
+        }
+
+        // Remove unselected
+        if (!IsCollapsingItem)
+        {
+            foreach (var item in e.RemovedItems)
             {
                 SelectedItems.Remove(item);
             }
@@ -88,7 +99,10 @@ public class TreeListView : ListView
         // Add newly selected
         foreach (var item in e.AddedItems)
         {
-            SelectedItems.Add(item);
+            if (!SelectedItems.Contains(item))
+            {
+                SelectedItems.Add(item);
+            }
         }
     }
 

--- a/src/MaterialDesignThemes.Wpf/TreeListView.cs
+++ b/src/MaterialDesignThemes.Wpf/TreeListView.cs
@@ -20,7 +20,7 @@ public class TreeListView : ListView
 
     internal TreeListViewItemsCollection? InternalItemsSource { get; set; }
 
-    internal bool IsCollapsingItem { get; set; } = false;
+    private bool IsCollapsingItem { get; set; }
     public new IList SelectedItems
     {
         get => (IList)GetValue(SelectedItemsProperty);
@@ -88,16 +88,13 @@ public class TreeListView : ListView
         // Add newly selected
         foreach (var item in e.AddedItems)
         {
-            if (!SelectedItems.Contains(item))
-            {
-                SelectedItems.Add(item);
-            }
+            SelectedItems.Add(item);
         }
     }
 
     private void SelectedItems_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        // NB: Everytime we modify the base.SelectedItems we have to unsubscribe from the SelectionChanged event
+        // NB: Every time we modify the base.SelectedItems we have to unsubscribe from the SelectionChanged event
         //     The base.SelectedItems only contains the visually selected items,
         //     while the SelectedItems contains all selected items, even ones which are not "visible"
         this.SelectionChanged -= TreeListView_SelectionChanged;
@@ -122,10 +119,7 @@ public class TreeListView : ListView
 
             foreach (var item in e.NewItems ?? Array.Empty<object>())
             {
-                if (!base.SelectedItems.Contains(item))
-                {
-                    base.SelectedItems.Add(item);
-                }
+                base.SelectedItems.Add(item);
             }
         }
 
@@ -210,7 +204,7 @@ public class TreeListView : ListView
                 {
                     itemsSource.InsertWithLevel(i + index + 1, children[i], parentLevel + 1);
                 }
-                // if a node, which has a selected childs, is expanded (added) we need to visually select the child (i.e.: update base.SelectedItems)
+                // if a node, which has a selected child, is expanded (added) we need to visually select the child (i.e.: update base.SelectedItems)
                 SyncUISelectionWithSelectedItems();
             }
             else
@@ -343,7 +337,7 @@ public class TreeListView : ListView
 
     private List<object?> GetExpandedChildrenAndGrandChildren(object? dataItem)
     {
-        List<object?> expandedChildren = new();
+        List<object?> expandedChildren = [];
         if (dataItem is null || ItemContainerGenerator.ContainerFromItem(dataItem) is not TreeListViewItem { IsExpanded: true } container)
             return expandedChildren;
 

--- a/src/MaterialDesignThemes.Wpf/TreeListView.cs
+++ b/src/MaterialDesignThemes.Wpf/TreeListView.cs
@@ -99,10 +99,7 @@ public class TreeListView : ListView
         // Add newly selected
         foreach (var item in e.AddedItems)
         {
-            if (!SelectedItems.Contains(item))
-            {
-                SelectedItems.Add(item);
-            }
+            SelectedItems.Add(item);
         }
     }
 

--- a/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewDataBinding.xaml
+++ b/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewDataBinding.xaml
@@ -32,6 +32,7 @@
     <StackPanel Grid.Row="1" Orientation="Horizontal">
       <Button Content="Add" Click="Add_OnClick" />
       <Button Content="Add with Children" Click="AddWithChildren_OnClick" />
+      <Button Content="Add Duplicate" Click="AddDuplicate_OnClick" />
       <Button Content="Remove" Click="Remove_OnClick" />
       <Button Content="Replace" Click="Replace_OnClick" />
       <Button Content="Down" Click="MoveDown_OnClick" />

--- a/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewDataBinding.xaml
+++ b/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewDataBinding.xaml
@@ -15,7 +15,8 @@
     </Grid.RowDefinitions>
     <materialDesign:TreeListView
       x:Name="TreeListView"
-      ItemsSource="{Binding Items}">
+      ItemsSource="{Binding Items}"
+      SelectedItems="{Binding SelectedItems}">
       <materialDesign:TreeListView.ItemTemplate>
         <HierarchicalDataTemplate DataType="{x:Type local:TreeItem}"
             ItemsSource="{Binding Children}">

--- a/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewDataBinding.xaml.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewDataBinding.xaml.cs
@@ -8,7 +8,8 @@ namespace MaterialDesignThemes.UITests.WPF.TreeListViews;
 public partial class TreeListViewDataBinding
 {
     //NB: making the assumption changes occur on the UI thread
-    public ObservableCollection<TreeItem> Items { get; } = new();
+    public ObservableCollection<TreeItem> Items { get; } = [];
+    public ObservableCollection<TreeItem> SelectedItems { get; } = [];
 
     public TreeListViewDataBinding()
     {

--- a/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewDataBinding.xaml.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewDataBinding.xaml.cs
@@ -21,6 +21,7 @@ public partial class TreeListViewDataBinding
 
     public void Add_OnClick(object sender, EventArgs e) => AddItem();
     public void AddWithChildren_OnClick(object sender, EventArgs e) => AddItemWithChildren();
+    public void AddDuplicate_OnClick(object sender, EventArgs e) => AddDuplicateItem();
 
     private void AddItem()
     {
@@ -31,6 +32,23 @@ public partial class TreeListViewDataBinding
         else
         {
             Items.Add(new TreeItem(Items.Count.ToString(), null));
+        }
+    }
+
+    private void AddDuplicateItem()
+    {
+        if (TreeListView.SelectedItem is TreeItem selectedItem)
+        {
+            if (selectedItem.Parent is { } parent)
+            {
+                int childIndex = parent.Children.IndexOf(selectedItem);
+                parent.Children.Insert(childIndex + 1, selectedItem);
+            }
+            else
+            {
+                int itemIndex = Items.IndexOf(selectedItem);
+                Items.Insert(itemIndex + 1, selectedItem);
+            }
         }
     }
 

--- a/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewImplicitTemplate.xaml
+++ b/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewImplicitTemplate.xaml
@@ -15,7 +15,8 @@
     </Grid.RowDefinitions>
     <materialDesign:TreeListView
       x:Name="TreeListView"
-      ItemsSource="{Binding Items}">
+      ItemsSource="{Binding Items}"
+      SelectedItems="{Binding SelectedItems}">
       <materialDesign:TreeListView.Resources>
         <HierarchicalDataTemplate DataType="{x:Type local:TreeItem}"
             ItemsSource="{Binding Children}">

--- a/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewImplicitTemplate.xaml.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewImplicitTemplate.xaml.cs
@@ -8,7 +8,8 @@ namespace MaterialDesignThemes.UITests.WPF.TreeListViews;
 public partial class TreeListViewImplicitTemplate
 {
     //NB: making the assumption changes occur on the UI thread
-    public ObservableCollection<TreeItem> Items { get; } = new();
+    public ObservableCollection<TreeItem> Items { get; } = [];
+    public ObservableCollection<TreeItem> SelectedItems { get; } = [];
 
     public TreeListViewImplicitTemplate()
     {

--- a/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewImplicitTemplate.xaml.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewImplicitTemplate.xaml.cs
@@ -41,12 +41,9 @@ public partial class TreeListViewImplicitTemplate
         }
     }
 
-    private void RemoveItem(IList<TreeItem> items, TreeItem toRemove)
+    private static void RemoveItem(IList<TreeItem> items, TreeItem toRemove)
     {
-        if (items.Contains(toRemove))
-        {
-            items.Remove(toRemove);
-        }
+        items.Remove(toRemove);
         foreach (TreeItem item in items)
         {
             RemoveItem(item.Children, toRemove);

--- a/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewTests.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Windows.Media;
 
 namespace MaterialDesignThemes.UITests.WPF.TreeListViews;
@@ -155,7 +156,7 @@ public class TreeListViewTests : TestBase
         await secondItem.LeftClickExpander();
 
         // Select child item and add three children and expand it
-        IVisualElement<TreeListViewItem>? childElement =  await treeListView.GetElement<TreeListViewItem>("/TreeListViewItem[3]");
+        IVisualElement<TreeListViewItem>? childElement = await treeListView.GetElement<TreeListViewItem>("/TreeListViewItem[3]");
         await AddChildren(childElement!, 3, addButton);
 
         //NB: Needs to be long enough delay so the next click does not register as a double click
@@ -519,7 +520,7 @@ public class TreeListViewTests : TestBase
 
         await AssertTreeItemContent(treeListView, 0, "0");
         await AssertTreeItemContent(treeListView, 1, "2");
-        
+
         recorder.Success();
     }
 
@@ -930,7 +931,7 @@ public class TreeListViewTests : TestBase
 
         // NOTE: This may not be needed, I am not entirely sure.
         item1 = await treeListView.GetElement<TreeListViewItem>("/TreeListViewItem[2]");
-        
+
         // Expand item "1"
         await item1.LeftClickExpander();
 
@@ -1021,6 +1022,40 @@ public class TreeListViewTests : TestBase
         await AssertTreeItemContent(treeListView, 4, "3_0");
         await AssertTreeItemContent(treeListView, 5, "3_1");
         await AssertTreeItemContent(treeListView, 6, "3_2");
+
+        recorder.Success();
+    }
+
+    [Theory]
+    [MemberData(nameof(GetTestControls))]
+    public async Task TreeListView_SelectingMultipleItems_AddsThemToSelectedItems(Type userControlType)
+    {
+        await using var recorder = new TestRecorder(App);
+
+        IVisualElement<Grid> root = (await LoadUserControl(userControlType)).As<Grid>();
+        IVisualElement<TreeListView> treeListView = await root.GetElement<TreeListView>();
+
+        IVisualElement<TreeListViewItem> item1 = await treeListView.GetElement<TreeListViewItem>("/TreeListViewItem[1]");
+        IVisualElement<TreeListViewItem> item2 = await treeListView.GetElement<TreeListViewItem>("/TreeListViewItem[2]");
+        await item1.LeftClick();
+        await Task.Delay(100);
+
+        // TODO: Hold Ctrl and select item2
+        item2.SendInput(new KeyboardInput(Key.LeftCtrl));
+        await item2.LeftClick();
+
+        await Task.Delay(1000);
+
+        static IList GetSelectedItems(TreeListView treeListView)
+        {
+            var idk = treeListView.SelectedItems;
+            string type = idk.GetType().ToString();
+            return (IList)idk;
+        }
+
+        var selectedItems = await treeListView.RemoteExecute(GetSelectedItems);
+
+        Assert.Equal(2, selectedItems.Count);
 
         recorder.Success();
     }

--- a/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewTests.cs
@@ -1037,27 +1037,28 @@ public class TreeListViewTests : TestBase
 
         IVisualElement<TreeListViewItem> item1 = await treeListView.GetElement<TreeListViewItem>("/TreeListViewItem[1]");
         IVisualElement<TreeListViewItem> item2 = await treeListView.GetElement<TreeListViewItem>("/TreeListViewItem[2]");
+
+        // Select multiple items
         await item1.LeftClick();
-        await Task.Delay(100);
-
-        // TODO: Hold Ctrl and select item2
-        item2.SendInput(new KeyboardInput(Key.LeftCtrl));
+        await Task.Delay(50);
+        await treeListView.SendKeyboardInput($"{ModifierKeys.Control}");
         await item2.LeftClick();
+        await Task.Delay(50);
 
-        await Task.Delay(1000);
-
-        static IList GetSelectedItems(TreeListView treeListView)
-        {
-            var idk = treeListView.SelectedItems;
-            string type = idk.GetType().ToString();
-            return (IList)idk;
-        }
+        // Release modifiers
+        await treeListView.SendKeyboardInput($"{ModifierKeys.None}");
 
         var selectedItems = await treeListView.RemoteExecute(GetSelectedItems);
 
+        Assert.NotNull(selectedItems);
         Assert.Equal(2, selectedItems.Count);
 
         recorder.Success();
+
+        static IList GetSelectedItems(TreeListView treeListView)
+        {
+            return treeListView.SelectedItems;
+        }
     }
 
     private static async Task AssertTreeItemContent(IVisualElement<TreeListView> treeListView, int index, string content, bool isExpanded = false)

--- a/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewTests.cs
@@ -521,7 +521,6 @@ public class TreeListViewTests : TestBase
 
         await AssertTreeItemContent(treeListView, 0, "0");
         await AssertTreeItemContent(treeListView, 1, "2");
-
         recorder.Success();
     }
 
@@ -932,7 +931,6 @@ public class TreeListViewTests : TestBase
 
         // NOTE: This may not be needed, I am not entirely sure.
         item1 = await treeListView.GetElement<TreeListViewItem>("/TreeListViewItem[2]");
-
         // Expand item "1"
         await item1.LeftClickExpander();
 

--- a/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewTests.cs
@@ -1048,16 +1048,16 @@ public class TreeListViewTests : TestBase
         // Release modifiers
         await treeListView.SendKeyboardInput($"{ModifierKeys.None}");
 
-        var selectedItems = await treeListView.RemoteExecute(GetSelectedItems);
-
-        Assert.NotNull(selectedItems);
-        Assert.Equal(2, selectedItems.Count);
+        await treeListView.RemoteExecute(AssertSelectedItems);
 
         recorder.Success();
 
-        static IList GetSelectedItems(TreeListView treeListView)
+        // Assert inside of the remote executed method because we can't return an IList, since it's not serializable
+        static void AssertSelectedItems(TreeListView treeListView)
         {
-            return treeListView.SelectedItems;
+            var selectedItems = treeListView.SelectedItems;
+            Assert.NotNull(selectedItems);
+            Assert.Equal(2, selectedItems.Count);
         }
     }
 

--- a/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewTests.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.ComponentModel;
 using System.Windows.Media;
 
 namespace MaterialDesignThemes.UITests.WPF.TreeListViews;
@@ -1069,6 +1070,7 @@ public class TreeListViewTests : TestBase
     }
 
     [Fact]
+    [Description($"When collapsing a parent node all child nodes are visually removed (due to its impl.) from the ListView. A selected child nodes should stay in the {nameof(TreeListView.SelectedItems)} DP even when collapsing its parent.")]
     public async Task TreeListView_CollapsingParentOfSelectedChild_DoesNotRemoveChildFromSelectedItems()
     {
         await using var recorder = new TestRecorder(App);

--- a/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewWithCollectionView.xaml.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TreeListViews/TreeListViewWithCollectionView.xaml.cs
@@ -9,7 +9,7 @@ namespace MaterialDesignThemes.UITests.WPF.TreeListViews;
 /// </summary>
 public partial class TreeListViewWithCollectionView : UserControl
 {
-    private ObservableCollection<TreeItem> ItemsSource { get; } = new();
+    private ObservableCollection<TreeItem> ItemsSource { get; } = [];
 
     public ICollectionView Items { get; }
 


### PR DESCRIPTION
This adds a DP called `SelectedItems` to the `TreeListView` control.
There was a small hurdle to overcome, because of the `TreeListView`s impl., which adds (when expanding) and deletes (when collapsing) childs.
Bascially internally there are now 2 `SelectedItems` Lists:
1. The `base.SelectedItems` (inherited from `ListView`) which only contains the visually selected items
2. The `SelectedItems` (Dependency property) which always contains all of the selected items. This is the one the consumers see/use.

I also added tests for this new DP and showcases to the MD2&3 demos.

![treeListViewSelectedItems](https://github.com/user-attachments/assets/e4f02904-7ddd-418e-9a59-36bac7f7efd6)
