### PR TITLE
Fixes binding error in DialogHost template

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -22,6 +22,9 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="wpf:DialogHost">
+          <ControlTemplate.Resources>
+            <converters:FirstNonNullConverter x:Key="FirstNonNullConverter" />
+          </ControlTemplate.Resources>
           <Grid x:Name="DialogHostRoot" Focusable="False">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="PopupStates">
@@ -217,7 +220,7 @@
               <Grid.OpacityMask>
                 <VisualBrush>
                   <VisualBrush.Visual>
-                    <MultiBinding Converter="{x:Static converters:FirstNonNullConverter.Instance}">
+                    <MultiBinding Converter="{StaticResource FirstNonNullConverter}">
                       <Binding ElementName="ContentCoverBorder" />
                       <Binding Source="{x:Static DependencyProperty.UnsetValue}" />
                     </MultiBinding>
@@ -259,6 +262,9 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="wpf:DialogHost">
+          <ControlTemplate.Resources>
+            <converters:FirstNonNullConverter x:Key="FirstNonNullConverter" />
+          </ControlTemplate.Resources>
           <Grid x:Name="DialogHostRoot" Focusable="False">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="PopupStates">
@@ -407,7 +413,7 @@
               <Grid.OpacityMask>
                 <VisualBrush>
                   <VisualBrush.Visual>
-                    <MultiBinding Converter="{x:Static converters:FirstNonNullConverter.Instance}">
+                    <MultiBinding Converter="{StaticResource FirstNonNullConverter}">
                       <Binding ElementName="ContentCoverBorder" />
                       <Binding Source="{x:Static DependencyProperty.UnsetValue}" />
                     </MultiBinding>


### PR DESCRIPTION
- Corrects a binding error in the DialogHost control template by using `StaticResource` instead of `x:Static` to reference the `FirstNonNullConverter`.

Fixes #3834