### PR TITLE
Remove duplicate padding in card style

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -83,7 +83,6 @@
                     Background="{TemplateBinding Background}"
                     Clip="{TemplateBinding ContentClip}">
               <ContentPresenter x:Name="ContentPresenter"
-                                Margin="{TemplateBinding Padding}"
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Content="{TemplateBinding ContentControl.Content}"


### PR DESCRIPTION
fixes #4008

The `Padding` property was applied twice in the `MaterialDesignOutlinedCard` style. Once on the `ContentPresenter` and once more on the parent `Border`.

This effectively doubled the Paddings value specified on the call-site.

<img width="134" height="244" alt="image" src="https://github.com/user-attachments/assets/918527b8-5bab-435f-aec3-abe7d30ff8cc" />

<!-- gk-ai-analysis-start:d277095f8ef397c5461c1c889cbf204cac64fcf1 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiUmVtb3ZlcyByZWR1bmRhbnQgUGFkZGluZyBmcm9tIHRoZSBNYXRlcmlhbERlc2lnbk91dGxpbmVkQ2FyZCBzdHlsZSB0byBwcmV2ZW50IHRoZSBwcm9wZXJ0eSBmcm9tIGJlaW5nIGFwcGxpZWQgdHdpY2UuIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiUmVkdW5kYW50IFBhZGRpbmcgVGVtcGxhdGVCaW5kaW5nIHJlbW92YWwiLCJkZXNjcmlwdGlvbiI6IlRoZSBQYWRkaW5nIGFzc2lnbm1lbnQgaXMgcmVtb3ZlZCBmcm9tIHRoZSBpbm5lciBDb250ZW50UHJlc2VudGVyIHdpdGhpbiB0aGUgTWF0ZXJpYWxEZXNpZ25PdXRsaW5lZENhcmQgdGVtcGxhdGUsIGFzIHRoZSBwYXJlbnQgQm9yZGVyIGFscmVhZHkgYXBwbGllcyB0aGUgc2FtZSBUZW1wbGF0ZUJpbmRpbmcsIHdoaWNoIHByZXZpb3VzbHkgY2F1c2VkIHRoZSBwYWRkaW5nIHZhbHVlIHRvIGJlIGRvdWJsZWQuIiwic2V2ZXJpdHkiOiJtZWRpdW0iLCJmaWxlUGF0aCI6Ik1hdGVyaWFsRGVzaWduVGhlbWVzLldwZi9UaGVtZXMvTWF0ZXJpYWxEZXNpZ25UaGVtZS5DYXJkLnhhbWwiLCJsaW5lU3RhcnQiOjF9XSwiaXNzdWVzIjpbeyJ0aXRsZSI6IlB1bGwgcmVxdWVzdCBjb250YWlucyBubyBmaWxlIGNoYW5nZXMiLCJkZXNjcmlwdGlvbiI6IlRoZSBQUiBtZXRhZGF0YSByZXBvcnRzIDAgZmlsZXMgY2hhbmdlZCBhbmQgdGhlIGRpZmYgaXMgZW1wdHksIGluZGljYXRpbmcgdGhhdCB0aGUgZml4IGRlc2NyaWJlZCBpbiB0aGUgUFIgdGl0bGUgYW5kIGRlc2NyaXB0aW9uIGhhcyBub3QgYmVlbiBwcm9wZXJseSBjb21taXR0ZWQgb3Igc3RhZ2VkLiIsInNldmVyaXR5IjoiaGlnaCIsImZpbGVQYXRoIjoiTWF0ZXJpYWxEZXNpZ25UaGVtZXMuV3BmL1RoZW1lcy9NYXRlcmlhbERlc2lnblRoZW1lLkNhcmQueGFtbCIsImxpbmVTdGFydCI6MX1dLCJzdWdnZXN0aW9ucyI6W10sInNlY3VyaXR5IjpbXX0= -->
<!-- gk-ai-analysis-end:d277095f8ef397c5461c1c889cbf204cac64fcf1 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/MaterialDesignInXAML/MaterialDesignInXamlToolkit/pull/4009">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->