### PR TITLE
fix(DataGrid): add VerticalContentAlignment/HorizontalContentAlignment bindings to DataGridCell ContentPresenter

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
@@ -259,7 +259,10 @@
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"
                     SnapsToDevicePixels="True" />
-            <ContentPresenter Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                              Margin="{TemplateBinding Padding}"
+                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
           </Grid>
         </ControlTemplate>
       </Setter.Value>


### PR DESCRIPTION
## Description

Fixes #3999 — Vertical Centering of DataGrid Cells producing extra border lines.

### Root cause
The  ControlTemplate's ContentPresenter was missing bindings for  and . 

When users wanted to vertically center cell content, they would set  on the DataGridCell style. This caused the DataGridCell itself to shrink vertically within its row, exposing DataGrid horizontal grid lines as unwanted border artifacts above and below the cell.

The correct property to use is  — but even that had no effect because the ContentPresenter lacked the TemplateBinding.

### Fix
Added  and  to the ContentPresenter, matching the pattern already used in  (line 322 of the same file).

### Before


### After


### Usage
Users can now vertically center cell content correctly:
