### PR TITLE
Set SmartHint.IsContentNullOrEmpty on initial load

### DIFF
--- a/src/MaterialDesignThemes.Wpf/SmartHint.cs
+++ b/src/MaterialDesignThemes.Wpf/SmartHint.cs
@@ -253,6 +253,8 @@ public class SmartHint : Control
         if (proxy is null) return;
         if (!proxy.IsVisible) return;
 
+        IsContentNullOrEmpty = proxy.IsEmpty();
+
         var action = new Action(() =>
         {
             string state = string.Empty;

--- a/tests/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
@@ -585,6 +585,33 @@ public class TextBoxTests : TestBase
 
         recorder.Success();
     }
+
+    [Test]
+    [Description("Issue 3914")]
+    public async Task TextBox_ClearButtonRemainsHidden_WhenInitiallyCollapsedAndMadeVisible()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        var grid = await LoadXaml<Grid>($"""
+            <Grid Margin="30">
+                <TextBox Visibility="Collapsed"
+                         VerticalAlignment="Center"
+                         materialDesign:TextFieldAssist.HasClearButton="True">
+                </TextBox>
+            </Grid>
+         """);
+
+        var textBox = await grid.GetElement<TextBox>("/TextBox");
+
+        await textBox.SetVisibility(Visibility.Visible);
+
+        var clearButton = await grid.GetElement<Button>("PART_ClearButton");
+        Visibility clearButtonVisibility = await clearButton.GetVisibility();
+
+        await Assert.That(clearButtonVisibility).IsEqualTo(Visibility.Collapsed);
+
+        recorder.Success();
+    }
 }
 
 public class NotEmptyValidationRule : ValidationRule


### PR DESCRIPTION
fixes #3914

As far as I can tell, the root cause of this issue is that the `SmartHint.IsContentNullOrEmpty` is not updated when the visibility changes, and therefore set to `false` (even though it should be `true`).
Setting the `IsContentNullOrEmpty` initially (in the `RefreshState` method) fixes this issue.

![485673542-c0fd7ea8-2535-49e3-ab85-10fb743c3e0a](https://github.com/user-attachments/assets/5291817c-622e-405c-853a-d2b9373358da)
