### PR TITLE
Chip: Fixed without icon padding

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Chip.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Chip.xaml
@@ -28,10 +28,10 @@
 
                             <Border>
                                 <Border.Background>
-                                    <VisualBrush Visual="{Binding ElementName=PART_MonthView}" Stretch="UniformToFill"/>
+                                    <VisualBrush Visual="{Binding ElementName=PART_MonthView}" Stretch="UniformToFill" />
                                 </Border.Background>
                                 <Border.RenderTransform>
-                                    <TranslateTransform X="0"/>
+                                    <TranslateTransform X="0" />
                                 </Border.RenderTransform>
                             </Border>
 
@@ -63,7 +63,7 @@
                             <ContentControl Grid.Column="1" Content="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:Chip}, Path=Content}"
                                             FontSize="13" />
                             <ContentControl Grid.Column="1" Grid.Row="1" Content="{TemplateBinding Content}"
-                                            FontSize="11"/>
+                                            FontSize="11" />
                         </Grid>
                     </wpf:Card>
                 </ControlTemplate>
@@ -161,14 +161,14 @@
               </Button.Template>
             </Button>
           </Grid>
-          <ControlTemplate.Triggers>
-            <Trigger SourceName="IconControl" Property="Visibility" Value="Collapsed">
-              <Setter TargetName="TextBlock" Property="Margin" Value="12,0,12,0" />
-            </Trigger>
-          </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
+    <Style.Triggers>
+      <Trigger Property="Icon" Value="{x:Null}">
+        <Setter Property="Padding" Value="12,0" />
+      </Trigger>
+    </Style.Triggers>
   </Style>
 
   <Style x:Key="MaterialDesignOutlineChip" TargetType="{x:Type wpf:Chip}">
@@ -287,13 +287,13 @@
               </Button.Template>
             </Button>
           </Grid>
-          <ControlTemplate.Triggers>
-            <Trigger SourceName="IconControl" Property="Visibility" Value="Collapsed">
-              <Setter TargetName="TextBlock" Property="Margin" Value="12,0,12,0" />
-            </Trigger>
-          </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
+    <Style.Triggers>
+      <Trigger Property="Icon" Value="{x:Null}">
+        <Setter Property="Padding" Value="12,0" />
+      </Trigger>
+    </Style.Triggers>
   </Style>
 </ResourceDictionary>


### PR DESCRIPTION
When fixing the padding in https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/pull/3850. I overlooked that there was a special margin set when no Icon was set. Now also applied padding to correct value when no Icon is set.