### PR TITLE
feat(AutoSuggestBox): add ShowSuggestionsOnFocus property

### DIFF
--- a/src/MainDemo.Wpf/Domain/MainWindowViewModel.cs
+++ b/src/MainDemo.Wpf/Domain/MainWindowViewModel.cs
@@ -485,4 +485,19 @@ public partial class MainWindowViewModel : ObservableObject
                && item.Name.IndexOf(searchKeyword, StringComparison.OrdinalIgnoreCase) >= 0;
 #endif
     }
+
+    [RelayCommand]
+    private async Task OpenQuickSearchAsync()
+    {
+        var quickSearchDialog = new QuickSearchDialog
+        {
+            DataContext = new QuickSearchDialogViewModel(DemoItems)
+        };
+        var result = await DialogHost.Show(quickSearchDialog, "RootDialog");
+        if (result is DemoItem selectedItem)
+        {
+            SelectedItem = selectedItem;
+            SelectedIndex = DemoItems.IndexOf(selectedItem);
+        }
+    }
 }

--- a/src/MainDemo.Wpf/Domain/QuickSearchDialog.xaml
+++ b/src/MainDemo.Wpf/Domain/QuickSearchDialog.xaml
@@ -3,9 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:MaterialDesignDemo"
+             xmlns:domain="clr-namespace:MaterialDesignDemo.Domain"
              xmlns:materialDesign="clr-namespace:MaterialDesignThemes.Wpf;assembly=MaterialDesignThemes.Wpf"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              Padding="24,16"
+             d:DataContext="{d:DesignInstance Type=domain:QuickSearchDialogViewModel, IsDesignTimeCreatable=False}"
              d:DesignHeight="450"
              d:DesignWidth="800"
              mc:Ignorable="d">

--- a/src/MainDemo.Wpf/Domain/QuickSearchDialog.xaml
+++ b/src/MainDemo.Wpf/Domain/QuickSearchDialog.xaml
@@ -1,0 +1,28 @@
+﻿<UserControl x:Class="MaterialDesignDemo.QuickSearchDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:MaterialDesignDemo"
+             xmlns:materialDesign="clr-namespace:MaterialDesignThemes.Wpf;assembly=MaterialDesignThemes.Wpf"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             Padding="24,16"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             mc:Ignorable="d">
+  <Grid Width="500" Height="500">
+    <materialDesign:AutoSuggestBox VerticalAlignment="Top"
+                                   materialDesign:HintAssist.Hint="Search (Esc to close)"
+                                   materialDesign:TextFieldAssist.HasClearButton="True"
+                                   materialDesign:TextFieldAssist.HasLeadingIcon="True"
+                                   materialDesign:TextFieldAssist.LeadingIcon="Search"
+                                   DisplayMember="Name"
+                                   DropDownMaxHeight="420"
+                                   FontSize="20"
+                                   PreviewKeyDown="SearchBox_KeyDown"
+                                   SelectedItem="{Binding SelectedItem}"
+                                   ShowSuggestionsOnFocus="True"
+                                   Style="{StaticResource MaterialDesignOutlinedAutoSuggestBox}"
+                                   Suggestions="{Binding FilteredItems}"
+                                   Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+  </Grid>
+</UserControl>

--- a/src/MainDemo.Wpf/Domain/QuickSearchDialog.xaml.cs
+++ b/src/MainDemo.Wpf/Domain/QuickSearchDialog.xaml.cs
@@ -1,0 +1,22 @@
+﻿using MaterialDesignThemes.Wpf;
+
+namespace MaterialDesignDemo;
+
+/// <summary>
+/// Interaction logic for QuickSearchDialog.xaml
+/// </summary>
+public partial class QuickSearchDialog : UserControl
+{
+    public QuickSearchDialog()
+    {
+        InitializeComponent();
+    }
+
+    private void SearchBox_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            DialogHost.Close("RootDialog", null);
+        }
+    }
+}

--- a/src/MainDemo.Wpf/Domain/QuickSearchDialogViewModel.cs
+++ b/src/MainDemo.Wpf/Domain/QuickSearchDialogViewModel.cs
@@ -1,0 +1,32 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using MaterialDesignDemo.Shared.Domain;
+using MaterialDesignThemes.Wpf;
+
+namespace MaterialDesignDemo.Domain;
+
+public partial class QuickSearchDialogViewModel(IReadOnlyCollection<DemoItem> items) : ObservableObject
+{
+    private readonly IReadOnlyCollection<DemoItem> _items = items;
+
+    [ObservableProperty]
+    private string _searchText = "";
+
+    partial void OnSearchTextChanged(string value)
+        => OnPropertyChanged(nameof(FilteredItems));
+
+    [ObservableProperty]
+    private DemoItem? _selectedItem;
+
+    partial void OnSelectedItemChanged(DemoItem? value)
+    {
+        if (value is not null)
+        {
+            DialogHost.Close("RootDialog", value);
+        }
+    }
+
+    public IReadOnlyCollection<DemoItem> FilteredItems
+        => string.IsNullOrWhiteSpace(SearchText)
+        ? _items
+        : _items.Where(i => i.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase)).ToList();
+}

--- a/src/MainDemo.Wpf/Domain/QuickSearchDialogViewModel.cs
+++ b/src/MainDemo.Wpf/Domain/QuickSearchDialogViewModel.cs
@@ -28,5 +28,5 @@ public partial class QuickSearchDialogViewModel(IReadOnlyCollection<DemoItem> it
     public IReadOnlyCollection<DemoItem> FilteredItems
         => string.IsNullOrWhiteSpace(SearchText)
         ? _items
-        : _items.Where(i => i.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase)).ToList();
+        : [.. _items.Where(i => i.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase))];
 }

--- a/src/MainDemo.Wpf/Fields.xaml
+++ b/src/MainDemo.Wpf/Fields.xaml
@@ -709,9 +709,11 @@
                    VerticalAlignment="Center"
                    Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
                    Text="Simple source list" />
+        <CheckBox Content="ShowSuggestionsOnFocus" x:Name="cbShowSuggestionsOnFocus"/>
 
         <smtx:XamlDisplay UniqueKey="fields_autosuggestion_1">
           <materialDesign:AutoSuggestBox VerticalAlignment="Bottom"
+                                         ShowSuggestionsOnFocus="{Binding ElementName=cbShowSuggestionsOnFocus, Path=IsChecked}"
                                          Suggestions="{Binding AutoSuggestBox1Suggestions}"
                                          Text="{Binding AutoSuggestBox1Text, UpdateSourceTrigger=PropertyChanged}" />
         </smtx:XamlDisplay>

--- a/src/MainDemo.Wpf/Home.xaml
+++ b/src/MainDemo.Wpf/Home.xaml
@@ -51,7 +51,7 @@
                 Style="{StaticResource MaterialDesignFlatButton}">
           <StackPanel Orientation="Horizontal">
             <materialDesign:PackIcon Kind="Binoculars" />
-            <TextBlock Margin="8,0,0,0" Text="EXPLORE" />
+            <TextBlock Margin="8,0,0,0" Text="EXPLORE (Ctrl+K)" />
           </StackPanel>
         </Button>
       </StackPanel>

--- a/src/MainDemo.Wpf/MainWindow.xaml
+++ b/src/MainDemo.Wpf/MainWindow.xaml
@@ -16,6 +16,11 @@
         Style="{StaticResource MaterialDesignWindow}"
         WindowStartupLocation="CenterScreen"
         mc:Ignorable="d">
+  <Window.InputBindings>
+    <KeyBinding Key="K"
+                Modifiers="Control"
+                Command="{Binding OpenQuickSearchCommand}" />
+  </Window.InputBindings>
   <Window.CommandBindings>
     <CommandBinding Command="Copy" Executed="OnCopy" />
   </Window.CommandBindings>

--- a/src/MaterialDesign3.Demo.Wpf/Domain/MainWindowViewModel.cs
+++ b/src/MaterialDesign3.Demo.Wpf/Domain/MainWindowViewModel.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Configuration;
 using System.Windows.Data;
+using CommunityToolkit.Mvvm.Input;
 using MaterialColorUtilities;
 using MaterialDesignDemo.Shared.Domain;
 using MaterialDesignThemes.Wpf;
@@ -9,7 +10,7 @@ using MaterialDesignThemes.Wpf.Transitions;
 
 namespace MaterialDesign3Demo.Domain;
 
-public class MainWindowViewModel : ViewModelBase
+public partial class MainWindowViewModel : ViewModelBase
 {
     public MainWindowViewModel(ISnackbarMessageQueue snackbarMessageQueue, string? startupPage)
     {
@@ -501,5 +502,20 @@ public class MainWindowViewModel : ViewModelBase
 
         return obj is DemoItem item
                && item.Name.ToLower().Contains(_searchKeyword!.ToLower());
+    }
+
+    [RelayCommand]
+    private async Task OpenQuickSearchAsync()
+    {
+        var quickSearchDialog = new QuickSearchDialog
+        {
+            DataContext = new QuickSearchDialogViewModel(DemoItems)
+        };
+        var result = await DialogHost.Show(quickSearchDialog, "RootDialog");
+        if (result is DemoItem selectedItem)
+        {
+            SelectedItem = selectedItem;
+            SelectedIndex = DemoItems.IndexOf(selectedItem);
+        }
     }
 }

--- a/src/MaterialDesign3.Demo.Wpf/Domain/QuickSearchDialog.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Domain/QuickSearchDialog.xaml
@@ -1,0 +1,39 @@
+﻿<UserControl x:Class="MaterialDesign3Demo.Domain.QuickSearchDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:MaterialDesign3Demo.Domain"
+             xmlns:materialDesign="clr-namespace:MaterialDesignThemes.Wpf;assembly=MaterialDesignThemes.Wpf"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             Padding="24,16"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             mc:Ignorable="d">
+  <Grid Width="500" Height="500">
+    <materialDesign:AutoSuggestBox VerticalAlignment="Top"
+                                   materialDesign:HintAssist.Hint="Search (Esc to close)"
+                                   materialDesign:TextFieldAssist.HasClearButton="True"
+                                   materialDesign:TextFieldAssist.HasLeadingIcon="True"
+                                   materialDesign:TextFieldAssist.LeadingIcon="Search"
+                                   DisplayMember="Name"
+                                   DropDownMaxHeight="420"
+                                   FontSize="20"
+                                   PreviewKeyDown="SearchBox_KeyDown"
+                                   SelectedItem="{Binding SelectedItem}"
+                                   ShowSuggestionsOnFocus="True"
+                                   Style="{StaticResource MaterialDesignOutlinedAutoSuggestBox}"
+                                   Suggestions="{Binding FilteredItems}"
+                                   Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}">
+      <materialDesign:AutoSuggestBox.ItemTemplate>
+        <DataTemplate>
+          <DockPanel>
+            <materialDesign:PackIcon Kind="{Binding UnselectedIcon}" ScaleToSizeOfWith="{Binding ElementName=tbName}" />
+            <TextBlock x:Name="tbName"
+                       Margin="8,0,0,0"
+                       Text="{Binding Name}" />
+          </DockPanel>
+        </DataTemplate>
+      </materialDesign:AutoSuggestBox.ItemTemplate>
+    </materialDesign:AutoSuggestBox>
+  </Grid>
+</UserControl>

--- a/src/MaterialDesign3.Demo.Wpf/Domain/QuickSearchDialog.xaml.cs
+++ b/src/MaterialDesign3.Demo.Wpf/Domain/QuickSearchDialog.xaml.cs
@@ -1,0 +1,22 @@
+﻿using MaterialDesignThemes.Wpf;
+
+namespace MaterialDesign3Demo.Domain;
+
+/// <summary>
+/// Interaction logic for QuickSearchDialog.xaml
+/// </summary>
+public partial class QuickSearchDialog : UserControl
+{
+    public QuickSearchDialog()
+    {
+        InitializeComponent();
+    }
+
+    private void SearchBox_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            DialogHost.Close("RootDialog", null);
+        }
+    }
+}

--- a/src/MaterialDesign3.Demo.Wpf/Domain/QuickSearchDialogViewModel.cs
+++ b/src/MaterialDesign3.Demo.Wpf/Domain/QuickSearchDialogViewModel.cs
@@ -1,0 +1,30 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using MaterialDesignThemes.Wpf;
+
+namespace MaterialDesign3Demo.Domain;
+public partial class QuickSearchDialogViewModel(IReadOnlyCollection<DemoItem> items) : ObservableObject
+{
+    private readonly IReadOnlyCollection<DemoItem> _items = items;
+
+    [ObservableProperty]
+    private string _searchText = "";
+
+    partial void OnSearchTextChanged(string value)
+        => OnPropertyChanged(nameof(FilteredItems));
+
+    [ObservableProperty]
+    private DemoItem? _selectedItem;
+
+    partial void OnSelectedItemChanged(DemoItem? value)
+    {
+        if (value is not null)
+        {
+            DialogHost.Close("RootDialog", value);
+        }
+    }
+
+    public IReadOnlyCollection<DemoItem> FilteredItems
+        => string.IsNullOrWhiteSpace(SearchText)
+        ? _items
+        : _items.Where(i => i.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase)).ToList();
+}

--- a/src/MaterialDesign3.Demo.Wpf/Home.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Home.xaml
@@ -51,7 +51,7 @@
                 Style="{StaticResource MaterialDesignFlatButton}">
           <StackPanel Orientation="Horizontal">
             <materialDesign:PackIcon Kind="Binoculars" />
-            <TextBlock Margin="8,0,0,0" Text="EXPLORE" />
+            <TextBlock Margin="8,0,0,0" Text="EXPLORE (Ctrl+K)" />
           </StackPanel>
         </Button>
       </StackPanel>

--- a/src/MaterialDesign3.Demo.Wpf/MainWindow.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/MainWindow.xaml
@@ -17,6 +17,11 @@
         Style="{StaticResource MaterialDesignWindow}"
         WindowStartupLocation="CenterScreen"
         mc:Ignorable="d">
+  <Window.InputBindings>
+    <KeyBinding Key="K"
+                Modifiers="Control"
+                Command="{Binding OpenQuickSearchCommand}" />
+  </Window.InputBindings>
   <Window.CommandBindings>
     <CommandBinding Command="Copy" Executed="OnCopy" />
   </Window.CommandBindings>

--- a/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
+++ b/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
@@ -186,27 +186,18 @@ public class AutoSuggestBox : TextBox
         {
             case Key.Down:
                 IncrementSelection();
-                e.Handled = true;
                 break;
             case Key.Up:
                 DecrementSelection();
-                e.Handled = true;
                 break;
             case Key.Enter:
                 CommitValueSelection();
-                e.Handled = true;
                 break;
             case Key.Escape:
                 CloseAutoSuggestionPopUp();
-                e.Handled = true;
                 break;
             case Key.Tab:
-                bool wasItemSelected = CommitValueSelection();
-                // Only mark the event as handled if the SuggestionList is open and therefore the Selection was successful
-                if (wasItemSelected)
-                {
-                    e.Handled = true;
-                }
+                CommitValueSelection();
                 break;
             default:
                 return;

--- a/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
+++ b/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
@@ -134,18 +134,40 @@ public class AutoSuggestBox : TextBox
         remove => RemoveHandler(SuggestionChosenEvent, value);
     }
 
+    public bool ShowSuggestionsOnFocus
+    {
+        get => (bool)GetValue(ShowSuggestionsOnFocusProperty);
+        set => SetValue(ShowSuggestionsOnFocusProperty, value);
+    }
+
+    public static readonly DependencyProperty ShowSuggestionsOnFocusProperty =
+        DependencyProperty.Register(
+            nameof(ShowSuggestionsOnFocus),
+            typeof(bool),
+            typeof(AutoSuggestBox),
+            new PropertyMetadata(false));
+
     #endregion
 
+    protected override void OnGotFocus(RoutedEventArgs e)
+    {
+        base.OnGotFocus(e);
+
+        if (ShowSuggestionsOnFocus &&
+            _autoSuggestBoxList is not null &&
+            _autoSuggestBoxList.Items.Count > 0 &&
+            !IsSuggestionOpen)
+        {
+            IsSuggestionOpen = true;
+        }
+    }
     static AutoSuggestBox() => DefaultStyleKeyProperty.OverrideMetadata(typeof(AutoSuggestBox), new FrameworkPropertyMetadata(typeof(AutoSuggestBox)));
 
     #region Override methods
 
     public override void OnApplyTemplate()
     {
-        if (_autoSuggestBoxList is not null)
-        {
-            _autoSuggestBoxList.PreviewMouseDown -= AutoSuggestionListBox_PreviewMouseDown;
-        }
+        _autoSuggestBoxList?.PreviewMouseDown -= AutoSuggestionListBox_PreviewMouseDown;
 
         if (GetTemplateChild(AutoSuggestBoxListPart) is ListBox listBox)
         {
@@ -207,10 +229,27 @@ public class AutoSuggestBox : TextBox
         base.OnTextChanged(e);
         if (_autoSuggestBoxList is null)
             return;
-        if ((Text.Length == 0 || _autoSuggestBoxList.Items.Count == 0) && IsSuggestionOpen)
-            IsSuggestionOpen = false;
-        else if (Text.Length > 0 && !IsSuggestionOpen && IsFocused && _autoSuggestBoxList.Items.Count > 0)
+
+        bool hasItems = _autoSuggestBoxList.Items.Count > 0;
+        bool isEmpty = string.IsNullOrEmpty(Text);
+
+        bool shouldOpen =
+            IsFocused &&
+            hasItems &&
+            (ShowSuggestionsOnFocus || !isEmpty);
+
+        bool shouldClose =
+            !hasItems ||
+            (!ShowSuggestionsOnFocus && isEmpty);
+
+        if (shouldOpen)
+        {
             IsSuggestionOpen = true;
+        }
+        else if (shouldClose)
+        {
+            IsSuggestionOpen = false;
+        }
     }
 
     #endregion

--- a/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
+++ b/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
@@ -292,8 +292,7 @@ public class AutoSuggestBox : TextBox
         return element.GetVisualAncestry()
             .Where(x => x != this)
             .Select(IsInteractive)
-            .Where(x => x is not null)
-            .FirstOrDefault() ?? false;
+            .FirstOrDefault(x => x is not null) ?? false;
 
         static bool? IsInteractive(DependencyObject element)
         {

--- a/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
+++ b/src/MaterialDesignThemes.Wpf/AutoSuggestBox.cs
@@ -368,7 +368,7 @@ public class AutoSuggestBox : TextBox
         if (_autoSuggestBoxList is null || Suggestions is null)
             return;
         ICollectionView collectionView = CollectionViewSource.GetDefaultView(Suggestions);
-        int itemCount = collectionView.Cast<object>().Count();
+        int itemCount = GetItemCount(collectionView);
 
         // If we're at the last item, wrap around to the first.
         if (collectionView.CurrentPosition == itemCount - 1)
@@ -376,6 +376,15 @@ public class AutoSuggestBox : TextBox
         else
             collectionView.MoveCurrentToNext();
         _autoSuggestBoxList.ScrollIntoView(_autoSuggestBoxList.SelectedItem);
+    }
+
+    private static int GetItemCount(ICollectionView collectionView)
+    {
+        if (collectionView is ListCollectionView lcv)
+        {
+            return lcv.Count;
+        }
+        return collectionView.Cast<object>().Count();
     }
 
     #endregion

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -262,6 +262,8 @@
                          Focusable="False"
                          IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsSuggestionOpen, Mode=TwoWay}"
                          PopupAnimation="Slide"
+                         Placement="Bottom"
+                         PlacementTarget="{Binding ElementName=OuterBorder}"
                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                          StaysOpen="True"
                          Visibility="Collapsed">

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.AutoSuggestBox.xaml
@@ -263,7 +263,7 @@
                          IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsSuggestionOpen, Mode=TwoWay}"
                          PopupAnimation="Slide"
                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                         StaysOpen="False"
+                         StaysOpen="True"
                          Visibility="Collapsed">
               <wpf:Card x:Name="PopupCard"
                         Margin="{TemplateBinding DropDownElevation, Converter={x:Static converters:ElevationMarginConverter.Instance}}"

--- a/tests/MaterialDesignThemes.UITests/WPF/AutoSuggestBoxes/AutoSuggestTextBoxTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/AutoSuggestBoxes/AutoSuggestTextBoxTests.cs
@@ -305,6 +305,56 @@ public class AutoSuggestBoxTests : TestBase
         await Assert.That(selectedIndex).IsEqualTo(2); 
     }
 
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task ShowSuggestionsOnFocus_Keyboard_FollowsSetting(bool showSuggestionsOnFocus)
+    {
+        // Arrange
+        IVisualElement userControl = await LoadUserControl<AutoSuggestTextBoxWithCollectionView>();
+        IVisualElement<AutoSuggestBox> suggestBox = await userControl.GetElement<AutoSuggestBox>();
+        IVisualElement<Popup> popup = await suggestBox.GetElement<Popup>();
+
+        static void SetShowSuggestionsOnFocus(AutoSuggestBox autoSuggestBox, bool value)
+        {
+            autoSuggestBox.ShowSuggestionsOnFocus = value;
+        }
+        await suggestBox.RemoteExecute(SetShowSuggestionsOnFocus, showSuggestionsOnFocus);
+
+        // Act
+        await suggestBox.MoveKeyboardFocus();
+        await Task.Delay(100, TestContext.Current!.Execution.CancellationToken);
+
+        // Assert
+        await Assert.That(await suggestBox.GetIsSuggestionOpen()).IsEqualTo(showSuggestionsOnFocus);
+        await Assert.That(await popup.GetIsOpen()).IsEqualTo(showSuggestionsOnFocus);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task ShowSuggestionsOnFocus_Mouse_FollowsSetting(bool showSuggestionsOnFocus)
+    {
+        // Arrange
+        IVisualElement userControl = await LoadUserControl<AutoSuggestTextBoxWithCollectionView>();
+        IVisualElement<AutoSuggestBox> suggestBox = await userControl.GetElement<AutoSuggestBox>();
+        IVisualElement<Popup> popup = await suggestBox.GetElement<Popup>();
+
+        static void SetShowSuggestionsOnFocus(AutoSuggestBox autoSuggestBox, bool value)
+        {
+            autoSuggestBox.ShowSuggestionsOnFocus = value;
+        }
+        await suggestBox.RemoteExecute(SetShowSuggestionsOnFocus, showSuggestionsOnFocus);
+
+        // Act
+        await suggestBox.LeftClick();
+        await Task.Delay(100, TestContext.Current!.Execution.CancellationToken);
+
+        // Assert
+        await Assert.That(await suggestBox.GetIsSuggestionOpen()).IsEqualTo(showSuggestionsOnFocus);
+        await Assert.That(await popup.GetIsOpen()).IsEqualTo(showSuggestionsOnFocus);
+    }
+
     private static async Task AssertExists(IVisualElement<ListBox> suggestionListBox, string text, bool existsOrNotCheck = true)
     {
         try


### PR DESCRIPTION
Initially I just wanted to add a search dialog (blatantly stolen from [mudblazor](https://mudblazor.com/)). While doing so, I noticed a few things with the `AutoSuggestBox`.

## Demo app changes
Added a shortcut `Ctrl+K` to open a dialog so users can search and jump to pages using hotkeys.

| MD2 app    | MD3 app |
| -------- | ------- |
| <img width="1136" height="746" alt="image" src="https://github.com/user-attachments/assets/a2184c00-e61b-496b-9f37-21e12e75b08a" />  | <img width="1086" height="793" alt="image" src="https://github.com/user-attachments/assets/936ccb0c-f969-4c13-96e3-4c53fd667166" /> |


## `AutoSuggestBox` changes
1. added a new DP `ShowSuggestionsOnFocus`
2. override `OnGotFocus` method to open the suggestion listbox when `ShowSuggestionsOnFocus="True"`
3. Removed the `e.Handled="true"` in the `OnPreviewKeyDown`. With this in place, consumers can't have custom actions on the `AutoSuggestBox` on the call-site. For example handling the `Esc` key to close the search-dialog (like I have done it in the demo apps).
 For some reason I can't reproduce the bug that `e.Handled="true"` was supposed to fix.
4. Some refactoring and performance improvement (`GetItemCount()`)
5. Added `Placement="Bottom"` and `PlacementTarget="{Binding ElementName=OuterBorder}"` to the `PopupEx`, because without it the popup wouldn't update it's position when moving the window:

<img width="1030" height="730" alt="image" src="https://github.com/user-attachments/assets/9d2a6f95-f490-46b4-b11f-6ad63fd37c85" />

6. With `StaysOpen="False"` the list wasn't reliably opened, so I changed it to `true` (e.g. open search dialog -> move window -> focus the `AutoSuggestBox` again and see that the list wouldn't open again)
7. Added tests to validate the new behavior