### PR TITLE
Add AP to control TabControl Headers behavior

### DIFF
--- a/src/MainDemo.Wpf/Domain/TabsViewModel.cs
+++ b/src/MainDemo.Wpf/Domain/TabsViewModel.cs
@@ -4,10 +4,10 @@ using MaterialDesignDemo.Shared.Domain;
 
 namespace MaterialDesignDemo.Domain;
 
-internal class TabsViewModel : ViewModelBase
+internal partial class TabsViewModel : ObservableObject
 {
     public ObservableCollection<CustomTab> CustomTabs { get; }
-
+    public List<int> LongList { get; }
     public CustomTab? SelectedTab { get; set; }
 
     public string? VeryLongText { get; set; } = @"
@@ -47,6 +47,8 @@ Nulla a porta libero, quis hendrerit ex. In ut pharetra sem. Nunc gravida ante r
                 CustomContent = "Custom content 3",
             },
         };
+
+        LongList = Enumerable.Range(1, 20).ToList();
     }
 
 }

--- a/src/MainDemo.Wpf/Tabs.xaml
+++ b/src/MainDemo.Wpf/Tabs.xaml
@@ -755,5 +755,87 @@
       </materialDesign:Card>
     </smtx:XamlDisplay>
 
+    <Border Width="720"
+        BorderBrush="{DynamicResource MaterialDesign.Brush.Primary}"
+        BorderThickness="1">
+      <Grid>
+        <Grid.RowDefinitions>
+          <RowDefinition Height="auto" />
+          <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*" MinWidth="50" />
+          <ColumnDefinition Width="2" />
+          <ColumnDefinition Width="*" MinWidth="50" />
+        </Grid.ColumnDefinitions>
+
+        <materialDesign:ColorZone Grid.ColumnSpan="2"
+                              Padding="8"
+                              Mode="PrimaryMid">
+          <TextBlock Text="materialDesign:TabAssist.HeaderBehavior=&quot;Scrolling&quot;" />
+        </materialDesign:ColorZone>
+
+        <materialDesign:ColorZone Grid.Column="2"
+                              Padding="8"
+                              Mode="PrimaryMid">
+          <TextBlock Text="materialDesign:TabAssist.HeaderBehavior=&quot;Wrapping&quot;" />
+        </materialDesign:ColorZone>
+
+        <smtx:XamlDisplay Grid.Row="1"
+                      Grid.Column="0"
+                      Margin="16"
+                      UniqueKey="tabs_tabAssist_1">
+          <TabControl materialDesign:TabAssist.HeaderBehavior="Scrolling"
+                  ItemsSource="{Binding LongList}"
+                  Style="{StaticResource MaterialDesignTabControl}">
+            <TabControl.ItemTemplate>
+              <DataTemplate>
+                <StackPanel Orientation="Horizontal">
+                  <TextBlock Text="{Binding ., StringFormat=Header {0}}" />
+                </StackPanel>
+              </DataTemplate>
+            </TabControl.ItemTemplate>
+            <TabControl.ContentTemplate>
+              <DataTemplate>
+                <TextBlock Margin="10"
+                       FontSize="18"
+                       Text="{Binding ., StringFormat=Content {0}}" />
+              </DataTemplate>
+            </TabControl.ContentTemplate>
+          </TabControl>
+        </smtx:XamlDisplay>
+
+        <GridSplitter Grid.RowSpan="2"
+                  Grid.Column="1"
+                  HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch" />
+
+        <smtx:XamlDisplay Grid.Row="1"
+                      Grid.Column="2"
+                      Margin="16"
+                      UniqueKey="tabs_tabAssist_2">
+          <TabControl materialDesign:TabAssist.HeaderBehavior="Wrapping"
+                  ItemsSource="{Binding LongList}"
+                  Style="{StaticResource MaterialDesignTabControl}">
+            <TabControl.ItemTemplate>
+              <DataTemplate>
+                <StackPanel Orientation="Horizontal">
+                  <TextBlock Text="{Binding ., StringFormat=Header {0}}" />
+                </StackPanel>
+              </DataTemplate>
+            </TabControl.ItemTemplate>
+            <TabControl.ContentTemplate>
+              <DataTemplate>
+                <TextBlock Margin="10"
+                       FontSize="18"
+                       Text="{Binding ., StringFormat=Content {0}}" />
+              </DataTemplate>
+            </TabControl.ContentTemplate>
+          </TabControl>
+        </smtx:XamlDisplay>
+
+      </Grid>
+    </Border>
+
   </StackPanel>
 </UserControl>

--- a/src/MaterialDesignThemes.Wpf/TabAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/TabAssist.cs
@@ -1,5 +1,10 @@
 namespace MaterialDesignThemes.Wpf;
 
+public enum TabControlHeaderBehavior
+{
+    Scrolling,
+    Wrapping
+}
 public static class TabAssist
 {
     public static readonly DependencyProperty HasFilledTabProperty = DependencyProperty.RegisterAttached(
@@ -54,4 +59,14 @@ public static class TabAssist
 
     public static readonly DependencyProperty TabHeaderCursorProperty =
         DependencyProperty.RegisterAttached("TabHeaderCursor", typeof(Cursor), typeof(TabAssist), new PropertyMetadata(Cursors.Hand));
+
+    public static TabControlHeaderBehavior GetHeaderBehavior(DependencyObject obj)
+        => (TabControlHeaderBehavior)obj.GetValue(HeaderBehaviorProperty);
+
+    public static void SetHeaderBehavior(DependencyObject obj, TabControlHeaderBehavior value)
+        => obj.SetValue(HeaderBehaviorProperty, value);
+
+    public static readonly DependencyProperty HeaderBehaviorProperty =
+        DependencyProperty.RegisterAttached("HeaderBehavior", typeof(TabControlHeaderBehavior), typeof(TabAssist),
+            new PropertyMetadata(TabControlHeaderBehavior.Scrolling));
 }

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -21,157 +21,221 @@
     </Setter>
   </Style>
 
-  <Style x:Key="MaterialDesignTabControlBase" TargetType="{x:Type TabControl}">
-    <Setter Property="Background" Value="Transparent" />
-    <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground), FallbackValue=Black}" />
-    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-    <Setter Property="Padding" Value="0" />
-    <Setter Property="Template">
-      <Setter.Value>
-        <ControlTemplate TargetType="{x:Type TabControl}">
-          <DockPanel KeyboardNavigation.TabNavigation="Local">
-            <wpf:ColorZone x:Name="PART_HeaderZone"
+  <ControlTemplate x:Key="ScrollingTabControlTemplate" TargetType="{x:Type TabControl}">
+    <DockPanel KeyboardNavigation.TabNavigation="Local">
+      <wpf:ColorZone x:Name="PART_HeaderZone"
                            VerticalAlignment="Stretch"
                            Panel.ZIndex="1"
                            wpf:ElevationAssist.Elevation="{TemplateBinding wpf:ElevationAssist.Elevation}"
                            Background="{TemplateBinding wpf:ColorZoneAssist.Background}"
                            DockPanel.Dock="Top"
                            Focusable="False">
-              <ScrollViewer wpf:ScrollViewerAssist.BubbleVerticalScroll="True"
-                            wpf:ScrollViewerAssist.SupportHorizontalScroll="True"
-                            wpf:ScrollViewerAssist.IgnorePadding="{Binding Path=(wpf:ScrollViewerAssist.IgnorePadding), RelativeSource={RelativeSource TemplatedParent}}"
-                            wpf:ScrollViewerAssist.PaddingMode="{Binding Path=(wpf:ScrollViewerAssist.PaddingMode), RelativeSource={RelativeSource TemplatedParent}}"
-                            HorizontalScrollBarVisibility="Hidden"
-                            VerticalScrollBarVisibility="Hidden">
-                <StackPanel>
-                  <UniformGrid x:Name="CenteredHeaderPanel"
-                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                               Margin="{Binding Path=(wpf:TabAssist.HeaderPanelMargin), RelativeSource={RelativeSource TemplatedParent}}"
-                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                               wpf:TabAssist.BindableIsItemsHost="{Binding Visibility, RelativeSource={RelativeSource Self}}"
-                               Focusable="False"
-                               KeyboardNavigation.TabIndex="1"
-                               Rows="1" />
-                  <VirtualizingStackPanel x:Name="HeaderPanel"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          Margin="{Binding Path=(wpf:TabAssist.HeaderPanelMargin), RelativeSource={RelativeSource TemplatedParent}}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          wpf:TabAssist.BindableIsItemsHost="{Binding Visibility, RelativeSource={RelativeSource Self}}"
-                                          Focusable="False"
-                                          KeyboardNavigation.TabIndex="1"
-                                          Orientation="Horizontal" />
-                </StackPanel>
-              </ScrollViewer>
-            </wpf:ColorZone>
-            <Border x:Name="PART_BorderSelectedContent"
+        <ScrollViewer wpf:ScrollViewerAssist.BubbleVerticalScroll="True"
+                              wpf:ScrollViewerAssist.SupportHorizontalScroll="True"
+                              wpf:ScrollViewerAssist.IgnorePadding="{Binding Path=(wpf:ScrollViewerAssist.IgnorePadding), RelativeSource={RelativeSource TemplatedParent}}"
+                              wpf:ScrollViewerAssist.PaddingMode="{Binding Path=(wpf:ScrollViewerAssist.PaddingMode), RelativeSource={RelativeSource TemplatedParent}}"
+                              HorizontalScrollBarVisibility="Hidden"
+                              VerticalScrollBarVisibility="Hidden">
+          <StackPanel>
+            <UniformGrid x:Name="CenteredHeaderPanel"
+                                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                     Margin="{Binding Path=(wpf:TabAssist.HeaderPanelMargin), RelativeSource={RelativeSource TemplatedParent}}"
+                                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                     wpf:TabAssist.BindableIsItemsHost="{Binding Visibility, RelativeSource={RelativeSource Self}}"
+                                     Focusable="False"
+                                     KeyboardNavigation.TabIndex="1"
+                                     Rows="1" />
+            <VirtualizingStackPanel x:Name="HeaderPanel"
+                                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                Margin="{Binding Path=(wpf:TabAssist.HeaderPanelMargin), RelativeSource={RelativeSource TemplatedParent}}"
+                                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                wpf:TabAssist.BindableIsItemsHost="{Binding Visibility, RelativeSource={RelativeSource Self}}"
+                                                Focusable="False"
+                                                KeyboardNavigation.TabIndex="1"
+                                                Orientation="Horizontal" />
+          </StackPanel>
+        </ScrollViewer>
+      </wpf:ColorZone>
+
+      <Border x:Name="PART_BorderSelectedContent"
                     Padding="{TemplateBinding Padding}"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
                     Panel.ZIndex="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Panel.ZIndex)}"
                     Background="{x:Null}"
                     Focusable="False">
-              <ContentPresenter x:Name="PART_SelectedContentHost"
-                                Margin="{TemplateBinding Padding}"
-                                ContentSource="SelectedContent"
-                                ContentStringFormat="{TemplateBinding SelectedContentStringFormat}"
-                                ContentTemplate="{TemplateBinding SelectedContentTemplate}"
-                                ContentTemplateSelector="{TemplateBinding SelectedContentTemplateSelector}"
-                                Focusable="False"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-            </Border>
-          </DockPanel>
+        <ContentPresenter x:Name="PART_SelectedContentHost"
+                                  Margin="{TemplateBinding Padding}"
+                                  ContentSource="SelectedContent"
+                                  ContentStringFormat="{TemplateBinding SelectedContentStringFormat}"
+                                  ContentTemplate="{TemplateBinding SelectedContentTemplate}"
+                                  ContentTemplateSelector="{TemplateBinding SelectedContentTemplateSelector}"
+                                  Focusable="False"
+                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+      </Border>
+    </DockPanel>
 
-          <ControlTemplate.Triggers>
-            <Trigger Property="HorizontalContentAlignment" Value="Stretch">
-              <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
-              <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
-            </Trigger>
+    <ControlTemplate.Triggers>
+      <Trigger Property="HorizontalContentAlignment" Value="Stretch">
+        <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
+        <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
+      </Trigger>
 
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="HorizontalContentAlignment" Value="Center" />
-                <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="False" />
-              </MultiTrigger.Conditions>
-              <MultiTrigger.Setters>
-                <Setter TargetName="HeaderPanel" Property="Visibility" Value="Visible" />
-                <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Collapsed" />
-              </MultiTrigger.Setters>
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="HorizontalContentAlignment" Value="Center" />
-                <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="True" />
-              </MultiTrigger.Conditions>
-              <MultiTrigger.Setters>
-                <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
-                <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
-              </MultiTrigger.Setters>
-            </MultiTrigger>
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="HorizontalContentAlignment" Value="Center" />
+          <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="False" />
+        </MultiTrigger.Conditions>
+        <MultiTrigger.Setters>
+          <Setter TargetName="HeaderPanel" Property="Visibility" Value="Visible" />
+          <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Collapsed" />
+        </MultiTrigger.Setters>
+      </MultiTrigger>
 
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="HorizontalContentAlignment" Value="Left" />
-                <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="False" />
-              </MultiTrigger.Conditions>
-              <MultiTrigger.Setters>
-                <Setter TargetName="HeaderPanel" Property="Visibility" Value="Visible" />
-                <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Collapsed" />
-              </MultiTrigger.Setters>
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="HorizontalContentAlignment" Value="Left" />
-                <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="True" />
-              </MultiTrigger.Conditions>
-              <MultiTrigger.Setters>
-                <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
-                <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
-              </MultiTrigger.Setters>
-            </MultiTrigger>
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="HorizontalContentAlignment" Value="Center" />
+          <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="True" />
+        </MultiTrigger.Conditions>
+        <MultiTrigger.Setters>
+          <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
+          <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
+        </MultiTrigger.Setters>
+      </MultiTrigger>
 
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="HorizontalContentAlignment" Value="Right" />
-                <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="False" />
-              </MultiTrigger.Conditions>
-              <MultiTrigger.Setters>
-                <Setter TargetName="HeaderPanel" Property="Visibility" Value="Visible" />
-                <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Collapsed" />
-              </MultiTrigger.Setters>
-            </MultiTrigger>
-            <MultiTrigger>
-              <MultiTrigger.Conditions>
-                <Condition Property="HorizontalContentAlignment" Value="Right" />
-                <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="True" />
-              </MultiTrigger.Conditions>
-              <MultiTrigger.Setters>
-                <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
-                <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
-              </MultiTrigger.Setters>
-            </MultiTrigger>
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="HorizontalContentAlignment" Value="Left" />
+          <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="False" />
+        </MultiTrigger.Conditions>
+        <MultiTrigger.Setters>
+          <Setter TargetName="HeaderPanel" Property="Visibility" Value="Visible" />
+          <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Collapsed" />
+        </MultiTrigger.Setters>
+      </MultiTrigger>
 
-            <Trigger Property="TabStripPlacement" Value="Bottom">
-              <Setter TargetName="PART_HeaderZone" Property="DockPanel.Dock" Value="Bottom" />
-            </Trigger>
-            <Trigger Property="TabStripPlacement" Value="Left">
-              <Setter TargetName="CenteredHeaderPanel" Property="Columns" Value="1" />
-              <Setter TargetName="CenteredHeaderPanel" Property="Rows" Value="0" />
-              <Setter TargetName="PART_HeaderZone" Property="DockPanel.Dock" Value="Left" />
-            </Trigger>
-            <Trigger Property="TabStripPlacement" Value="Right">
-              <Setter TargetName="CenteredHeaderPanel" Property="Columns" Value="1" />
-              <Setter TargetName="CenteredHeaderPanel" Property="Rows" Value="0" />
-              <Setter TargetName="PART_HeaderZone" Property="DockPanel.Dock" Value="Right" />
-            </Trigger>
-          </ControlTemplate.Triggers>
-        </ControlTemplate>
-      </Setter.Value>
-    </Setter>
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="HorizontalContentAlignment" Value="Left" />
+          <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="True" />
+        </MultiTrigger.Conditions>
+        <MultiTrigger.Setters>
+          <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
+          <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
+        </MultiTrigger.Setters>
+      </MultiTrigger>
+
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="HorizontalContentAlignment" Value="Right" />
+          <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="False" />
+        </MultiTrigger.Conditions>
+        <MultiTrigger.Setters>
+          <Setter TargetName="HeaderPanel" Property="Visibility" Value="Visible" />
+          <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Collapsed" />
+        </MultiTrigger.Setters>
+      </MultiTrigger>
+
+      <MultiTrigger>
+        <MultiTrigger.Conditions>
+          <Condition Property="HorizontalContentAlignment" Value="Right" />
+          <Condition Property="wpf:TabAssist.HasUniformTabWidth" Value="True" />
+        </MultiTrigger.Conditions>
+        <MultiTrigger.Setters>
+          <Setter TargetName="HeaderPanel" Property="Visibility" Value="Collapsed" />
+          <Setter TargetName="CenteredHeaderPanel" Property="Visibility" Value="Visible" />
+        </MultiTrigger.Setters>
+      </MultiTrigger>
+
+      <Trigger Property="TabStripPlacement" Value="Bottom">
+        <Setter TargetName="PART_HeaderZone" Property="DockPanel.Dock" Value="Bottom" />
+      </Trigger>
+      <Trigger Property="TabStripPlacement" Value="Left">
+        <Setter TargetName="CenteredHeaderPanel" Property="Columns" Value="1" />
+        <Setter TargetName="CenteredHeaderPanel" Property="Rows" Value="0" />
+        <Setter TargetName="PART_HeaderZone" Property="DockPanel.Dock" Value="Left" />
+      </Trigger>
+      <Trigger Property="TabStripPlacement" Value="Right">
+        <Setter TargetName="CenteredHeaderPanel" Property="Columns" Value="1" />
+        <Setter TargetName="CenteredHeaderPanel" Property="Rows" Value="0" />
+        <Setter TargetName="PART_HeaderZone" Property="DockPanel.Dock" Value="Right" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+
+  <ControlTemplate x:Key="WrappingTabControlTemplate" TargetType="{x:Type TabControl}">
+    <DockPanel KeyboardNavigation.TabNavigation="Local">
+      <wpf:ColorZone x:Name="PART_HeaderZone"
+                           VerticalAlignment="Stretch"
+                           Panel.ZIndex="1"
+                           wpf:ElevationAssist.Elevation="{TemplateBinding wpf:ElevationAssist.Elevation}"
+                           Background="{TemplateBinding wpf:ColorZoneAssist.Background}"
+                           DockPanel.Dock="Top"
+                           Focusable="False">
+        <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                              VerticalScrollBarVisibility="Auto">
+          <WrapPanel x:Name="HeaderWrapPanel"
+                               Margin="{Binding Path=(wpf:TabAssist.HeaderPanelMargin), RelativeSource={RelativeSource TemplatedParent}}"
+                               Background="Transparent"
+                               IsItemsHost="True"
+                               KeyboardNavigation.TabIndex="1" />
+        </ScrollViewer>
+      </wpf:ColorZone>
+
+      <Border x:Name="PART_BorderSelectedContent"
+                    Padding="{TemplateBinding Padding}"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Panel.ZIndex="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Panel.ZIndex)}"
+                    Background="{x:Null}"
+                    Focusable="False">
+        <ContentPresenter x:Name="PART_SelectedContentHost"
+                                  Margin="{TemplateBinding Padding}"
+                                  ContentSource="SelectedContent"
+                                  ContentStringFormat="{TemplateBinding SelectedContentStringFormat}"
+                                  ContentTemplate="{TemplateBinding SelectedContentTemplate}"
+                                  ContentTemplateSelector="{TemplateBinding SelectedContentTemplateSelector}"
+                                  Focusable="False"
+                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+      </Border>
+    </DockPanel>
+
+    <ControlTemplate.Triggers>
+      <Trigger Property="TabStripPlacement" Value="Bottom">
+        <Setter TargetName="PART_HeaderZone" Property="DockPanel.Dock" Value="Bottom" />
+      </Trigger>
+      <Trigger Property="TabStripPlacement" Value="Left">
+        <Setter TargetName="PART_HeaderZone" Property="DockPanel.Dock" Value="Left" />
+      </Trigger>
+      <Trigger Property="TabStripPlacement" Value="Right">
+        <Setter TargetName="PART_HeaderZone" Property="DockPanel.Dock" Value="Right" />
+      </Trigger>
+    </ControlTemplate.Triggers>
+  </ControlTemplate>
+
+  <Style x:Key="MaterialDesignTabControlBase" TargetType="{x:Type TabControl}">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground"
+                Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}},
+                                Path=(TextElement.Foreground),
+                                FallbackValue=Black}" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="Template" Value="{StaticResource ScrollingTabControlTemplate}" />
     <Setter Property="VerticalContentAlignment" Value="Stretch" />
     <Setter Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid" />
     <Setter Property="wpf:ElevationAssist.Elevation" Value="Dp4" />
     <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesign.Brush.Button.Ripple}" />
     <Setter Property="wpf:TabAssist.HasUniformTabWidth" Value="False" />
+
+    <Style.Triggers>
+      <Trigger Property="wpf:TabAssist.HeaderBehavior" Value="Wrapping">
+        <Setter Property="Template" Value="{StaticResource WrappingTabControlTemplate}" />
+      </Trigger>
+      <Trigger Property="wpf:TabAssist.HeaderBehavior" Value="Scrolling">
+        <Setter Property="Template" Value="{StaticResource ScrollingTabControlTemplate}" />
+      </Trigger>
+    </Style.Triggers>
   </Style>
 
   <Style x:Key="MaterialDesignTabControl"


### PR DESCRIPTION
fixes https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/3863
old PR and conversation https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/pull/3873

Simply switching out the content of the colorzone doesn't work, because the `ControlTemplate` contains triggers which reference nested elements inside of the colorzone.
I couldn't find an easy way around that, so I now opted for the following approach:

Split the `MaterialDesignTabControlBase` into 2 dedicated templates (`ScrollingTabControlTemplate` and `WrappingTabControlTemplate`). The `MaterialDesignTabControlBase` then switches it's own template to the one of the above, based on the AP.

