### PR TITLE
Clarify DialogHost.Close parameter documentation

### DIFF
--- a/src/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/src/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -186,7 +186,7 @@ public class DialogHost : ContentControl
     ///  Close a modal dialog.
     /// </summary>
     /// <param name="dialogIdentifier"> of the instance where the dialog should be closed. Typically this will match an identifier set in XAML. </param>
-    /// <param name="parameter"> to provide to close handler</param>
+    /// <param name="parameter"> Value returned by DialogHost.ShowDialog(...) or passed to close handler if one is provided.</param>
     public static void Close(object? dialogIdentifier, object? parameter)
     {
         DialogHost dialogHost = GetInstance(dialogIdentifier);


### PR DESCRIPTION
The documentation for DialogHost.Close(...) described the `parameter` argument as being "to provide to close handler", which is misleading and incomplete.

Internally, DialogHost.Close forwards the value directly to DialogSession.Close(parameter). In DialogSession.Close, the parameter is correctly documented as the dialog result value, which is returned by DialogHost.Show(...) and exposed through DialogClosingEventArgs.Parameter.

This change aligns the DialogHost.Close documentation with the existing DialogSession.Close documentation, making it clear that the parameter represents the dialog result and is not solely intended for close handlers.