### PR TITLE
fix(SplitButton): apply correct CornerRadius to hover-border in SplitButton

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SplitButton.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SplitButton.xaml
@@ -75,6 +75,7 @@
                           Grid.Column="1"
                           wpf:RippleAssist.IsDisabled="True"
                           Height="{TemplateBinding Height}"
+                          wpf:ButtonAssist.CornerRadius="{TemplateBinding wpf:ButtonAssist.CornerRadius, Converter={StaticResource RightButtonCornerRadiusConverter}}"
                           Padding="0"
                           Margin="0"
                           PopupUniformCornerRadius="{TemplateBinding PopupUniformCornerRadius}"


### PR DESCRIPTION
fixes #4043 

`ButtonAssist.CornerRadius` wasn’t set on the PopupBox, although the button style inside it depends on it.

<img width="211" height="117" alt="image" src="https://github.com/user-attachments/assets/a86d63b2-2ff2-4c92-870a-37e05f181964" />
