### PR TITLE
Improves UpDown text input clamping behavior

### DIFF
--- a/src/MaterialDesignThemes.Wpf/UpDownBase.cs
+++ b/src/MaterialDesignThemes.Wpf/UpDownBase.cs
@@ -47,6 +47,8 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
     private static int Compare(T value1, T value2) => _arithmetic.Compare(value1, value2);
 #endif
 
+    private bool _isTextChanging;
+
     #region DependencyProperties
 
     #region DependencyProperty : MinimumProperty
@@ -116,7 +118,7 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
         };
         upDownBase.RaiseEvent(args);
 
-        if (upDownBase._textBoxField is { } textBox)
+        if (!upDownBase._isTextChanging && upDownBase._textBoxField is { } textBox)
         {
             textBox.Text = Convert.ToString(e.NewValue, CultureInfo.CurrentCulture);
         }
@@ -196,10 +198,13 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
     public override void OnApplyTemplate()
     {
         if (_increaseButton != null)
+        {
             _increaseButton.Click -= IncreaseButtonOnClick;
-
+        }
         if (_decreaseButton != null)
+        {
             _decreaseButton.Click -= DecreaseButtonOnClick;
+        }
         if (_textBoxField != null)
         {
             _textBoxField.TextChanged -= OnTextBoxTextChanged;
@@ -243,7 +248,9 @@ public class UpDownBase<T, TArithmetic> : UpDownBase
         {
             if (TryParse(textBoxField.Text, CultureInfo.CurrentCulture, out T? value))
             {
+                _isTextChanging = true;
                 SetCurrentValue(ValueProperty, ClampValue(value));
+                _isTextChanging = false;
             }
         }
     }

--- a/tests/MaterialDesignThemes.UITests/WPF/UpDownControls/NumericUpDownTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/UpDownControls/NumericUpDownTests.cs
@@ -214,6 +214,30 @@ public class NumericUpDownTests : TestBase
     }
 
     [Test]
+    [Description("Issue 4061")]
+    public async Task NumericUpDown_WhenMinimumIsPositiveNumber_ItAllowsTextToBeChangedWithoutClamping()
+    {
+        //Arrange
+        //NB: Value should be something that is not equal to the minimum
+        var numericUpDown = await LoadXaml<NumericUpDown>("""
+        <materialDesign:NumericUpDown Tag="{Binding Value, RelativeSource={RelativeSource Self}, UpdateSourceTrigger=PropertyChanged}" Maximum="150" Minimum="60" Value="70" />
+        """);
+
+        var textBox = await numericUpDown.GetElement<TextBox>("PART_TextBox");
+
+        //Act
+        await textBox.MoveKeyboardFocus();
+        await textBox.SendKeyboardInput($"{ModifierKeys.Control}{Key.A}{ModifierKeys.None}8");
+        object? firstValue = await numericUpDown.GetTag();
+        await textBox.SendKeyboardInput($"7");
+        object? secondValue = await numericUpDown.GetTag();
+
+        //Assert
+        await Assert.That(firstValue?.ToString()).IsEqualTo("60");
+        await Assert.That(secondValue?.ToString()).IsEqualTo("87");
+    }
+
+    [Test]
     [Description("Issue 3827")]
     public async Task NumericUpDown_WhenBindingUpdateTriggerIsLostFocus_ItDoesNotUpdateUntilItLoosesFocus()
     {


### PR DESCRIPTION
Addresses an issue in the `NumericUpDown` control where, during user input, a partially typed number that temporarily fell outside the `Minimum` or `Maximum` range would cause the control to immediately clamp the value. This clamped value would then overwrite the user's ongoing input in the textbox, making it difficult to complete the desired number.

Introduces an `_isTextChanging` flag to prevent the textbox from being programmatically updated when the `Value` changes as a direct result of user input in the textbox. This ensures that the user's input remains undisturbed during typing, allowing them to complete their intended value without premature overwrites.

A new UI test validates this improved behavior, confirming that the control now correctly handles typing sequences.

Fixes #4061