### PR TITLE
Remove explicit Win32 SetFocus call when opening DialogHost

### DIFF
--- a/src/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/src/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -834,11 +834,6 @@ public class DialogHost : ContentControl
         var child = _popup?.Child ?? _popupContentControl;
         if (child is null) return null;
 
-        if (PresentationSource.FromVisual(child) is HwndSource hwndSource)
-        {
-            SetFocus(hwndSource.Handle);
-        }
-
         CommandManager.InvalidateRequerySuggested();
         var focusable = child.VisualDepthFirstTraversal().OfType<UIElement>().FirstOrDefault(ui => ui.Focusable);
         if (focusable is null) return null;


### PR DESCRIPTION
The manual call to SetFocus via HwndSource was redundant and could cause unexpected focus behavior. The subsequent logic already handles focus by finding the first focusable element within the dialog's content.
