### PR TITLE
Fix ToolBar overflow button background not inheriting from ToolBar

### DIFF
--- a/src/MainDemo.Wpf/MenusAndToolBars.xaml
+++ b/src/MainDemo.Wpf/MenusAndToolBars.xaml
@@ -380,7 +380,7 @@
 
     <smtx:XamlDisplay Margin="0,16,0,16" UniqueKey="menus_toolbar_custom_bg">
       <ToolBarTray>
-        <ToolBar Background="{DynamicResource MaterialDesign.Brush.Primary.Dark}"
+        <ToolBar Background="{DynamicResource MaterialDesign.Brush.Primary}"
                  ClipToBounds="False"
                  Style="{StaticResource MaterialDesignToolBar}">
           <Button Content="{materialDesign:PackIcon Kind=ContentSave}" ToolTip="Save" />

--- a/src/MainDemo.Wpf/MenusAndToolBars.xaml
+++ b/src/MainDemo.Wpf/MenusAndToolBars.xaml
@@ -378,6 +378,22 @@
       </ToolBarTray>
     </smtx:XamlDisplay>
 
+    <smtx:XamlDisplay Margin="0,16,0,16" UniqueKey="menus_toolbar_custom_bg">
+      <ToolBarTray>
+        <ToolBar Background="{DynamicResource MaterialDesign.Brush.Primary.Dark}"
+                 ClipToBounds="False"
+                 Style="{StaticResource MaterialDesignToolBar}">
+          <Button Content="{materialDesign:PackIcon Kind=ContentSave}" ToolTip="Save" />
+          <Button Content="{materialDesign:PackIcon Kind=ContentCut}" ToolTip="Cut" />
+          <Button Content="{materialDesign:PackIcon Kind=ContentCopy}" ToolTip="Copy" />
+          <Button Content="{materialDesign:PackIcon Kind=ContentPaste}" ToolTip="Paste" />
+          <Button Content="{materialDesign:PackIcon Kind=FormatBold}" ToolBar.OverflowMode="Always" />
+          <Button Content="{materialDesign:PackIcon Kind=FormatItalic}" ToolBar.OverflowMode="Always" />
+          <Button Content="{materialDesign:PackIcon Kind=FormatUnderline}" ToolBar.OverflowMode="Always" />
+        </ToolBar>
+      </ToolBarTray>
+    </smtx:XamlDisplay>
+
     <Rectangle Style="{StaticResource PageSectionSeparator}" />
     <TextBlock Style="{StaticResource PageSectionTitleTextBlock}" Text="Context Menus" />
 

--- a/src/MaterialDesign3.Demo.Wpf/MenusAndToolBars.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/MenusAndToolBars.xaml
@@ -346,6 +346,24 @@
       </ToolBarTray>
     </smtx:XamlDisplay>
 
+    <smtx:XamlDisplay Margin="5,16,0,16"
+                      DockPanel.Dock="Top"
+                      UniqueKey="menus_toolbar_custom_bg">
+      <ToolBarTray>
+        <ToolBar Background="{DynamicResource MaterialDesign.Brush.Primary.Dark}"
+                 ClipToBounds="False"
+                 Style="{StaticResource MaterialDesignToolBar}">
+          <Button Content="{materialDesign:PackIcon Kind=ContentSave}" ToolTip="Save" />
+          <Button Content="{materialDesign:PackIcon Kind=ContentCut}" ToolTip="Cut" />
+          <Button Content="{materialDesign:PackIcon Kind=ContentCopy}" ToolTip="Copy" />
+          <Button Content="{materialDesign:PackIcon Kind=ContentPaste}" ToolTip="Paste" />
+          <Button Content="{materialDesign:PackIcon Kind=FormatBold}" ToolBar.OverflowMode="Always" />
+          <Button Content="{materialDesign:PackIcon Kind=FormatItalic}" ToolBar.OverflowMode="Always" />
+          <Button Content="{materialDesign:PackIcon Kind=FormatUnderline}" ToolBar.OverflowMode="Always" />
+        </ToolBar>
+      </ToolBarTray>
+    </smtx:XamlDisplay>
+
     <Rectangle Style="{StaticResource PageSectionSeparator}" />
     <TextBlock Style="{StaticResource PageSectionTitleTextBlock}" Text="Context Menus" />
 

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBar.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBar.xaml
@@ -17,7 +17,7 @@
   </ResourceDictionary.MergedDictionaries>
 
   <Style x:Key="MaterialDesignToolBarVerticalOverflowButtonStyle" TargetType="{x:Type ToggleButton}">
-    <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.ToolBar.Background}" />
+    <Setter Property="Background" Value="{Binding Background, RelativeSource={RelativeSource AncestorType=ToolBar}}" />
     <Setter Property="MinHeight" Value="0" />
     <Setter Property="MinWidth" Value="0" />
     <Setter Property="Template">
@@ -55,7 +55,7 @@
   </Style>
 
   <Style x:Key="MaterialDesignToolBarHorizontalOverflowButtonStyle" TargetType="{x:Type ToggleButton}">
-    <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.ToolBar.Background}" />
+    <Setter Property="Background" Value="{Binding Background, RelativeSource={RelativeSource AncestorType=ToolBar}}" />
     <Setter Property="MinHeight" Value="0" />
     <Setter Property="MinWidth" Value="0" />
     <Setter Property="Template">
@@ -187,7 +187,7 @@
                      CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
                 <Border x:Name="ToolBarSubMenuBorder"
                         Margin="1"
-                        Background="{DynamicResource MaterialDesign.Brush.ToolBar.Background}"
+                        Background="{TemplateBinding Background}"
                         BorderBrush="{DynamicResource MaterialDesign.Brush.ToolBar.Overflow.Border}"
                         BorderThickness="1"
                         CornerRadius="2"
@@ -246,7 +246,6 @@
               <Setter TargetName="ToolBarSubMenuBorder" Property="Margin" Value="5,5,5,5" />
             </Trigger>
             <Trigger Property="Orientation" Value="Vertical">
-              <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.ToolBar.Background}" />
               <Setter TargetName="Grid" Property="Margin" Value="1,3,1,1" />
               <Setter TargetName="MainPanelBorder" Property="Margin" Value="0,0,0,11" />
               <Setter TargetName="OverflowButton" Property="Style" Value="{StaticResource MaterialDesignToolBarVerticalOverflowButtonStyle}" />

--- a/tests/MaterialDesignThemes.UITests/WPF/ToolBars/ToolBarTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/ToolBars/ToolBarTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Windows.Media;
 
 
 namespace MaterialDesignThemes.UITests.WPF.ToolBars;
@@ -27,6 +28,30 @@ public class ToolBarTests : TestBase
 
         //Assert
         await Assert.That(dock).IsEqualTo(expectedOverflowGridDock);
+
+        recorder.Success();
+    }
+
+    [Description("Issue 3694")]
+    [Test]
+    public async Task ToolBar_OverflowButton_InheritsCustomBackground()
+    {
+        await using var recorder = new TestRecorder(App);
+
+        //Arrange
+        var toolBarTray = await LoadXaml<ToolBarTray>(@"
+<ToolBarTray DockPanel.Dock=""Top"">
+  <ToolBar Style=""{StaticResource MaterialDesignToolBar}"" Background=""Fuchsia"" OverflowMode=""Always"">
+    <Button Content=""{materialDesign:PackIcon Kind=File}""/>
+  </ToolBar>
+</ToolBarTray>");
+        var overflowButton = await toolBarTray.GetElement<ToggleButton>("OverflowButton");
+
+        //Act
+        Color? overflowBackground = await overflowButton.GetBackgroundColor();
+
+        //Assert
+        await Assert.That(overflowBackground).IsEqualTo(Colors.Fuchsia);
 
         recorder.Success();
     }


### PR DESCRIPTION
## Summary

Fixes #3694

When a user sets a custom `Background` on a `ToolBar`, the overflow button (the "..." toggle button that appears when items overflow) did not inherit that background — it stayed hardcoded to `MaterialDesign.Brush.ToolBar.Background`, creating a visual mismatch.

## Changes

**`MaterialDesignTheme.ToolBar.xaml`:**
- Both `MaterialDesignToolBarVerticalOverflowButtonStyle` and `MaterialDesignToolBarHorizontalOverflowButtonStyle` now bind their `Background` to the ancestor `ToolBar`'s `Background` using a `RelativeSource` binding instead of hardcoding the theme resource
- The overflow popup border (`ToolBarSubMenuBorder`) now uses `TemplateBinding Background` to inherit the ToolBar's background
- Removed the redundant `Background` setter in the vertical orientation trigger that was resetting to the static resource

**`ToolBarTests.cs`:**
- Added a UI test (`ToolBar_OverflowButton_InheritsCustomBackground`) that verifies the overflow button inherits a custom background set on the ToolBar

## Default behavior preserved

When no custom `Background` is set, the ToolBar's own `Background` defaults to `MaterialDesign.Brush.ToolBar.Background`, so the overflow button inherits the same value as before — no visual change for existing users.

The `HighContrast` DataTrigger on both overflow button styles still overrides the background when high contrast mode is active.