### PR TITLE
Fix3904

### DIFF
--- a/src/MainDemo.Wpf/Home.xaml
+++ b/src/MainDemo.Wpf/Home.xaml
@@ -54,11 +54,6 @@
             <TextBlock Margin="8,0,0,0" Text="EXPLORE" />
           </StackPanel>
         </Button>
-
-        <ComboBox materialDesign:HintAssist.Hint="Routing"
-                  Style="{StaticResource MaterialDesignFilledComboBox}"
-                  Width="400"/>
-        
       </StackPanel>
     </Grid>
 

--- a/src/MainDemo.Wpf/Home.xaml
+++ b/src/MainDemo.Wpf/Home.xaml
@@ -54,6 +54,11 @@
             <TextBlock Margin="8,0,0,0" Text="EXPLORE" />
           </StackPanel>
         </Button>
+
+        <ComboBox materialDesign:HintAssist.Hint="Routing"
+                  Style="{StaticResource MaterialDesignFilledComboBox}"
+                  Width="400"/>
+        
       </StackPanel>
     </Grid>
 

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -23,6 +23,7 @@
       <converters:OutlinedStyleActiveBorderMarginCompensationConverter x:Key="OutlinedStyleActiveBorderMarginCompensationConverter" />
       <converters:ElevationRadiusConverter x:Key="ElevationRadiusConverter" Multiplier="-1" />
     </Style.Resources>
+    <Setter Property="AutomationProperties.Name" Value="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource Self}}" />
     <Setter Property="DropDownBackground" Value="{DynamicResource MaterialDesign.Brush.Card.Background}" />
     <Setter Property="DropDownElevation" Value="Dp2" />
     <Setter Property="Template">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -884,6 +884,7 @@
   </ControlTemplate>
 
   <Style x:Key="MaterialDesignComboBox" TargetType="{x:Type ComboBox}">
+    <Setter Property="AutomationProperties.Name" Value="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource Self}}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ComboBox.Border}" />
     <Setter Property="BorderThickness" Value="0,0,0,1" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -19,6 +19,7 @@
     <Style.Resources>
       <Style x:Key="NestedTextBoxStyle" TargetType="{x:Type DatePickerTextBox}" BasedOn="{StaticResource MaterialDesignTextBox}" />
     </Style.Resources>
+    <Setter Property="AutomationProperties.Name" Value="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource Self}}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
     <Setter Property="BorderThickness" Value="0,0,0,1" />
     <Setter Property="CalendarStyle" Value="{StaticResource MaterialDesignDatePickerCalendarPortrait}" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.NumericUpDown.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.NumericUpDown.xaml
@@ -33,6 +33,7 @@
              TargetType="{x:Type ButtonBase}"
              BasedOn="{StaticResource MaterialDesignNumericUpDownButtonsStyle}" />
     </Style.Resources>
+    <Setter Property="AutomationProperties.Name" Value="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource Self}}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
     <Setter Property="BorderThickness" Value="0,0,0,1" />
     <Setter Property="DecreaseContent" Value="{StaticResource ContentDecrease}" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -51,6 +51,7 @@
       </Style>
     </Style.Resources>
     <Setter Property="AllowDrop" Value="true" />
+    <Setter Property="AutomationProperties.Name" Value="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource Self}}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
     <Setter Property="BorderThickness" Value="0,0,0,1" />
@@ -608,6 +609,7 @@
       </Style>
     </Style.Resources>
     <Setter Property="AllowDrop" Value="true" />
+    <Setter Property="AutomationProperties.Name" Value="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource Self}}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
     <Setter Property="BorderThickness" Value="0,0,0,1" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -49,6 +49,7 @@
       <converters:ThicknessCloneConverter x:Key="ThicknessCloneConverter" CloneEdges="All" AdditionalOffsetBottom="-1" />
     </Style.Resources>
 
+    <Setter Property="AutomationProperties.Name" Value="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource Self}}" />
     <Setter Property="AllowDrop" Value="true" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.TextBox.Border}" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -11,6 +11,7 @@
     <Style.Resources>
       <Style x:Key="NestedTextBoxStyle" TargetType="wpf:TimePickerTextBox" BasedOn="{StaticResource MaterialDesignTextBox}" />
     </Style.Resources>
+    <Setter Property="AutomationProperties.Name" Value="{Binding Path=(wpf:HintAssist.Hint), RelativeSource={RelativeSource Self}}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesign.Brush.ForegroundLight}" />
     <Setter Property="BorderThickness" Value="0,0,0,1" />
     <Setter Property="ClockHostContentControlStyle">


### PR DESCRIPTION
fixes #3904

This PR sets the default value of the `AutomationProperties.Name` to the `HintAssist.Hint` of the respective input control, so that a screen reader picks up the hint-text by default.
The effected controls are essentially all the input controls:
- `TextBox`
- `PasswordBox`
- `ComboBox`
- `DatePicker`
- `TimePicker`
- `NumericUpDown`
- `AutoSuggestBox`

I successfully tested the changes with the [NVDA](https://www.nvaccess.org/download/) screen reader.

The issuer is talking about supporting "complex headers" too, but do we really want to support something like this?
In my opinion, we shouldn't, see my [comment](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/3904#issuecomment-3225135283).