### PR TITLE
Postpone DialogHost.Show() task completion until closing dialog animation has completed

### DIFF
--- a/MaterialDesignToolkit.Full.slnx
+++ b/MaterialDesignToolkit.Full.slnx
@@ -6,6 +6,7 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/Demos/">
+    <Project Path="src/Issue4017/Issue4017.csproj" />
     <Project Path="src/MahMaterialDragablzMashUp/MahAppsDragablzDemo.csproj" />
     <Project Path="src/MainDemo.Wpf/MaterialDesignDemo.csproj" />
     <Project Path="src/MaterialDesign3.Demo.Wpf/MaterialDesign3Demo.csproj" />

--- a/src/Issue4017/App.xaml
+++ b/src/Issue4017/App.xaml
@@ -1,0 +1,18 @@
+﻿<Application x:Class="Issue4017.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Issue4017"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             StartupUri="MainWindow.xaml">
+  <Application.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <materialDesign:BundledTheme BaseTheme="Light"
+                               ColorAdjustment="{materialDesign:ColorAdjustment}"
+                               PrimaryColor="DeepPurple"
+                               SecondaryColor="Lime" />
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign2.Defaults.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Application.Resources>
+</Application>

--- a/src/Issue4017/App.xaml.cs
+++ b/src/Issue4017/App.xaml.cs
@@ -1,0 +1,6 @@
+﻿namespace Issue4017
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/src/Issue4017/AssemblyInfo.cs
+++ b/src/Issue4017/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/src/Issue4017/Issue4017.csproj
+++ b/src/Issue4017/Issue4017.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MaterialDesignThemes.Wpf\MaterialDesignThemes.Wpf.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Issue4017/MainWindow.xaml
+++ b/src/Issue4017/MainWindow.xaml
@@ -1,0 +1,25 @@
+﻿<Window x:Class="Issue4017.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        xmlns:local="clr-namespace:Issue4017"
+        mc:Ignorable="d"
+        Style="{StaticResource MaterialDesignWindow}"
+        Title="MainWindow" Height="450" Width="800">
+  <materialDesign:DialogHost Style="{StaticResource MaterialDesignEmbeddedDialogHost}">
+    <materialDesign:DialogHost.DialogContent>
+      <StackPanel Margin="40">
+        <TextBlock Text="This is a dialog" Style="{StaticResource MaterialDesignHeadline6TextBlock}" />
+        <Button Margin="0,20,0,0" Content="Close" Click="CloseDialog_Click" />
+      </StackPanel>
+    </materialDesign:DialogHost.DialogContent>
+    <Grid>
+      <StackPanel VerticalAlignment="Bottom">
+        <ProgressBar Style="{StaticResource MaterialDesignCircularProgressBar}" IsIndeterminate="True" Margin="0,0,0,10" />
+        <Button VerticalAlignment="Bottom" HorizontalAlignment="Center" Content="Open Dialog" Click="OpenDialog_Click" />
+      </StackPanel>
+    </Grid>
+  </materialDesign:DialogHost>
+</Window>

--- a/src/Issue4017/MainWindow.xaml.cs
+++ b/src/Issue4017/MainWindow.xaml.cs
@@ -1,0 +1,23 @@
+﻿using MaterialDesignThemes.Wpf;
+
+namespace Issue4017
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+
+        private async void OpenDialog_Click(object sender, RoutedEventArgs e)
+        {
+            await DialogHostEx.ShowDialog(this, null!);
+            Task.Delay(5000).Wait();    // Block UI thread (i.e. spinner stops spinning)
+        }
+
+        private void CloseDialog_Click(object sender, RoutedEventArgs e)
+        {
+            DialogHost.Close(null);
+        }
+    }
+}

--- a/src/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/src/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -358,7 +358,14 @@ public class DialogHost : ContentControl
             }
 
             //NB: _dialogTaskCompletionSource is only set in the case where the dialog is shown with Show
-            dialogHost._dialogTaskCompletionSource?.TrySetResult(closeParameter);
+            if (dialogHost._dialogTaskCompletionSource is { } taskCompletionSource)
+            {
+                Task.Run(async () =>
+                {
+                    await Task.Delay(400);  // Wait for the closing animation to finish before completing the DialogHost.Show() task.
+                    taskCompletionSource.TrySetResult(closeParameter);
+                });
+            }
 
             // Don't attempt to Invoke if _restoreFocusDialogClose hasn't been assigned yet. Can occur
             // if the MainWindow has started up minimized. Even when Show() has been called, this doesn't


### PR DESCRIPTION
Fixes #4017 

As mentioned in the issue, the `Task` returned by `DialogHost.Show()` completes BEFORE the closing animation has completed. This can result in the dialog "being stuck" on screen in case the UI thread is being used for other work immediately after the `await DialogHost.Show()` call.

This PR attempts to handle this very specific case by simply postponing the task completion with 400ms which ensures the closing animation has completed. To see the issue reproduced, you can simply revert the last commit on the branch.

Currently only creating this as a draft, because I am not sure I like this solution to the problem. But on the other hand I struggle to see any straight-forward alternatives. @Keboo if you have some input, it would be very much appreciated.

Like the OP, I have also had to add a custom delay in some cases after my dialog closes, just to be sure the dialog has disappeared off screen before I do other work.

UPDATE: There is a test failing, which is definitely related. The test attempts to access `dialogHost.IsOpen` after the the dialog closes, and now the test is on a different thread which doesn't own the `dialogHost`. Perhaps this can be mitigated using `STAThreadExecutor`, but it points to something being wrong in my implementation IMO.

Lastly, before this can be merged (if we get to that point), the sample project reproducing the issue needs to be removed again.