### PR TITLE
Modify DecimalUpDown basic test to ensure culture is respected in string-value conversions

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -34,6 +34,7 @@ jobs:
                   dotnet-version: |
                       6.x
                       8.x
+                      9.x
 
             - name: Restore dependencies
               run: dotnet restore ${{ env.solution }}

--- a/Directory.packages.props
+++ b/Directory.packages.props
@@ -26,7 +26,7 @@
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="VirtualizingWrapPanel" Version="1.5.8" />
-    <PackageVersion Include="XAMLTest" Version="1.2.2" />
+    <PackageVersion Include="XAMLTest" Version="1.3.0-ci602" />
     <PackageVersion Include="xunit" Version="2.6.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.4" />
     <PackageVersion Include="Xunit.StaFact" Version="1.1.11" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.300",
     "rollForward": "latestMinor"
   }
 }

--- a/tests/MaterialDesignThemes.UITests/MaterialDesignThemes.UITests.csproj
+++ b/tests/MaterialDesignThemes.UITests/MaterialDesignThemes.UITests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>false</SignAssembly>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION
My previous PR (#3860 ) fixed the culture issue, but I was unable to write a UI test for it. This PR leverages the new XAMLTest API for `App.RemoteExecute(...)` to get some testing in place.

Changes included:
* Consume latest nightly build of XAMLTest
* Updated TFM on UI tests project to `net9.0-windows`
* Updated global.json SDK version to `9.0.300`
* Updates the pipeline to use `net9.0` as well
* Updated the basic `DecimalUpDown` test to make it actually use a decimal increment
* Updated the basic `DecimalUpDown` test to be data-driven for a given set of cultures
  * For now, I just choose `en-US`, `da-DK` (my own), and a couple of others I suspect could be problematic.

![image](https://github.com/user-attachments/assets/2f27e293-9f6b-472b-b154-112aadd0a41f)

### Update
Reverting #3860 temporarily, yields these test results, so perhaps my choice of cultures was not that great 😛 

![image](https://github.com/user-attachments/assets/67e63683-5cc0-47cd-9f2e-a8f83e44dbab)

