### PR TITLE
Support `CornerRadius` in `Clock` control

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
@@ -3,10 +3,7 @@
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
-  <converters:CornerRadiusCloneConverter x:Key="FixedBottomCornerRadiusConverter"
-                                         FixedBottomLeft="0"
-                                         FixedBottomRight="0" />
-
+  
   <Style x:Key="MaterialDesignClockItemThumb" TargetType="{x:Type Thumb}">
     <Setter Property="Template">
       <Setter.Value>
@@ -93,6 +90,11 @@
   </Style>
 
   <Style x:Key="MaterialDesignClock" TargetType="{x:Type wpf:Clock}">
+    <Style.Resources>
+      <converters:CornerRadiusCloneConverter x:Key="FixedBottomCornerRadiusConverter"
+                                             FixedBottomLeft="0"
+                                             FixedBottomRight="0" />
+    </Style.Resources>
     <Setter Property="Background" Value="{DynamicResource MaterialDesign.Brush.Background}" />
     <Setter Property="BorderThickness" Value="1" />
     <Setter Property="ButtonRadiusInnerRatio" Value=".6" />

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
@@ -3,6 +3,10 @@
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
+  <converters:CornerRadiusCloneConverter x:Key="FixedBottomCornerRadiusConverter"
+                                         FixedBottomLeft="2"
+                                         FixedBottomRight="2" />
+
   <Style x:Key="MaterialDesignClockItemThumb" TargetType="{x:Type Thumb}">
     <Setter Property="Template">
       <Setter.Value>
@@ -180,7 +184,7 @@
           <Border Background="{TemplateBinding Background}"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
-                  CornerRadius="2">
+                  CornerRadius="{TemplateBinding CornerRadius}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="DisplayModeStates">
                 <VisualStateGroup.Transitions>
@@ -621,7 +625,7 @@
               <Border Height="120"
                       Margin="0,0,0,12"
                       Background="{DynamicResource MaterialDesign.Brush.Primary}"
-                      CornerRadius="2 2 0 0"
+                      CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource FixedBottomCornerRadiusConverter}}"
                       Visibility="{TemplateBinding IsHeaderVisible, Converter={x:Static converters:BooleanToVisibilityConverter.CollapsedInstance}}">
                 <StackPanel x:Name="TimeReadoutStackPanel"
                             Margin="24"
@@ -940,7 +944,7 @@
           <Border Background="{TemplateBinding Background}"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
-                  CornerRadius="2">
+                  CornerRadius="{TemplateBinding CornerRadius}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="DisplayModeStates">
                 <VisualStateGroup.Transitions>
@@ -1762,7 +1766,7 @@
           <Border Background="{TemplateBinding Background}"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
-                  CornerRadius="2">
+                  CornerRadius="{TemplateBinding CornerRadius}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="DisplayModeStates">
                 <VisualStateGroup.Transitions>
@@ -2577,7 +2581,7 @@
           <Border Background="{TemplateBinding Background}"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
-                  CornerRadius="2">
+                  CornerRadius="{TemplateBinding CornerRadius}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="DisplayModeStates">
                 <VisualStateGroup.Transitions>
@@ -3398,7 +3402,7 @@
           <Border Background="{TemplateBinding Background}"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
-                  CornerRadius="2">
+                  CornerRadius="{TemplateBinding CornerRadius}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="DisplayModeStates">
                 <VisualStateGroup.Transitions>

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
@@ -97,6 +97,7 @@
     <Setter Property="BorderThickness" Value="1" />
     <Setter Property="ButtonRadiusInnerRatio" Value=".6" />
     <Setter Property="ButtonRadiusRatio" Value=".835" />
+    <Setter Property="CornerRadius" Value="2"/>
     <Setter Property="ButtonStyle">
       <Setter.Value>
         <Style TargetType="{x:Type wpf:ClockItemButton}">
@@ -859,6 +860,7 @@
     <Setter Property="BorderThickness" Value="1" />
     <Setter Property="ButtonRadiusInnerRatio" Value=".6" />
     <Setter Property="ButtonRadiusRatio" Value=".835" />
+    <Setter Property="CornerRadius" Value="2"/>
     <Setter Property="ButtonStyle">
       <Setter.Value>
         <Style TargetType="{x:Type wpf:ClockItemButton}">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Clock.xaml
@@ -4,8 +4,8 @@
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
 
   <converters:CornerRadiusCloneConverter x:Key="FixedBottomCornerRadiusConverter"
-                                         FixedBottomLeft="2"
-                                         FixedBottomRight="2" />
+                                         FixedBottomLeft="0"
+                                         FixedBottomRight="0" />
 
   <Style x:Key="MaterialDesignClockItemThumb" TargetType="{x:Type Thumb}">
     <Setter Property="Template">


### PR DESCRIPTION
The `Clock` exposes a `CornerRadius` property but does not actually use it in it's template.

The converter `FixedBottomCornerRadiusConverter` is there to apply the `CornerRadius` to only the top left & top right corners of the "header":
<img width="343" height="463" alt="image" src="https://github.com/user-attachments/assets/bfb74504-4147-462f-8528-340196b788aa" />
