### PR TITLE
Move background color change into ControlTemplate trigger collection

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
@@ -431,6 +431,14 @@
                                  Visibility="{Binding HeadersVisibility, ConverterParameter={x:Static DataGridHeadersVisibility.Row}, Converter={x:Static DataGrid.HeadersVisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}, FallbackValue=Visible}" />
             </SelectiveScrollingGrid>
           </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="DGR_Border" Property="Background" Value="{DynamicResource MaterialDesign.Brush.DataGrid.RowHoverBackground}" />
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+              <Setter TargetName="DGR_Border" Property="Background" Value="{DynamicResource MaterialDesign.Brush.DataGrid.Selected}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
@@ -446,12 +454,6 @@
       </Setter.Value>
     </Setter>
     <Style.Triggers>
-      <Trigger Property="IsSelected" Value="True">
-        <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.DataGrid.Selected}" />
-      </Trigger>
-      <Trigger Property="IsMouseOver" Value="True">
-        <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.DataGrid.RowHoverBackground}" />
-      </Trigger>
       <Trigger Property="IsNewItem" Value="True">
         <Setter Property="Margin" Value="{Binding NewItemMargin, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}, FallbackValue=0}" />
       </Trigger>


### PR DESCRIPTION
Fixes #3964 

Moving the background changes inside of the `ControlTemplate.Triggers` collection changes the binding precedence order such that our `IsMouseOver` trigger is even closer to the DGR_Border than a local value set directly on the `DataGrid` (e.g. `<DataGrid AlternatingRowBackground="Green" ...>`) and thus takes precedence.

I moved the `IsSelected` trigger as well, as this seemed to suffer from a similar issue.

**Before:**
![Issue3964](https://github.com/user-attachments/assets/8bce77d1-8777-461a-8a85-d1df615aac3e)

**After:**
![Issue3964Fixed](https://github.com/user-attachments/assets/fb923832-41f2-4cfc-b594-3a0ecdcf8f16)
