### PR TITLE
Revert usage of x:Reference

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
@@ -68,10 +68,10 @@
                              Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Value)}">
                   <ProgressBar.Clip>
                     <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                      <Binding Source="{x:Reference border}" Path="ActualWidth" />
-                      <Binding Source="{x:Reference border}" Path="ActualHeight" />
-                      <Binding Source="{x:Reference border}" Path="CornerRadius" />
-                      <Binding Source="{x:Reference border}" Path="BorderThickness" />
+                      <Binding ElementName="border" Path="ActualWidth" />
+                      <Binding ElementName="border" Path="ActualHeight" />
+                      <Binding ElementName="border" Path="CornerRadius" />
+                      <Binding ElementName="border" Path="BorderThickness" />
                     </MultiBinding>
                   </ProgressBar.Clip>
                 </ProgressBar>
@@ -87,10 +87,10 @@
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <wpf:Ripple.Clip>
                 <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                  <Binding Source="{x:Reference border}" Path="ActualWidth" />
-                  <Binding Source="{x:Reference border}" Path="ActualHeight" />
-                  <Binding Source="{x:Reference border}" Path="CornerRadius" />
-                  <Binding Source="{x:Reference border}" Path="BorderThickness" />
+                  <Binding ElementName="border" Path="ActualWidth" />
+                  <Binding ElementName="border" Path="ActualHeight" />
+                  <Binding ElementName="border" Path="CornerRadius" />
+                  <Binding ElementName="border" Path="BorderThickness" />
                 </MultiBinding>
               </wpf:Ripple.Clip>
             </wpf:Ripple>
@@ -199,10 +199,10 @@
                          Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Value)}">
               <ProgressBar.Clip>
                 <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                  <Binding Source="{x:Reference border}" Path="ActualWidth" />
-                  <Binding Source="{x:Reference border}" Path="ActualHeight" />
-                  <Binding Source="{x:Reference border}" Path="CornerRadius" />
-                  <Binding Source="{x:Reference border}" Path="BorderThickness" />
+                  <Binding ElementName="border" Path="ActualWidth" />
+                  <Binding ElementName="border" Path="ActualHeight" />
+                  <Binding ElementName="border" Path="CornerRadius" />
+                  <Binding ElementName="border" Path="BorderThickness" />
                 </MultiBinding>
               </ProgressBar.Clip>
             </ProgressBar>
@@ -217,10 +217,10 @@
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <wpf:Ripple.Clip>
                 <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                  <Binding Source="{x:Reference border}" Path="ActualWidth" />
-                  <Binding Source="{x:Reference border}" Path="ActualHeight" />
-                  <Binding Source="{x:Reference border}" Path="CornerRadius" />
-                  <Binding Source="{x:Reference border}" Path="BorderThickness" />
+                  <Binding ElementName="border" Path="ActualWidth" />
+                  <Binding ElementName="border" Path="ActualHeight" />
+                  <Binding ElementName="border" Path="CornerRadius" />
+                  <Binding ElementName="border" Path="BorderThickness" />
                 </MultiBinding>
               </wpf:Ripple.Clip>
             </wpf:Ripple>
@@ -357,10 +357,10 @@
                          Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ButtonProgressAssist.Value)}">
               <ProgressBar.Clip>
                 <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                  <Binding Source="{x:Reference border}" Path="ActualWidth" />
-                  <Binding Source="{x:Reference border}" Path="ActualHeight" />
-                  <Binding Source="{x:Reference border}" Path="CornerRadius" />
-                  <Binding Source="{x:Reference border}" Path="BorderThickness" />
+                  <Binding ElementName="border" Path="ActualWidth" />
+                  <Binding ElementName="border" Path="ActualHeight" />
+                  <Binding ElementName="border" Path="CornerRadius" />
+                  <Binding ElementName="border" Path="BorderThickness" />
                 </MultiBinding>
               </ProgressBar.Clip>
             </ProgressBar>
@@ -375,10 +375,10 @@
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <wpf:Ripple.Clip>
                 <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                  <Binding Source="{x:Reference border}" Path="ActualWidth" />
-                  <Binding Source="{x:Reference border}" Path="ActualHeight" />
-                  <Binding Source="{x:Reference border}" Path="CornerRadius" />
-                  <Binding Source="{x:Reference border}" Path="BorderThickness" />
+                  <Binding ElementName="border" Path="ActualWidth" />
+                  <Binding ElementName="border" Path="ActualHeight" />
+                  <Binding ElementName="border" Path="CornerRadius" />
+                  <Binding ElementName="border" Path="BorderThickness" />
                 </MultiBinding>
               </wpf:Ripple.Clip>
             </wpf:Ripple>
@@ -802,10 +802,10 @@
                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <wpf:Ripple.Clip>
                 <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                  <Binding Source="{x:Reference border}" Path="ActualWidth" />
-                  <Binding Source="{x:Reference border}" Path="ActualHeight" />
-                  <Binding Source="{x:Reference border}" Path="CornerRadius" />
-                  <Binding Source="{x:Reference border}" Path="BorderThickness" />
+                  <Binding ElementName="border" Path="ActualWidth" />
+                  <Binding ElementName="border" Path="ActualHeight" />
+                  <Binding ElementName="border" Path="CornerRadius" />
+                  <Binding ElementName="border" Path="BorderThickness" />
                 </MultiBinding>
               </wpf:Ripple.Clip>
             </wpf:Ripple>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
@@ -184,26 +184,26 @@
                     StrokeThickness="3">
                 <Path.Data>
                   <PathGeometry>
-                    <PathFigure StartPoint="{Binding Source={x:Reference PathGrid}, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:StartPointConverter.Instance}, Mode=OneWay}">
-                      <ArcSegment Size="{Binding Source={x:Reference PathGrid}, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:ArcSizeConverter.Instance}, Mode=OneWay}" SweepDirection="Clockwise">
+                    <PathFigure StartPoint="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:StartPointConverter.Instance}, Mode=OneWay}">
+                      <ArcSegment Size="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:ArcSizeConverter.Instance}, Mode=OneWay}" SweepDirection="Clockwise">
                         <ArcSegment.Point>
                           <MultiBinding Converter="{x:Static circularProgressBarConverters:ArcEndPointConverter.Instance}" ConverterParameter="{x:Static circularProgressBarConverters:ArcEndPointConverter.ParameterMidPoint}">
-                            <Binding Source="{x:Reference PathGrid}" Path="ActualWidth" />
+                            <Binding ElementName="PathGrid" Path="ActualWidth" />
                             <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                             <Binding Path="Minimum" RelativeSource="{RelativeSource TemplatedParent}" />
                             <Binding Path="Maximum" RelativeSource="{RelativeSource TemplatedParent}" />
-                            <Binding Source="{x:Reference FullyIndeterminateGridScaleTransform}" Path="ScaleX" />
+                            <Binding ElementName="FullyIndeterminateGridScaleTransform" Path="ScaleX" />
                           </MultiBinding>
                         </ArcSegment.Point>
                       </ArcSegment>
-                      <ArcSegment Size="{Binding Source={x:Reference PathGrid}, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:ArcSizeConverter.Instance}, Mode=OneWay}" SweepDirection="Clockwise">
+                      <ArcSegment Size="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:ArcSizeConverter.Instance}, Mode=OneWay}" SweepDirection="Clockwise">
                         <ArcSegment.Point>
                           <MultiBinding Converter="{x:Static circularProgressBarConverters:ArcEndPointConverter.Instance}">
-                            <Binding Source="{x:Reference PathGrid}" Path="ActualWidth" />
+                            <Binding ElementName="PathGrid" Path="ActualWidth" />
                             <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                             <Binding Path="Minimum" RelativeSource="{RelativeSource TemplatedParent}" />
                             <Binding Path="Maximum" RelativeSource="{RelativeSource TemplatedParent}" />
-                            <Binding Source="{x:Reference FullyIndeterminateGridScaleTransform}" Path="ScaleX" />
+                            <Binding ElementName="FullyIndeterminateGridScaleTransform" Path="ScaleX" />
                           </MultiBinding>
                         </ArcSegment.Point>
                       </ArcSegment>
@@ -212,9 +212,7 @@
                 </Path.Data>
                 <Path.RenderTransform>
                   <TransformGroup>
-                    <RotateTransform x:Name="RotateTransform"
-                                     CenterX="{Binding Source={x:Reference PathGrid}, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:RotateTransformCentreConverter.Instance}, Mode=OneWay}"
-                                     CenterY="{Binding Source={x:Reference PathGrid}, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:RotateTransformCentreConverter.Instance}, Mode=OneWay}" />
+                    <RotateTransform x:Name="RotateTransform" CenterX="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:RotateTransformCentreConverter.Instance}, Mode=OneWay}" CenterY="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:RotateTransformCentreConverter.Instance}, Mode=OneWay}" />
                   </TransformGroup>
                 </Path.RenderTransform>
               </Path>


### PR DESCRIPTION
We found out that the earlier change to x:Reference causes System.Xaml.XamlObjectWriterException to occur internally in XAML.

With some further digging we found in the documentation on https://learn.microsoft.com/en-us/dotnet/desktop/xaml-services/xreference-markup-extension?redirectedfrom=MSDN:
x:Reference is a construct defined in XAML 2009. In WPF, you can use XAML 2009 features, but only for XAML that is not WPF markup-compiled. Markup-compiled XAML and the BAML form of XAML do not currently support the XAML 2009 language keywords and features.

Thought the x:Reference at first glance seems to work it creates internal exceptions within XAML, therefore it is probably wise to revert it back.