### PR TITLE
Fix `TextBox` horizontal scrollbar position when `VerticalContentAlignment` is set to `Top`

### DIFF
--- a/src/MainDemo.Wpf/Fields.xaml
+++ b/src/MainDemo.Wpf/Fields.xaml
@@ -340,12 +340,14 @@
 
           <TextBox Height="100"
                    VerticalAlignment="Top"
+                   VerticalContentAlignment="Top"
                    materialDesign:HintAssist.Hint="This is a text area"
                    AcceptsReturn="True"
                    IsEnabled="{Binding Path=IsChecked, ElementName=MaterialDesignOutlinedTextBoxEnabledComboBox}"
                    Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                   TextWrapping="Wrap"
-                   VerticalScrollBarVisibility="Auto" />
+                   TextWrapping="NoWrap"
+                   VerticalScrollBarVisibility="Auto"
+                   HorizontalScrollBarVisibility="Auto" />
         </StackPanel>
       </smtx:XamlDisplay>
 

--- a/src/MaterialDesignThemes.Wpf/Converters/VerticalAlignmentConverter.cs
+++ b/src/MaterialDesignThemes.Wpf/Converters/VerticalAlignmentConverter.cs
@@ -3,7 +3,6 @@ using System.Windows.Data;
 
 namespace MaterialDesignThemes.Wpf.Converters;
 
-[Obsolete("This class is obsolete and will be removed in a future version.")]
 public class VerticalAlignmentConverter : IValueConverter
 {
     public VerticalAlignment StretchReplacement { get; set; } = VerticalAlignment.Top;

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -43,6 +43,7 @@
     <Style.Resources>
       <convertersInternal:TextFieldClearButtonVisibilityConverter x:Key="ClearButtonVisibilityConverter" ContentEmptyVisibility="Collapsed" />
       <converters:TextFieldPrefixTextVisibilityConverter x:Key="PrefixSuffixTextVisibilityConverter" HiddenState="Collapsed" />
+      <converters:VerticalAlignmentConverter x:Key="PrefixSuffixTextVerticalAlignmentConverter" StretchReplacement="Center" />
       <converters:BooleanToDashStyleConverter x:Key="BooleanToDashStyleConverter" TrueValue="{x:Static DashStyles.Solid}" />
       <converters:ThicknessCloneConverter x:Key="HelperTextMarginConverter" CloneEdges="Left,Right" />
       <converters:MathConverter x:Key="DivisionConverter" Operation="Divide" Offset="1.5" />
@@ -133,7 +134,7 @@
 
                 <Grid x:Name="ContentGrid"
                       MinHeight="16"
-                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                      VerticalAlignment="Stretch">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
@@ -156,7 +157,7 @@
                   <ScrollViewer x:Name="PART_ContentHost"
                                 Grid.Column="2"
                                 HorizontalAlignment="Stretch"
-                                VerticalAlignment="Center"
+                                VerticalAlignment="Stretch"
                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Panel.ZIndex="1"
@@ -224,7 +225,7 @@
                   <TextBlock x:Name="PrefixTextBlock"
                              Grid.Column="1"
                              Margin="0,0,2,0"
-                             VerticalAlignment="Center"
+                             VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource PrefixSuffixTextVerticalAlignmentConverter}}"
                              FontSize="{TemplateBinding FontSize}"
                              Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                              Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}">
@@ -242,7 +243,7 @@
                   <TextBlock x:Name="SuffixTextBlock"
                              Grid.Column="3"
                              Margin="2,0,0,0"
-                             VerticalAlignment="Center"
+                             VerticalAlignment="{TemplateBinding VerticalContentAlignment, Converter={StaticResource PrefixSuffixTextVerticalAlignmentConverter}}"
                              FontSize="{TemplateBinding FontSize}"
                              Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                              Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}">

--- a/tests/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TextBoxes/TextBoxTests.cs
@@ -537,34 +537,6 @@ public class TextBoxTests : TestBase
     }
 
     [Test]
-    [Arguments(VerticalAlignment.Stretch, VerticalAlignment.Stretch)]
-    [Arguments(VerticalAlignment.Top, VerticalAlignment.Top)]
-    [Arguments(VerticalAlignment.Bottom, VerticalAlignment.Bottom)]
-    [Arguments(VerticalAlignment.Center, VerticalAlignment.Center)]
-    [Description("Issue 3161")]
-    public async Task TextBox_MultiLineAndFixedHeight_RespectsVerticalContentAlignment(VerticalAlignment alignment, VerticalAlignment expectedFloatingHintAlignment)
-    {
-        await using var recorder = new TestRecorder(App);
-
-        var stackPanel = await LoadXaml<StackPanel>($$"""
-            <StackPanel>
-              <TextBox Style="{StaticResource MaterialDesignFilledTextBox}"
-                materialDesign:HintAssist.Hint="Hint text"
-                VerticalContentAlignment="{{alignment}}"
-                AcceptsReturn="True"
-                Height="200" />
-            </StackPanel>
-            """);
-
-        IVisualElement<TextBox> textBox = await stackPanel.GetElement<TextBox>("/TextBox");
-        IVisualElement<Grid> contentGrid = await textBox.GetElement<Grid>("ContentGrid");
-
-        await Assert.That(await contentGrid.GetVerticalAlignment()).IsEqualTo(expectedFloatingHintAlignment);
-
-        recorder.Success();
-    }
-
-    [Test]
     [Description("Issue 3176")]
     public async Task ValidationErrorTemplate_WithChangingErrors_UpdatesValidation()
     {


### PR DESCRIPTION
Will most likely be replaced by PR #3934.

---

Since #3486, if you have `VerticalContentAlignment="Top"` set on a `TextBox`, the horizontal scrollbar will not be at the bottom of the `TextBox`.

I'm demonstrating this bug by making some changes to the first outlined TextBox in the demo app:

- Added `VerticalContentAlignment="Top"`
- Disabled text wrapping.
- Enabled horizontal scrollbar.

I'm keeping these changes in the PR, because the second textbox already has the content centered and text wrapping enabled. Let me know if you prefer keeping the first TextBox as-is.

Before the fix:

<img width="655" height="336" alt="before the fix" src="https://github.com/user-attachments/assets/fdc85248-fcd6-47b5-92b3-caa068a35e62" />

After the fix:

<img width="651" height="329" alt="after the fix" src="https://github.com/user-attachments/assets/9bea4a6d-d5d3-4ef6-b4cd-6d7baae6d7c6" />

The fix is fairly straightforward. `VerticalContentAlignment` was mistakenly bound to `VerticalAlignment`. The `ScrollViewer` should always stretch to fill the whole space.

I also tested the fix with `VerticalContentAlignment="Bottom"`, and everything still looks as expected:

<img width="651" height="334" alt="tested fix with Bottom" src="https://github.com/user-attachments/assets/6a38188b-ee2a-49fa-a2b0-864156244ba6" />

For context, my app uses a `TextBox` to display logs. #3486 broke my `TextBox` in 2 ways:

- Without `AcceptsReturn="True"`, the `TextBox` now defaults to centering the text, which is certainly not what you want for displaying logs. I didn't have `AcceptsReturn="True"` on my `TextBox` before, because it already has `IsReadOnly="True"`. This is kind of a breaking change in behavior, but I'm OK with keeping it as-is.
- After adding `VerticalContentAlignment="Top"`, I encountered this exact bug, which this PR fixes.