### PR TITLE
fix when the TreeListView expands too much content, scrolling to the …

### DIFF
--- a/src/MaterialDesignThemes.Wpf/TreeListView.cs
+++ b/src/MaterialDesignThemes.Wpf/TreeListView.cs
@@ -51,24 +51,24 @@ public class TreeListView : ListView
     protected override bool IsItemItsOwnContainerOverride(object? item)
         => item is TreeListViewItem;
 
-    protected override void PrepareContainerForItemOverride(DependencyObject element, object? item)
-    {
-        base.PrepareContainerForItemOverride(element, item);
+    //protected override void PrepareContainerForItemOverride(DependencyObject element, object? item)
+    //{
+    //    base.PrepareContainerForItemOverride(element, item);
 
-        if (element is TreeListViewItem treeListViewItem)
-        {
-            int level = 0;
-            bool isExpanded = false;
-            int index = ItemContainerGenerator.IndexFromContainer(treeListViewItem);
-            if (index >= 0 && InternalItemsSource is { } itemsSource)
-            {
-                level = itemsSource.GetLevel(index);
-                isExpanded = itemsSource.GetIsExpanded(index);
-            }
+    //    if (element is TreeListViewItem treeListViewItem)
+    //    {
+    //        int level = 0;
+    //        bool isExpanded = false;
+    //        int index = ItemContainerGenerator.IndexFromContainer(treeListViewItem);
+    //        if (index >= 0 && InternalItemsSource is { } itemsSource)
+    //        {
+    //            level = itemsSource.GetLevel(index);
+    //            isExpanded = itemsSource.GetIsExpanded(index);
+    //        }
 
-            treeListViewItem.PrepareTreeListViewItem(item, this, level, isExpanded);
-        }
-    }
+    //        treeListViewItem.PrepareTreeListViewItem(item, this, level, isExpanded);
+    //    }
+    //}
 
     protected override void ClearContainerForItemOverride(DependencyObject element, object item)
     {
@@ -86,11 +86,19 @@ public class TreeListView : ListView
             int index = ItemContainerGenerator.IndexFromContainer(item);
             //Issue 3572
             if (index < 0) return;
-            var children = item.GetChildren().ToList();
-            bool isExpanded = item.IsExpanded;
+            var isExpanded = item.IsExpanded;
+            var internalIsExpanded = itemsSource.GetIsExpanded(index);
+
+            if (internalIsExpanded == isExpanded)
+            {
+                return;
+            }
+
             itemsSource.SetIsExpanded(index, isExpanded);
+
             if (isExpanded)
             {
+                var children = item.GetChildren().ToList();
                 int parentLevel = itemsSource.GetLevel(index);
                 for (int i = 0; i < children.Count; i++)
                 {

--- a/src/MaterialDesignThemes.Wpf/TreeListViewItem.cs
+++ b/src/MaterialDesignThemes.Wpf/TreeListViewItem.cs
@@ -146,7 +146,18 @@ public class TreeListViewItem : ListViewItem
 
             void OnTemplateChanged(object? sender, EventArgs e)
             {
-                PrepareTreeListViewItem(Content, TreeListView!, Level, IsExpanded);
+                int level = 0;
+                bool isExpanded = false;
+                int index = TreeListView!.ItemContainerGenerator.IndexFromContainer(this);
+
+
+                if (index >= 0 && TreeListView.InternalItemsSource is { } itemsSource)
+                {
+                    level = itemsSource.GetLevel(index);
+                    isExpanded = itemsSource.GetIsExpanded(index);
+                }
+
+                PrepareTreeListViewItem(Content, TreeListView, level, isExpanded);
             }
         }
     }


### PR DESCRIPTION
…top will shrink the content #3640

Hi Keboo. I think we can fix this with easy trick. I get `IsExpanded` from `itemsSource.GetIsExpanded(index)` to `PrepareTreeListViewItem` `OnApplyTemplate`. Always `PrepareTreeListViewItem` is called twice from  `PrepareContainerForItemOverride` and `OnApplyTemplate` so we can remove `PrepareContainerForItemOverride` in TreeListView but that is optional. Calling `PrepareTreeListViewItem` once was not the solution since `ItemExpandedChanged` was called multiple times causes items to be added twice so it should be changed to have no effect when IsExpanded was not changed actually.