### PR TITLE
Implementing conversions from int to System.Windows.Media.Color for MaterialColorUtilities

### DIFF
--- a/src/MaterialDesign3.MaterialColorUtilities/DynamicColor/DynamicColor.cs
+++ b/src/MaterialDesign3.MaterialColorUtilities/DynamicColor/DynamicColor.cs
@@ -140,10 +140,8 @@ public sealed class DynamicColor
         return (argb & 0x00ffffff) | (alpha << 24);
     }
 
-#if WPF
     public System.Windows.Media.Color GetColor(DynamicScheme scheme)
         => ColorUtils.ColorFromArgb(GetArgb(scheme));
-#endif
 
     public Hct GetHct(DynamicScheme scheme)
     {

--- a/src/MaterialDesign3.MaterialColorUtilities/MaterialColorUtilities.csproj
+++ b/src/MaterialDesign3.MaterialColorUtilities/MaterialColorUtilities.csproj
@@ -24,11 +24,6 @@
     <NoWarn>CS0618</NoWarn>
   </PropertyGroup>
 
-  <!-- WPF may not be available when we want to target non-windows platforms in future -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net8.0-windows'">
-    <DefineConstants>$(DefineConstants);WPF</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
       <_Parameter1>MDIXColorsVersion</_Parameter1>

--- a/src/MaterialDesign3.MaterialColorUtilities/Scheme/DynamicSchemeFactory.cs
+++ b/src/MaterialDesign3.MaterialColorUtilities/Scheme/DynamicSchemeFactory.cs
@@ -1,0 +1,71 @@
+﻿using System.Windows.Media;
+
+namespace MaterialColorUtilities;
+
+/// <summary>
+/// Factory for creating a dynamic color scheme.
+/// </summary>
+public static class DynamicSchemeFactory
+{
+    /// <summary>
+    /// Factory method for creating a dynamic color scheme.
+    /// </summary>
+    /// <remarks>
+    /// The colors are optional. If any of them are null,
+    /// the color will be automatically generated based on the source color.
+    /// </remarks>
+    public static DynamicScheme Create(
+        Color sourceColor,
+        Variant variant,
+        bool isDark,
+        double contrastLevel,
+        Platform platform,
+        SpecVersion specVersion,
+        Color? primary,
+        Color? secondary,
+        Color? tertiary,
+        Color? neutral,
+        Color? neutralVariant,
+        Color? error)
+    {
+        var sourceColorHct = Hct.FromInt(ColorUtils.ArgbFromColor(sourceColor));
+
+        TonalPalette primaryPalette = primary == null
+            ? ColorSpecs.Get(specVersion).GetPrimaryPalette(variant, sourceColorHct, isDark, platform, contrastLevel)
+            : ColorSpecs.Get(specVersion).GetPrimaryPalette(variant, Hct.FromInt(ColorUtils.ArgbFromColor(primary.Value)), isDark, platform, contrastLevel);
+
+        TonalPalette secondaryPalette = secondary == null
+            ? ColorSpecs.Get(specVersion).GetSecondaryPalette(variant, sourceColorHct, isDark, platform, contrastLevel)
+            : ColorSpecs.Get(specVersion).GetSecondaryPalette(variant, Hct.FromInt(ColorUtils.ArgbFromColor(secondary.Value)), isDark, platform, contrastLevel);
+
+        TonalPalette tertiaryPalette = tertiary == null
+            ? ColorSpecs.Get(specVersion).GetTertiaryPalette(variant, sourceColorHct, isDark, platform, contrastLevel)
+            : ColorSpecs.Get(specVersion).GetTertiaryPalette(variant, Hct.FromInt(ColorUtils.ArgbFromColor(tertiary.Value)), isDark, platform, contrastLevel);
+
+        TonalPalette neutralPalette = neutral == null
+            ? ColorSpecs.Get(specVersion).GetNeutralPalette(variant, sourceColorHct, isDark, platform, contrastLevel)
+            : ColorSpecs.Get(specVersion).GetNeutralPalette(variant, Hct.FromInt(ColorUtils.ArgbFromColor(neutral.Value)), isDark, platform, contrastLevel);
+
+        TonalPalette neutralVariantPalette = neutralVariant == null
+            ? ColorSpecs.Get(specVersion).GetNeutralVariantPalette(variant, sourceColorHct, isDark, platform, contrastLevel)
+            : ColorSpecs.Get(specVersion).GetNeutralVariantPalette(variant, Hct.FromInt(ColorUtils.ArgbFromColor(neutralVariant.Value)), isDark, platform, contrastLevel);
+
+        TonalPalette? errorPalette = error == null
+            ? ColorSpecs.Get(specVersion).GetErrorPalette(variant, sourceColorHct, isDark, platform, contrastLevel)
+            : ColorSpecs.Get(specVersion).GetErrorPalette(variant, Hct.FromInt(ColorUtils.ArgbFromColor(error.Value)), isDark, platform, contrastLevel);
+
+        return new DynamicScheme(
+            sourceColorHct,
+            variant,
+            isDark,
+            contrastLevel,
+            platform,
+            specVersion,
+            primaryPalette,
+            secondaryPalette,
+            tertiaryPalette,
+            neutralPalette,
+            neutralVariantPalette,
+            errorPalette);
+    }
+}

--- a/src/MaterialDesign3.MaterialColorUtilities/Utils/ColorUtils.cs
+++ b/src/MaterialDesign3.MaterialColorUtilities/Utils/ColorUtils.cs
@@ -26,7 +26,6 @@ public static class ColorUtils
     /// </summary>
     public static int ArgbFromRgb(int red, int green, int blue) => (255 << 24) | ((red & 255) << 16) | ((green & 255) << 8) | (blue & 255);
 
-#if WPF
     /// <summary>
     /// Converts a color in ARGB format to a <see cref="System.Windows.Media.Color"/>.
     /// </summary>
@@ -42,7 +41,6 @@ public static class ColorUtils
     /// </summary>
     public static int ArgbFromColor(System.Windows.Media.Color color) =>
         (color.A << 24) | (color.R << 16) | (color.G << 8) | color.B;
-#endif
 
     /// <summary>
     /// Converts a color from linear RGB components to ARGB format.

--- a/tests/MaterialColorUtilities.Tests/ColorUtilsTests.cs
+++ b/tests/MaterialColorUtilities.Tests/ColorUtilsTests.cs
@@ -1,6 +1,4 @@
-#if WPF
 using System.Windows.Media;
-#endif
 
 namespace MaterialColorUtilities.Tests;
 
@@ -269,7 +267,6 @@ public sealed class ColorUtilsTests
         }
     }
 
-#if WPF
     public static IEnumerable<Func<(int argb, Color color)>> TestColors()
     {
         yield return () => (unchecked((int)0xFFFF0000), Colors.Red);
@@ -306,5 +303,4 @@ public sealed class ColorUtilsTests
 
         await Assert.That(result).IsEqualTo(expected);
     }
-#endif
 }

--- a/tests/MaterialColorUtilities.Tests/DynamicSchemeTests.cs
+++ b/tests/MaterialColorUtilities.Tests/DynamicSchemeTests.cs
@@ -66,7 +66,6 @@ public sealed class DynamicSchemeTests
         await Assert.That(hue).IsEqualTo(163.0).Within(1.0);
     }
 
-#if WPF
     /// <summary>
     /// Shows how te crate a theme from a primary color.
     /// </summary>
@@ -169,5 +168,4 @@ public sealed class DynamicSchemeTests
             () => mdc.TextHintInverse.GetColor(scheme).ShouldBe(Color.FromArgb(0xFF, 0x19, 0x1C, 0x17)));
         await Task.CompletedTask;
     }
-#endif
 }

--- a/tests/MaterialColorUtilities.Tests/MaterialColorUtilities.Tests.csproj
+++ b/tests/MaterialColorUtilities.Tests/MaterialColorUtilities.Tests.csproj
@@ -14,11 +14,6 @@
     <SuppressImplicitGitSourceLink>true</SuppressImplicitGitSourceLink>
   </PropertyGroup>
 
-  <!-- WPF may not be available when we want to target non-windows platforms in future -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net8.0-windows'">
-    <DefineConstants>$(DefineConstants);WPF</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\MaterialDesign3.MaterialColorUtilities\MaterialColorUtilities.csproj" />
   </ItemGroup>


### PR DESCRIPTION
- Implemented conversion methods for colors given as `int` to `System.Windows.Media.Color`
- Added unit tests for the conversion methods and for showcasing schema generation.

**Notes:**
- `System.Windows.Media.Color` is not available when targeting Non-WPF (WinForms, MAUI, MacOS, Linux, etc.) plattforms. E.g. the following is not supported:
    - MAUI (`Microsoft.Maui.Graphics.Color`)
    - WinForms (`System.Drawing.Color`)
    - [Splat](https://github.com/reactiveui/splat) (`Splat.SplatColor`)
- The current methods do not easily support the scenario that the user wants to pick secondary/tertiary/error/panel colors manually. We may want to implement custom factories for this purpose.
- I've added a dependency to [Shouldly](https://docs.shouldly.org/) to implement multi-asserts properly
 