### PR TITLE
Add AP to control TabControl Headers behavior

### DIFF
--- a/src/MainDemo.Wpf/Domain/TabsViewModel.cs
+++ b/src/MainDemo.Wpf/Domain/TabsViewModel.cs
@@ -4,10 +4,10 @@ using MaterialDesignDemo.Shared.Domain;
 
 namespace MaterialDesignDemo.Domain;
 
-internal class TabsViewModel : ViewModelBase
+internal partial class TabsViewModel : ObservableObject
 {
     public ObservableCollection<CustomTab> CustomTabs { get; }
-
+    public List<int> LongList { get; }
     public CustomTab? SelectedTab { get; set; }
 
     public string? VeryLongText { get; set; } = @"
@@ -47,6 +47,8 @@ Nulla a porta libero, quis hendrerit ex. In ut pharetra sem. Nunc gravida ante r
                 CustomContent = "Custom content 3",
             },
         };
+
+        LongList = Enumerable.Range(1, 20).ToList();
     }
 
 }

--- a/src/MainDemo.Wpf/Tabs.xaml
+++ b/src/MainDemo.Wpf/Tabs.xaml
@@ -755,5 +755,87 @@
       </materialDesign:Card>
     </smtx:XamlDisplay>
 
+    <Border Width="720"
+        BorderBrush="{DynamicResource MaterialDesign.Brush.Primary}"
+        BorderThickness="1">
+      <Grid>
+        <Grid.RowDefinitions>
+          <RowDefinition Height="auto" />
+          <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*" MinWidth="50" />
+          <ColumnDefinition Width="2" />
+          <ColumnDefinition Width="*" MinWidth="50" />
+        </Grid.ColumnDefinitions>
+
+        <materialDesign:ColorZone Grid.ColumnSpan="2"
+                              Padding="8"
+                              Mode="PrimaryMid">
+          <TextBlock Text="materialDesign:TabAssist.HeaderBehavior=&quot;Scrolling&quot;" />
+        </materialDesign:ColorZone>
+
+        <materialDesign:ColorZone Grid.Column="2"
+                              Padding="8"
+                              Mode="PrimaryMid">
+          <TextBlock Text="materialDesign:TabAssist.HeaderBehavior=&quot;Wrapping&quot;" />
+        </materialDesign:ColorZone>
+
+        <smtx:XamlDisplay Grid.Row="1"
+                      Grid.Column="0"
+                      Margin="16"
+                      UniqueKey="tabs_tabAssist_1">
+          <TabControl materialDesign:TabAssist.HeaderBehavior="Scrolling"
+                  ItemsSource="{Binding LongList}"
+                  Style="{StaticResource MaterialDesignTabControl}">
+            <TabControl.ItemTemplate>
+              <DataTemplate>
+                <StackPanel Orientation="Horizontal">
+                  <TextBlock Text="{Binding ., StringFormat=Header {0}}" />
+                </StackPanel>
+              </DataTemplate>
+            </TabControl.ItemTemplate>
+            <TabControl.ContentTemplate>
+              <DataTemplate>
+                <TextBlock Margin="10"
+                       FontSize="18"
+                       Text="{Binding ., StringFormat=Content {0}}" />
+              </DataTemplate>
+            </TabControl.ContentTemplate>
+          </TabControl>
+        </smtx:XamlDisplay>
+
+        <GridSplitter Grid.RowSpan="2"
+                  Grid.Column="1"
+                  HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch" />
+
+        <smtx:XamlDisplay Grid.Row="1"
+                      Grid.Column="2"
+                      Margin="16"
+                      UniqueKey="tabs_tabAssist_2">
+          <TabControl materialDesign:TabAssist.HeaderBehavior="Wrapping"
+                  ItemsSource="{Binding LongList}"
+                  Style="{StaticResource MaterialDesignTabControl}">
+            <TabControl.ItemTemplate>
+              <DataTemplate>
+                <StackPanel Orientation="Horizontal">
+                  <TextBlock Text="{Binding ., StringFormat=Header {0}}" />
+                </StackPanel>
+              </DataTemplate>
+            </TabControl.ItemTemplate>
+            <TabControl.ContentTemplate>
+              <DataTemplate>
+                <TextBlock Margin="10"
+                       FontSize="18"
+                       Text="{Binding ., StringFormat=Content {0}}" />
+              </DataTemplate>
+            </TabControl.ContentTemplate>
+          </TabControl>
+        </smtx:XamlDisplay>
+
+      </Grid>
+    </Border>
+
   </StackPanel>
 </UserControl>

--- a/src/MaterialDesignThemes.Wpf/TabAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/TabAssist.cs
@@ -1,5 +1,11 @@
 namespace MaterialDesignThemes.Wpf;
 
+public enum TabControlHeaderBehavior
+{
+    Scrolling,
+    Wrapping
+}
+
 public static class TabAssist
 {
     public static readonly DependencyProperty HasFilledTabProperty = DependencyProperty.RegisterAttached(
@@ -27,7 +33,7 @@ public static class TabAssist
         => element.SetValue(HeaderPanelMarginProperty, value);
 
     public static Thickness GetHeaderPanelMargin(DependencyObject element)
-        => (Thickness) element.GetValue(HeaderPanelMarginProperty);
+        => (Thickness)element.GetValue(HeaderPanelMarginProperty);
 
     internal static Visibility GetBindableIsItemsHost(DependencyObject obj)
         => (Visibility)obj.GetValue(BindableIsItemsHostProperty);
@@ -45,4 +51,14 @@ public static class TabAssist
             panel.IsItemsHost = (Visibility)e.NewValue == Visibility.Visible;
         }
     }
+
+    public static TabControlHeaderBehavior GetHeaderBehavior(DependencyObject obj)
+    => (TabControlHeaderBehavior)obj.GetValue(HeaderBehaviorProperty);
+
+    public static void SetHeaderBehavior(DependencyObject obj, TabControlHeaderBehavior value)
+        => obj.SetValue(HeaderBehaviorProperty, value);
+
+    public static readonly DependencyProperty HeaderBehaviorProperty =
+        DependencyProperty.RegisterAttached("HeaderBehavior", typeof(TabControlHeaderBehavior), typeof(TabAssist),
+            new PropertyMetadata(TabControlHeaderBehavior.Scrolling));
 }

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -31,57 +31,83 @@
         <ControlTemplate TargetType="{x:Type TabControl}">
           <DockPanel KeyboardNavigation.TabNavigation="Local">
             <wpf:ColorZone x:Name="PART_HeaderZone"
-                           VerticalAlignment="Stretch"
-                           Panel.ZIndex="1"
-                           wpf:ElevationAssist.Elevation="{TemplateBinding wpf:ElevationAssist.Elevation}"
-                           Background="{TemplateBinding wpf:ColorZoneAssist.Background}"
-                           DockPanel.Dock="Top"
-                           Focusable="False">
-              <ScrollViewer wpf:ScrollViewerAssist.BubbleVerticalScroll="True"
-                            wpf:ScrollViewerAssist.SupportHorizontalScroll="True"
+                         VerticalAlignment="Stretch"
+                         Panel.ZIndex="1"
+                         wpf:ElevationAssist.Elevation="{TemplateBinding wpf:ElevationAssist.Elevation}"
+                         Background="{TemplateBinding wpf:ColorZoneAssist.Background}"
+                         DockPanel.Dock="Top"
+                         Focusable="False">
+              <Grid>
+                <!-- Scrollable headers -->
+                <ScrollViewer x:Name="PART_HeaderScrollViewer"
+                            wpf:ScrollViewerAssist.BubbleVerticalScroll="True"
                             wpf:ScrollViewerAssist.IgnorePadding="{Binding Path=(wpf:ScrollViewerAssist.IgnorePadding), RelativeSource={RelativeSource TemplatedParent}}"
                             wpf:ScrollViewerAssist.PaddingMode="{Binding Path=(wpf:ScrollViewerAssist.PaddingMode), RelativeSource={RelativeSource TemplatedParent}}"
+                            wpf:ScrollViewerAssist.SupportHorizontalScroll="True"
                             HorizontalScrollBarVisibility="Hidden"
                             VerticalScrollBarVisibility="Hidden">
-                <StackPanel>
-                  <UniformGrid x:Name="CenteredHeaderPanel"
-                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                  <StackPanel>
+                    <UniformGrid x:Name="CenteredHeaderPanel"
                                Margin="{Binding Path=(wpf:TabAssist.HeaderPanelMargin), RelativeSource={RelativeSource TemplatedParent}}"
+                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                wpf:TabAssist.BindableIsItemsHost="{Binding Visibility, RelativeSource={RelativeSource Self}}"
                                Focusable="False"
                                KeyboardNavigation.TabIndex="1"
                                Rows="1" />
-                  <VirtualizingStackPanel x:Name="HeaderPanel"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                    <VirtualizingStackPanel x:Name="HeaderPanel"
                                           Margin="{Binding Path=(wpf:TabAssist.HeaderPanelMargin), RelativeSource={RelativeSource TemplatedParent}}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                           wpf:TabAssist.BindableIsItemsHost="{Binding Visibility, RelativeSource={RelativeSource Self}}"
                                           Focusable="False"
                                           KeyboardNavigation.TabIndex="1"
                                           Orientation="Horizontal" />
-                </StackPanel>
-              </ScrollViewer>
+                  </StackPanel>
+                </ScrollViewer>
+
+                <!-- Wrapping headers -->
+                <ScrollViewer x:Name="PART_HeaderWrapScrollViewer"
+                            HorizontalScrollBarVisibility="Disabled"
+                            VerticalScrollBarVisibility="Auto"
+                            Visibility="Collapsed">
+                  <WrapPanel x:Name="HeaderWrapPanel"
+                           Margin="{Binding Path=(wpf:TabAssist.HeaderPanelMargin), RelativeSource={RelativeSource TemplatedParent}}"
+                           Background="Transparent"
+                           IsItemsHost="True"
+                           KeyboardNavigation.TabIndex="1" />
+                </ScrollViewer>
+              </Grid>
             </wpf:ColorZone>
             <Border x:Name="PART_BorderSelectedContent"
-                    Padding="{TemplateBinding Padding}"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    Panel.ZIndex="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Panel.ZIndex)}"
-                    Background="{x:Null}"
-                    Focusable="False">
+                  Padding="{TemplateBinding Padding}"
+                  HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch"
+                  Panel.ZIndex="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Panel.ZIndex)}"
+                  Background="{x:Null}"
+                  Focusable="False">
               <ContentPresenter x:Name="PART_SelectedContentHost"
-                                Margin="{TemplateBinding Padding}"
-                                ContentSource="SelectedContent"
-                                ContentStringFormat="{TemplateBinding SelectedContentStringFormat}"
-                                ContentTemplate="{TemplateBinding SelectedContentTemplate}"
-                                ContentTemplateSelector="{TemplateBinding SelectedContentTemplateSelector}"
-                                Focusable="False"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                              Margin="{TemplateBinding Padding}"
+                              ContentSource="SelectedContent"
+                              ContentStringFormat="{TemplateBinding SelectedContentStringFormat}"
+                              ContentTemplate="{TemplateBinding SelectedContentTemplate}"
+                              ContentTemplateSelector="{TemplateBinding SelectedContentTemplateSelector}"
+                              Focusable="False"
+                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
             </Border>
           </DockPanel>
 
           <ControlTemplate.Triggers>
+
+            <Trigger Property="wpf:TabAssist.HeaderBehavior" Value="Scrolling">
+              <Setter TargetName="PART_HeaderScrollViewer" Property="Visibility" Value="Visible"/>
+              <Setter TargetName="PART_HeaderWrapScrollViewer" Property="Visibility" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="wpf:TabAssist.HeaderBehavior" Value="Wrapping">
+              <Setter TargetName="PART_HeaderScrollViewer" Property="Visibility" Value="Collapsed"/>
+              <Setter TargetName="PART_HeaderWrapScrollViewer" Property="Visibility" Value="Visible"/>
+            </Trigger>
+
             <Trigger Property="HorizontalContentAlignment" Value="Stretch">
               <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
               <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />


### PR DESCRIPTION
fixes #3863

This PR adds a new attached property (`materialDesign:TabAssist.HeaderBehavior`) to let consumers decide on how to display the headers of a `TabControl`.

Currently the headers are always contained inside of a ScrollViewer, which is not always ideal. Under certain circumstances the user is unable to click on "the next" tab, because it is simply not shown:

![455977593-05159782-e2c0-48dc-96f7-40ac3e8f9c08](https://github.com/user-attachments/assets/0fe532a4-c153-4033-8c72-b65a3c3ba0f5)


With the new AP TabControls can be forced to wrap their headers in a `WrapPanel`, e.g.: `materialDesign:TabAssist.HeaderBehavior="Wrapping"`.
There is basically now a trigger in the ControlTemplate which swaps out the header of the TabControl.

![455977937-18020632-72d4-45b5-a850-e11e186f5825](https://github.com/user-attachments/assets/6ee41dfc-d1cc-4a23-914a-62aaf604c6cd)

## Note
As of right now the AP can't be changed at runtime. Apparently applying the template when the property changes isn't enough. The TabControl sometimes doesn't show it's content when selecting a Tab after changing the `materialDesign:TabAssist.HeaderBehavior`. I would argue having the need of changing this AP at runtime is rather rare.
```csharp
private static void OnHeaderBehaviorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
{
    if (d is TabControl tabControl)
    {
        tabControl.ApplyTemplate();
    }
}
```