### PR TITLE
Remove duplicate Shouldly package version

### DIFF
--- a/Directory.packages.props
+++ b/Directory.packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="Microsoft.Toolkit.MVVM" Version="7.1.2" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.77" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Shouldly" Version="4.2.1" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="ShowMeTheXAML" Version="2.0.0" />
     <PackageVersion Include="ShowMeTheXAML.AvalonEdit" Version="2.0.0" />
     <PackageVersion Include="ShowMeTheXAML.MSBuild" Version="2.0.0" />
@@ -38,6 +38,5 @@
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
     <PackageVersion Include="Polyfill" Version="8.8.1" />
-    <PackageVersion Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
PR #3949 introduced a second package version for `Shouldly` instead of updating the existing entry. This PR removes the duplicate entry and uses the newest of the two versions.