### PR TITLE
New ToolTips page and RichToolTip example

### DIFF
--- a/src/MainDemo.Wpf/Domain/MainWindowViewModel.cs
+++ b/src/MainDemo.Wpf/Domain/MainWindowViewModel.cs
@@ -450,6 +450,14 @@ public partial class MainWindowViewModel : ObservableObject
             DocumentationLink.ApiLink<DecimalUpDown>(),
             DocumentationLink.ApiLink<UpDownBase>()
         ]);
+
+        yield return new DemoItem(
+            "ToolTips",
+            typeof(ToolTips),
+            [
+                DocumentationLink.DemoPageLink<PopupBox>(),
+                DocumentationLink.DemoPageLink<ToolTipsViewModel>("Demo View Model", "Domain"),
+            ]);
     }
 
     private bool DemoItemsFilter(object obj)

--- a/src/MainDemo.Wpf/ToolTips.xaml
+++ b/src/MainDemo.Wpf/ToolTips.xaml
@@ -1,0 +1,167 @@
+﻿<UserControl x:Class="MaterialDesignDemo.ToolTips"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:domain="clr-namespace:MaterialDesignDemo.Shared.Domain;assembly=MaterialDesignDemo.Shared"
+             xmlns:local="clr-namespace:MaterialDesignDemo"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
+             d:DataContext="{d:DesignInstance Type=domain:ToolTipsViewModel}"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             mc:Ignorable="d">
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Button.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.PopupBox.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+      <Thickness x:Key="Spacer">0,16,0,0</Thickness>
+    </ResourceDictionary>
+  </UserControl.Resources>
+  <StackPanel>
+    <TextBlock Style="{StaticResource PageTitleTextBlock}" Text="ToolTip" />
+
+    <TextBlock Style="{StaticResource PageSectionTitleTextBlock}" Text="Default" />
+
+    <smtx:XamlDisplay UniqueKey="toolTip_1">
+      <Button HorizontalAlignment="Left"
+              Content="Example"
+              ToolTip="This a simple tooltip" />
+    </smtx:XamlDisplay>
+
+    <Rectangle Style="{StaticResource PageSectionSeparator}" />
+
+    <TextBlock Style="{StaticResource PageSectionTitleTextBlock}" Text="Rich tool tips" />
+
+    <Grid>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="250" />
+      </Grid.ColumnDefinitions>
+
+      <Grid Grid.Column="0">
+
+        <smtx:XamlDisplay HorizontalAlignment="Center"
+                          VerticalAlignment="Center"
+                          UniqueKey="richToolTip_1">
+
+          <materialDesign:PopupBox IsPopupOpen="{Binding IsPopupOpen}"
+                                   PlacementMode="{Binding SelectedPopupBoxPlacementMode}"
+                                   PopupAnimation="{Binding SelectedPopupAnimation}"
+                                   PopupElevation="{Binding SelectedElevation}"
+                                   PopupHorizontalOffset="{Binding PopupHorizontalOffset}"
+                                   PopupMode="{Binding SelectedPopupBoxPopupMode}"
+                                   PopupUniformCornerRadius="{Binding PopupUniformCornerRadius}"
+                                   PopupVerticalOffset="{Binding PopupVerticalOffset}">
+            <materialDesign:PopupBox.ToggleContent>
+              <materialDesign:PackIcon Width="40"
+                                       Height="{Binding ActualWidth, RelativeSource={RelativeSource Mode=Self}}"
+                                       Foreground="DodgerBlue"
+                                       Kind="Information" />
+            </materialDesign:PopupBox.ToggleContent>
+            <materialDesign:PopupBox.PopupContent>
+              <Grid Width="312" Margin="16,12,16,8">
+                <Grid.RowDefinitions>
+                  <RowDefinition Height="Auto" />
+                  <RowDefinition Height="4" />
+                  <RowDefinition Height="*" />
+                  <RowDefinition Height="12" />
+                  <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <TextBlock Grid.Row="0"
+                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                           Text="Rich tooltip" />
+                <TextBlock Grid.Row="2"
+                           Text="Rich tooltips bring attention to a particular element of feature that warrants the user's focus. It supports multiple lines of informational text."
+                           TextWrapping="Wrap" />
+
+                <StackPanel Grid.Row="4" Orientation="Horizontal">
+                  <Button Content="Action 1" Style="{StaticResource MaterialDesignFlatButton}" />
+                  <Button Margin="4,0,0,0"
+                          Content="Action 2"
+                          Style="{StaticResource MaterialDesignFlatButton}" />
+                </StackPanel>
+              </Grid>
+            </materialDesign:PopupBox.PopupContent>
+          </materialDesign:PopupBox>
+        </smtx:XamlDisplay>
+      </Grid>
+
+      <StackPanel Grid.Column="1">
+        <GroupBox Padding="8">
+          <GroupBox.Header>
+            <StackPanel Orientation="Horizontal">
+              <materialDesign:PackIcon Kind="Wrench" />
+              <TextBlock Margin="8,0,0,0" Text="Properties" />
+
+            </StackPanel>
+          </GroupBox.Header>
+
+          <StackPanel Orientation="Vertical">
+            <Button HorizontalAlignment="Stretch"
+                    Command="{Binding ResetToDefaultsCommand}"
+                    Content="{materialDesign:PackIcon Kind=Reload}" />
+
+            <DockPanel Margin="{StaticResource Spacer}">
+              <ToggleButton DockPanel.Dock="Right"
+                            IsChecked="{Binding IsPopupOpen}"
+                            Style="{StaticResource MaterialDesignSwitchToggleButton}" />
+              <TextBlock DockPanel.Dock="Left" Text="IsPopupOpen" />
+            </DockPanel>
+
+            <ComboBox Margin="{StaticResource Spacer}"
+                      materialDesign:HintAssist.Hint="PopupElevation"
+                      materialDesign:TextFieldAssist.HasLeadingIcon="True"
+                      materialDesign:TextFieldAssist.LeadingIcon="Layers"
+                      ItemsSource="{Binding Elevations}"
+                      SelectedItem="{Binding SelectedElevation}"
+                      Style="{StaticResource MaterialDesignFilledComboBox}" />
+
+            <materialDesign:NumericUpDown Margin="{StaticResource Spacer}"
+                                          materialDesign:HintAssist.Hint="PopupUniformCornerRadius"
+                                          materialDesign:TextFieldAssist.HasLeadingIcon="True"
+                                          materialDesign:TextFieldAssist.LeadingIcon="BorderRadius"
+                                          Minimum="0"
+                                          Style="{StaticResource MaterialDesignFilledNumericUpDown}"
+                                          Value="{Binding PopupUniformCornerRadius}" />
+
+            <materialDesign:NumericUpDown Margin="{StaticResource Spacer}"
+                                          materialDesign:HintAssist.Hint="PopupHorizontalOffset"
+                                          materialDesign:TextFieldAssist.HasLeadingIcon="True"
+                                          materialDesign:TextFieldAssist.LeadingIcon="CompareHorizontal"
+                                          Style="{StaticResource MaterialDesignFilledNumericUpDown}"
+                                          Value="{Binding PopupHorizontalOffset}" />
+
+            <materialDesign:NumericUpDown Margin="{StaticResource Spacer}"
+                                          materialDesign:HintAssist.Hint="PopupVerticalOffset"
+                                          materialDesign:TextFieldAssist.HasLeadingIcon="True"
+                                          materialDesign:TextFieldAssist.LeadingIcon="CompareVertical"
+                                          Style="{StaticResource MaterialDesignFilledNumericUpDown}"
+                                          Value="{Binding PopupVerticalOffset}" />
+
+            <ComboBox Margin="{StaticResource Spacer}"
+                      materialDesign:HintAssist.Hint="PlacementMode"
+                      ItemsSource="{Binding PopupBoxPlacementModes}"
+                      SelectedItem="{Binding SelectedPopupBoxPlacementMode}"
+                      Style="{StaticResource MaterialDesignFilledComboBox}" />
+
+            <ComboBox Margin="{StaticResource Spacer}"
+                      materialDesign:HintAssist.Hint="PopupAnimation"
+                      ItemsSource="{Binding PopupAnimations}"
+                      SelectedItem="{Binding SelectedPopupAnimation}"
+                      Style="{StaticResource MaterialDesignFilledComboBox}" />
+
+            <ComboBox Margin="{StaticResource Spacer}"
+                      materialDesign:HintAssist.Hint="PopupBoxPopupMode"
+                      ItemsSource="{Binding PopupBoxPopupModes}"
+                      SelectedItem="{Binding SelectedPopupBoxPopupMode}"
+                      Style="{StaticResource MaterialDesignFilledComboBox}" />
+          </StackPanel>
+        </GroupBox>
+      </StackPanel>
+    </Grid>
+  </StackPanel>
+</UserControl>

--- a/src/MainDemo.Wpf/ToolTips.xaml.cs
+++ b/src/MainDemo.Wpf/ToolTips.xaml.cs
@@ -1,0 +1,15 @@
+﻿using MaterialDesignDemo.Shared.Domain;
+
+namespace MaterialDesignDemo;
+
+/// <summary>
+/// Interaction logic for ToolTips.xaml
+/// </summary>
+public partial class ToolTips : UserControl
+{
+    public ToolTips()
+    {
+        DataContext = new ToolTipsViewModel();
+        InitializeComponent();
+    }
+}

--- a/src/MaterialDesign3.Demo.Wpf/Domain/MainWindowViewModel.cs
+++ b/src/MaterialDesign3.Demo.Wpf/Domain/MainWindowViewModel.cs
@@ -12,36 +12,31 @@ public class MainWindowViewModel : ViewModelBase
 {
     public MainWindowViewModel(ISnackbarMessageQueue snackbarMessageQueue, string? startupPage)
     {
-        DemoItems = new ObservableCollection<DemoItem>
-        {
+        DemoItems =
+        [
           new DemoItem(
                 "Home",
                 typeof(Home),
-                new[]
-                {
+                [
                     new DocumentationLink(
                         DocumentationLinkType.Wiki,
                         $"{ConfigurationManager.AppSettings["GitHub"]}/wiki",
                         "WIKI"),
                     DocumentationLink.DemoPageLink<Home>()
-                },
+                ],
                 selectedIcon: PackIconKind.Home,
-                unselectedIcon: PackIconKind.HomeOutline)
-        };
+                unselectedIcon: PackIconKind.HomeOutline),
+          .. GenerateDemoItems(snackbarMessageQueue).OrderBy(i => i.Name),
+        ];
 
-        foreach (var item in GenerateDemoItems(snackbarMessageQueue).OrderBy(i => i.Name))
-        {
-            DemoItems.Add(item);
-        }
-
-        MainDemoItems = new ObservableCollection<DemoItem>
-        {
+        MainDemoItems =
+        [
             DemoItems.First(x => x.Name == "Home"),
             DemoItems.First(x => x.Name == "Buttons"),
             DemoItems.First(x => x.Name == "Toggles"),
             DemoItems.First(x => x.Name == "Fields"),
             DemoItems.First(x => x.Name == "Pickers")
-        };
+        ];
         SelectedItem = DemoItems.FirstOrDefault(di => string.Equals(di.Name, startupPage, StringComparison.CurrentCultureIgnoreCase)) ?? DemoItems.First();
         _demoItemsView = CollectionViewSource.GetDefaultView(DemoItems);
         _demoItemsView.Filter = DemoItemsFilter;
@@ -136,148 +131,136 @@ public class MainWindowViewModel : ViewModelBase
         yield return new DemoItem(
             "Palette",
             typeof(PaletteSelector),
-            new[]
-            {
+            [
                 DocumentationLink.WikiLink("Brush-Names", "Brushes"),
                 DocumentationLink.WikiLink("Custom-Palette-Hues", "Custom Palettes"),
                 DocumentationLink.WikiLink("Swatches-and-Recommended-Colors", "Swatches"),
                 DocumentationLink.DemoPageLink<PaletteSelector>("Demo View"),
                 DocumentationLink.DemoPageLink<PaletteSelectorViewModel>("Demo View Model"),
                 DocumentationLink.ApiLink<PaletteHelper>()
-            },
+            ],
             selectedIcon: PackIconKind.Palette,
             unselectedIcon: PackIconKind.PaletteOutline);
 
         yield return new DemoItem(
             "Color Tool",
             typeof(ColorTool),
-            new[]
-            {
+            [
                 DocumentationLink.WikiLink("Brush-Names", "Brushes"),
                 DocumentationLink.WikiLink("Custom-Palette-Hues", "Custom Palettes"),
                 DocumentationLink.WikiLink("Swatches-and-Recommended-Colors", "Swatches"),
                 DocumentationLink.DemoPageLink<ColorTool>("Demo View"),
                 DocumentationLink.DemoPageLink<ColorToolViewModel>("Demo View Model"),
                 DocumentationLink.ApiLink<PaletteHelper>()
-            },
+            ],
             selectedIcon: PackIconKind.Eyedropper,
             unselectedIcon: PackIconKind.EyedropperVariant);
 
         yield return new DemoItem(
             "Buttons",
             typeof(Buttons),
-            new[]
-            {
+            [
                 DocumentationLink.WikiLink("Button-Styles", "Buttons"),
                 DocumentationLink.DemoPageLink<Buttons>("Demo View"),
                 DocumentationLink.DemoPageLink<ButtonsViewModel>("Demo View Model"),
                 DocumentationLink.StyleLink("Button"),
                 DocumentationLink.StyleLink("PopupBox"),
                 DocumentationLink.ApiLink<PopupBox>()
-            },
+            ],
             selectedIcon: PackIconKind.GestureTapHold,
             unselectedIcon: PackIconKind.GestureTapHold);
 
         yield return new DemoItem(
             "Toggles",
             typeof(Toggles),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<Toggles>(),
                 DocumentationLink.StyleLink("ToggleButton", true),
                 DocumentationLink.StyleLink("CheckBox")
-            },
+            ],
             selectedIcon: PackIconKind.ToggleSwitch,
             unselectedIcon: PackIconKind.ToggleSwitchOffOutline);
 
         yield return new DemoItem(
             "Rating Bar",
             typeof(RatingBar),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<RatingBar>(),
                 DocumentationLink.StyleLink("RatingBar"),
                 DocumentationLink.ApiLink<RatingBar>()
-            },
+            ],
             selectedIcon: PackIconKind.Star,
             unselectedIcon: PackIconKind.StarOutline);
 
         yield return new DemoItem(
             "Fields",
             typeof(Fields),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<Fields>(),
                 DocumentationLink.StyleLink("TextBox")
-            },
+            ],
             selectedIcon: PackIconKind.Pencil,
             unselectedIcon: PackIconKind.PencilOutline);
 
         yield return new DemoItem(
             "Fields line up",
             typeof(FieldsLineUp),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<FieldsLineUp>()
-            },
+            ],
             selectedIcon: PackIconKind.PencilBox,
             unselectedIcon: PackIconKind.PencilBoxOutline);
 
         yield return new DemoItem(
             "ComboBoxes",
             typeof(ComboBoxes),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<ComboBoxes>(),
                 DocumentationLink.StyleLink("ComboBox")
-            },
+            ],
             selectedIcon: PackIconKind.CheckboxMarked,
             unselectedIcon: PackIconKind.CheckboxMarkedOutline);
 
         yield return new DemoItem(
             "Pickers",
             typeof(Pickers),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<Pickers>(),
                 DocumentationLink.StyleLink("Clock"),
                 DocumentationLink.StyleLink("DatePicker"),
                 DocumentationLink.ApiLink<TimePicker>()
-            },
+            ],
             selectedIcon: PackIconKind.Clock,
             unselectedIcon: PackIconKind.ClockOutline);
 
         yield return new DemoItem(
             "Sliders",
             typeof(Sliders),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<Sliders>(),
                 DocumentationLink.StyleLink("Slider")
-            },
+            ],
             selectedIcon: PackIconKind.TuneVariant,
             unselectedIcon: PackIconKind.TuneVariant);
 
         yield return new DemoItem(
             "Chips",
             typeof(Chips),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<Chips>(),
                 DocumentationLink.StyleLink("Chip"),
                 DocumentationLink.ApiLink<Chip>()
-            },
+            ],
             selectedIcon: PackIconKind.None,
             unselectedIcon: PackIconKind.None);
 
         yield return new DemoItem(
             "Typography",
             typeof(Typography),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<Typography>(),
                 DocumentationLink.StyleLink("TextBlock", true)
-            },
+            ],
             selectedIcon: PackIconKind.FormatSize,
             unselectedIcon: PackIconKind.FormatTitle)
         {
@@ -287,24 +270,22 @@ public class MainWindowViewModel : ViewModelBase
         yield return new DemoItem(
             "Cards",
             typeof(Cards),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<Cards>(),
                 DocumentationLink.StyleLink("Card"),
                 DocumentationLink.ApiLink<Card>()
-            },
+            ],
             selectedIcon: PackIconKind.Card,
             unselectedIcon: PackIconKind.CardOutline);
 
         yield return new DemoItem(
             "Icon Pack",
             typeof(IconPack),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<IconPack>("Demo View"),
                 DocumentationLink.DemoPageLink<IconPackViewModel>("Demo View Model"),
                 DocumentationLink.ApiLink<PackIcon>()
-            },
+            ],
             selectedIcon: PackIconKind.Robot,
             unselectedIcon: PackIconKind.RobotOutline,
             new IconPackViewModel(snackbarMessageQueue))
@@ -315,104 +296,95 @@ public class MainWindowViewModel : ViewModelBase
         yield return new DemoItem(
             "Colour Zones",
             typeof(ColorZones),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<ColorZones>(),
                 DocumentationLink.ApiLink<ColorZone>()
-            },
+            ],
             selectedIcon: PackIconKind.Subtitles,
             unselectedIcon: PackIconKind.SubtitlesOutline);
 
         yield return new DemoItem(
             "Lists",
             typeof(Lists),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<Lists>("Demo View"),
                 DocumentationLink.DemoPageLink<ListsAndGridsViewModel>("Demo View Model", "Domain"),
                 DocumentationLink.StyleLink("ListBox"),
                 DocumentationLink.StyleLink("ListView")
-            },
+            ],
             selectedIcon: PackIconKind.FormatListBulletedSquare,
             unselectedIcon: PackIconKind.FormatListCheckbox);
 
         yield return new DemoItem(
             "Trees",
             typeof(Trees),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<Trees>("Demo View"),
                 DocumentationLink.DemoPageLink<TreesViewModel>("Demo View Model"),
                 DocumentationLink.StyleLink("TreeView")
-            },
+            ],
             selectedIcon: PackIconKind.FileTree,
             unselectedIcon: PackIconKind.FileTreeOutline);
 
         yield return new DemoItem(
             "Data Grids",
             typeof(DataGrids),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<DataGrids>("Demo View"),
                 DocumentationLink.DemoPageLink<ListsAndGridsViewModel>("Demo View Model", "Domain"),
                 DocumentationLink.StyleLink("DataGrid")
-            },
+            ],
             selectedIcon: PackIconKind.ViewGrid,
             unselectedIcon: PackIconKind.ViewGridOutline);
 
         yield return new DemoItem(
             "Expander",
             typeof(Expander),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<Expander>(),
                 DocumentationLink.StyleLink("Expander")
-            },
+            ],
             selectedIcon: PackIconKind.UnfoldMoreHorizontal,
             unselectedIcon: PackIconKind.UnfoldMoreHorizontal);
 
         yield return new DemoItem(
             "Group Boxes",
             typeof(GroupBoxes),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<GroupBoxes>(),
                 DocumentationLink.StyleLink("GroupBox")
-            },
+            ],
             selectedIcon: PackIconKind.TextBoxMultiple,
             unselectedIcon: PackIconKind.TextBoxMultipleOutline);
 
         yield return new DemoItem(
             "Menus & Tool Bars",
             typeof(MenusAndToolBars),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<MenusAndToolBars>(),
                 DocumentationLink.StyleLink("Menu"),
                 DocumentationLink.StyleLink("ToolBar")
-            },
+            ],
             selectedIcon: PackIconKind.DotsHorizontalCircle,
             unselectedIcon: PackIconKind.DotsHorizontalCircleOutline);
 
         yield return new DemoItem(
             "Progress Indicators",
             typeof(Progress),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<Progress>(),
                 DocumentationLink.StyleLink("ProgressBar")
-            },
+            ],
             selectedIcon: PackIconKind.ProgressClock,
             unselectedIcon: PackIconKind.ProgressClock);
 
         yield return new DemoItem(
             "Navigation Rail",
             typeof(NavigationRail),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<NavigationRail>(),
                 DocumentationLink.StyleLink("NavigationRail", true),
-            },
+            ],
             selectedIcon: PackIconKind.NavigationVariant,
             unselectedIcon: PackIconKind.NavigationVariantOutline)
         {
@@ -422,11 +394,10 @@ public class MainWindowViewModel : ViewModelBase
         yield return new DemoItem(
             "Navigation Bar",
             typeof(NavigationBar),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<NavigationBar>(),
                 DocumentationLink.StyleLink("NavigationBar", true),
-            },
+            ],
             selectedIcon: PackIconKind.NavigationVariant,
             unselectedIcon: PackIconKind.NavigationVariantOutline)
         {
@@ -436,13 +407,12 @@ public class MainWindowViewModel : ViewModelBase
         yield return new DemoItem(
             "Dialogs",
             typeof(Dialogs),
-            new[]
-            {
+            [
                 DocumentationLink.WikiLink("Dialogs", "Dialogs"),
                 DocumentationLink.DemoPageLink<Dialogs>("Demo View"),
                 DocumentationLink.DemoPageLink<DialogsViewModel>("Demo View Model", "Domain"),
                 DocumentationLink.ApiLink<DialogHost>()
-            },
+            ],
             selectedIcon: PackIconKind.CommentAlert,
             unselectedIcon: PackIconKind.CommentAlertOutline)
         {
@@ -452,25 +422,23 @@ public class MainWindowViewModel : ViewModelBase
         yield return new DemoItem(
             "Drawer",
             typeof(Drawers),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<Drawers>("Demo View"),
                 DocumentationLink.ApiLink<DrawerHost>()
-            },
+            ],
             selectedIcon: PackIconKind.ExpandAll,
             unselectedIcon: PackIconKind.ExpandAll);
 
         yield return new DemoItem(
             "Snackbar",
             typeof(Snackbars),
-            new[]
-            {
+            [
                 DocumentationLink.WikiLink("Snackbar", "Snackbar"),
                 DocumentationLink.DemoPageLink<Snackbars>(),
                 DocumentationLink.StyleLink("Snackbar"),
                 DocumentationLink.ApiLink<Snackbar>(),
                 DocumentationLink.ApiLink<ISnackbarMessageQueue>()
-            },
+            ],
             selectedIcon: PackIconKind.InformationCircle,
             unselectedIcon: PackIconKind.InformationCircleOutline)
         {
@@ -480,28 +448,36 @@ public class MainWindowViewModel : ViewModelBase
         yield return new DemoItem(
             "Transitions",
             typeof(Transitions),
-            new[]
-            {
+            [
                 DocumentationLink.WikiLink("Transitions", "Transitions"),
                 DocumentationLink.DemoPageLink<Transitions>(),
                 DocumentationLink.ApiLink<Transitioner>("Transitions"),
                 DocumentationLink.ApiLink<TransitionerSlide>("Transitions"),
                 DocumentationLink.ApiLink<TransitioningContent>("Transitions"),
-            },
+            ],
             selectedIcon: PackIconKind.TransitionMasked,
             unselectedIcon: PackIconKind.Transition);
 
         yield return new DemoItem(
             "Elevation",
             typeof(Elevation),
-            new[]
-            {
+            [
                 DocumentationLink.DemoPageLink<Elevation>(),
                 DocumentationLink.StyleLink("Shadows"),
                 DocumentationLink.SpecsLink("https://material.io/design/environment/elevation.html", "Elevation")
-            },
+            ],
             selectedIcon: PackIconKind.BoxShadow,
             unselectedIcon: PackIconKind.BoxShadow);
+
+        yield return new DemoItem(
+            "ToolTips",
+            typeof(ToolTips),
+            [
+                DocumentationLink.DemoPageLink<PopupBox>(),
+                DocumentationLink.DemoPageLink<ToolTipsViewModel>("Demo View Model", "Domain"),
+            ],
+            selectedIcon: PackIconKind.Tooltip,
+            unselectedIcon: PackIconKind.Tooltip);
     }
 
     private bool DemoItemsFilter(object obj)

--- a/src/MaterialDesign3.Demo.Wpf/ToolTips.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/ToolTips.xaml
@@ -1,0 +1,167 @@
+﻿<UserControl x:Class="MaterialDesign3Demo.ToolTips"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:domain="clr-namespace:MaterialDesignDemo.Shared.Domain;assembly=MaterialDesignDemo.Shared"
+             xmlns:local="clr-namespace:MaterialDesign3Demo"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
+             d:DataContext="{d:DesignInstance Type=domain:ToolTipsViewModel}"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             mc:Ignorable="d">
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Button.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.PopupBox.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+      <Thickness x:Key="Spacer">0,16,0,0</Thickness>
+    </ResourceDictionary>
+  </UserControl.Resources>
+  <StackPanel>
+    <TextBlock Style="{StaticResource PageTitleTextBlock}" Text="ToolTip" />
+
+    <TextBlock Style="{StaticResource PageSectionTitleTextBlock}" Text="Default" />
+
+    <smtx:XamlDisplay UniqueKey="toolTip_1">
+      <Button HorizontalAlignment="Left"
+              Content="Example"
+              ToolTip="This a simple tooltip" />
+    </smtx:XamlDisplay>
+
+    <Rectangle Style="{StaticResource PageSectionSeparator}" />
+
+    <TextBlock Style="{StaticResource PageSectionTitleTextBlock}" Text="Rich tool tips" />
+
+    <Grid>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="250" />
+      </Grid.ColumnDefinitions>
+
+      <Grid Grid.Column="0">
+
+        <smtx:XamlDisplay HorizontalAlignment="Center"
+                          VerticalAlignment="Center"
+                          UniqueKey="richToolTip_1">
+
+          <materialDesign:PopupBox IsPopupOpen="{Binding IsPopupOpen}"
+                                   PlacementMode="{Binding SelectedPopupBoxPlacementMode}"
+                                   PopupAnimation="{Binding SelectedPopupAnimation}"
+                                   PopupElevation="{Binding SelectedElevation}"
+                                   PopupHorizontalOffset="{Binding PopupHorizontalOffset}"
+                                   PopupMode="{Binding SelectedPopupBoxPopupMode}"
+                                   PopupUniformCornerRadius="{Binding PopupUniformCornerRadius}"
+                                   PopupVerticalOffset="{Binding PopupVerticalOffset}">
+            <materialDesign:PopupBox.ToggleContent>
+              <materialDesign:PackIcon Width="40"
+                                       Height="{Binding ActualWidth, RelativeSource={RelativeSource Mode=Self}}"
+                                       Foreground="DodgerBlue"
+                                       Kind="Information" />
+            </materialDesign:PopupBox.ToggleContent>
+            <materialDesign:PopupBox.PopupContent>
+              <Grid Width="312" Margin="16,12,16,8">
+                <Grid.RowDefinitions>
+                  <RowDefinition Height="Auto" />
+                  <RowDefinition Height="4" />
+                  <RowDefinition Height="*" />
+                  <RowDefinition Height="12" />
+                  <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <TextBlock Grid.Row="0"
+                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                           Text="Rich tooltip" />
+                <TextBlock Grid.Row="2"
+                           Text="Rich tooltips bring attention to a particular element of feature that warrants the user's focus. It supports multiple lines of informational text."
+                           TextWrapping="Wrap" />
+
+                <StackPanel Grid.Row="4" Orientation="Horizontal">
+                  <Button Content="Action 1" Style="{StaticResource MaterialDesignFlatButton}" />
+                  <Button Margin="4,0,0,0"
+                          Content="Action 2"
+                          Style="{StaticResource MaterialDesignFlatButton}" />
+                </StackPanel>
+              </Grid>
+            </materialDesign:PopupBox.PopupContent>
+          </materialDesign:PopupBox>
+        </smtx:XamlDisplay>
+      </Grid>
+
+      <StackPanel Grid.Column="1">
+        <GroupBox Padding="8">
+          <GroupBox.Header>
+            <StackPanel Orientation="Horizontal">
+              <materialDesign:PackIcon Kind="Wrench" />
+              <TextBlock Margin="8,0,0,0" Text="Properties" />
+
+            </StackPanel>
+          </GroupBox.Header>
+
+          <StackPanel Orientation="Vertical">
+            <Button HorizontalAlignment="Stretch"
+                    Command="{Binding ResetToDefaultsCommand}"
+                    Content="{materialDesign:PackIcon Kind=Reload}" />
+
+            <DockPanel Margin="{StaticResource Spacer}">
+              <ToggleButton DockPanel.Dock="Right"
+                            IsChecked="{Binding IsPopupOpen}"
+                            Style="{StaticResource MaterialDesignSwitchToggleButton}" />
+              <TextBlock DockPanel.Dock="Left" Text="IsPopupOpen" />
+            </DockPanel>
+
+            <ComboBox Margin="{StaticResource Spacer}"
+                      materialDesign:HintAssist.Hint="PopupElevation"
+                      materialDesign:TextFieldAssist.HasLeadingIcon="True"
+                      materialDesign:TextFieldAssist.LeadingIcon="Layers"
+                      ItemsSource="{Binding Elevations}"
+                      SelectedItem="{Binding SelectedElevation}"
+                      Style="{StaticResource MaterialDesignFilledComboBox}" />
+
+            <materialDesign:NumericUpDown Margin="{StaticResource Spacer}"
+                                          materialDesign:HintAssist.Hint="PopupUniformCornerRadius"
+                                          materialDesign:TextFieldAssist.HasLeadingIcon="True"
+                                          materialDesign:TextFieldAssist.LeadingIcon="BorderRadius"
+                                          Minimum="0"
+                                          Style="{StaticResource MaterialDesignFilledNumericUpDown}"
+                                          Value="{Binding PopupUniformCornerRadius}" />
+
+            <materialDesign:NumericUpDown Margin="{StaticResource Spacer}"
+                                          materialDesign:HintAssist.Hint="PopupHorizontalOffset"
+                                          materialDesign:TextFieldAssist.HasLeadingIcon="True"
+                                          materialDesign:TextFieldAssist.LeadingIcon="CompareHorizontal"
+                                          Style="{StaticResource MaterialDesignFilledNumericUpDown}"
+                                          Value="{Binding PopupHorizontalOffset}" />
+
+            <materialDesign:NumericUpDown Margin="{StaticResource Spacer}"
+                                          materialDesign:HintAssist.Hint="PopupVerticalOffset"
+                                          materialDesign:TextFieldAssist.HasLeadingIcon="True"
+                                          materialDesign:TextFieldAssist.LeadingIcon="CompareVertical"
+                                          Style="{StaticResource MaterialDesignFilledNumericUpDown}"
+                                          Value="{Binding PopupVerticalOffset}" />
+
+            <ComboBox Margin="{StaticResource Spacer}"
+                      materialDesign:HintAssist.Hint="PlacementMode"
+                      ItemsSource="{Binding PopupBoxPlacementModes}"
+                      SelectedItem="{Binding SelectedPopupBoxPlacementMode}"
+                      Style="{StaticResource MaterialDesignFilledComboBox}" />
+
+            <ComboBox Margin="{StaticResource Spacer}"
+                      materialDesign:HintAssist.Hint="PopupAnimation"
+                      ItemsSource="{Binding PopupAnimations}"
+                      SelectedItem="{Binding SelectedPopupAnimation}"
+                      Style="{StaticResource MaterialDesignFilledComboBox}" />
+
+            <ComboBox Margin="{StaticResource Spacer}"
+                      materialDesign:HintAssist.Hint="PopupBoxPopupMode"
+                      ItemsSource="{Binding PopupBoxPopupModes}"
+                      SelectedItem="{Binding SelectedPopupBoxPopupMode}"
+                      Style="{StaticResource MaterialDesignFilledComboBox}" />
+          </StackPanel>
+        </GroupBox>
+      </StackPanel>
+    </Grid>
+  </StackPanel>
+</UserControl>

--- a/src/MaterialDesign3.Demo.Wpf/ToolTips.xaml.cs
+++ b/src/MaterialDesign3.Demo.Wpf/ToolTips.xaml.cs
@@ -1,0 +1,13 @@
+﻿namespace MaterialDesign3Demo;
+
+/// <summary>
+/// Interaction logic for ToolTips.xaml
+/// </summary>
+public partial class ToolTips : UserControl
+{
+    public ToolTips()
+    {
+        DataContext = new MaterialDesignDemo.Shared.Domain.ToolTipsViewModel();
+        InitializeComponent();
+    }
+}

--- a/src/MaterialDesignDemo.Shared/Domain/ToolTipsViewModel.cs
+++ b/src/MaterialDesignDemo.Shared/Domain/ToolTipsViewModel.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using MaterialDesignThemes.Wpf;
+
+namespace MaterialDesignDemo.Shared.Domain;
+
+public partial class ToolTipsViewModel : ObservableObject
+{
+    public ToolTipsViewModel()
+    {
+        ResetToDefaults();
+    }
+
+    [RelayCommand]
+    private void ResetToDefaults()
+    {
+        IsPopupOpen = false;
+        SelectedElevation = Elevation.Dp6;
+        PopupUniformCornerRadius = 8;
+        PopupHorizontalOffset = 0;
+        PopupVerticalOffset = 0;
+        SelectedPopupBoxPlacementMode = PopupBoxPlacementMode.TopAndAlignCentres;
+        SelectedPopupAnimation = PopupAnimation.Fade;
+        SelectedPopupBoxPopupMode = PopupBoxPopupMode.Click;
+    }
+
+    [ObservableProperty]
+    private bool _isPopupOpen;
+
+    public List<Elevation> Elevations { get; } = EnumToEnumerable<Elevation>().ToList();
+    [ObservableProperty]
+    private Elevation _selectedElevation;
+
+    [ObservableProperty]
+    private int _popupUniformCornerRadius;
+
+    [ObservableProperty]
+    private int _popupHorizontalOffset;
+
+    [ObservableProperty]
+    private int _popupVerticalOffset;
+
+    public List<PopupBoxPlacementMode> PopupBoxPlacementModes { get; } = EnumToEnumerable<PopupBoxPlacementMode>().ToList();
+    [ObservableProperty]
+    private PopupBoxPlacementMode _selectedPopupBoxPlacementMode;
+
+    public List<PopupAnimation> PopupAnimations { get; } = EnumToEnumerable<PopupAnimation>().ToList();
+    [ObservableProperty]
+    private PopupAnimation _selectedPopupAnimation;
+
+    public List<PopupBoxPopupMode> PopupBoxPopupModes { get; } = EnumToEnumerable<PopupBoxPopupMode>().ToList();
+    [ObservableProperty]
+    private PopupBoxPopupMode _selectedPopupBoxPopupMode;
+
+    private static IEnumerable<T> EnumToEnumerable<T>() where T : Enum
+        => Enum.GetValues(typeof(T)).Cast<T>();
+}

--- a/src/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/src/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -384,8 +384,23 @@ public class PopupBox : ContentControl
     /// </summary>
     public Elevation PopupElevation
     {
-        get { return (Elevation) GetValue(PopupElevationProperty); }
-        set { SetValue(PopupElevationProperty, value); }
+        get => (Elevation)GetValue(PopupElevationProperty);
+        set => SetValue(PopupElevationProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the animation of the popup card.
+    /// </summary>
+    public static readonly DependencyProperty PopupAnimationProperty = DependencyProperty.Register(
+        nameof(PopupAnimation), typeof(PopupAnimation), typeof(PopupBox), new PropertyMetadata(PopupAnimation.Fade));
+
+    /// <summary>
+    /// Gets or sets the animation of the popup card.
+    /// </summary>
+    public PopupAnimation PopupAnimation
+    {
+        get => (PopupAnimation)GetValue(PopupAnimationProperty);
+        set => SetValue(PopupAnimationProperty, value);
     }
 
     /// <summary>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -128,7 +128,7 @@
                          HorizontalOffset="{TemplateBinding PopupElevation, Converter={StaticResource ElevationRadiusConverter}}"
                          IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsPopupOpen, Mode=TwoWay}"
                          Placement="Custom"
-                         PopupAnimation="Fade"
+                         PopupAnimation="{TemplateBinding PopupAnimation}"
                          VerticalOffset="{TemplateBinding PopupElevation, Converter={StaticResource ElevationRadiusConverter}}">
               <wpf:PopupEx.PlacementTarget>
                 <MultiBinding Converter="{x:Static converters:FirstNonNullConverter.Instance}">
@@ -200,6 +200,7 @@
     <Setter Property="HorizontalAlignment" Value="Left" />
     <Setter Property="PlacementMode" Value="TopAndAlignCentres" />
     <Setter Property="PopupMode" Value="Click" />
+    <Setter Property="PopupAnimation" Value="None" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type wpf:PopupBox}">
@@ -404,7 +405,7 @@
                          CustomPopupPlacementCallback="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PopupPlacementMethod}"
                          IsOpen="False"
                          Placement="Custom"
-                         PopupAnimation="None">
+                         PopupAnimation="{TemplateBinding PopupAnimation}">
               <wpf:PopupEx.PlacementTarget>
                 <MultiBinding Converter="{x:Static converters:FirstNonNullConverter.Instance}">
                   <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="PlacementTarget" />


### PR DESCRIPTION
In one of my apps I needed a RichToolTip and I noticed the demo app doesn't have a page to showcase Tooltips.

This PR:
1. adds a showcase of how the `PopupBox` can be used as a RichToolTip.
2. exposes the `PopupAnimation` of the internally used `PopupEx` in the `PopupBox`-template.
![image](https://github.com/user-attachments/assets/f4dc6238-4199-46ac-8b9f-816ecca0fe6d)
