### PR TITLE
TextBoxLineCountBehavior: Fixed NullReferenceException when used within Virtualizing DataGrid

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
+++ b/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xaml.Behaviors;
+﻿using System.Windows.Threading;
+using Microsoft.Xaml.Behaviors;
 
 namespace MaterialDesignThemes.Wpf.Behaviors;
 
@@ -14,8 +15,13 @@ public class TextBoxLineCountBehavior : Behavior<TextBox>
     {
         if (AssociatedObject is { } associatedObject)
         {
-            associatedObject.SetCurrentValue(TextFieldAssist.TextBoxLineCountProperty, associatedObject.LineCount);
-            associatedObject.SetCurrentValue(TextFieldAssist.TextBoxIsMultiLineProperty, associatedObject.LineCount > 1);
+            associatedObject.Dispatcher
+                .BeginInvoke(() =>
+                {
+                    associatedObject.SetCurrentValue(TextFieldAssist.TextBoxLineCountProperty, associatedObject.LineCount);
+                    associatedObject.SetCurrentValue(TextFieldAssist.TextBoxIsMultiLineProperty, associatedObject.LineCount > 1);
+                },
+                DispatcherPriority.Background);
         }
     }
 


### PR DESCRIPTION
When a TextBox was used within a DataGrid that has virtualization enabled we got a NullReferenceException.
During the (re)drawing of a DataGrid some references used in the callstack of the TextBox.LineCount getter are null during the  LayoutUpdated call. 
Dispatching to the GUI thread with priority background resolves this because then the DataGrid has time to fully recalculate before the LineCount is retrieved.