### PR TITLE
Followup fix for ScrollViewerAssist PR

### DIFF
--- a/src/MaterialDesignThemes.Wpf/ScrollViewerAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/ScrollViewerAssist.cs
@@ -306,11 +306,13 @@ public static class ScrollViewerAssist
         }
 
         // This relay is only needed because the UIElement.AddHandler() has strict requirements for the signature of the passed Delegate
-        static void ScrollViewerOnMouseWheel(object? sender, RoutedEventArgs e) => HandleMouseWheel(sender, (MouseWheelEventArgs)e);
+        static void ScrollViewerOnMouseWheel(object sender, RoutedEventArgs e) => HandleMouseWheel(sender, (MouseWheelEventArgs)e);
 
-        static void HandleMouseWheel(object? sender, MouseWheelEventArgs e)
+        static void HandleMouseWheel(object sender, MouseWheelEventArgs e)
         {
-            if (sender is not ScrollViewer sv || sv.GetVisualAncestry().Skip(1).FirstOrDefault() is not UIElement parentUiElement)
+            var scrollViewer = (ScrollViewer)sender;
+
+            if (scrollViewer.GetVisualAncestry().Skip(1).FirstOrDefault() is not UIElement parentUiElement)
                 return;
 
             // Re-raise the mouse wheel event on the visual parent to bubble it upwards


### PR DESCRIPTION
Fixes #3439 

The last PR (#4015) only partially fixed the issue, and actually introduced another issue. So this PR reverts the changes done in that PR, and adds what I hope to be a proper fix. It covers 2 "features": HorizontalScroll (in the `TabControl` headers with mouse tilt), and BubbleVerticalScroll (e.g. in the `TabControl` header to bubble the scroll event when the capturing `ScrollViewer` "does not need it").

The attached property (2 of them, one for each feature) is needed to hold on to the hook instance for the scenario where we unregister the hook in the `Unloaded` event (where we don't have access to the local function).

The PR also encapsulates the event registrations/deregistrations into methods simply to have a better overview of when things are registered/unregistered, and to have a centralized way of avoiding double registrations (I believe the `Loaded`/`Unloaded` are prone to asymmetry).