### PR TITLE
Use Service Account PAT for checkout in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,6 +275,8 @@ jobs:
     steps:
       # Checkout is needed so that we can update the get_versions.yml file
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.SA_PAT }}
 
       - name: Increment Version Numbers
         run: |


### PR DESCRIPTION
The checkout step now uses a Personal Access Token (SA_PAT) to ensure the workflow has the necessary permissions to commit and push changes back to the repository, specifically for updating get_versions.yml.
