### PR TITLE
Fix TabControl issue where tabs (in a dialog) stopped working

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Behaviors/Internal/TabControlHeaderScrollBehavior.cs
+++ b/src/MaterialDesignThemes.Wpf/Behaviors/Internal/TabControlHeaderScrollBehavior.cs
@@ -336,13 +336,14 @@ public class TabControlHeaderScrollBehavior : Behavior<ScrollViewer>
             return;
         if ( _isAnimatingScroll || _desiredScrollStart is not { } desiredOffsetStart)
             return;
+        if (!TabControl.IsHitTestVisible)
+            return;
 
         double originalValue = desiredOffsetStart;
         double newValue = e.HorizontalOffset;
         _isAnimatingScroll = true;
 
         // HACK: Temporarily disable user interaction while the animated scroll is ongoing. This prevents the double-click of a tab stopping the animation prematurely.
-        bool originalIsHitTestVisibleValue = TabControl.IsHitTestVisible;
         TabControl.SetCurrentValue(FrameworkElement.IsHitTestVisibleProperty, false);
 
         AssociatedObject.ScrollToHorizontalOffset(originalValue);
@@ -355,8 +356,8 @@ public class TabControlHeaderScrollBehavior : Behavior<ScrollViewer>
             _desiredScrollStart = null;
             _isAnimatingScroll = false;
 
-            // HACK: Set the hit test visibility back to its original value
-            TabControl.SetCurrentValue(FrameworkElement.IsHitTestVisibleProperty, originalIsHitTestVisibleValue);
+            // HACK: Re-enable hit test visibility
+            TabControl.SetCurrentValue(FrameworkElement.IsHitTestVisibleProperty, true);
         };
         AssociatedObject.BeginAnimation(TabControlHeaderScrollBehavior.CustomHorizontalOffsetProperty, scrollAnimation);
     }


### PR DESCRIPTION
Fixes #4063 

The hack that was added to avoid multi-click/keypress navigation from screwing with the animation, was causing some issues in particular when used inside of a Popup - e.g. `DialogHost` with the default style. I believe this is because the `Popup` apparently sets `PopupRoot.IsHitTestVisible=False` when it closes (See [here](https://source.dot.net/#PresentationFramework/System/Windows/Controls/Primitives/Popup.cs,1672)). So in cases where the dialog reopens with the same content, their initial value for `IsHitTestVisible` will be false.

To mitigate this issue, the hack (and the animation) is now skipped in case `TabControl.IsHitTestVisible == False` when the animation is intended to occur. This avoids the issue the OP was experiencing, and still works in the "normal" use cases.