### PR TITLE
Fix CultureInfo issue in UpDown variants

### DIFF
--- a/src/MaterialDesignThemes.Wpf/UpDownBase.cs
+++ b/src/MaterialDesignThemes.Wpf/UpDownBase.cs
@@ -118,7 +118,7 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
 
         if (upDownBase._textBoxField is { } textBox)
         {
-            textBox.Text = e.NewValue.ToString();
+            textBox.Text = Convert.ToString(e.NewValue, CultureInfo.CurrentCulture);
         }
 
         upDownBase.UpdateDecreaseButtonEnabled();
@@ -224,7 +224,7 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
         {
             _textBoxField.TextChanged += OnTextBoxTextChanged;
             _textBoxField.LostFocus += OnTextBoxLostFocus;
-            _textBoxField.Text = Value?.ToString();
+            _textBoxField.Text = Convert.ToString(Value, CultureInfo.CurrentCulture);
         }
 
     }
@@ -233,7 +233,7 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
     {
         if (_textBoxField is { } textBoxField)
         {
-            textBoxField.Text = Value?.ToString();
+            textBoxField.Text = Convert.ToString(Value, CultureInfo.CurrentCulture);
         }
     }
 
@@ -241,7 +241,7 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
     {
         if (_textBoxField is { } textBoxField)
         {
-            if (TryParse(textBoxField.Text, CultureInfo.CurrentUICulture, out T? value))
+            if (TryParse(textBoxField.Text, CultureInfo.CurrentCulture, out T? value))
             {
                 SetCurrentValue(ValueProperty, ClampValue(value));
             }


### PR DESCRIPTION
Fixes #3858 

This ensures that `CultureInfo.CurrentCulture` is used in the string conversions of the `Value` property throughout the control. This allows the control to be used in cultures that do not use a "dot" as the decimal separator (like danish `da-DK` for example).

**Tests**
I left a comment on the issue, because I wanted to write some UI tests for this, but I believe I am missing an API hook in XAMLTest that will allow me to inject a culture for the WPF app that is spun up. Feature request 😛 

<br/>

**NOTE:** The previous implementation was using `CultureInfo.CurrentUICulture` which I don't believe was correct. To my knowledge (and please correct me if I am wrong), the "UI" variant is newer property primarily used for translations of strings, whereas `CultureInfo.CurrentCulture` should be used for number formatting etc.

It is not uncommon for people like myself (at least in the dev world) to want to use their own local numbering scheme (thus `CultureInfo.CurrentCulture=da-DK` in my case), but still want UI strings to be in English (thus `CultureInfo.CurrentUICulture=en-US` in my case).