### PR TITLE
Allow for additional content in NavigationRail-bar

### DIFF
--- a/src/MainDemo.Wpf/NavigationRail.xaml
+++ b/src/MainDemo.Wpf/NavigationRail.xaml
@@ -792,5 +792,61 @@
         </materialDesign:Card>
       </smtx:XamlDisplay>
     </StackPanel>
+
+    <Rectangle Style="{StaticResource PageSectionSeparator}" />
+
+    <TextBlock Style="{StaticResource PageSectionTitleTextBlock}" Text="Additional End Content" />
+
+    <smtx:XamlDisplay UniqueKey="navrail_additionalEndContent_1">
+      <materialDesign:Card>
+        <TabControl Height="400"
+                    materialDesign:NavigationRailAssist.ShowSelectionBackground="True"
+                    SnapsToDevicePixels="True"
+                    Style="{StaticResource MaterialDesignNavigationRailTabControl}"
+                    TabStripPlacement="Left">
+          <materialDesign:NavigationRailAssist.AdditionalEndContent>
+            <StackPanel>
+              <Button Margin="8"
+                      Background="{DynamicResource MaterialDesign.Brush.ToolBar.Background}"
+                      Content="{materialDesign:PackIcon Kind=Person}"
+                      Style="{StaticResource MaterialDesignIconButton}" />
+              <Button Margin="8"
+                      Content="{materialDesign:PackIcon Kind=Cog}"
+                      Style="{StaticResource MaterialDesignIconButton}" />
+            </StackPanel>
+          </materialDesign:NavigationRailAssist.AdditionalEndContent>
+          <TabItem>
+            <TabItem.Header>
+              <StackPanel Width="auto" Height="auto">
+                <materialDesign:PackIcon Width="24"
+                                         Height="24"
+                                         HorizontalAlignment="Center"
+                                         Kind="Folder" />
+                <TextBlock HorizontalAlignment="Center" Text="All Files" />
+              </StackPanel>
+            </TabItem.Header>
+            <TextBlock Margin="16"
+                       Style="{StaticResource MaterialDesignHeadline5TextBlock}"
+                       Text="All Files" />
+          </TabItem>
+
+          <TabItem>
+            <TabItem.Header>
+              <StackPanel Width="auto" Height="auto">
+                <materialDesign:PackIcon Width="24"
+                                         Height="24"
+                                         HorizontalAlignment="Center"
+                                         Kind="ClockOutline" />
+                <TextBlock HorizontalAlignment="Center" Text="Recent" />
+              </StackPanel>
+            </TabItem.Header>
+            <TextBlock Margin="16"
+                       Style="{StaticResource MaterialDesignHeadline5TextBlock}"
+                       Text="Recent" />
+          </TabItem>
+        </TabControl>
+      </materialDesign:Card>
+    </smtx:XamlDisplay>
+
   </StackPanel>
 </UserControl>

--- a/src/MaterialDesignThemes.Wpf/NavigationRailAssist.cs
+++ b/src/MaterialDesignThemes.Wpf/NavigationRailAssist.cs
@@ -2,7 +2,7 @@ namespace MaterialDesignThemes.Wpf;
 
 public static class NavigationRailAssist
 {
-    private static readonly CornerRadius DefaultCornerRadius = new CornerRadius(2.0);
+    private static readonly CornerRadius DefaultCornerRadius = new(2.0);
 
     #region CornerRadius
     /// <summary>
@@ -27,6 +27,13 @@ public static class NavigationRailAssist
     public static object GetFloatingContent(DependencyObject element) => (object)element.GetValue(FloatingContentProperty);
     public static void SetFloatingContent(DependencyObject element, object value) => element.SetValue(FloatingContentProperty, value);
 
+    #endregion
+
+    #region Property AdditionalEndContent
+    public static readonly DependencyProperty AdditionalEndContentProperty = DependencyProperty.RegisterAttached(
+        "AdditionalEndContent", typeof(object), typeof(NavigationRailAssist), new PropertyMetadata(null));
+    public static object GetAdditionalEndContent(DependencyObject obj) => (object)obj.GetValue(AdditionalEndContentProperty);
+    public static void SetAdditionalEndContent(DependencyObject obj, object value) => obj.SetValue(AdditionalEndContentProperty, value);
     #endregion
 
     #region Property ShowSelectionBackground

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -820,10 +820,12 @@
                   <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="1*" />
+                    <RowDefinition Height="Auto" />
                   </Grid.RowDefinitions>
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="1*" />
+                    <ColumnDefinition Width="Auto" />
                   </Grid.ColumnDefinitions>
                   <ContentPresenter x:Name="FloatingContentPanel"
                                     Grid.Row="0"
@@ -842,8 +844,16 @@
                                IsItemsHost="True"
                                Rows="0" />
 
+                  <ContentPresenter x:Name="AdditionalEndContentPresenter"
+                                    Grid.Row="2"
+                                    Grid.Column="0"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Bottom"
+                                    Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:NavigationRailAssist.AdditionalEndContent)}"
+                                    Focusable="False" />
+
                   <Rectangle x:Name="DividerRect"
-                             Grid.RowSpan="2"
+                             Grid.RowSpan="3"
                              Width="1"
                              Height="Auto"
                              HorizontalAlignment="Right"
@@ -881,7 +891,7 @@
             </Trigger>
             <Trigger Property="TabStripPlacement" Value="Top">
               <Setter Property="BorderThickness" Value="0,0,0,1" />
-              <Setter TargetName="DividerRect" Property="Grid.ColumnSpan" Value="2" />
+              <Setter TargetName="DividerRect" Property="Grid.ColumnSpan" Value="3" />
               <Setter TargetName="DividerRect" Property="Grid.RowSpan" Value="1" />
               <Setter TargetName="DividerRect" Property="Height" Value="1" />
               <Setter TargetName="DividerRect" Property="HorizontalAlignment" Value="Stretch" />
@@ -892,10 +902,12 @@
               <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
               <Setter TargetName="HeaderPanel" Property="Rows" Value="1" />
               <Setter TargetName="TabGrid" Property="DockPanel.Dock" Value="Top" />
+              <Setter TargetName="AdditionalEndContentPresenter" Property="Grid.Column" Value="2" />
+              <Setter TargetName="AdditionalEndContentPresenter" Property="Grid.Row" Value="0" />
             </Trigger>
             <Trigger Property="TabStripPlacement" Value="Bottom">
               <Setter Property="BorderThickness" Value="0,1,0,0" />
-              <Setter TargetName="DividerRect" Property="Grid.ColumnSpan" Value="2" />
+              <Setter TargetName="DividerRect" Property="Grid.ColumnSpan" Value="3" />
               <Setter TargetName="DividerRect" Property="Grid.RowSpan" Value="1" />
               <Setter TargetName="DividerRect" Property="Height" Value="1" />
               <Setter TargetName="DividerRect" Property="HorizontalAlignment" Value="Stretch" />
@@ -906,6 +918,8 @@
               <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
               <Setter TargetName="HeaderPanel" Property="Rows" Value="1" />
               <Setter TargetName="TabGrid" Property="DockPanel.Dock" Value="Bottom" />
+              <Setter TargetName="AdditionalEndContentPresenter" Property="Grid.Column" Value="2" />
+              <Setter TargetName="AdditionalEndContentPresenter" Property="Grid.Row" Value="0" />
             </Trigger>
             <Trigger Property="TabStripPlacement" Value="Right">
               <Setter Property="BorderThickness" Value="1,0,0,0" />


### PR DESCRIPTION
Adds a new attached property `materialDesign:NavigationRailAssist.AdditionalEndContent` to allow consumers to add additional content to the "bar" of the NavigationRail (similar to how it's done in Visual Studio Code - Tabs at the top and buttons at the bottom).

I'm not completely sold on the property name, so feel free to rename it if you find a clearer alternative.
<img width="522" height="461" alt="image" src="https://github.com/user-attachments/assets/49e0fcbc-47b4-4d3e-8c75-158c65155a57" />
