### PR TITLE
Allow for waiting for DialogHost animations.

### DIFF
--- a/src/MainDemo.Wpf/Dialogs.xaml.cs
+++ b/src/MainDemo.Wpf/Dialogs.xaml.cs
@@ -42,8 +42,12 @@ public partial class Dialogs
     }
 
     // Used for DialogHost.DialogClosingAttached
-    private void Sample2_DialogHost_OnDialogClosing(object sender, DialogClosingEventArgs eventArgs)
-        => Debug.WriteLine($"SAMPLE 2: Closing dialog with parameter: {eventArgs.Parameter ?? string.Empty}");
+    private async void Sample2_DialogHost_OnDialogClosing(object sender, DialogClosingEventArgs eventArgs)
+    {
+        Debug.WriteLine($"{DateTime.Now.TimeOfDay} SAMPLE 2: Closing dialog with parameter: {eventArgs.Parameter ?? string.Empty}");
+        await eventArgs.Session.DialogHost.WaitForClosed();
+        Debug.WriteLine($"{DateTime.Now.TimeOfDay} SAMPLE 2: Closed dialog with parameter: {eventArgs.Parameter ?? string.Empty}");
+    }
 
     private void Sample2_DialogHost_OnDialogClosed(object sender, DialogClosedEventArgs eventArgs)
         => Debug.WriteLine($"SAMPLE 2: Closed dialog with parameter: {eventArgs.Parameter ?? string.Empty}");

--- a/src/MaterialDesign3.Demo.Wpf/Dialogs.xaml.cs
+++ b/src/MaterialDesign3.Demo.Wpf/Dialogs.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Threading;
 using MaterialDesign3Demo.Domain;
 using MaterialDesignThemes.Wpf;
 
@@ -27,8 +28,12 @@ public partial class Dialogs
     }
 
     // Used for DialogHost.DialogClosingAttached
-    private void Sample2_DialogHost_OnDialogClosing(object sender, DialogClosingEventArgs eventArgs)
-        => Debug.WriteLine($"SAMPLE 2: Closing dialog with parameter: {eventArgs.Parameter ?? string.Empty}");
+    private async void Sample2_DialogHost_OnDialogClosing(object sender, DialogClosingEventArgs eventArgs)
+    {
+        Debug.WriteLine($"{DateTime.Now.TimeOfDay} SAMPLE 2: Closing dialog with parameter: {eventArgs.Parameter ?? string.Empty}");
+        await eventArgs.Session.DialogHost.WaitForClosed();
+        Debug.WriteLine($"{DateTime.Now.TimeOfDay} SAMPLE 2: Closed dialog with parameter: {eventArgs.Parameter ?? string.Empty}");
+    }
 
     private void Sample5_DialogHost_OnDialogClosing(object sender, DialogClosingEventArgs eventArgs)
     {

--- a/src/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/src/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -1,9 +1,12 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security;
+using System.Threading;
 using System.Windows.Data;
 using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Threading;
+using MaterialDesignThemes.Wpf.Internal;
 
 namespace MaterialDesignThemes.Wpf;
 
@@ -31,13 +34,18 @@ public enum DialogHostOpenDialogCommandDataContextSource
 [TemplatePart(Name = PopupPartName, Type = typeof(Popup))]
 [TemplatePart(Name = PopupPartName, Type = typeof(ContentControl))]
 [TemplatePart(Name = ContentCoverGridName, Type = typeof(Grid))]
-[TemplateVisualState(GroupName = "PopupStates", Name = OpenStateName)]
-[TemplateVisualState(GroupName = "PopupStates", Name = ClosedStateName)]
+[TemplatePart(Name = RootContentPartName, Type = typeof(FrameworkElement))]
+[TemplateVisualState(GroupName = VisualStateGroupName, Name = OpenStateName)]
+[TemplateVisualState(GroupName = VisualStateGroupName, Name = ClosedStateName)]
 public class DialogHost : ContentControl
 {
+    public const string VisualStateGroupName = "PopupStates";
+
     public const string PopupPartName = "PART_Popup";
     public const string PopupContentPartName = "PART_PopupContentElement";
     public const string ContentCoverGridName = "PART_ContentCoverGrid";
+    public const string RootContentPartName = "PART_DialogHostRoot";
+
     public const string OpenStateName = "Open";
     public const string ClosedStateName = "Closed";
 
@@ -56,6 +64,9 @@ public class DialogHost : ContentControl
     private DialogClosingEventHandler? _asyncShowClosingEventHandler;
     private DialogClosedEventHandler? _asyncShowClosedEventHandler;
     private TaskCompletionSource<object?>? _dialogTaskCompletionSource;
+
+    private VisualStateMonitor? _visualStateMonitor;
+
 
     private Popup? _popup;
     private ContentControl? _popupContentControl;
@@ -395,7 +406,8 @@ public class DialogHost : ContentControl
 
         //https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/187
         //totally not happy about this, but on immediate validation we can get some weird looking stuff...give WPF a kick to refresh...
-        Task.Delay(300).ContinueWith(t => dialogHost.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() => {
+        Task.Delay(300).ContinueWith(t => dialogHost.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
+        {
             CommandManager.InvalidateRequerySuggested();
             //Delay focusing the popup until after the animation has some time, Issue #2912
             UIElement? child = dialogHost.FocusPopup();
@@ -628,8 +640,25 @@ public class DialogHost : ContentControl
 
         VisualStateManager.GoToState(this, GetStateName(), false);
 
+        if (GetTemplateChild(RootContentPartName) is FrameworkElement root &&
+            VisualStateManager.GetVisualStateGroups(root) is [VisualStateGroup stateGroup, ..])
+        {
+            var stateNames = stateGroup.States.OfType<VisualStateGroup>().Select(x => x.Name).ToList();
+            if (stateNames.Contains(OpenStateName) && stateNames.Contains(ClosedStateName))
+            {
+                _visualStateMonitor = new(stateGroup);
+            }
+        }
         base.OnApplyTemplate();
     }
+
+    public Task WaitForOpened(CancellationToken cancellationToken = default)
+        => _visualStateMonitor?.WaitForState(OpenStateName, cancellationToken)
+        ?? throw new InvalidOperationException("Unable to locate visual states for the DialogHost, cannot wait for state transitions");
+
+    public Task WaitForClosed(CancellationToken cancellationToken = default)
+        => _visualStateMonitor?.WaitForState(ClosedStateName, cancellationToken)
+        ?? throw new InvalidOperationException("Unable to locate visual states for the DialogHost, cannot wait for state transitions");
 
     #region restore focus properties
 
@@ -965,11 +994,6 @@ public class DialogHost : ContentControl
                 (popup as PopupEx)?.RefreshPosition();
             }
         }
-    }
-
-    private void OnPreviewGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
-    {
-
     }
 
     [SecurityCritical]

--- a/src/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/src/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -227,6 +227,33 @@ public class DialogHost : ContentControl
     /// <returns></returns>
     public static bool IsDialogOpen(object? dialogIdentifier) => GetDialogSession(dialogIdentifier)?.IsEnded == false;
 
+
+    /// <summary>
+    /// Waits for the DialogHost to move into the Opened visual state. This is useful when you want to ensure that the dialog is fully opened before performing a UI action, such as focusing a control within the dialog.
+    /// </summary>
+    /// <param name="dialogIdentifier">of the instance where the dialog should be closed. Typically this will match an identifier set in XAML.</param>
+    /// <param name="cancellationToken">A token to determine how long to wait.</param>
+    /// <returns>A task that completes when the DialogHost has moved into the Opened visual state.</returns>
+    /// <exception cref="InvalidOperationException">Throw when the DialogHost template does not contain the Opened visual state.</exception>
+    public static Task WaitForOpened(object? dialogIdentifier = null, CancellationToken cancellationToken = default)
+    {
+        var instance = GetInstance(dialogIdentifier);
+        return instance.WaitForOpened(cancellationToken);
+    }
+
+    /// <summary>
+    /// Waits for the DialogHost to move into the Closed visual state. This is useful when you want to ensure that the dialog is fully closed before performing a UI action, such as focusing a control outside of the dialog.
+    /// </summary>
+    /// <param name="dialogIdentifier">of the instance where the dialog should be closed. Typically this will match an identifier set in XAML.</param>
+    /// <param name="cancellationToken">A token to determine how long to wait.</param>
+    /// <returns>A task that completes when the DialogHost has moved into the Closed visual state.</returns>
+    /// <exception cref="InvalidOperationException">Throw when the DialogHost template does not contain the Closed visual state.</exception>
+    public static Task WaitForClosed(object? dialogIdentifier = null, CancellationToken cancellationToken = default)
+    {
+        var instance = GetInstance(dialogIdentifier);
+        return instance.WaitForClosed(cancellationToken);
+    }
+
     private static DialogHost GetInstance(object? dialogIdentifier)
     {
         if (LoadedInstances.Count == 0)
@@ -652,10 +679,22 @@ public class DialogHost : ContentControl
         base.OnApplyTemplate();
     }
 
+    /// <summary>
+    /// Waits for the DialogHost to move into the Opened visual state. This is useful when you want to ensure that the dialog is fully opened before performing a UI action, such as focusing a control within the dialog.
+    /// </summary>
+    /// <param name="cancellationToken">A token to determine how long to wait.</param>
+    /// <returns>A task that completes when the DialogHost has moved into the Opened visual state.</returns>
+    /// <exception cref="InvalidOperationException">Throw when the DialogHost template does not contain the Opened visual state.</exception>
     public Task WaitForOpened(CancellationToken cancellationToken = default)
         => _visualStateMonitor?.WaitForState(OpenStateName, cancellationToken)
         ?? throw new InvalidOperationException("Unable to locate visual states for the DialogHost, cannot wait for state transitions");
 
+    /// <summary>
+    /// Waits for the DialogHost to move into the Closed visual state. This is useful when you want to ensure that the dialog is fully closed before performing a UI action, such as focusing a control outside of the dialog.
+    /// </summary>
+    /// <param name="cancellationToken">A token to determine how long to wait.</param>
+    /// <returns>A task that completes when the DialogHost has moved into the Closed visual state.</returns>
+    /// <exception cref="InvalidOperationException">Throw when the DialogHost template does not contain the Closed visual state.</exception>
     public Task WaitForClosed(CancellationToken cancellationToken = default)
         => _visualStateMonitor?.WaitForState(ClosedStateName, cancellationToken)
         ?? throw new InvalidOperationException("Unable to locate visual states for the DialogHost, cannot wait for state transitions");

--- a/src/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/src/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -643,7 +643,7 @@ public class DialogHost : ContentControl
         if (GetTemplateChild(RootContentPartName) is FrameworkElement root &&
             VisualStateManager.GetVisualStateGroups(root) is [VisualStateGroup stateGroup, ..])
         {
-            var stateNames = stateGroup.States.OfType<VisualStateGroup>().Select(x => x.Name).ToList();
+            var stateNames = stateGroup.States.OfType<VisualState>().Select(x => x.Name).ToList();
             if (stateNames.Contains(OpenStateName) && stateNames.Contains(ClosedStateName))
             {
                 _visualStateMonitor = new(stateGroup);

--- a/src/MaterialDesignThemes.Wpf/DialogSession.cs
+++ b/src/MaterialDesignThemes.Wpf/DialogSession.cs
@@ -7,16 +7,16 @@ namespace MaterialDesignThemes.Wpf;
 /// </summary>
 public class DialogSession
 {
-    private readonly DialogHost _owner;
-
     internal DialogSession(DialogHost owner)
-        => _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+        => DialogHost = owner ?? throw new ArgumentNullException(nameof(owner));
+
+    public DialogHost DialogHost { get; }
 
     /// <summary>
-    /// Indicates if the dialog session has ended.  Once ended no further method calls will be permitted.
+    /// Indicates if the dialog session has ended. Once ended no further method calls will be permitted.
     /// </summary>
     /// <remarks>
-    /// Client code cannot set this directly, this is internally managed.  To end the dialog session use <see cref="Close()"/>.
+    /// Client code cannot set this directly, this is internally managed. To end the dialog session use <see cref="Close()"/>.
     /// </remarks>
     public bool IsEnded { get; internal set; }
 
@@ -28,7 +28,7 @@ public class DialogSession
     /// <summary>
     /// Gets the <see cref="DialogHost.DialogContent"/> which is currently displayed, so this could be a view model or a UI element.
     /// </summary>
-    public object? Content => _owner.DialogContent;
+    public object? Content => DialogHost.DialogContent;
 
     /// <summary>
     /// Update the current content in the dialog.
@@ -36,11 +36,11 @@ public class DialogSession
     /// <param name="content"></param>
     public void UpdateContent(object? content)
     {
-        _owner.AssertTargetableContent();
-        _owner.DialogContent = content;
-        _owner.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
+        DialogHost.AssertTargetableContent();
+        DialogHost.DialogContent = content;
+        DialogHost.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
         {
-            _owner.FocusPopup();
+            DialogHost.FocusPopup();
         }));
     }
 
@@ -52,7 +52,7 @@ public class DialogSession
     {
         if (IsEnded) throw new InvalidOperationException("Dialog session has ended.");
 
-        _owner.InternalClose(null);
+        DialogHost.InternalClose(null);
     }
 
     /// <summary>
@@ -64,6 +64,6 @@ public class DialogSession
     {
         if (IsEnded) throw new InvalidOperationException("Dialog session has ended.");
 
-        _owner.InternalClose(parameter);
+        DialogHost.InternalClose(parameter);
     }
 }

--- a/src/MaterialDesignThemes.Wpf/Internal/VisualStateMonitor.cs
+++ b/src/MaterialDesignThemes.Wpf/Internal/VisualStateMonitor.cs
@@ -2,15 +2,10 @@
 
 namespace MaterialDesignThemes.Wpf.Internal;
 
-internal sealed class VisualStateMonitor
+internal sealed class VisualStateMonitor(VisualStateGroup visualStateGroup)
 {
-    private readonly VisualStateGroup _visualStateGroup;
-
-    public VisualStateMonitor(VisualStateGroup visualStateGroup)
-    {
-        _visualStateGroup = visualStateGroup ??
+    private readonly VisualStateGroup _visualStateGroup = visualStateGroup ??
             throw new ArgumentNullException(nameof(visualStateGroup));
-    }
 
     public Task WaitForState(string state, CancellationToken cancellationToken)
     {
@@ -18,7 +13,6 @@ internal sealed class VisualStateMonitor
         if (currentState == state) return Task.CompletedTask;
 
         TaskCompletionSource<string> tcs = new();
-        cancellationToken.Register(() => tcs.TrySetCanceled());
 
         EventHandler<VisualStateChangedEventArgs> stateChanged = null!;
         stateChanged = (sender, e) =>
@@ -29,6 +23,12 @@ internal sealed class VisualStateMonitor
                 tcs.TrySetResult(state);
             }
         };
+
+        cancellationToken.Register(() =>
+        {
+            _visualStateGroup.CurrentStateChanged -= stateChanged;
+            tcs.TrySetCanceled(cancellationToken);
+        });
 
         _visualStateGroup.CurrentStateChanged += stateChanged;
 

--- a/src/MaterialDesignThemes.Wpf/Internal/VisualStateMonitor.cs
+++ b/src/MaterialDesignThemes.Wpf/Internal/VisualStateMonitor.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading;
+
+namespace MaterialDesignThemes.Wpf.Internal;
+
+internal sealed class VisualStateMonitor
+{
+    private readonly VisualStateGroup _visualStateGroup;
+
+    public VisualStateMonitor(VisualStateGroup visualStateGroup)
+    {
+        _visualStateGroup = visualStateGroup ??
+            throw new ArgumentNullException(nameof(visualStateGroup));
+    }
+
+    public Task WaitForState(string state, CancellationToken cancellationToken)
+    {
+        string currentState = _visualStateGroup.CurrentState.Name;
+        if (currentState == state) return Task.CompletedTask;
+
+        TaskCompletionSource<string> tcs = new();
+        cancellationToken.Register(() => tcs.TrySetCanceled());
+
+        EventHandler<VisualStateChangedEventArgs> stateChanged = null!;
+        stateChanged = (sender, e) =>
+        {
+            if (e.NewState.Name == state)
+            {
+                _visualStateGroup.CurrentStateChanged -= stateChanged;
+                tcs.TrySetResult(state);
+            }
+        };
+
+        _visualStateGroup.CurrentStateChanged += stateChanged;
+
+        currentState = _visualStateGroup.CurrentState.Name;
+        if (currentState == state)
+        {
+            _visualStateGroup.CurrentStateChanged -= stateChanged;
+
+            return Task.CompletedTask;
+        }
+
+        return tcs.Task;
+    }
+}

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DialogHost.xaml
@@ -25,11 +25,11 @@
           <ControlTemplate.Resources>
             <converters:FirstNonNullConverter x:Key="FirstNonNullConverter" />
           </ControlTemplate.Resources>
-          <Grid x:Name="DialogHostRoot" Focusable="False">
+          <Grid x:Name="PART_DialogHostRoot" Focusable="False">
             <VisualStateManager.VisualStateGroups>
-              <VisualStateGroup x:Name="PopupStates">
+              <VisualStateGroup Name="{x:Static wpf:DialogHost.VisualStateGroupName}">
                 <VisualStateGroup.Transitions>
-                  <VisualTransition From="Closed" To="Open">
+                  <VisualTransition From="{x:Static wpf:DialogHost.ClosedStateName}" To="{x:Static wpf:DialogHost.OpenStateName}">
                     <Storyboard>
                       <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup" Storyboard.TargetProperty="IsOpen">
                         <DiscreteBooleanKeyFrame KeyTime="0" Value="True" />
@@ -68,7 +68,7 @@
                       </DoubleAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="Open" To="Closed">
+                  <VisualTransition From="{x:Static wpf:DialogHost.OpenStateName}" To="{x:Static wpf:DialogHost.ClosedStateName}">
                     <Storyboard>
                       <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup" Storyboard.TargetProperty="IsOpen">
                         <DiscreteBooleanKeyFrame KeyTime="0:0:0.3" Value="False" />
@@ -111,7 +111,7 @@
                     </Storyboard>
                   </VisualTransition>
                 </VisualStateGroup.Transitions>
-                <VisualState x:Name="Open">
+                <VisualState Name="{x:Static wpf:DialogHost.OpenStateName}">
                   <Storyboard>
                     <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup"
                                                     Storyboard.TargetProperty="IsOpen"
@@ -136,7 +136,7 @@
                                      Duration="0" />
                   </Storyboard>
                 </VisualState>
-                <VisualState x:Name="Closed">
+                <VisualState Name="{x:Static wpf:DialogHost.ClosedStateName}">
                   <Storyboard>
                     <BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup" Storyboard.TargetProperty="IsOpen">
                       <DiscreteBooleanKeyFrame KeyTime="0" Value="False" />
@@ -152,7 +152,7 @@
             <wpf:PopupEx x:Name="PART_Popup"
                          wpf:ThemeAssist.Theme="{TemplateBinding DialogTheme}"
                          Placement="{TemplateBinding Placement}"
-                         PlacementTarget="{Binding ElementName=DialogHostRoot, Mode=OneWay}"
+                         PlacementTarget="{Binding ElementName=PART_DialogHostRoot, Mode=OneWay}"
                          Style="{TemplateBinding PopupStyle}">
               <Grid>
                 <Border Background="Transparent" IsHitTestVisible="{TemplateBinding CloseOnClickAway}">
@@ -265,11 +265,11 @@
           <ControlTemplate.Resources>
             <converters:FirstNonNullConverter x:Key="FirstNonNullConverter" />
           </ControlTemplate.Resources>
-          <Grid x:Name="DialogHostRoot" Focusable="False">
+          <Grid x:Name="PART_DialogHostRoot" Focusable="False">
             <VisualStateManager.VisualStateGroups>
-              <VisualStateGroup x:Name="PopupStates">
+              <VisualStateGroup Name="{x:Static wpf:DialogHost.VisualStateGroupName}">
                 <VisualStateGroup.Transitions>
-                  <VisualTransition From="Closed" To="Open">
+                  <VisualTransition From="{x:Static wpf:DialogHost.ClosedStateName}" To="{x:Static wpf:DialogHost.OpenStateName}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup" Storyboard.TargetProperty="Visibility">
                         <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
@@ -308,7 +308,7 @@
                       </DoubleAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="Open" To="Closed">
+                  <VisualTransition From="{x:Static wpf:DialogHost.OpenStateName}" To="{x:Static wpf:DialogHost.ClosedStateName}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup" Storyboard.TargetProperty="Visibility">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0.3" Value="{x:Static Visibility.Collapsed}" />
@@ -351,7 +351,7 @@
                     </Storyboard>
                   </VisualTransition>
                 </VisualStateGroup.Transitions>
-                <VisualState x:Name="Open">
+                <VisualState Name="{x:Static wpf:DialogHost.OpenStateName}">
                   <Storyboard>
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup"
                                                    Storyboard.TargetProperty="Visibility"
@@ -376,7 +376,7 @@
                                      Duration="0" />
                   </Storyboard>
                 </VisualState>
-                <VisualState x:Name="Closed">
+                <VisualState Name="{x:Static wpf:DialogHost.ClosedStateName}">
                   <Storyboard>
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_Popup"
                                                    Storyboard.TargetProperty="Visibility"

--- a/tests/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Threading;
 using System.Windows.Media;
 using MaterialDesignThemes.UITests.Samples.DialogHost;
 
@@ -14,7 +15,7 @@ public class DialogHostTests : TestBase
     }
 
     [Test]
-    public async Task WaitForClosed_CompletesAfterDialogCloses()
+    public async Task WaitForOpenAndClosed_CompletesAfterDialogAnimates()
     {
         var dialogHost = await LoadXaml<DialogHost>("<materialDesign:DialogHost />");
 
@@ -26,16 +27,48 @@ public class DialogHostTests : TestBase
 
         static async Task OpenAndWaitForCompletion(DialogHost dialogHost)
         {
-            Task wait = dialogHost.WaitForOpened();
+            CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
+            Task wait = dialogHost.WaitForOpened(cts.Token);
             dialogHost.IsOpen = true;
             await wait;
         }
 
         static async Task CloseAndWaitForCompletion(DialogHost dialogHost)
         {
-            Task wait = dialogHost.WaitForClosed();
+            CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
+            Task wait = dialogHost.WaitForClosed(cts.Token);
             dialogHost.IsOpen = false;
             await wait;
+        }
+    }
+
+    [Test]
+    public async Task WaitAlreadyReachedState_CompletesImmediately()
+    {
+        var dialogHost = await LoadXaml<DialogHost>("<materialDesign:DialogHost />");
+
+        await dialogHost.RemoteExecute(OpenAndWaitForCompletionTwice);
+        await Assert.That(dialogHost.GetIsOpen()).IsTrue();
+
+        await dialogHost.RemoteExecute(CloseAndWaitForCompletionTwice);
+        await Assert.That(dialogHost.GetIsOpen()).IsFalse();
+
+        static async Task OpenAndWaitForCompletionTwice(DialogHost dialogHost)
+        {
+            CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
+            Task wait = dialogHost.WaitForOpened(cts.Token);
+            dialogHost.IsOpen = true;
+            await wait;
+            await dialogHost.WaitForOpened(cts.Token);
+        }
+
+        static async Task CloseAndWaitForCompletionTwice(DialogHost dialogHost)
+        {
+            CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
+            Task wait = dialogHost.WaitForClosed(cts.Token);
+            dialogHost.IsOpen = false;
+            await wait;
+            await dialogHost.WaitForClosed(cts.Token);
         }
     }
 

--- a/tests/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/DialogHosts/DialogHostTests.cs
@@ -14,6 +14,32 @@ public class DialogHostTests : TestBase
     }
 
     [Test]
+    public async Task WaitForClosed_CompletesAfterDialogCloses()
+    {
+        var dialogHost = await LoadXaml<DialogHost>("<materialDesign:DialogHost />");
+
+        await dialogHost.RemoteExecute(OpenAndWaitForCompletion);
+        await Assert.That(dialogHost.GetIsOpen()).IsTrue();
+
+        await dialogHost.RemoteExecute(CloseAndWaitForCompletion);
+        await Assert.That(dialogHost.GetIsOpen()).IsFalse();
+
+        static async Task OpenAndWaitForCompletion(DialogHost dialogHost)
+        {
+            Task wait = dialogHost.WaitForOpened();
+            dialogHost.IsOpen = true;
+            await wait;
+        }
+
+        static async Task CloseAndWaitForCompletion(DialogHost dialogHost)
+        {
+            Task wait = dialogHost.WaitForClosed();
+            dialogHost.IsOpen = false;
+            await wait;
+        }
+    }
+
+    [Test]
     public async Task OnOpenDialog_OverlayCoversContent()
     {
         IVisualElement dialogHost = await LoadUserControl<WithCounter>();
@@ -288,7 +314,7 @@ public class DialogHostTests : TestBase
         await Wait.For(async () =>
         {
             var contentCoverBorder = await dialogHost.GetElement<Border>("ContentCoverBorder");
-                
+
             await Assert.That((await contentCoverBorder.GetCornerRadius()).TopLeft).IsEqualTo(1);
             await Assert.That((await contentCoverBorder.GetCornerRadius()).TopRight).IsEqualTo(2);
             await Assert.That((await contentCoverBorder.GetCornerRadius()).BottomRight).IsEqualTo(3);
@@ -450,7 +476,7 @@ public class DialogHostTests : TestBase
         var comboBox = await dialogHost.GetElement<ComboBox>("TargetedPlatformComboBox");
         await Task.Delay(500, TestContext.Current!.Execution.CancellationToken);
         await comboBox.LeftClick();
-        
+
         var item = await Wait.For(() => comboBox.GetElement<ComboBoxItem>("TargetItem"));
         await Task.Delay(TimeSpan.FromSeconds(1));
         await item.LeftClick();
@@ -507,7 +533,7 @@ public class DialogHostTests : TestBase
         await Wait.For(async () => await Assert.That(await textBoxOne.GetIsFocused()).IsTrue());
 
         await textBoxOne.SendInput(new KeyboardInput(inputActions));
-        
+
         await Wait.For(async () => await Assert.That(await textBoxTwo.GetIsFocused()).IsTrue());
 
         await textBoxTwo.SendInput(new KeyboardInput(inputActions));


### PR DESCRIPTION
Potential Fix for #4017

Introduces `WaitForOpened` and `WaitForClosed` methods on `DialogHost` to enable asynchronous waiting for the completion of the dialog's visual state transitions. This provides more precise control for executing logic precisely after the dialog has fully opened or closed, rather than just when events are dispatched.

Outstanding items:
1. Are the WaitFor* methods named properly?
2. Tests, need to have them. Will be impossible to test race conditions reliably, but happy path should be there.
3. Should the CancelationToken int he WaitFor* methods be required rather than optional? 

Updates the `DialogSession` to expose the parent `DialogHost` instance, facilitating access to these new awaitable methods.
