### PR TITLE
Position popups below input fields

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -121,7 +121,7 @@
             <Popup x:Name="PART_Popup"
                    AllowsTransparency="True"
                    CustomPopupPlacementCallback="{x:Static wpf:CustomPopupPlacementCallbackHelper.LargePopupCallback}"
-                   Placement="Custom"
+                   Placement="Bottom"
                    PlacementTarget="{Binding ElementName=PART_TextBox}"
                    PopupAnimation="Fade"
                    StaysOpen="False" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -133,7 +133,7 @@
             <Popup x:Name="PART_Popup"
                    AllowsTransparency="True"
                    CustomPopupPlacementCallback="{x:Static wpf:CustomPopupPlacementCallbackHelper.LargePopupCallback}"
-                   Placement="Custom"
+                   Placement="Bottom"
                    PlacementTarget="{Binding ElementName=PART_TextBox}"
                    PopupAnimation="Fade"
                    StaysOpen="False" />


### PR DESCRIPTION
Is there any reason the `Placement` is set to `Custom` if it blocks visibility of the selected time/date?
<img width="219" height="172" alt="image" src="https://github.com/user-attachments/assets/96cf802e-c289-4cee-a42f-ec0db02b3664" />


MD2 specs:
<img width="1064" height="784" alt="image" src="https://github.com/user-attachments/assets/6beef756-4049-4577-a7b9-43453f67715d" />
