### PR TITLE
Remove apparently pointless Margin necessitating an extra Border to handle hit testing

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -155,13 +155,6 @@
                          PlacementTarget="{Binding ElementName=DialogHostRoot, Mode=OneWay}"
                          Style="{TemplateBinding PopupStyle}">
               <Grid>
-                <Border Background="Transparent" IsHitTestVisible="{TemplateBinding CloseOnClickAway}">
-                  <Border.InputBindings>
-                    <MouseBinding Command="{x:Static wpf:DialogHost.CloseDialogCommand}"
-                                  CommandParameter="{TemplateBinding CloseOnClickAwayParameter}"
-                                  MouseAction="LeftClick" />
-                  </Border.InputBindings>
-                </Border>
                 <wpf:Card x:Name="PART_PopupContentElement"
                           wpf:ElevationAssist.Elevation="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ElevationAssist.Elevation)}"
                           Content="{TemplateBinding DialogContent}"


### PR DESCRIPTION
Non-rhetorical question: Why would a dialog need margin?

This border was added in a12e00b8da09bdc8ec773c63938cd21e59c9a80d: "Clicking on dialog shadow now dismisses dialog (#2290)". If you remove it and turn on `CloseOnClickAway`, the `Margin` leaves a dead zone 35 pixels wide around the dialog. But why can't we just remove the `Margin` instead of adding an extra click handler behind it?