### PR TITLE
chore(deps): update MahApps.Metro to 2.4.11

### DIFF
--- a/Directory.packages.props
+++ b/Directory.packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Dragablz" Version="0.0.3.234" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
-    <PackageVersion Include="MahApps.Metro" Version="2.4.10" />
+    <PackageVersion Include="MahApps.Metro" Version="2.4.11" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />


### PR DESCRIPTION
fixes https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/4005

A bug in MahApps.Metro version 2.4.11 was fixed where WPF Windows on .net10 could simply not be moved with the mouse.