### PR TITLE
fix(combobox): allow dropdown toggle when clicking prefix or suffix text

### DIFF
--- a/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -350,6 +350,7 @@
                          Grid.Column="1"
                          Margin="0,0,2,0"
                          FontSize="{TemplateBinding FontSize}"
+                         IsHitTestVisible="False"
                          Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                          Text="{TemplateBinding wpf:TextFieldAssist.PrefixText}"
                          VerticalAlignment="Center">
@@ -446,6 +447,7 @@
                          Grid.Column="3"
                          Margin="2,0,0,0"
                          FontSize="{TemplateBinding FontSize}"
+                         IsHitTestVisible="False"
                          Opacity="{TemplateBinding wpf:HintAssist.HintOpacity}"
                          Text="{TemplateBinding wpf:TextFieldAssist.SuffixText}"
                          VerticalAlignment="Center">

--- a/tests/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
+++ b/tests/MaterialDesignThemes.UITests/WPF/ComboBoxes/ComboBoxTests.cs
@@ -299,4 +299,39 @@ public class ComboBoxTests : TestBase
         await Assert.That(popupBackground).IsNotNull();
         await Assert.That(popupBackground).IsEqualTo((Color)ColorConverter.ConvertFromString("#CC336699"));
     }
+
+    [Test]
+    [Description("https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/issues/4090")]
+    public async Task ComboBox_OpensDropDown_WhenClickingOnPrefixOrSuffixTextBlock()
+    {
+        var comboBox = await LoadXaml<ComboBox>($"""
+            <ComboBox materialDesign:TextFieldAssist.PrefixText="Some prefix"
+                      materialDesign:TextFieldAssist.SuffixText="Some suffix"
+                      SelectedIndex="1">
+                <ComboBoxItem Content="Android" />
+                <ComboBoxItem Content="iOS" />
+                <ComboBoxItem Content="Linux" />
+                <ComboBoxItem Content="Windows" />
+            </ComboBox>
+            """);
+
+        await Assert.That(await comboBox.GetIsDropDownOpen()).IsFalse();
+
+        var prefixTextBlock = await comboBox.GetElement<TextBlock>("PrefixTextBlock");
+        await AssertOpensAndClosesDropDown(prefixTextBlock);
+
+        var suffixTextBlock = await comboBox.GetElement<TextBlock>("SuffixTextBlock");
+        await AssertOpensAndClosesDropDown(suffixTextBlock);
+
+        async Task AssertOpensAndClosesDropDown(IVisualElement<TextBlock> textBlock)
+        {
+            await textBlock.LeftClick();
+            await Task.Delay(50, TestContext.Current!.Execution.CancellationToken);
+            await Assert.That(await comboBox.GetIsDropDownOpen()).IsTrue();
+
+            await textBlock.LeftClick();
+            await Task.Delay(50, TestContext.Current!.Execution.CancellationToken);
+            await Assert.That(await comboBox.GetIsDropDownOpen()).IsFalse();
+        }
+    }
 }


### PR DESCRIPTION
fixes #4090

Sets `IsHitTestVisible="False"` on the internal `PrefixTextBlock` and `SuffixTextBlock` so mouse events are handled by the underlying `ComboBox`.

I tested clicking both the Prefix and Suffix in the same test rather than using two separate tests (or making the test data-driven) to avoid the overhead of starting the app multiple times.

@Keboo I'm not 100% sure whether the `Task.Delay(50)` is appropriate here, or if this should instead use a `Wait.For(...)` call. There is a test above that uses the same 50ms delay, so I followed that approach.