### PR TITLE
Enhance Mouseover Visuals for `RadioButton`

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
@@ -440,8 +440,8 @@
                   </Ellipse.RenderTransform>
                 </Ellipse>
                 <Ellipse x:Name="halo"
-                         Width="25"
-                         Height="25"
+                         Width="22"
+                         Height="22"
                          Margin="0"
                          HorizontalAlignment="Center"
                          VerticalAlignment="Center"


### PR DESCRIPTION
This adds a halo effect when hovering over a `RadioButton` as the MD2 specs suggest (see here under the "States" heading):
https://m2.material.io/components/switches#behavior

## Before
<img width="773" height="508" alt="image" src="https://github.com/user-attachments/assets/0ab03e19-ff52-4637-b628-b84775b2a3c0" />

## After
<img width="794" height="508" alt="image" src="https://github.com/user-attachments/assets/caab76b3-5f4d-4542-b5e1-3f9e139913f0" />
