### PR TITLE
Prefer TemplateBinding over Binding with RelativeSource

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
@@ -316,7 +316,7 @@
                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                   <Grid.LayoutTransform>
-                    <RotateTransform Angle="{Binding Path=ExpandDirection, RelativeSource={RelativeSource AncestorType=Expander}, Converter={x:Static convertersInternal:ExpanderRotateAngleConverter.Instance}, ConverterParameter=-1}" />
+                    <RotateTransform Angle="{TemplateBinding ExpandDirection, Converter={x:Static convertersInternal:ExpanderRotateAngleConverter.Instance}, ConverterParameter=-1}" />
                   </Grid.LayoutTransform>
 
                   <ContentPresenter Name="PART_Content"

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
@@ -303,11 +303,11 @@
                             Opacity="0.87"
                             TextElement.FontSize="{TemplateBinding wpf:ExpanderAssist.HeaderFontSize}" />
 
-              <Border Name="ContentSite">
+              <Border>
                 <Border.LayoutTransform>
                   <TransformGroup>
                     <ScaleTransform x:Name="ContentSiteScaleTransform" />
-                    <RotateTransform Angle="{Binding Path=ExpandDirection, RelativeSource={RelativeSource AncestorType=Expander}, Converter={x:Static convertersInternal:ExpanderRotateAngleConverter.Instance}}" />
+                    <RotateTransform Angle="{TemplateBinding ExpandDirection, Converter={x:Static convertersInternal:ExpanderRotateAngleConverter.Instance}}" />
                   </TransformGroup>
                 </Border.LayoutTransform>
 


### PR DESCRIPTION
fixes #3890

This fixes a runtime binding error.
The exact same binding I fixed in this PR is also used a few lines above, however that binding does **not** throw a binding error (I'm honestly not sure why 😆 ):
https://github.com/corvinsz/MaterialDesignInXamlToolkit/blob/6b115b0cb43fa18142c78429f30ec7dcc7585552/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml?plain=1#L310