### PR TITLE
Restricts horizontal scrolling to mouse over

### DIFF
--- a/src/MaterialDesignThemes.Wpf/ScrollViewerAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/ScrollViewerAssist.cs
@@ -140,17 +140,12 @@ public static class ScrollViewerAssist
                 const int WM_MOUSEHWHEEL = 0x020E;
                 switch (msg)
                 {
-                    case WM_MOUSEHWHEEL:
+                    case WM_MOUSEHWHEEL when scrollViewer.IsMouseOver:
                         int tilt = (short)((wParam.ToInt64() >> 16) & 0xFFFF);
-                        OnMouseTilt(tilt);
+                        scrollViewer.ScrollToHorizontalOffset(scrollViewer.HorizontalOffset + tilt);
                         return (IntPtr)1;
                 }
                 return IntPtr.Zero;
-            }
-
-            void OnMouseTilt(int tilt)
-            {
-                scrollViewer.ScrollToHorizontalOffset(scrollViewer.HorizontalOffset + tilt);
             }
         }
     }


### PR DESCRIPTION
Ensures horizontal mouse wheel events only affect the ScrollViewer when the mouse cursor is directly over it. This prevents unintended scrolling of background or non-focused elements.

Simplifies the scroll handling by inlining the logic and removing a redundant helper method.

This fixes some odd behavior I saw while testing #3952