### PR TITLE
Fix TextBoxLineCountBehavior memory leak

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
+++ b/src/MaterialDesignThemes.Wpf/Behaviors/TextBoxLineCountBehavior.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Threading;
+﻿using System.Threading;
+using System.Windows.Threading;
 using Microsoft.Xaml.Behaviors;
 
 namespace MaterialDesignThemes.Wpf.Behaviors;
@@ -11,18 +12,22 @@ public class TextBoxLineCountBehavior : Behavior<TextBox>
     private void AssociatedObjectOnTextChanged(object sender, TextChangedEventArgs e) => UpdateAttachedProperties();
     private void AssociatedObjectOnLayoutUpdated(object? sender, EventArgs e) => UpdateAttachedProperties();
 
+    private int _uiUpdateInProgress = 0;
+
     private void UpdateAttachedProperties()
     {
-        if (AssociatedObject is { } associatedObject)
+        if (AssociatedObject is { } associatedObject &&
+            Interlocked.CompareExchange(ref _uiUpdateInProgress, 1, 0) == 0)
         {
             associatedObject.Dispatcher
-                .BeginInvoke(() =>
-                {
-                    int lineCount = associatedObject.LineCount;
-                    associatedObject.SetCurrentValue(TextFieldAssist.TextBoxLineCountProperty, lineCount);
-                    associatedObject.SetCurrentValue(TextFieldAssist.TextBoxIsMultiLineProperty, lineCount > 1);
-                },
-                DispatcherPriority.Background);
+            .BeginInvoke(() =>
+            {
+                int lineCount = associatedObject.LineCount;
+                associatedObject.SetCurrentValue(TextFieldAssist.TextBoxLineCountProperty, lineCount);
+                associatedObject.SetCurrentValue(TextFieldAssist.TextBoxIsMultiLineProperty, lineCount > 1);
+                Interlocked.CompareExchange(ref _uiUpdateInProgress, 0, 1);
+            },
+            DispatcherPriority.Background);
         }
     }
 
@@ -35,10 +40,10 @@ public class TextBoxLineCountBehavior : Behavior<TextBox>
 
     protected override void OnDetaching()
     {
-        if (AssociatedObject != null)
+        if (AssociatedObject is { } associatedObject)
         {
-            AssociatedObject.TextChanged -= AssociatedObjectOnTextChanged;
-            AssociatedObject.LayoutUpdated -= AssociatedObjectOnLayoutUpdated;
+            associatedObject.TextChanged -= AssociatedObjectOnTextChanged;
+            associatedObject.LayoutUpdated -= AssociatedObjectOnLayoutUpdated;
         }
         base.OnDetaching();
     }


### PR DESCRIPTION
Fixes #4003 

This PR fixes (or at least drastically improves) the memory leak mentioned in the issue. Basically, the code was blindly queuing new updates of the attached property on every layout update. When resizing a window or doing something else causing a lot of layout events, this would "congest" the message pump with essentially the same lambda.

This PR introduces a flag `_uiUpdateInProgress` which is set once an update is being queued, and cleared once an update has finished. If a layout change happens in between, it is simply ignored.

The below shows the memory usage captured in the Visual Studio diagnostics tools before/after the fix. The reproduction step was to open the app (from the linked issue), and repeatedly resize the window.

Memory usage before the fix (continuous growth, insane number of GC calls, no drop-down to "normal" after resizing finishes):
<img width="1060" height="152" alt="image" src="https://github.com/user-attachments/assets/067b2b64-a2a3-4e41-a9d7-d19c50168a05" />

Memory usage after the fix (still growth which is expected, much fewer GC calls, and a drop-down to "normal" after resizing finishes):
<img width="1066" height="154" alt="image" src="https://github.com/user-attachments/assets/0b173015-1698-4bac-a4de-6e11a09edb57" />
