### PR TITLE
Used x:Reference in Button and ProgressBar ControlTemplates

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
@@ -68,10 +68,10 @@
                              Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Value)}">
                   <ProgressBar.Clip>
                     <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                      <Binding ElementName="border" Path="ActualWidth" />
-                      <Binding ElementName="border" Path="ActualHeight" />
-                      <Binding ElementName="border" Path="CornerRadius" />
-                      <Binding ElementName="border" Path="BorderThickness" />
+                      <Binding Source="{x:Reference border}" Path="ActualWidth" />
+                      <Binding Source="{x:Reference border}" Path="ActualHeight" />
+                      <Binding Source="{x:Reference border}" Path="CornerRadius" />
+                      <Binding Source="{x:Reference border}" Path="BorderThickness" />
                     </MultiBinding>
                   </ProgressBar.Clip>
                 </ProgressBar>
@@ -87,10 +87,10 @@
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <wpf:Ripple.Clip>
                 <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                  <Binding ElementName="border" Path="ActualWidth" />
-                  <Binding ElementName="border" Path="ActualHeight" />
-                  <Binding ElementName="border" Path="CornerRadius" />
-                  <Binding ElementName="border" Path="BorderThickness" />
+                  <Binding Source="{x:Reference border}" Path="ActualWidth" />
+                  <Binding Source="{x:Reference border}" Path="ActualHeight" />
+                  <Binding Source="{x:Reference border}" Path="CornerRadius" />
+                  <Binding Source="{x:Reference border}" Path="BorderThickness" />
                 </MultiBinding>
               </wpf:Ripple.Clip>
             </wpf:Ripple>
@@ -199,10 +199,10 @@
                          Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Value)}">
               <ProgressBar.Clip>
                 <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                  <Binding ElementName="border" Path="ActualWidth" />
-                  <Binding ElementName="border" Path="ActualHeight" />
-                  <Binding ElementName="border" Path="CornerRadius" />
-                  <Binding ElementName="border" Path="BorderThickness" />
+                  <Binding Source="{x:Reference border}" Path="ActualWidth" />
+                  <Binding Source="{x:Reference border}" Path="ActualHeight" />
+                  <Binding Source="{x:Reference border}" Path="CornerRadius" />
+                  <Binding Source="{x:Reference border}" Path="BorderThickness" />
                 </MultiBinding>
               </ProgressBar.Clip>
             </ProgressBar>
@@ -217,10 +217,10 @@
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <wpf:Ripple.Clip>
                 <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                  <Binding ElementName="border" Path="ActualWidth" />
-                  <Binding ElementName="border" Path="ActualHeight" />
-                  <Binding ElementName="border" Path="CornerRadius" />
-                  <Binding ElementName="border" Path="BorderThickness" />
+                  <Binding Source="{x:Reference border}" Path="ActualWidth" />
+                  <Binding Source="{x:Reference border}" Path="ActualHeight" />
+                  <Binding Source="{x:Reference border}" Path="CornerRadius" />
+                  <Binding Source="{x:Reference border}" Path="BorderThickness" />
                 </MultiBinding>
               </wpf:Ripple.Clip>
             </wpf:Ripple>
@@ -357,10 +357,10 @@
                          Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Value)}">
               <ProgressBar.Clip>
                 <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                  <Binding ElementName="border" Path="ActualWidth" />
-                  <Binding ElementName="border" Path="ActualHeight" />
-                  <Binding ElementName="border" Path="CornerRadius" />
-                  <Binding ElementName="border" Path="BorderThickness" />
+                  <Binding Source="{x:Reference border}" Path="ActualWidth" />
+                  <Binding Source="{x:Reference border}" Path="ActualHeight" />
+                  <Binding Source="{x:Reference border}" Path="CornerRadius" />
+                  <Binding Source="{x:Reference border}" Path="BorderThickness" />
                 </MultiBinding>
               </ProgressBar.Clip>
             </ProgressBar>
@@ -375,10 +375,10 @@
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <wpf:Ripple.Clip>
                 <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                  <Binding ElementName="border" Path="ActualWidth" />
-                  <Binding ElementName="border" Path="ActualHeight" />
-                  <Binding ElementName="border" Path="CornerRadius" />
-                  <Binding ElementName="border" Path="BorderThickness" />
+                  <Binding Source="{x:Reference border}" Path="ActualWidth" />
+                  <Binding Source="{x:Reference border}" Path="ActualHeight" />
+                  <Binding Source="{x:Reference border}" Path="CornerRadius" />
+                  <Binding Source="{x:Reference border}" Path="BorderThickness" />
                 </MultiBinding>
               </wpf:Ripple.Clip>
             </wpf:Ripple>
@@ -802,10 +802,10 @@
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <wpf:Ripple.Clip>
                 <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                  <Binding ElementName="border" Path="ActualWidth" />
-                  <Binding ElementName="border" Path="ActualHeight" />
-                  <Binding ElementName="border" Path="CornerRadius" />
-                  <Binding ElementName="border" Path="BorderThickness" />
+                  <Binding Source="{x:Reference border}" Path="ActualWidth" />
+                  <Binding Source="{x:Reference border}" Path="ActualHeight" />
+                  <Binding Source="{x:Reference border}" Path="CornerRadius" />
+                  <Binding Source="{x:Reference border}" Path="BorderThickness" />
                 </MultiBinding>
               </wpf:Ripple.Clip>
             </wpf:Ripple>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
@@ -184,26 +184,26 @@
                     StrokeThickness="3">
                 <Path.Data>
                   <PathGeometry>
-                    <PathFigure StartPoint="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:StartPointConverter.Instance}, Mode=OneWay}">
-                      <ArcSegment Size="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:ArcSizeConverter.Instance}, Mode=OneWay}" SweepDirection="Clockwise">
+                    <PathFigure StartPoint="{Binding Source={x:Reference PathGrid}, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:StartPointConverter.Instance}, Mode=OneWay}">
+                      <ArcSegment Size="{Binding Source={x:Reference PathGrid}, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:ArcSizeConverter.Instance}, Mode=OneWay}" SweepDirection="Clockwise">
                         <ArcSegment.Point>
                           <MultiBinding Converter="{x:Static circularProgressBarConverters:ArcEndPointConverter.Instance}" ConverterParameter="{x:Static circularProgressBarConverters:ArcEndPointConverter.ParameterMidPoint}">
-                            <Binding ElementName="PathGrid" Path="ActualWidth" />
+                            <Binding Source="{x:Reference PathGrid}" Path="ActualWidth" />
                             <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                             <Binding Path="Minimum" RelativeSource="{RelativeSource TemplatedParent}" />
                             <Binding Path="Maximum" RelativeSource="{RelativeSource TemplatedParent}" />
-                            <Binding ElementName="FullyIndeterminateGridScaleTransform" Path="ScaleX" />
+                            <Binding Source="{x:Reference FullyIndeterminateGridScaleTransform}" Path="ScaleX" />
                           </MultiBinding>
                         </ArcSegment.Point>
                       </ArcSegment>
-                      <ArcSegment Size="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:ArcSizeConverter.Instance}, Mode=OneWay}" SweepDirection="Clockwise">
+                      <ArcSegment Size="{Binding Source={x:Reference PathGrid}, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:ArcSizeConverter.Instance}, Mode=OneWay}" SweepDirection="Clockwise">
                         <ArcSegment.Point>
                           <MultiBinding Converter="{x:Static circularProgressBarConverters:ArcEndPointConverter.Instance}">
-                            <Binding ElementName="PathGrid" Path="ActualWidth" />
+                            <Binding Source="{x:Reference PathGrid}" Path="ActualWidth" />
                             <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                             <Binding Path="Minimum" RelativeSource="{RelativeSource TemplatedParent}" />
                             <Binding Path="Maximum" RelativeSource="{RelativeSource TemplatedParent}" />
-                            <Binding ElementName="FullyIndeterminateGridScaleTransform" Path="ScaleX" />
+                            <Binding Source="{x:Reference FullyIndeterminateGridScaleTransform}" Path="ScaleX" />
                           </MultiBinding>
                         </ArcSegment.Point>
                       </ArcSegment>
@@ -212,7 +212,9 @@
                 </Path.Data>
                 <Path.RenderTransform>
                   <TransformGroup>
-                    <RotateTransform x:Name="RotateTransform" CenterX="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:RotateTransformCentreConverter.Instance}, Mode=OneWay}" CenterY="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:RotateTransformCentreConverter.Instance}, Mode=OneWay}" />
+                    <RotateTransform x:Name="RotateTransform"
+                                     CenterX="{Binding Source={x:Reference PathGrid}, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:RotateTransformCentreConverter.Instance}, Mode=OneWay}"
+                                     CenterY="{Binding Source={x:Reference PathGrid}, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:RotateTransformCentreConverter.Instance}, Mode=OneWay}" />
                   </TransformGroup>
                 </Path.RenderTransform>
               </Path>


### PR DESCRIPTION
Used x:Reference in Button and ProgressBar ControlTemplates to fix some binding errors.

The issue is that ElementName does a Runtime lookup of the element. At some moments in time or on freezable objects this does not work, because they are not available in the visual tree. Therefore within a ControlTemplate x:Reference can be used to do a compile time / load time lookup.

Note that because the lookup is compile time / load time this also has a small performance gain during load of the element.