### PR TITLE
fix(DataGrid): Center DataGridCell-Content by default

### DIFF
--- a/src/MainDemo.Wpf/DataGrids.xaml
+++ b/src/MainDemo.Wpf/DataGrids.xaml
@@ -184,6 +184,58 @@
                 CanUserAddRows="False"
                 ItemsSource="{Binding Items4}" />
     </smtx:XamlDisplay>
+
+    <Rectangle Style="{StaticResource PageSectionSeparator}" />
+
+    <TextBlock Style="{StaticResource PageSectionTitleTextBlock}" Text="Custom row height" />
+
+    <smtx:XamlDisplay UniqueKey="grids_5">
+      <DataGrid AutoGenerateColumns="False"
+                IsReadOnly="True"
+                ItemsSource="{Binding Items1}">
+        <DataGrid.Columns>
+          <DataGridTemplateColumn Header="Actions">
+            <DataGridTemplateColumn.CellTemplate>
+              <DataTemplate>
+                <StackPanel Orientation="Horizontal">
+                  <Button Command="{Binding DataContext.EditItemCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                          CommandParameter="{Binding .}"
+                          Content="{materialDesign:PackIcon Kind=Pen}"
+                          Style="{StaticResource MaterialDesignIconButton}"
+                          ToolTip="Edit">
+                    <Button.Resources>
+                      <SolidColorBrush x:Key="MaterialDesign.Brush.Primary" Color="Orange" />
+                    </Button.Resources>
+                  </Button>
+                  <Button Command="{Binding DataContext.DuplicateItemCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                          CommandParameter="{Binding .}"
+                          Content="{materialDesign:PackIcon Kind=ContentDuplicate}"
+                          Style="{StaticResource MaterialDesignIconButton}"
+                          ToolTip="Duplicate">
+                    <Button.Resources>
+                      <SolidColorBrush x:Key="MaterialDesign.Brush.Primary" Color="DodgerBlue" />
+                    </Button.Resources>
+                  </Button>
+                  <Button Command="{Binding DataContext.DeleteItemCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                          CommandParameter="{Binding .}"
+                          Content="{materialDesign:PackIcon Kind=Bin}"
+                          Style="{StaticResource MaterialDesignIconButton}"
+                          ToolTip="Delete">
+                    <Button.Resources>
+                      <SolidColorBrush x:Key="MaterialDesign.Brush.Primary" Color="Red" />
+                    </Button.Resources>
+                  </Button>
+                </StackPanel>
+              </DataTemplate>
+            </DataGridTemplateColumn.CellTemplate>
+          </DataGridTemplateColumn>
+          <DataGridTextColumn Binding="{Binding Code}" Header="Code" />
+          <DataGridTextColumn Binding="{Binding Name}" Header="Name" />
+          <DataGridTextColumn Binding="{Binding Description}" Header="Description" />
+        </DataGrid.Columns>
+      </DataGrid>
+    </smtx:XamlDisplay>
+
   </StackPanel>
 </UserControl>
 

--- a/src/MainDemo.Wpf/DataGrids.xaml.cs
+++ b/src/MainDemo.Wpf/DataGrids.xaml.cs
@@ -6,7 +6,7 @@ public partial class DataGrids
 {
     public DataGrids()
     {
-        DataContext = new ListsAndGridsViewModel();
+        DataContext = new ListsAndGridsViewModel(MainWindow.Snackbar.MessageQueue!);
         InitializeComponent();
     }
 }

--- a/src/MainDemo.Wpf/Domain/ListsAndGridsViewModel.cs
+++ b/src/MainDemo.Wpf/Domain/ListsAndGridsViewModel.cs
@@ -1,12 +1,17 @@
 using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.Input;
 using MaterialDesignDemo.Shared.Domain;
+using MaterialDesignThemes.Wpf;
 
 namespace MaterialDesignDemo.Domain;
 
-public class ListsAndGridsViewModel : ViewModelBase
+public partial class ListsAndGridsViewModel : ViewModelBase
 {
-    public ListsAndGridsViewModel()
+    private readonly ISnackbarMessageQueue _snackbarMessageQueue;
+
+    public ListsAndGridsViewModel(ISnackbarMessageQueue snackbarMessageQueue)
     {
+        _snackbarMessageQueue = snackbarMessageQueue;
         Items1 = CreateData();
         Items2 = CreateData();
         Items3 = CreateData();
@@ -21,7 +26,7 @@ public class ListsAndGridsViewModel : ViewModelBase
             };
         }
 
-        Files = new List<string>();
+        Files = [];
 
         for (int i = 0; i < 1000; i++)
         {
@@ -56,8 +61,8 @@ public class ListsAndGridsViewModel : ViewModelBase
 
     private static ObservableCollection<SelectableViewModel> CreateData()
     {
-        return new ObservableCollection<SelectableViewModel>
-        {
+        return
+        [
             new SelectableViewModel
             {
                 Code = 'M',
@@ -77,7 +82,7 @@ public class ListsAndGridsViewModel : ViewModelBase
                 Name = "Predator",
                 Description = "If it bleeds, we can kill it"
             }
-        };
+        ];
     }
 
     public ObservableCollection<SelectableViewModel> Items1 { get; }
@@ -85,9 +90,21 @@ public class ListsAndGridsViewModel : ViewModelBase
     public ObservableCollection<SelectableViewModel> Items3 { get; }
     public ObservableCollection<SelectableViewModel> Items4 { get; }
 
-    public IEnumerable<string> Foods => new[] { "Burger", "Fries", "Shake", "Lettuce" };
+    public IEnumerable<string> Foods => ["Burger", "Fries", "Shake", "Lettuce"];
 
     public IList<string> Files { get; }
 
-    public IEnumerable<DataGridSelectionUnit> SelectionUnits => new[] { DataGridSelectionUnit.FullRow, DataGridSelectionUnit.Cell, DataGridSelectionUnit.CellOrRowHeader };
+    public IEnumerable<DataGridSelectionUnit> SelectionUnits => [DataGridSelectionUnit.FullRow, DataGridSelectionUnit.Cell, DataGridSelectionUnit.CellOrRowHeader];
+
+    [RelayCommand]
+    private void EditItem(SelectableViewModel item)
+        => _snackbarMessageQueue.Enqueue($"Editing {item.Name}");
+
+    [RelayCommand]
+    private void DuplicateItem(SelectableViewModel item)
+        => _snackbarMessageQueue.Enqueue($"Duplicating {item.Name}");
+
+    [RelayCommand]
+    private void DeleteItem(SelectableViewModel item)
+        => _snackbarMessageQueue.Enqueue($"Deleting {item.Name}");
 }

--- a/src/MainDemo.Wpf/Lists.xaml.cs
+++ b/src/MainDemo.Wpf/Lists.xaml.cs
@@ -6,7 +6,7 @@ public partial class Lists
 {
     public Lists()
     {
-        DataContext = new ListsAndGridsViewModel();
+        DataContext = new ListsAndGridsViewModel(MainWindow.Snackbar.MessageQueue!);
         InitializeComponent();
     }
 }

--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
@@ -259,12 +259,16 @@
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"
                     SnapsToDevicePixels="True" />
-            <ContentPresenter Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+            <ContentPresenter Margin="{TemplateBinding Padding}"
+                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
           </Grid>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
     <Setter Property="Validation.ErrorTemplate" Value="{x:Null}" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Style.Triggers>
       <Trigger Property="IsKeyboardFocusWithin" Value="True">
         <Setter Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource AncestorType=DataGrid}, Path=(wpf:DataGridAssist.SelectedCellBorderBrush)}" />
@@ -381,7 +385,7 @@
                                   RecognizesAccessKey="True"
                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                 <Control SnapsToDevicePixels="false"
-                         Template="{Binding ValidationErrorTemplate, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}},FallbackValue={x:Null}}"
+                         Template="{Binding ValidationErrorTemplate, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}, FallbackValue={x:Null}}"
                          Visibility="{Binding (Validation.HasError), Converter={x:Static converters:BooleanToVisibilityConverter.CollapsedInstance}, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}, FallbackValue=Collapsed}" />
               </StackPanel>
             </Border>
@@ -489,7 +493,9 @@
                   BorderThickness="{TemplateBinding BorderThickness}"
                   CornerRadius="{TemplateBinding wpf:DataGridAssist.CornerRadius}"
                   SnapsToDevicePixels="True">
-            <ScrollViewer x:Name="DG_ScrollViewer" Focusable="false" wpf:ScrollViewerAssist.BubbleVerticalScroll="{Binding Path=(wpf:ScrollViewerAssist.BubbleVerticalScroll), RelativeSource={RelativeSource TemplatedParent}}">
+            <ScrollViewer x:Name="DG_ScrollViewer"
+                          wpf:ScrollViewerAssist.BubbleVerticalScroll="{Binding Path=(wpf:ScrollViewerAssist.BubbleVerticalScroll), RelativeSource={RelativeSource TemplatedParent}}"
+                          Focusable="false">
               <ScrollViewer.Template>
                 <ControlTemplate TargetType="{x:Type ScrollViewer}">
                   <Grid>


### PR DESCRIPTION
fixes #3999

## Problem

`MaterialDesignDataGridCell`'s `ControlTemplate` doesn't forward `HorizontalContentAlignment`/`VerticalContentAlignment` to its `ContentPresenter`, so setting those properties has no effect. As a workaround, users set `VerticalAlignment="Center"` on the cell itself instead:

```xaml
<DataGrid.CellStyle>
  <Style TargetType="DataGridCell" BasedOn="{StaticResource MaterialDesignDataGridCell}">
    <Setter Property="VerticalAlignment" Value="Center" />
  </Style>
</DataGrid.CellStyle>
```

This centers the cell itself rather than its content - so when `RowHeight` is taller than the cell's desired height, the cell no longer stretches to fill the row. That leaves a gap above and below each cell, which appears as duplicate horizontal gridlines when `GridLinesVisibility` includes `Horizontal`.

## Fix

Bind `HorizontalAlignment`/`VerticalAlignment` on the `ContentPresenter` to `HorizontalContentAlignment`/`VerticalContentAlignment` via `TemplateBinding`. With that in place, `VerticalContentAlignment="Center"` centers the content while the cell itself still stretches to fill the row, so there's no gap and no duplicate gridlines.

## Testing

I wasn't sure how to reasonably cover this with an automated test, so I added an example to the demo app instead. Happy to open a follow-up PR to bring this example into the MD3 demo app and consolidate view models.

## Current default behavior
<img width="631" height="244" alt="grafik" src="https://github.com/user-attachments/assets/edd84679-089b-4b7c-869b-34c3d3075e77" />

## Current default behavior with the `DataGridCell` style below applied
<img width="631" height="251" alt="grafik" src="https://github.com/user-attachments/assets/be4a1531-00f3-498b-9254-901721e556bf" />

```xaml
<DataGrid.CellStyle>
  <Style TargetType="DataGridCell" BasedOn="{StaticResource MaterialDesignDataGridCell}">
    <Setter Property="VerticalAlignment" Value="Center" />
  </Style>
</DataGrid.CellStyle>
```

## New default behavior
<img width="615" height="252" alt="grafik" src="https://github.com/user-attachments/assets/b3817451-06a6-46c7-ae35-ca3ca4d1ce15" />

