### PR TITLE
Fixed PopUpBox VerticalContentAlignment

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -80,6 +80,7 @@
     <Setter Property="PopupHorizontalOffset" Value="0" />
     <Setter Property="PopupUniformCornerRadius" Value="2" />
     <Setter Property="PopupVerticalOffset" Value="0" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type wpf:PopupBox}">


### PR DESCRIPTION
The content inside a button is not centered anymore as can be seen in the following screenshot of the Demo App. This PR fixes the default while maintaining the fix provided in https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/pull/3856

![image](https://github.com/user-attachments/assets/2978efa3-529b-4deb-a7b9-32ec630f6521)
