### PR TITLE
ToggleButton uses EllipseClipConverter

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Converters/EllipseClipConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/EllipseClipConverter.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace MaterialDesignThemes.Wpf.Converters
+{
+    public class EllipseClipConverter : IMultiValueConverter
+    {
+        public static readonly EllipseClipConverter Instance = new();
+
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values is [double width, double height, ..])
+            {
+                if (width < 1.0 || height < 1.0)
+                {
+                    return Geometry.Empty;
+                }
+
+                Point center = new Point(width / 2.0, height / 2.0);
+                double radiusX = width / 2.0;
+                double radiusY = height / 2.0;
+
+                EllipseGeometry geometry = new EllipseGeometry(center, radiusX, radiusY);
+                geometry.Freeze();
+
+                return geometry;
+            }
+
+            return DependencyProperty.UnsetValue;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+            => throw new NotImplementedException();
+    }
+}

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
@@ -136,20 +136,10 @@
                                 ContentTemplate="{TemplateBinding ContentTemplate}"
                                 FlowDirection="LeftToRight" />
               <Grid.Clip>
-                <EllipseGeometry RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Width, Converter={x:Static converters:MathConverter.DivideInstance}, ConverterParameter=2.0}" RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height, Converter={x:Static converters:MathConverter.DivideInstance}, ConverterParameter=2.0}">
-                  <EllipseGeometry.Center>
-                    <MultiBinding Converter="{x:Static converters:PointValueConverter.Instance}">
-                      <Binding Converter="{x:Static converters:MathConverter.DivideInstance}"
-                               ConverterParameter="2.0"
-                               Path="Width"
-                               RelativeSource="{RelativeSource TemplatedParent}" />
-                      <Binding Converter="{x:Static converters:MathConverter.DivideInstance}"
-                               ConverterParameter="2.0"
-                               Path="Height"
-                               RelativeSource="{RelativeSource TemplatedParent}" />
-                    </MultiBinding>
-                  </EllipseGeometry.Center>
-                </EllipseGeometry>
+                <MultiBinding Converter="{x:Static converters:EllipseClipConverter.Instance}">
+                  <Binding Path="ActualWidth" RelativeSource="{RelativeSource TemplatedParent}" />
+                  <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
+                </MultiBinding>
               </Grid.Clip>
               <Grid.RenderTransform>
                 <ScaleTransform x:Name="OffScaleTransform" ScaleX="1" ScaleY="1" />
@@ -164,20 +154,10 @@
                                 ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ToggleButtonAssist.OnContentTemplate)}"
                                 FlowDirection="LeftToRight" />
               <Grid.Clip>
-                <EllipseGeometry RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Width, Converter={x:Static converters:MathConverter.DivideInstance}, ConverterParameter=2.0}" RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height, Converter={x:Static converters:MathConverter.DivideInstance}, ConverterParameter=2.0}">
-                  <EllipseGeometry.Center>
-                    <MultiBinding Converter="{x:Static converters:PointValueConverter.Instance}">
-                      <Binding Converter="{x:Static converters:MathConverter.DivideInstance}"
-                               ConverterParameter="2.0"
-                               Path="Width"
-                               RelativeSource="{RelativeSource TemplatedParent}" />
-                      <Binding Converter="{x:Static converters:MathConverter.DivideInstance}"
-                               ConverterParameter="2.0"
-                               Path="Height"
-                               RelativeSource="{RelativeSource TemplatedParent}" />
-                    </MultiBinding>
-                  </EllipseGeometry.Center>
-                </EllipseGeometry>
+                <MultiBinding Converter="{x:Static converters:EllipseClipConverter.Instance}">
+                  <Binding Path="ActualWidth" RelativeSource="{RelativeSource TemplatedParent}" />
+                  <Binding Path="ActualHeight" RelativeSource="{RelativeSource TemplatedParent}" />
+                </MultiBinding>
               </Grid.Clip>
               <Grid.RenderTransform>
                 <ScaleTransform x:Name="OnScaleTransform" ScaleX="0" ScaleY="1" />


### PR DESCRIPTION
ToggleButton now uses an EllipseClipConverter to create the Ellipse for clipping of button.

This fixes some binding errors like: System.Windows.Data Error: 2 : Cannot find governing FrameworkElement or FrameworkContentElement for target element. BindingExpression:Path=Width; DataItem=null; target element is 'EllipseGeometry' (HashCode=37186555); target property is 'RadiusX' (type 'Double')