### PR TITLE
#1631: ColorPicker doesn't triger color Change event after color chan…

### DIFF
--- a/src/MaterialDesignThemes.Wpf/ColorPicker.cs
+++ b/src/MaterialDesignThemes.Wpf/ColorPicker.cs
@@ -33,19 +33,19 @@ public class ColorPicker : Control
     private static void ColorPropertyChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         var colorPicker = (ColorPicker)d;
-        if (colorPicker._inCallback)
+
+        if (!colorPicker._inCallback)
         {
-            return;
+            colorPicker._inCallback = true;
+            colorPicker.SetCurrentValue(HsbProperty, ((Color)e.NewValue).ToHsb());
+            colorPicker._inCallback = false;
         }
 
-        colorPicker._inCallback = true;
-        colorPicker.SetCurrentValue(HsbProperty, ((Color)e.NewValue).ToHsb());
         var args = new RoutedPropertyChangedEventArgs<Color>(
             (Color)e.OldValue,
             (Color)e.NewValue)
         { RoutedEvent = ColorChangedEvent };
         colorPicker.RaiseEvent(args);
-        colorPicker._inCallback = false;
     }
 
     public static readonly RoutedEvent ColorChangedEvent =

--- a/tests/MaterialDesignThemes.Wpf.Tests/ColorPickerTests.cs
+++ b/tests/MaterialDesignThemes.Wpf.Tests/ColorPickerTests.cs
@@ -104,6 +104,28 @@ public class ColorPickerTests
     }
 
     [Test]
+    public async Task ColorChangedShouldFireWhenColorIsChangedThroughHsb()
+    {
+        var colorPicker = new ColorPicker();
+
+        var called = false;
+        Color receivedColor = default;
+
+        colorPicker.ColorChanged += (_, args) =>
+        {
+            called = true;
+            receivedColor = args.NewValue;
+        };
+
+        colorPicker.SetCurrentValue(
+            ColorPicker.HsbProperty,
+            new Hsb(120, 1, 1));
+
+        await Assert.That(called).IsTrue();
+        await Assert.That(receivedColor).IsEqualTo(Colors.Lime);
+    }
+
+    [Test]
     public async Task DraggingTheHueSliderChangesHue()
     {
         ColorPicker colorPicker = CreateElement();


### PR DESCRIPTION
Fix #1631: Raise ColorChanged event when ColorPicker color changes from UI

The ColorChanged routed event was not raised when the color was changed through the UI (for example via the HSB controls) because the ColorPropertyChangedCallback returned early while synchronizing the Color and Hsb dependency properties.

This change keeps the recursion guard for the Color/Hsb synchronization but ensures that the ColorChanged event is raised when the Color dependency property value actually changes.

Added a regression test covering UI-driven color changes.