### PR TITLE
Updates SDK, LangVersion, and enables CPM

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <Copyright>Copyright © 2022</Copyright>
     <Company>Mulholland Software/James Willock</Company>
 
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>13.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
 
     <SignAssembly>true</SignAssembly>
@@ -14,7 +14,6 @@
 
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     
     <!-- Common Package Properties -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/Directory.packages.props
+++ b/Directory.packages.props
@@ -1,4 +1,10 @@
 <Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- https://learn.microsoft.com/nuget/consume-packages/Central-Package-Management?WT.mc_id=DT-MVP-5003472#transitive-pinning -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageVersion Include="BluwolfIcons" Version="1.0.1" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.300",
+    "version": "9.0.306",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
Updates .NET SDK to 9.0.306, sets C# LangVersion to 13.0, and enables Central Package Management (CPM) with transitive pinning.
