### PR TITLE
Introduce base style for Hyperlink

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Hyperlink.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Hyperlink.xaml
@@ -2,9 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
   <!-- updated specification 2018 -->
-  <Style x:Key="MaterialDesignBody1Hyperlink" TargetType="{x:Type Hyperlink}">
-    <Setter Property="FontSize" Value="16" />
-    <Setter Property="FontWeight" Value="Regular" />
+  <Style x:Key="MaterialDesignHyperlink" TargetType="{x:Type Hyperlink}">
     <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Foreground}" />
     <Setter Property="TextDecorations" Value="None" />
     <Style.Triggers>
@@ -22,6 +20,13 @@
         <Setter Property="TextDecorations" Value="Underline" />
       </MultiTrigger>
     </Style.Triggers>
+  </Style>
+
+  <Style x:Key="MaterialDesignBody1Hyperlink"
+         TargetType="{x:Type Hyperlink}"
+         BasedOn="{StaticResource MaterialDesignHyperlink}">
+    <Setter Property="FontSize" Value="16" />
+    <Setter Property="FontWeight" Value="Regular" />
   </Style>
 
   <Style x:Key="MaterialDesignBody2Hyperlink"

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBlock.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBlock.xaml
@@ -5,6 +5,9 @@
   </ResourceDictionary.MergedDictionaries>
 
   <Style x:Key="MaterialDesignTextBlock" TargetType="{x:Type TextBlock}">
+    <Style.Resources>
+      <Style TargetType="Hyperlink" BasedOn="{StaticResource MaterialDesignHyperlink}" />
+    </Style.Resources>
     <Setter Property="FontSize" Value="13" />
     <Setter Property="FontWeight" Value="Regular" />
     <Setter Property="Padding" Value="0,4" />


### PR DESCRIPTION
Users can select "MaterialDesignHyperlink" style when they want font size and font weight to align with parent elements in the visual tree (instead of being limited to the various preset properties set in the current styles)

This PR introduces a behavioral change side-effect where the default textblock style changes from having hyperlinks at 16pt/regular to "inherit from parent". 