### PR TITLE
fix(snackbar): Change type of CornerRadius-Property from Thickness to CornerRadius

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Snackbar.cs
+++ b/src/MaterialDesignThemes.Wpf/Snackbar.cs
@@ -189,13 +189,13 @@ public class Snackbar : Control
     }
 
     public static readonly DependencyProperty CornerRadiusProperty = DependencyProperty.Register(
-        nameof(CornerRadius), typeof(Thickness), typeof(Snackbar), new PropertyMetadata(new Thickness(0)));
+        nameof(CornerRadius), typeof(CornerRadius), typeof(Snackbar), new PropertyMetadata(new CornerRadius(3)));
 
     [Bindable(true)]
     [Category("Appearance")]
-    public Thickness CornerRadius
+    public CornerRadius CornerRadius
     {
-        get => (Thickness)GetValue(CornerRadiusProperty);
+        get => (CornerRadius)GetValue(CornerRadiusProperty);
         set => SetValue(CornerRadiusProperty, value);
     }
 }


### PR DESCRIPTION
fixes #4018 

the `Snackbar.CornerRadius` property is wrongfully of type `Thickness` instead of `CornerRadius`