### PR TITLE
Fix nightly release workflow previous run detection

### DIFF
--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -25,9 +25,8 @@ jobs:
     - id: check_for_changes
       name: Check for changes
       run: |
-        # Grab the last two run, since the latest run will be the current one executing
-        $workflowList = gh run list --workflow "${{ github.workflow }}" --branch "${{ github.ref_name }}" --json databaseId --limit 2 --repo "${{ github.repository }}"
-        $runId = ($workflowList | ConvertFrom-Json)[1].databaseId
+        $workflowList = gh run list --workflow "${{ github.workflow }}" --branch "${{ github.ref_name }}" --json databaseId --status completed --repo "${{ github.repository }}"
+        $runId = ($workflowList | ConvertFrom-Json)[0].databaseId
         $lastRunHash = ((gh run view $runId --json headSha --repo "${{ github.repository }}") | ConvertFrom-Json).headSha
 
         echo "Last hash $lastRunHash"


### PR DESCRIPTION
Ensure the `check_for_changes` step reliably identifies the last *completed* workflow run. The previous logic could pick an incorrect run due to inconsistent indexing. By explicitly filtering for `--status completed`, the latest completed run is correctly identified.
