### PR TITLE
I aimed for .cs files. Not enough experienced for .xaml files.

### DIFF
--- a/src/MahMaterialDragablzMashUp/DialogsViewModel.cs
+++ b/src/MahMaterialDragablzMashUp/DialogsViewModel.cs
@@ -11,18 +11,18 @@ public class DialogsViewModel
 
     public ICommand ShowLeftFlyoutCommand { get; }
 
-    private ResourceDictionary DialogDictionary = new ResourceDictionary() { Source = new Uri("pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Dialogs.xaml") };
+    private readonly ResourceDictionary DialogDictionary = new ResourceDictionary() { Source = new Uri("pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Dialogs.xaml") };
 
     public DialogsViewModel()
     {
-        ShowInputDialogCommand = new AnotherCommandImplementation(_ => InputDialog());
-        ShowProgressDialogCommand = new AnotherCommandImplementation(_ => ProgressDialog());
+        ShowInputDialogCommand = new AnotherCommandImplementation(async _ => await InputDialog());
+        ShowProgressDialogCommand = new AnotherCommandImplementation(async _ => await ProgressDialog());
         ShowLeftFlyoutCommand = new AnotherCommandImplementation(_ => ShowLeftFlyout());
     }
 
     public Flyout? LeftFlyout { get; set; }
 
-    private void InputDialog()
+    private async Task InputDialog()
     {
         var metroDialogSettings = new MetroDialogSettings
         {
@@ -30,10 +30,10 @@ public class DialogsViewModel
             NegativeButtonText = "CANCEL"
         };
 
-        DialogCoordinator.Instance.ShowInputAsync(this, "MahApps Dialog", "Using Material Design Themes", metroDialogSettings);
+        await DialogCoordinator.Instance.ShowInputAsync(this, "MahApps Dialog", "Using Material Design Themes", metroDialogSettings);
     }
 
-    private async void ProgressDialog()
+    private async Task ProgressDialog()
     {
         var metroDialogSettings = new MetroDialogSettings
         {
@@ -49,6 +49,12 @@ public class DialogsViewModel
 
     private void ShowLeftFlyout()
     {
-        ((MainWindow)Application.Current.MainWindow).LeftFlyout.IsOpen = !((MainWindow)Application.Current.MainWindow).LeftFlyout.IsOpen;
+        // Avoid direct cast to the project's MainWindow type (XAML-generated partials can confuse the analyzer).
+        // Find the named flyout from the main window and toggle its IsOpen state.
+        var leftFlyout = Application.Current?.MainWindow?.FindName("LeftFlyout") as Flyout;
+        if (leftFlyout != null)
+        {
+            leftFlyout.IsOpen = !leftFlyout.IsOpen;
+        }
     }
 }

--- a/src/MahMaterialDragablzMashUp/MahViewModel.cs
+++ b/src/MahMaterialDragablzMashUp/MahViewModel.cs
@@ -21,7 +21,7 @@ public class MahViewModel : INotifyPropertyChanged
         {
             if (value < 0)
             {
-                throw new Exception("Value must be positive");
+                throw new System.ArgumentOutOfRangeException(nameof(UpDownValue), value, "Value must be non-negative");
             }
             if (_UpDownValue != value)
             {


### PR DESCRIPTION
Two things I have to write before I specify what I did:

1. I apologize if I broke any rules when it comes to contribution.

2. I did use GitHub CoPilot in certain cases since I do not want to mess up the source code even though I forked it.

Anyways: here is what I did:

1. I fixed the invalid cast error in src/MahMaterialDragablzMashUp/DialogsViewModel.cs:

* Replaced the direct cast ((MainWindow)Application.Current.MainWindow) with a safe lookup:
 * var leftFlyout = Application.Current?.MainWindow?.FindName("LeftFlyout") as Flyout;
 * Toggle leftFlyout.IsOpen if found.
 * This avoids the compile-time CS0030 error (Window -> MainWindow) and works regardless of XAML-generated partial class details.

I find it funny how this removed 4 errors and many warnings.

2. I made the two changes to address the warnings in DialogsViewModel.cs:
 * Marked DialogDictionary as readonly.
 * Changed ProgressDialog from async void to async Task.

3. I updated the property setter in MahVieModel.cs to throw an ArgumentOutOfRangeException instead of System.Exception, which static analyzers (S112) flag as a poor practice. Property setters should signal invalid argument values with a more specific exception type.

I replaced throw new Exception("Value must be positive") with throw new System.ArgumentOutOfRangeException(nameof(UpDownValue), value, "Value must be non-negative"), which provides a specific exception type, the offending parameter name, and the actual value.

4. Since there weren't any other .cs files, I decided to edit DialogsViewModel.cs:

* Changed InputDialog signature to: private async Task InputDialog() and used await DialogCoordinator.Instance.ShowInputAsync(...).

* Changed the command registrations in the constructor to async lambdas that await the methods:
 * ShowInputDialogCommand = new AnotherCommandImplementation(async _ => await InputDialog());
 * ShowProgressDialogCommand = new AnotherCommandImplementation(async _ => await ProgressDialog());

These make the async calls observed (awaited) and remove CS4014 warnings.

I have no intention of editing .xaml files since I have only studied XML, but not quite enough to understand what I can do.
If there is anything else I have to do, make sure to comment and specify eveything else I can fix. Or even add.

Edit: Oh, wait. I forgot I needed to close VS after installing one of NuGet packages... I will have to commit again just in case.

Edit edit: I saw errors for xaml files just to disappear. what?