### PR TITLE
Introduce BindingProxy to mitigate temporary XAML binding failures

### DIFF
--- a/src/MaterialDesignThemes.Wpf/BindingProxy.cs
+++ b/src/MaterialDesignThemes.Wpf/BindingProxy.cs
@@ -1,0 +1,15 @@
+﻿namespace MaterialDesignThemes.Wpf;
+
+public class BindingProxy : Freezable
+{
+    protected override Freezable CreateInstanceCore() => new BindingProxy();
+
+    public static readonly DependencyProperty DataProperty =
+        DependencyProperty.Register(nameof(Data), typeof(object), typeof(BindingProxy), new PropertyMetadata(null));
+
+    public object? Data
+    {
+        get => GetValue(DataProperty);
+        set => SetValue(DataProperty, value);
+    }
+}

--- a/src/MaterialDesignThemes.Wpf/Internal/BindingProxy.cs
+++ b/src/MaterialDesignThemes.Wpf/Internal/BindingProxy.cs
@@ -1,6 +1,6 @@
-﻿namespace MaterialDesignThemes.Wpf;
+﻿namespace MaterialDesignThemes.Wpf.Internal;
 
-public class BindingProxy : Freezable
+public sealed class BindingProxy : Freezable
 {
     protected override Freezable CreateInstanceCore() => new BindingProxy();
 

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:circularProgressBarConverters="clr-namespace:MaterialDesignThemes.Wpf.Converters.CircularProgressBar"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
+                    xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal"
                     xmlns:transitions="clr-namespace:MaterialDesignThemes.Wpf.Transitions"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
@@ -174,7 +175,7 @@
             <Grid x:Name="PathGrid" Margin="2" />
             <Canvas>
               <Canvas.Resources>
-                <wpf:BindingProxy x:Key="PathGridProxy" Data="{Binding ElementName=PathGrid}" />
+                <internal:BindingProxy x:Key="PathGridProxy" Data="{Binding ElementName=PathGrid}" />
               </Canvas.Resources>
               <Ellipse Width="{TemplateBinding Width}"
                        Height="{TemplateBinding Height}"

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
@@ -173,6 +173,9 @@
             </Grid>
             <Grid x:Name="PathGrid" Margin="2" />
             <Canvas>
+              <Canvas.Resources>
+                <wpf:BindingProxy x:Key="PathGridProxy" Data="{Binding ElementName=PathGrid}" />
+              </Canvas.Resources>
               <Ellipse Width="{TemplateBinding Width}"
                        Height="{TemplateBinding Height}"
                        Fill="{TemplateBinding Background}" />
@@ -184,11 +187,11 @@
                     StrokeThickness="3">
                 <Path.Data>
                   <PathGeometry>
-                    <PathFigure StartPoint="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:StartPointConverter.Instance}, Mode=OneWay}">
-                      <ArcSegment Size="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:ArcSizeConverter.Instance}, Mode=OneWay}" SweepDirection="Clockwise">
+                    <PathFigure StartPoint="{Binding Source={StaticResource PathGridProxy}, Path=Data.ActualWidth, Converter={x:Static circularProgressBarConverters:StartPointConverter.Instance}, Mode=OneWay}">
+                      <ArcSegment Size="{Binding Source={StaticResource PathGridProxy}, Path=Data.ActualWidth, Converter={x:Static circularProgressBarConverters:ArcSizeConverter.Instance}, Mode=OneWay}" SweepDirection="Clockwise">
                         <ArcSegment.Point>
                           <MultiBinding Converter="{x:Static circularProgressBarConverters:ArcEndPointConverter.Instance}" ConverterParameter="{x:Static circularProgressBarConverters:ArcEndPointConverter.ParameterMidPoint}">
-                            <Binding ElementName="PathGrid" Path="ActualWidth" />
+                            <Binding Source="{StaticResource PathGridProxy}" Path="Data.ActualWidth" />
                             <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                             <Binding Path="Minimum" RelativeSource="{RelativeSource TemplatedParent}" />
                             <Binding Path="Maximum" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -196,10 +199,10 @@
                           </MultiBinding>
                         </ArcSegment.Point>
                       </ArcSegment>
-                      <ArcSegment Size="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:ArcSizeConverter.Instance}, Mode=OneWay}" SweepDirection="Clockwise">
+                      <ArcSegment Size="{Binding Source={StaticResource PathGridProxy}, Path=Data.ActualWidth, Converter={x:Static circularProgressBarConverters:ArcSizeConverter.Instance}, Mode=OneWay}" SweepDirection="Clockwise">
                         <ArcSegment.Point>
                           <MultiBinding Converter="{x:Static circularProgressBarConverters:ArcEndPointConverter.Instance}">
-                            <Binding ElementName="PathGrid" Path="ActualWidth" />
+                            <Binding Source="{StaticResource PathGridProxy}" Path="Data.ActualWidth" />
                             <Binding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
                             <Binding Path="Minimum" RelativeSource="{RelativeSource TemplatedParent}" />
                             <Binding Path="Maximum" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -212,7 +215,7 @@
                 </Path.Data>
                 <Path.RenderTransform>
                   <TransformGroup>
-                    <RotateTransform x:Name="RotateTransform" CenterX="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:RotateTransformCentreConverter.Instance}, Mode=OneWay}" CenterY="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={x:Static circularProgressBarConverters:RotateTransformCentreConverter.Instance}, Mode=OneWay}" />
+                    <RotateTransform x:Name="RotateTransform" CenterX="{Binding Source={StaticResource PathGridProxy}, Path=Data.ActualWidth, Converter={x:Static circularProgressBarConverters:RotateTransformCentreConverter.Instance}, Mode=OneWay}" CenterY="{Binding Source={StaticResource PathGridProxy}, Path=Data.ActualWidth, Converter={x:Static circularProgressBarConverters:RotateTransformCentreConverter.Instance}, Mode=OneWay}" />
                   </TransformGroup>
                 </Path.RenderTransform>
               </Path>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
@@ -267,10 +267,13 @@
               IsHitTestVisible="False"
               RenderTransformOrigin="0.5,1"
               Visibility="Collapsed">
+          <Grid.Resources>
+            <wpf:BindingProxy x:Key="labelProxy" Data="{Binding ElementName=label}" />
+          </Grid.Resources>
           <Grid.RenderTransform>
             <TransformGroup>
               <ScaleTransform ScaleX="0" ScaleY="0" />
-              <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={x:Static convertersInternal:SliderValueLabelPositionConverter.Instance}, ConverterParameter={x:Static Orientation.Horizontal}}" Y="-40" />
+              <TranslateTransform X="{Binding Data.ActualWidth, Source={StaticResource labelProxy}, Converter={x:Static convertersInternal:SliderValueLabelPositionConverter.Instance}, ConverterParameter={x:Static Orientation.Horizontal}}" Y="-40" />
             </TransformGroup>
           </Grid.RenderTransform>
           <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
@@ -479,10 +482,13 @@
               IsHitTestVisible="False"
               RenderTransformOrigin="1,0.5"
               Visibility="Collapsed">
+          <Grid.Resources>
+            <wpf:BindingProxy x:Key="labelProxy" Data="{Binding ElementName=label}" />
+          </Grid.Resources>
           <Grid.RenderTransform>
             <TransformGroup>
               <ScaleTransform ScaleX="0" ScaleY="0" />
-              <TranslateTransform X="{Binding ActualWidth, ElementName=label, Converter={x:Static convertersInternal:SliderValueLabelPositionConverter.Instance}, ConverterParameter={x:Static Orientation.Vertical}}" Y="-7" />
+              <TranslateTransform X="{Binding Data.ActualWidth, Source={StaticResource labelProxy}, Converter={x:Static convertersInternal:SliderValueLabelPositionConverter.Instance}, ConverterParameter={x:Static Orientation.Vertical}}" Y="-7" />
             </TransformGroup>
           </Grid.RenderTransform>
           <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Slider.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:convertersInternal="clr-namespace:MaterialDesignThemes.Wpf.Converters.Internal"
+                    xmlns:internal="clr-namespace:MaterialDesignThemes.Wpf.Internal"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
   <ResourceDictionary.MergedDictionaries>
@@ -268,7 +269,7 @@
               RenderTransformOrigin="0.5,1"
               Visibility="Collapsed">
           <Grid.Resources>
-            <wpf:BindingProxy x:Key="labelProxy" Data="{Binding ElementName=label}" />
+            <internal:BindingProxy x:Key="labelProxy" Data="{Binding ElementName=label}" />
           </Grid.Resources>
           <Grid.RenderTransform>
             <TransformGroup>
@@ -483,7 +484,7 @@
               RenderTransformOrigin="1,0.5"
               Visibility="Collapsed">
           <Grid.Resources>
-            <wpf:BindingProxy x:Key="labelProxy" Data="{Binding ElementName=label}" />
+            <internal:BindingProxy x:Key="labelProxy" Data="{Binding ElementName=label}" />
           </Grid.Resources>
           <Grid.RenderTransform>
             <TransformGroup>


### PR DESCRIPTION
Fixes #3814 

Introduces a `BindingProxy` to mitigate the temporary binding failures occurring when bindings are used to reference something not in the current visual tree.

The issue was easily reproducible. I also went through the pages of the demo app (just opening them) to spot any immediate XAML binding failures. There were 2 apart from the `ProgressBar`:
* Slider (fixed, also using `BindingProxy`)
* Tree (not fixed, this seems to be a different issue)
<img width="1221" height="40" alt="image" src="https://github.com/user-attachments/assets/42173e8c-1561-46ab-9af9-47c8cc260015" />
