### PR TITLE
Align opacity of hint in AutoSuggestBox with "recent" changes in TextBox

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -339,14 +339,19 @@
             </MultiTrigger>
 
             <!-- Floating hint -->
-            <Trigger Property="wpf:HintAssist.IsFloating" Value="True">
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+              </MultiTrigger.Conditions>
               <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
-            </Trigger>
+            </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
                 <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
                 <Condition Property="IsKeyboardFocused" Value="True" />
               </MultiTrigger.Conditions>
+              <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
               <Setter TargetName="Hint" Property="Foreground" Value="{Binding Path=(wpf:HintAssist.Foreground), RelativeSource={RelativeSource TemplatedParent}}" />
             </MultiTrigger>
 


### PR DESCRIPTION
Fixes #3963 

Porting changes done in `TextBox` template regarding hint opacity from PR #3575 to the `AutoSuggestBox`.

**Before:**
<img width="800" height="272" alt="image" src="https://github.com/user-attachments/assets/40acfdf2-4866-4ec7-87d1-0f4c4bc0edca" />

**After:**
<img width="1216" height="406" alt="image" src="https://github.com/user-attachments/assets/b0ab02fb-26db-45dc-84c8-176c01fdb123" />
