### PR TITLE
Update `MaterialDesignPopupBoxButton` style properties

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -12,7 +12,8 @@
   <Style x:Key="MaterialDesignPopupBoxButton" TargetType="{x:Type Button}">
     <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Foreground}" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
-    <Setter Property="Padding" Value="16,0,16,16" />
+    <Setter Property="Cursor" Value="Hand" />
+    <Setter Property="Padding" Value="16,0,16,0" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Button}">
@@ -30,38 +31,38 @@
                 <VisualState Name="MouseOver">
                   <Storyboard>
                     <DoubleAnimation Storyboard.TargetName="MouseOverBorder"
-                                     Storyboard.TargetProperty="Opacity"
-                                     To="0.1"
-                                     Duration="0" />
+                                   Storyboard.TargetProperty="Opacity"
+                                   To="0.1"
+                                   Duration="0" />
                   </Storyboard>
                 </VisualState>
                 <VisualState Name="Disabled">
                   <Storyboard>
                     <DoubleAnimation Storyboard.TargetProperty="Opacity"
-                                     To="0.48"
-                                     Duration="0" />
+                                   To="0.48"
+                                   Duration="0" />
                   </Storyboard>
                 </VisualState>
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
             <Border x:Name="MouseOverBorder"
-                    Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
-                    Opacity="0" />
+                  Background="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
+                  Opacity="0" />
             <wpf:Ripple MinHeight="48"
-                        Padding="{TemplateBinding Padding}"
-                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                        Content="{TemplateBinding Content}"
-                        ContentTemplate="{TemplateBinding ContentTemplate}"
-                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                        Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
-                        Focusable="False"
-                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                      Padding="{TemplateBinding Padding}"
+                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                      Content="{TemplateBinding Content}"
+                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                      ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                      Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
+                      Focusable="False"
+                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
           </Grid>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
-    <Setter Property="VerticalContentAlignment" Value="Bottom" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
   </Style>
 
   <wpf:PackIcon x:Key="MaterialDesignPopupBoxToggleContent"


### PR DESCRIPTION
The default style (`MaterialDesignPopupBoxButton`) for Buttons inside of the `PopupBox` is behaving a bit weird when it comes to positioning custom content.

For example with an icon the content was always aligned at the top, without the user being able to change that.
I adjusted the style a bit so that:
1. consumers can adjust the `VerticalContentAlignment` (by removing the hardcoded `Margin` of `16,0,16,16`)
2. the `Cursor` becomes the `Hand` when hovering over

## Before
<img width="128" height="120" alt="image" src="https://github.com/user-attachments/assets/8b243dfd-4e30-49fa-b5d8-67c0b44decf6" />

## After
<img width="131" height="121" alt="image" src="https://github.com/user-attachments/assets/6307fe02-37a4-44da-89d8-72f7b13fa58c" />