### PR TITLE
fix(popupbox): close popup when toggle button is clicked while open

### DIFF
--- a/src/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/src/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -833,7 +833,7 @@ public class PopupBox : ContentControl
 
     private void ToggleButtonOnPreviewMouseLeftButtonUp(object? sender, MouseButtonEventArgs mouseButtonEventArgs)
     {
-        if (PopupMode == PopupBoxPopupMode.Click || !IsPopupOpen) return;
+        if (!IsPopupOpen) return;
 
         if (ToggleCheckedContent != null)
         {

--- a/tests/MaterialDesignThemes.UITests/WPF/PopupBoxes/PopupBoxTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/PopupBoxes/PopupBoxTests.cs
@@ -51,4 +51,33 @@ public class PopupBoxTests : TestBase
             await Assert.That(await border.GetBackgroundColor()).IsEqualTo(Colors.Red);
         });
     }
+
+    [Test]
+    [Description("https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/2280")]
+    public async Task PopupBox_WhenInOpenedState_ClosesWhenClicked()
+    {
+        //Arrange
+        IVisualElement<PopupBox> popupBox = await LoadXaml<PopupBox>("""
+            <materialDesign:PopupBox Style="{StaticResource MaterialDesignMultiFloatingActionPopupBox}" IsPopupOpen="True">
+                <StackPanel>
+                    <Button Content="1" />
+                    <Button Content="2" />
+                    <Button Content="3" />
+                </StackPanel>
+            </materialDesign:PopupBox>
+            """);
+        bool isOpen = await popupBox.GetIsPopupOpen();
+        await Assert.That(isOpen).IsTrue();
+
+        //Act
+        IVisualElement<ToggleButton> toggleButton = await popupBox.GetElement<ToggleButton>("/ToggleButton");
+        await toggleButton.LeftClick();
+
+        //Assert
+        await Wait.For(async () =>
+        {
+            isOpen = await popupBox.GetIsPopupOpen();
+            await Assert.That(isOpen).IsFalse();
+        });
+    }
 }


### PR DESCRIPTION
fixes #2280

The OP pointed out 3 things:
> PopupBox don't opened when cursor is hovered
 
As @Keboo mentioned, this is by design.
> PopupBox don't closed on second click (when opened).
 
That's what this PR is about.
The fix was just to remove a condition for an early exit in the `ToggleButtonOnPreviewMouseLeftButtonUp()` method.

I don't see the reason for an early exit in the `PopupBoxPopupMode.Click` mode. I guess this is just old code added 11 years ago. https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/commit/9c8d87340cdbee7fc420de99fb0eb034346d76f9

> PopupBox has incorrect Ripple on second click

Already fixed in #3843