### PR TITLE
Fix nullability errors in UI tests

### DIFF
--- a/tests/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
@@ -235,9 +235,9 @@ public class DialogHostTests : TestBase
         await Wait.For(async () =>
         {
             Color? foreground1 = await textBlock1.GetForegroundColor();
-            await Assert.That(foreground1).IsNotNull();
+            Color foreground1Value = await Assert.That(foreground1).IsNotNull();
             await AssertContrastRatio(
-                foreground1.Value,
+                foreground1Value,
                 await textBlock1.GetEffectiveBackground(),
                 MinimumContrastSmallText);
         });
@@ -245,9 +245,9 @@ public class DialogHostTests : TestBase
         await Wait.For(async () =>
         {
             Color? foreground2 = await textBlock2.GetForegroundColor();
-            await Assert.That(foreground2).IsNotNull();
+            Color foreground2Value = await Assert.That(foreground2).IsNotNull();
             await AssertContrastRatio(
-                foreground2.Value,
+                foreground2Value,
                 await textBlock2.GetEffectiveBackground(),
                 MinimumContrastSmallText);
         });

--- a/tests/MaterialDesignThemes.UITests/WPF/TabControls/TabControlTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/TabControls/TabControlTests.cs
@@ -35,12 +35,12 @@ public class TabControlTests : TestBase
         Color? selectedTabUnderline = await selectedTabBorder.GetBorderBrushColor();
 
         //Assert
-        await Assert.That(foreground).IsNotNull();
-        await Assert.That(background).IsNotNull();
+        Color foregroundValue = await Assert.That(foreground).IsNotNull();
+        Color backgroundValue = await Assert.That(background).IsNotNull();
 
-        await MaterialDesignSpec.AssertContrastRatio(foreground.Value, background.Value, MaterialDesignSpec.MinimumContrastSmallText);
+        await MaterialDesignSpec.AssertContrastRatio(foregroundValue, backgroundValue, MaterialDesignSpec.MinimumContrastSmallText);
 
-        await Assert.That(selectedTabUnderline).IsEqualTo(foreground);
+        await Assert.That(selectedTabUnderline).IsEqualTo(foregroundValue);
 
         recorder.Success();
     }

--- a/tests/MaterialDesignThemes.UITests/WPF/Theme/ColorAdjustTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/Theme/ColorAdjustTests.cs
@@ -47,11 +47,13 @@ public class ColorAdjustTests : TestBase
 
             Color? smallTextForeground = await smallText.GetForegroundColor();
             Color smallTextBackground = await smallText.GetEffectiveBackground();
+            Color largeTextForegroundValue = await Assert.That(largeTextForeground).IsNotNull();
+            Color smallTextForegroundValue = await Assert.That(smallTextForeground).IsNotNull();
 
-            double largeContrastRatio = ColorAssist.ContrastRatio(largeTextForeground.Value, largeTextBackground);
+            double largeContrastRatio = ColorAssist.ContrastRatio(largeTextForegroundValue, largeTextBackground);
             await Assert.That(largeContrastRatio).IsGreaterThanOrEqualTo(MaterialDesignSpec.MinimumContrastLargeText - tolerance)
                 .Because($"Large font contrast ratio '{largeContrastRatio}' does not meet material design spec {MaterialDesignSpec.MinimumContrastLargeText}");
-            double smallContrastRatio = ColorAssist.ContrastRatio(smallTextForeground.Value, smallTextBackground);
+            double smallContrastRatio = ColorAssist.ContrastRatio(smallTextForegroundValue, smallTextBackground);
             await Assert.That(smallContrastRatio).IsGreaterThanOrEqualTo(MaterialDesignSpec.MinimumContrastSmallText - tolerance).Because($"Small font contrast ratio '{smallContrastRatio}' does not meet material design spec {MaterialDesignSpec.MinimumContrastSmallText}");
         }
     }


### PR DESCRIPTION
## Why
The pipeline run against `master` surfaced `CS8629` nullability errors in UI tests where nullable `Color?` values were dereferenced via `.Value`.

## What changed
This updates the affected UI tests to use the non-null value returned by `await Assert.That(...).IsNotNull()` before contrast checks.

- `DialogHostTests`: use asserted non-null foreground values for both text blocks.
- `TabControlTests`: use asserted non-null foreground/background values in contrast and underline assertions.
- `ColorAdjustTests`: use asserted non-null foreground values in both contrast calculations.

## Notes
This keeps test behavior the same while satisfying nullable analysis and keeping assertion style consistent across the touched tests.