### PR TITLE
Updates versions to 5.3.1

### DIFF
--- a/.github/workflows/get_versions.yml
+++ b/.github/workflows/get_versions.yml
@@ -23,9 +23,9 @@ jobs:
   getting_versions:
     env:
       #Update these base version numbers
-      mdix-version: "5.3.0"
-      mdix-colors-version: "5.3.0"
-      mdix-mahapps-version: "5.3.0"
+      mdix-version: "5.3.1"
+      mdix-colors-version: "5.3.1"
+      mdix-mahapps-version: "5.3.1"
     name: Set version numbers
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,6 +305,8 @@ jobs:
                   Update-Version -Prefix "mdix-mahapps-version"
 
             - name: Open Pull Request
+              env:
+                  GH_TOKEN: ${{ secrets.SA_PAT }}
               run: |
                   git config --local user.email "github-actions[bot]@users.noreply.github.com"
                   git config --local user.name "github-actions[bot]"


### PR DESCRIPTION
Updates the base versions for mdix, mdix-colors, and mdix-mahapps to 5.3.1.

Sets the GH_TOKEN environment variable for the "Open Pull Request" step in the release workflow.
