### PR TITLE
fix: Clip ripple effect for default Button style in `materialDesign:PopupBox`

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -17,7 +17,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Button}">
-          <Grid x:Name="rootGrid">
+          <Grid ClipToBounds="True">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup Name="CommonStates">
                 <VisualStateGroup.Transitions>
@@ -57,14 +57,7 @@
                       ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
                       Feedback="{TemplateBinding Foreground, Converter={x:Static converters:BrushRoundConverter.Instance}}"
                       Focusable="False"
-                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" >
-              <wpf:Ripple.Clip>
-                <MultiBinding Converter="{x:Static converters:BorderClipConverter.Instance}">
-                  <Binding ElementName="rootGrid" Path="ActualWidth" />
-                  <Binding ElementName="rootGrid" Path="ActualHeight" />
-                </MultiBinding>
-              </wpf:Ripple.Clip>
-            </wpf:Ripple>
+                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
           </Grid>
         </ControlTemplate>
       </Setter.Value>


### PR DESCRIPTION
fixes #3982 

Use the `BorderClipConverter` to clip the ripple to the Buttons (`MaterialDesignPopupBoxButton`) bounds.
The current behavior can be seen in the linked issue.
New behavior:

https://github.com/user-attachments/assets/6b7df25a-467f-4bfd-81aa-e24782732285

