### PR TITLE
Fix dialog losing focus when changing WindowState

### DIFF
--- a/src/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/src/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -412,10 +412,10 @@ public class DialogHost : ContentControl
     
     private void ListenForWindowStateChanged(Window? window)
     {
-        window ??= Window.GetWindow(this);
 
         if (window is not null)
         {
+            window.StateChanged -= Window_StateChanged;
             window.StateChanged += Window_StateChanged;
         }
     }
@@ -437,12 +437,15 @@ public class DialogHost : ContentControl
 
         // We only need to focus anything manually if the window changes state from Minimized --> (Normal or Maximized)
         // Going from Normal --> Maximized (and vice versa) is fine since the focus is already kept correctly
-        if (IsWindowRestoredFromMinimized() && IsLastFocusedDialogElementFocusable())
+        if (IsWindowRestoredFromMinimized())
         {
             // Kinda hacky, but without a delay the focus doesn't always get set correctly because the Focus() method fires too early
             Task.Delay(50).ContinueWith(_ => this.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
             {
-                _lastFocusedDialogElement!.Focus();
+                if (IsLastFocusedDialogElementFocusable())
+                {
+                    _lastFocusedDialogElement!.Focus();
+                }
             })));
         }
         _previousWindowState = windowState;

--- a/tests/MaterialDesignThemes.UITests/Samples/DialogHost/WithMultipleTextBoxes.xaml
+++ b/tests/MaterialDesignThemes.UITests/Samples/DialogHost/WithMultipleTextBoxes.xaml
@@ -1,0 +1,28 @@
+﻿<UserControl x:Class="MaterialDesignThemes.UITests.Samples.DialogHost.WithMultipleTextBoxes"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:MaterialDesignThemes.UITests.Samples.DialogHost"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             mc:Ignorable="d">
+  <materialDesign:DialogHost x:Name="SampleDialogHost" Loaded="DialogHost_Loaded">
+    <materialDesign:DialogHost.DialogContent>
+      <StackPanel Margin="16"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Center">
+        <TextBox x:Name="TextBoxOne"
+                 MinWidth="200"
+                 Text="One" />
+        <TextBox x:Name="TextBoxTwo"
+                 MinWidth="200"
+                 Text="Two" />
+        <TextBox x:Name="TextBoxThree"
+                 MinWidth="200"
+                 Text="Three" />
+      </StackPanel>
+    </materialDesign:DialogHost.DialogContent>
+  </materialDesign:DialogHost>
+</UserControl>

--- a/tests/MaterialDesignThemes.UITests/Samples/DialogHost/WithMultipleTextBoxes.xaml.cs
+++ b/tests/MaterialDesignThemes.UITests/Samples/DialogHost/WithMultipleTextBoxes.xaml.cs
@@ -1,0 +1,16 @@
+﻿namespace MaterialDesignThemes.UITests.Samples.DialogHost;
+
+/// <summary>
+/// Interaction logic for WithMultipleTextBoxes.xaml
+/// </summary>
+public partial class WithMultipleTextBoxes : UserControl
+{
+    public WithMultipleTextBoxes()
+    {
+        InitializeComponent();
+    }
+    private void DialogHost_Loaded(object sender, RoutedEventArgs e)
+    {
+        SampleDialogHost.IsOpen = true;
+    }
+}

--- a/tests/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
@@ -314,7 +314,6 @@ public class DialogHostTests : TestBase
         await Wait.For(async () =>
         {
             var contentCoverBorder = await dialogHost.GetElement<Border>("ContentCoverBorder");
-
             await Assert.That((await contentCoverBorder.GetCornerRadius()).TopLeft).IsEqualTo(1);
             await Assert.That((await contentCoverBorder.GetCornerRadius()).TopRight).IsEqualTo(2);
             await Assert.That((await contentCoverBorder.GetCornerRadius()).BottomRight).IsEqualTo(3);
@@ -500,7 +499,6 @@ public class DialogHostTests : TestBase
         var comboBox = await dialogHost.GetElement<ComboBox>("TargetedPlatformComboBox");
         await Task.Delay(500, TestContext.Current!.CancellationToken);
         await comboBox.LeftClick();
-
         var item = await Wait.For(() => comboBox.GetElement<ComboBoxItem>("TargetItem"));
         await Task.Delay(TimeSpan.FromSeconds(1));
         await item.LeftClick();

--- a/tests/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
@@ -515,15 +515,24 @@ public class DialogHostTests : TestBase
 
     [Test]
     [Description("Issue 3434")]
-    [Arguments(WindowState.Minimized, WindowState.Maximized)]
-    [Arguments(WindowState.Minimized, WindowState.Normal)]
-    [Arguments(WindowState.Maximized, WindowState.Normal)]
-	public async Task DialogHost_WhenWindowStateChanges_FocusedElementStaysFocused(WindowState firstWindowState, WindowState secondWindowState)
+    [Arguments(WindowState.Minimized, WindowState.Maximized, null)]
+    [Arguments(WindowState.Minimized, WindowState.Normal, null)]
+    [Arguments(WindowState.Maximized, WindowState.Normal, null)]
+    [Arguments(WindowState.Minimized, WindowState.Maximized, "MaterialDesignEmbeddedDialogHost")]
+    [Arguments(WindowState.Minimized, WindowState.Normal, "MaterialDesignEmbeddedDialogHost")]
+    [Arguments(WindowState.Maximized, WindowState.Normal, "MaterialDesignEmbeddedDialogHost")]
+    public async Task DialogHost_WhenWindowStateChanges_FocusedElementStaysFocused(WindowState firstWindowState,
+                                                                                   WindowState secondWindowState,
+                                                                                   string? styleName)
 	{
 		await using var recorder = new TestRecorder(App);
 
 		var dialogHost = (await LoadUserControl<WithMultipleTextBoxes>()).As<DialogHost>();
-		await Task.Delay(400, TestContext.Current!.CancellationToken);
+        if (styleName is not null)
+        {
+            await dialogHost.RemoteExecute(SetDialogHostStyle, styleName);
+        }
+        await Task.Delay(400, TestContext.Current!.CancellationToken);
 
         // Select the second TextBox
         var tbTwo = await dialogHost.GetElement<TextBox>("TextBoxTwo");
@@ -547,5 +556,11 @@ public class DialogHostTests : TestBase
             window.WindowState = state;
             return null!;
         }
-	}
+        static object SetDialogHostStyle(DialogHost dialogHost, string styleName)
+        {
+            Style style = (Style)dialogHost.FindResource(styleName);
+            dialogHost.Style = style;
+            return null!;
+        }
+    }
 }


### PR DESCRIPTION
fixes #3434 

The fix is basically to listen for the `StateChanged` event of the parent `Window`.
If the window is restored from the minimized state, we focus the previously focused element, which got stored in a field `_lastFocusedDialogElement` when the window got minimized.

I want to point out the artificial delay I added, that we have in other places in the DialogHost class too. I just couldn't get it to work without the (50ms) delay, as described in my comment above the "hacky" code.
```csharp
...
// Kinda hacky, but without a delay the focus doesn't always get set correctly because the Focus() method fires too early
Task.Delay(50).ContinueWith(_ => this.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
...
```

<!-- gk-ai-analysis-start:34082b4928b5955fcd150b7f51f2985072b8bd83 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiQWRkcyBhIFVJIHRlc3Qgc2FtcGxlIHdpdGggbXVsdGlwbGUgZm9jdXNhYmxlIGVsZW1lbnRzIHRvIGZhY2lsaXRhdGUgdGVzdGluZyBvZiBEaWFsb2dIb3N0IGZvY3VzIHJlc3RvcmF0aW9uIGxvZ2ljIGR1cmluZyB3aW5kb3cgc3RhdGUgdHJhbnNpdGlvbnMuIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiRm9jdXMgdmFsaWRhdGlvbiB0ZXN0IHNhbXBsZSIsImRlc2NyaXB0aW9uIjoiSW50cm9kdWNlcyBhIGRlZGljYXRlZCAnV2l0aE11bHRpcGxlVGV4dEJveGVzJyBVc2VyQ29udHJvbCB0byB0aGUgVUkgdGVzdCBwcm9qZWN0LCBwcm92aWRpbmcgYSByZXByb2R1Y2libGUgZW52aXJvbm1lbnQgd2l0aCBzZXZlcmFsIGlucHV0IGZpZWxkcyB0byB2ZXJpZnkgZm9jdXMgcGVyc2lzdGVuY2UuIiwic2V2ZXJpdHkiOiJsb3ciLCJmaWxlUGF0aCI6InRlc3RzL01hdGVyaWFsRGVzaWduVGhlbWVzLlVJVGVzdHMvU2FtcGxlcy9EaWFsb2dIb3N0L1dpdGhNdWx0aXBsZVRleHRCb3hlcy54YW1sIiwibGluZVN0YXJ0IjoxLCJsaW5lRW5kIjoyOH0seyJ0aXRsZSI6IkF1dG9tYXRlZCBkaWFsb2cgYWN0aXZhdGlvbiBmb3IgdGVzdGluZyIsImRlc2NyaXB0aW9uIjoiVGhlIHRlc3Qgc2FtcGxlIGF1dG9tYXRpY2FsbHkgb3BlbnMgdGhlIERpYWxvZ0hvc3QgdXBvbiBsb2FkaW5nIHZpYSB0aGUgRGlhbG9nSG9zdF9Mb2FkZWQgZXZlbnQgaGFuZGxlciwgZW5zdXJpbmcgdGhlIGRpYWxvZyBpcyBhY3RpdmUgZm9yIFVJIGF1dG9tYXRpb24gd2l0aG91dCBtYW51YWwgc3RlcHMuIiwic2V2ZXJpdHkiOiJsb3ciLCJmaWxlUGF0aCI6InRlc3RzL01hdGVyaWFsRGVzaWduVGhlbWVzLlVJVGVzdHMvU2FtcGxlcy9EaWFsb2dIb3N0L1dpdGhNdWx0aXBsZVRleHRCb3hlcy54YW1sLmNzIiwibGluZVN0YXJ0IjoxMiwibGluZUVuZCI6MTV9LHsidGl0bGUiOiJNdWx0aS10YXJnZXQgZm9jdXMgbGF5b3V0IiwiZGVzY3JpcHRpb24iOiJJbmNsdWRlcyB0aHJlZSBkaXN0aW5jdCBUZXh0Qm94IGNvbnRyb2xzIHdpdGhpbiB0aGUgZGlhbG9nIGNvbnRlbnQgdG8gc3BlY2lmaWNhbGx5IHRlc3QgaWYgZm9jdXMgcmV0dXJucyB0byB0aGUgY29ycmVjdCBlbGVtZW50IGFtb25nIG11bHRpcGxlIHBvdGVudGlhbCB0YXJnZXRzLiIsInNldmVyaXR5IjoibG93IiwiZmlsZVBhdGgiOiJ0ZXN0cy9NYXRlcmlhbERlc2lnblRoZW1lcy5VSVRlc3RzL1NhbXBsZXMvRGlhbG9nSG9zdC9XaXRoTXVsdGlwbGVUZXh0Qm94ZXMueGFtbCIsImxpbmVTdGFydCI6MTYsImxpbmVFbmQiOjI0fV0sImlzc3VlcyI6W10sInN1Z2dlc3Rpb25zIjpbeyJ0aXRsZSI6IkRlZmluZSBpbml0aWFsIGZvY3VzIGZvciBwcmVkaWN0YWJpbGl0eSIsImRlc2NyaXB0aW9uIjoiQ29uc2lkZXIgc2V0dGluZyB0aGUgSW5pdGlhbEZvY3VzRWxlbWVudCBwcm9wZXJ0eSBvbiB0aGUgRGlhbG9nSG9zdCB0byBvbmUgb2YgdGhlIFRleHRCb3hlcyB0byBlbnN1cmUgYSBkZXRlcm1pbmlzdGljIHN0YXJ0aW5nIHN0YXRlIGZvciB0aGUgZm9jdXMtcmVsYXRlZCBVSSB0ZXN0cy4iLCJzZXZlcml0eSI6ImxvdyIsImZpbGVQYXRoIjoidGVzdHMvTWF0ZXJpYWxEZXNpZ25UaGVtZXMuVUlUZXN0cy9TYW1wbGVzL0RpYWxvZ0hvc3QvV2l0aE11bHRpcGxlVGV4dEJveGVzLnhhbWwiLCJsaW5lU3RhcnQiOjExfSx7InRpdGxlIjoiVXNlIERpc3BhdGNoZXIgZm9yIGRpYWxvZyBvcGVuaW5nIiwiZGVzY3JpcHRpb24iOiJPcGVuaW5nIGEgZGlhbG9nIGltbWVkaWF0ZWx5IHdpdGhpbiB0aGUgTG9hZGVkIGV2ZW50IGNhbiBvY2Nhc2lvbmFsbHkgbGVhZCB0byB0aW1pbmcgaXNzdWVzIGluIFdQRi4gV3JhcHBpbmcgdGhlIElzT3BlbiBhc3NpZ25tZW50IGluIGEgRGlzcGF0Y2hlci5CZWdpbkludm9rZSBjYWxsIG1heSBpbmNyZWFzZSB0ZXN0IHJlbGlhYmlsaXR5LiIsInNldmVyaXR5IjoibG93IiwiZmlsZVBhdGgiOiJ0ZXN0cy9NYXRlcmlhbERlc2lnblRoZW1lcy5VSVRlc3RzL1NhbXBsZXMvRGlhbG9nSG9zdC9XaXRoTXVsdGlwbGVUZXh0Qm94ZXMueGFtbC5jcyIsImxpbmVTdGFydCI6MTR9XSwic2VjdXJpdHkiOltdfQ== -->
<!-- gk-ai-analysis-end:34082b4928b5955fcd150b7f51f2985072b8bd83 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/MaterialDesignInXAML/MaterialDesignInXamlToolkit/pull/3923">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->