### PR TITLE
Set MaterialDesignPopupBox/PART_Toggle.VerticalAlignment to Stretch

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -108,7 +108,7 @@
           </ControlTemplate.Resources>
           <Grid>
             <ToggleButton x:Name="PART_Toggle"
-                          VerticalAlignment="Center"
+                          VerticalAlignment="Stretch"
                           HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                           VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                           Content="{TemplateBinding ToggleContent}"


### PR DESCRIPTION
Since the VerticalAlignment of the `PART_Toggle` in _MaterialDesignPopupBox_ is `Center` there is no effect when setting VerticalContentAlignment

This PR sets the VerticalAlignment to `Stretch`

This is also the value already used in _MaterialDesignMultiFloatingActionPopupBox_:

https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/35167dfbed5a541ed70369fdb916b03084819345/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml#L365
