### PR TITLE
Applies ColorZoneAssist forwarding to (rail) TabItems

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TabControl.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters"
                     xmlns:convertersInternal="clr-namespace:MaterialDesignThemes.Wpf.Converters.Internal"
@@ -781,6 +781,9 @@
         </ControlTemplate>
       </Setter.Value>
     </Setter>
+    <Setter Property="wpf:ColorZoneAssist.Background" Value="Transparent" />
+    <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, Path=(wpf:ColorZoneAssist.Foreground), FallbackValue=Black}" />
+    <Setter Property="wpf:ColorZoneAssist.Mode" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, Path=(wpf:ColorZoneAssist.Mode), FallbackValue=Standard}" />
     <Setter Property="Width" Value="72" />
     <Setter Property="wpf:DialogHost.RestoreFocusElement" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=TabControl}}" />
     <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesign.Brush.Button.Ripple}" />


### PR DESCRIPTION
Fixes #3962

Ensures (rail) `TabItems` within a `TabControl` correctly inherit `ColorZoneAssist` properties in the same way normal `TabItems` do.

This change binds the `Foreground` and `Mode` properties of `TabItem` to the corresponding `ColorZoneAssist` properties of its ancestor `TabControl`, providing consistent theming.

I suspect this was unintentionally missed when the forwarding of the `ColorZoneAssist` values was added to the normal `TabItem` template in the huge PR #2911.