### PR TITLE
Evaluate TextBox.LineCount only once in UpdateAttachedProperties

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
+++ b/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
@@ -18,8 +18,9 @@ public class TextBoxLineCountBehavior : Behavior<TextBox>
             associatedObject.Dispatcher
                 .BeginInvoke(() =>
                 {
-                    associatedObject.SetCurrentValue(TextFieldAssist.TextBoxLineCountProperty, associatedObject.LineCount);
-                    associatedObject.SetCurrentValue(TextFieldAssist.TextBoxIsMultiLineProperty, associatedObject.LineCount > 1);
+                    int lineCount = associatedObject.LineCount;
+                    associatedObject.SetCurrentValue(TextFieldAssist.TextBoxLineCountProperty, lineCount);
+                    associatedObject.SetCurrentValue(TextFieldAssist.TextBoxIsMultiLineProperty, lineCount > 1);
                 },
                 DispatcherPriority.Background);
         }


### PR DESCRIPTION
I have a performance issue in `TextBox.OnTextChanged` handler in Version 5.2.1 with poor responsiveness. I tracked it down to TextBoxLineCountBehavior:

![image](https://github.com/user-attachments/assets/bed113b5-0350-4c03-bdb3-0104155aa7c7)

There has already been an improvement to queue the update with `Background`-priority. That is good.

But I also noticed, that `TextBox.LineCount` is evaluated twice. This PR reduces the calls to one, so it improves background performance even more.