### PR TITLE
docs: add `DialogHost.WaitFor*` example

### DIFF
--- a/src/MainDemo.Wpf/App.xaml.cs
+++ b/src/MainDemo.Wpf/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using MaterialDesign.Shared;
+﻿using System.Reflection;
+using MaterialDesign.Shared;
 using MaterialDesignThemes.Wpf;
 using ShowMeTheXAML;
 
@@ -32,7 +33,9 @@ public partial class App : Application
                     XmlLanguage.GetLanguage(CultureInfo.CurrentCulture.IetfLanguageTag)));
         */
 
-        XamlDisplay.Init();
+        var sharedAssembly
+            = Assembly.GetAssembly(typeof(MaterialDesignDemo.Shared.IMaterialDesignDemoSharedAssemblyMarker));
+        XamlDisplay.Init(sharedAssembly);
 
         // test setup for Persian culture settings
         /*System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("fa-Ir");

--- a/src/MainDemo.Wpf/Dialogs.xaml
+++ b/src/MainDemo.Wpf/Dialogs.xaml
@@ -6,6 +6,7 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
+             xmlns:shared="clr-namespace:MaterialDesignDemo.Shared.Examples.Dialogs;assembly=MaterialDesignDemo.Shared"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
              d:DataContext="{d:DesignInstance domain:DialogsViewModel}"
              d:DesignHeight="1080"
@@ -367,6 +368,17 @@
         </Border>
       </materialDesign:DialogHost>
     </smtx:XamlDisplay>
+    <!--#endregion-->
+
+    <Rectangle Style="{StaticResource PageSectionSeparator}" />
+
+    <!--#region SAMPLE 7 - WaitForOpened / WaitForClosed demo-->
+    <TextBlock Style="{StaticResource PageSectionTitleTextBlock}" Text="Sample 7 - WaitForOpened / WaitForClosed" />
+
+    <TextBlock Margin="0,0,0,8"
+               Text="The DialogHost.WaitForOpened() and DialogHost.WaitForClosed() methods can be used to wait until the dialog is fully opened or closed respectively."
+               TextWrapping="Wrap" />
+    <shared:DialogHostWaitForExample />
     <!--#endregion-->
   </StackPanel>
 </UserControl>

--- a/src/MaterialDesign3.Demo.Wpf/Dialogs.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Dialogs.xaml
@@ -5,6 +5,7 @@
              xmlns:domain="clr-namespace:MaterialDesign3Demo.Domain"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:shared="clr-namespace:MaterialDesignDemo.Shared.Examples.Dialogs;assembly=MaterialDesignDemo.Shared"
              xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
              d:DataContext="{d:DesignInstance domain:DialogsViewModel}"
@@ -46,6 +47,7 @@
         <ColumnDefinition Width="320" />
         <ColumnDefinition Width="320" />
         <ColumnDefinition Width="320" />
+        <ColumnDefinition Width="600" />
       </Grid.ColumnDefinitions>
 
       <!--#region SAMPLE 1-->
@@ -324,6 +326,14 @@
           </Border>
         </materialDesign:DialogHost>
       </smtx:XamlDisplay>
+      <!--#endregion-->
+
+      <!--#region SAMPLE 7 - WaitForOpened / WaitForClosed demo-->
+      <StackPanel Grid.Row="0" Grid.Column="5">
+        <TextBlock Text="SAMPLE 6: WaitForOpened / WaitForClosed" />
+        <TextBlock Text="The DialogHost.WaitForOpened() and DialogHost.WaitForClosed() methods can be used to wait until the dialog is fully opened or closed respectively." TextWrapping="Wrap" />
+      </StackPanel>
+      <shared:DialogHostWaitForExample Grid.Row="1" Grid.Column="5" />
       <!--#endregion-->
     </Grid>
   </Grid>

--- a/src/MaterialDesign3.Demo.Wpf/Dialogs.xaml
+++ b/src/MaterialDesign3.Demo.Wpf/Dialogs.xaml
@@ -328,7 +328,7 @@
       </smtx:XamlDisplay>
       <!--#endregion-->
 
-      <!--#region SAMPLE 7 - WaitForOpened / WaitForClosed demo-->
+      <!--#region SAMPLE 6 - WaitForOpened / WaitForClosed demo-->
       <StackPanel Grid.Row="0" Grid.Column="5">
         <TextBlock Text="SAMPLE 6: WaitForOpened / WaitForClosed" />
         <TextBlock Text="The DialogHost.WaitForOpened() and DialogHost.WaitForClosed() methods can be used to wait until the dialog is fully opened or closed respectively." TextWrapping="Wrap" />

--- a/src/MaterialDesignDemo.Shared/Examples/Dialogs/DialogHostWaitForExample.xaml
+++ b/src/MaterialDesignDemo.Shared/Examples/Dialogs/DialogHostWaitForExample.xaml
@@ -1,0 +1,99 @@
+﻿<UserControl x:Class="MaterialDesignDemo.Shared.Examples.Dialogs.DialogHostWaitForExample"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <smtx:XamlDisplay UniqueKey="dialogs_sample65446545617">
+      <Border MinHeight="160"
+              Padding="16"
+              BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+              BorderThickness="1">
+        <Grid>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="280" />
+          </Grid.ColumnDefinitions>
+
+          <!-- Left: open button -->
+          <materialDesign:DialogHost x:Name="Sample7DialogHost" Grid.Column="0">
+            <materialDesign:DialogHost.DialogContent>
+              <StackPanel Margin="16">
+                <TextBlock Margin="0,0,0,8" Text="This is sample 7 dialog content." />
+                <Button Click="Sample7_CloseButton_Click"
+                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                        Content="Close Dialog"
+                        Style="{StaticResource MaterialDesignFlatButton}" />
+              </StackPanel>
+            </materialDesign:DialogHost.DialogContent>
+            <Button Width="160"
+                    Height="40"
+                    Click="Sample7_OpenButton_Click"
+                    Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
+                    Content="Open Dialog"
+                    Style="{StaticResource MaterialDesignRaisedButton}" />
+          </materialDesign:DialogHost>
+
+          <StackPanel Grid.Column="1">
+            <materialDesign:Card Padding="8"
+                                 VerticalAlignment="Top"
+                                 UniformCornerRadius="8">
+              <StackPanel>
+                <WrapPanel>
+                  <TextBlock Text="Open button clicked: " />
+                  <TextBlock x:Name="Sample7_OpenClicked" />
+                </WrapPanel>
+
+                <materialDesign:Chip HorizontalAlignment="Right" Foreground="Green">
+                  <WrapPanel VerticalAlignment="Center">
+                    <materialDesign:PackIcon Kind="ArrowLeftBottom" RenderTransformOrigin="0.5 0.5">
+                      <materialDesign:PackIcon.RenderTransform>
+                        <RotateTransform Angle="-45" />
+                      </materialDesign:PackIcon.RenderTransform>
+                    </materialDesign:PackIcon>
+                    <TextBlock x:Name="Sample7_OpenTimeDifference" />
+                  </WrapPanel>
+                </materialDesign:Chip>
+
+                <WrapPanel>
+                  <TextBlock Text="Opened animation finished: " />
+                  <TextBlock x:Name="Sample7_OpenedFinished" />
+                </WrapPanel>
+              </StackPanel>
+            </materialDesign:Card>
+
+            <materialDesign:Card Margin="0,8,0,0"
+                                 Padding="8"
+                                 VerticalAlignment="Top"
+                                 UniformCornerRadius="8">
+              <StackPanel>
+                <WrapPanel>
+                  <TextBlock Text="Closed button clicked: " />
+                  <TextBlock x:Name="Sample7_CloseClicked" />
+                </WrapPanel>
+
+                <materialDesign:Chip HorizontalAlignment="Right" Foreground="Red">
+                  <WrapPanel VerticalAlignment="Center">
+                    <materialDesign:PackIcon Kind="ArrowLeftBottom" RenderTransformOrigin="0.5 0.5">
+                      <materialDesign:PackIcon.RenderTransform>
+                        <RotateTransform Angle="-45" />
+                      </materialDesign:PackIcon.RenderTransform>
+                    </materialDesign:PackIcon>
+                    <TextBlock x:Name="Sample7_CloseTimeDifference" />
+                  </WrapPanel>
+                </materialDesign:Chip>
+
+                <WrapPanel>
+                  <TextBlock Text="Closed animation finished: " />
+                  <TextBlock x:Name="Sample7_ClosedFinished" />
+                </WrapPanel>
+              </StackPanel>
+            </materialDesign:Card>
+          </StackPanel>
+        </Grid>
+      </Border>
+    </smtx:XamlDisplay>
+</UserControl>

--- a/src/MaterialDesignDemo.Shared/Examples/Dialogs/DialogHostWaitForExample.xaml
+++ b/src/MaterialDesignDemo.Shared/Examples/Dialogs/DialogHostWaitForExample.xaml
@@ -19,18 +19,18 @@
           <ColumnDefinition Width="280" />
         </Grid.ColumnDefinitions>
 
-        <materialDesign:DialogHost x:Name="Sample7DialogHost" Grid.Column="0">
+        <materialDesign:DialogHost x:Name="SampleDialogHost" Grid.Column="0">
           <materialDesign:DialogHost.DialogContent>
             <StackPanel Margin="16">
-              <TextBlock Margin="0,0,0,8" Text="This is sample 7 dialog content." />
-              <Button Click="Sample7_CloseButton_Click"
+              <TextBlock Margin="0,0,0,8" Text="This is sample dialog content." />
+              <Button Click="Sample_CloseButton_Click"
                       Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
                       Content="Close Dialog"
                       Style="{StaticResource MaterialDesignFlatButton}" />
             </StackPanel>
           </materialDesign:DialogHost.DialogContent>
           <Button HorizontalAlignment="Center"
-                  Click="Sample7_OpenButton_Click"
+                  Click="Sample_OpenButton_Click"
                   Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
                   Content="Open Dialog"
                   Style="{StaticResource MaterialDesignRaisedButton}" />
@@ -43,7 +43,7 @@
             <StackPanel>
               <WrapPanel>
                 <TextBlock Text="Open button clicked: " />
-                <TextBlock x:Name="Sample7_OpenClicked" />
+                <TextBlock x:Name="Sample_OpenClicked" />
               </WrapPanel>
 
               <materialDesign:Chip HorizontalAlignment="Right" Foreground="Green">
@@ -53,13 +53,13 @@
                       <RotateTransform Angle="-45" />
                     </materialDesign:PackIcon.RenderTransform>
                   </materialDesign:PackIcon>
-                  <TextBlock x:Name="Sample7_OpenTimeDifference" />
+                  <TextBlock x:Name="Sample_OpenTimeDifference" />
                 </WrapPanel>
               </materialDesign:Chip>
 
               <WrapPanel>
                 <TextBlock Text="Opened animation finished: " />
-                <TextBlock x:Name="Sample7_OpenedFinished" />
+                <TextBlock x:Name="Sample_OpenedFinished" />
               </WrapPanel>
             </StackPanel>
           </materialDesign:Card>
@@ -71,23 +71,23 @@
             <StackPanel>
               <WrapPanel>
                 <TextBlock Text="Closed button clicked: " />
-                <TextBlock x:Name="Sample7_CloseClicked" />
+                <TextBlock x:Name="Sample_CloseClicked" />
               </WrapPanel>
 
-              <materialDesign:Chip HorizontalAlignment="Right" Foreground="Red">
+              <materialDesign:Chip HorizontalAlignment="Right" Foreground="{DynamicResource MaterialDesign.Brush.ValidationError}">
                 <WrapPanel VerticalAlignment="Center">
                   <materialDesign:PackIcon Kind="ArrowLeftBottom" RenderTransformOrigin="0.5 0.5">
                     <materialDesign:PackIcon.RenderTransform>
                       <RotateTransform Angle="-45" />
                     </materialDesign:PackIcon.RenderTransform>
                   </materialDesign:PackIcon>
-                  <TextBlock x:Name="Sample7_CloseTimeDifference" />
+                  <TextBlock x:Name="Sample_CloseTimeDifference" />
                 </WrapPanel>
               </materialDesign:Chip>
 
               <WrapPanel>
                 <TextBlock Text="Closed animation finished: " />
-                <TextBlock x:Name="Sample7_ClosedFinished" />
+                <TextBlock x:Name="Sample_ClosedFinished" />
               </WrapPanel>
             </StackPanel>
           </materialDesign:Card>

--- a/src/MaterialDesignDemo.Shared/Examples/Dialogs/DialogHostWaitForExample.xaml
+++ b/src/MaterialDesignDemo.Shared/Examples/Dialogs/DialogHostWaitForExample.xaml
@@ -1,98 +1,98 @@
 ﻿<UserControl x:Class="MaterialDesignDemo.Shared.Examples.Dialogs.DialogHostWaitForExample"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
-             mc:Ignorable="d"
-             d:DesignHeight="450" d:DesignWidth="800">
-    <smtx:XamlDisplay UniqueKey="DialogHostWaitForExample">
-      <Border MinHeight="160"
-              Padding="16"
-              BorderBrush="{DynamicResource PrimaryHueMidBrush}"
-              BorderThickness="1">
-        <Grid>
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="280" />
-          </Grid.ColumnDefinitions>
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             mc:Ignorable="d">
+  <smtx:XamlDisplay UniqueKey="DialogHostWaitForExample">
+    <Border MinHeight="160"
+            Padding="16"
+            BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+            BorderThickness="1">
+      <Grid>
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="280" />
+        </Grid.ColumnDefinitions>
 
-          <!-- Left: open button -->
-          <materialDesign:DialogHost x:Name="Sample7DialogHost" Grid.Column="0">
-            <materialDesign:DialogHost.DialogContent>
-              <StackPanel Margin="16">
-                <TextBlock Margin="0,0,0,8" Text="This is sample 7 dialog content." />
-                <Button Click="Sample7_CloseButton_Click"
-                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
-                        Content="Close Dialog"
-                        Style="{StaticResource MaterialDesignFlatButton}" />
-              </StackPanel>
-            </materialDesign:DialogHost.DialogContent>
-            <Button Click="Sample7_OpenButton_Click"
-                    Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
-                    Content="Open Dialog"
-                    HorizontalAlignment="Center"
-                    Style="{StaticResource MaterialDesignRaisedButton}" />
-          </materialDesign:DialogHost>
+        <materialDesign:DialogHost x:Name="Sample7DialogHost" Grid.Column="0">
+          <materialDesign:DialogHost.DialogContent>
+            <StackPanel Margin="16">
+              <TextBlock Margin="0,0,0,8" Text="This is sample 7 dialog content." />
+              <Button Click="Sample7_CloseButton_Click"
+                      Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                      Content="Close Dialog"
+                      Style="{StaticResource MaterialDesignFlatButton}" />
+            </StackPanel>
+          </materialDesign:DialogHost.DialogContent>
+          <Button HorizontalAlignment="Center"
+                  Click="Sample7_OpenButton_Click"
+                  Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
+                  Content="Open Dialog"
+                  Style="{StaticResource MaterialDesignRaisedButton}" />
+        </materialDesign:DialogHost>
 
-          <StackPanel Grid.Column="1">
-            <materialDesign:Card Padding="8"
-                                 VerticalAlignment="Top"
-                                 UniformCornerRadius="8">
-              <StackPanel>
-                <WrapPanel>
-                  <TextBlock Text="Open button clicked: " />
-                  <TextBlock x:Name="Sample7_OpenClicked" />
+        <StackPanel Grid.Column="1">
+          <materialDesign:Card Padding="8"
+                               VerticalAlignment="Top"
+                               UniformCornerRadius="8">
+            <StackPanel>
+              <WrapPanel>
+                <TextBlock Text="Open button clicked: " />
+                <TextBlock x:Name="Sample7_OpenClicked" />
+              </WrapPanel>
+
+              <materialDesign:Chip HorizontalAlignment="Right" Foreground="Green">
+                <WrapPanel VerticalAlignment="Center">
+                  <materialDesign:PackIcon Kind="ArrowLeftBottom" RenderTransformOrigin="0.5 0.5">
+                    <materialDesign:PackIcon.RenderTransform>
+                      <RotateTransform Angle="-45" />
+                    </materialDesign:PackIcon.RenderTransform>
+                  </materialDesign:PackIcon>
+                  <TextBlock x:Name="Sample7_OpenTimeDifference" />
                 </WrapPanel>
+              </materialDesign:Chip>
 
-                <materialDesign:Chip HorizontalAlignment="Right" Foreground="Green">
-                  <WrapPanel VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="ArrowLeftBottom" RenderTransformOrigin="0.5 0.5">
-                      <materialDesign:PackIcon.RenderTransform>
-                        <RotateTransform Angle="-45" />
-                      </materialDesign:PackIcon.RenderTransform>
-                    </materialDesign:PackIcon>
-                    <TextBlock x:Name="Sample7_OpenTimeDifference" />
-                  </WrapPanel>
-                </materialDesign:Chip>
+              <WrapPanel>
+                <TextBlock Text="Opened animation finished: " />
+                <TextBlock x:Name="Sample7_OpenedFinished" />
+              </WrapPanel>
+            </StackPanel>
+          </materialDesign:Card>
 
-                <WrapPanel>
-                  <TextBlock Text="Opened animation finished: " />
-                  <TextBlock x:Name="Sample7_OpenedFinished" />
+          <materialDesign:Card Margin="0,8,0,0"
+                               Padding="8"
+                               VerticalAlignment="Top"
+                               UniformCornerRadius="8">
+            <StackPanel>
+              <WrapPanel>
+                <TextBlock Text="Closed button clicked: " />
+                <TextBlock x:Name="Sample7_CloseClicked" />
+              </WrapPanel>
+
+              <materialDesign:Chip HorizontalAlignment="Right" Foreground="Red">
+                <WrapPanel VerticalAlignment="Center">
+                  <materialDesign:PackIcon Kind="ArrowLeftBottom" RenderTransformOrigin="0.5 0.5">
+                    <materialDesign:PackIcon.RenderTransform>
+                      <RotateTransform Angle="-45" />
+                    </materialDesign:PackIcon.RenderTransform>
+                  </materialDesign:PackIcon>
+                  <TextBlock x:Name="Sample7_CloseTimeDifference" />
                 </WrapPanel>
-              </StackPanel>
-            </materialDesign:Card>
+              </materialDesign:Chip>
 
-            <materialDesign:Card Margin="0,8,0,0"
-                                 Padding="8"
-                                 VerticalAlignment="Top"
-                                 UniformCornerRadius="8">
-              <StackPanel>
-                <WrapPanel>
-                  <TextBlock Text="Closed button clicked: " />
-                  <TextBlock x:Name="Sample7_CloseClicked" />
-                </WrapPanel>
-
-                <materialDesign:Chip HorizontalAlignment="Right" Foreground="Red">
-                  <WrapPanel VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="ArrowLeftBottom" RenderTransformOrigin="0.5 0.5">
-                      <materialDesign:PackIcon.RenderTransform>
-                        <RotateTransform Angle="-45" />
-                      </materialDesign:PackIcon.RenderTransform>
-                    </materialDesign:PackIcon>
-                    <TextBlock x:Name="Sample7_CloseTimeDifference" />
-                  </WrapPanel>
-                </materialDesign:Chip>
-
-                <WrapPanel>
-                  <TextBlock Text="Closed animation finished: " />
-                  <TextBlock x:Name="Sample7_ClosedFinished" />
-                </WrapPanel>
-              </StackPanel>
-            </materialDesign:Card>
-          </StackPanel>
-        </Grid>
-      </Border>
-    </smtx:XamlDisplay>
+              <WrapPanel>
+                <TextBlock Text="Closed animation finished: " />
+                <TextBlock x:Name="Sample7_ClosedFinished" />
+              </WrapPanel>
+            </StackPanel>
+          </materialDesign:Card>
+        </StackPanel>
+      </Grid>
+    </Border>
+  </smtx:XamlDisplay>
 </UserControl>

--- a/src/MaterialDesignDemo.Shared/Examples/Dialogs/DialogHostWaitForExample.xaml
+++ b/src/MaterialDesignDemo.Shared/Examples/Dialogs/DialogHostWaitForExample.xaml
@@ -7,7 +7,7 @@
              xmlns:smtx="clr-namespace:ShowMeTheXAML;assembly=ShowMeTheXAML"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
-    <smtx:XamlDisplay UniqueKey="dialogs_sample65446545617">
+    <smtx:XamlDisplay UniqueKey="DialogHostWaitForExample">
       <Border MinHeight="160"
               Padding="16"
               BorderBrush="{DynamicResource PrimaryHueMidBrush}"
@@ -29,11 +29,10 @@
                         Style="{StaticResource MaterialDesignFlatButton}" />
               </StackPanel>
             </materialDesign:DialogHost.DialogContent>
-            <Button Width="160"
-                    Height="40"
-                    Click="Sample7_OpenButton_Click"
+            <Button Click="Sample7_OpenButton_Click"
                     Command="{x:Static materialDesign:DialogHost.OpenDialogCommand}"
                     Content="Open Dialog"
+                    HorizontalAlignment="Center"
                     Style="{StaticResource MaterialDesignRaisedButton}" />
           </materialDesign:DialogHost>
 

--- a/src/MaterialDesignDemo.Shared/Examples/Dialogs/DialogHostWaitForExample.xaml.cs
+++ b/src/MaterialDesignDemo.Shared/Examples/Dialogs/DialogHostWaitForExample.xaml.cs
@@ -1,0 +1,49 @@
+﻿using ShowMeTheXAML;
+
+namespace MaterialDesignDemo.Shared.Examples.Dialogs;
+
+/// <summary>
+/// Interaction logic for DialogHostWaitForExample.xaml
+/// </summary>
+public partial class DialogHostWaitForExample : UserControl
+{
+    private DateTime? _sample7OpenClicked;
+    private DateTime? _sample7CloseClicked;
+
+    public DialogHostWaitForExample()
+    {
+        InitializeComponent();
+    }
+
+    private async void Sample7_OpenButton_Click(object sender, RoutedEventArgs e)
+    {
+        _sample7OpenClicked = DateTime.Now;
+        Sample7_OpenClicked.Text = _sample7OpenClicked.Value.TimeOfDay.ToString(@"hh\:mm\:ss\.fff");
+
+        await Sample7DialogHost.WaitForOpened();
+        var openedFinished = DateTime.Now;
+        Sample7_OpenedFinished.Text = openedFinished.TimeOfDay.ToString(@"hh\:mm\:ss\.fff");
+
+        if (_sample7OpenClicked.HasValue)
+        {
+            var diff = openedFinished - _sample7OpenClicked.Value;
+            Sample7_OpenTimeDifference.Text = ((long)diff.TotalMilliseconds).ToString() + " ms";
+        }
+
+        await Sample7DialogHost.WaitForClosed();
+        var closedFinished = DateTime.Now;
+        Sample7_ClosedFinished.Text = closedFinished.TimeOfDay.ToString(@"hh\:mm\:ss\.fff");
+
+        if (_sample7CloseClicked.HasValue)
+        {
+            var closeDiff = closedFinished - _sample7CloseClicked.Value;
+            Sample7_CloseTimeDifference.Text = ((long)closeDiff.TotalMilliseconds).ToString() + " ms";
+        }
+    }
+
+    private void Sample7_CloseButton_Click(object sender, RoutedEventArgs e)
+    {
+        _sample7CloseClicked = DateTime.Now;
+        Sample7_CloseClicked.Text = _sample7CloseClicked.Value.TimeOfDay.ToString(@"hh\:mm\:ss\.fff");
+    }
+}

--- a/src/MaterialDesignDemo.Shared/Examples/Dialogs/DialogHostWaitForExample.xaml.cs
+++ b/src/MaterialDesignDemo.Shared/Examples/Dialogs/DialogHostWaitForExample.xaml.cs
@@ -7,43 +7,43 @@ namespace MaterialDesignDemo.Shared.Examples.Dialogs;
 /// </summary>
 public partial class DialogHostWaitForExample : UserControl
 {
-    private DateTime? _sample7OpenClicked;
-    private DateTime? _sample7CloseClicked;
+    private DateTime? _sampleOpenClicked;
+    private DateTime? _sampleCloseClicked;
 
     public DialogHostWaitForExample()
     {
         InitializeComponent();
     }
 
-    private async void Sample7_OpenButton_Click(object sender, RoutedEventArgs e)
+    private async void Sample_OpenButton_Click(object sender, RoutedEventArgs e)
     {
-        _sample7OpenClicked = DateTime.Now;
-        Sample7_OpenClicked.Text = _sample7OpenClicked.Value.TimeOfDay.ToString(@"hh\:mm\:ss\.fff");
+        _sampleOpenClicked = DateTime.Now;
+        Sample_OpenClicked.Text = _sampleOpenClicked.Value.TimeOfDay.ToString(@"hh\:mm\:ss\.fff");
 
-        await Sample7DialogHost.WaitForOpened();
+        await SampleDialogHost.WaitForOpened();
         var openedFinished = DateTime.Now;
-        Sample7_OpenedFinished.Text = openedFinished.TimeOfDay.ToString(@"hh\:mm\:ss\.fff");
+        Sample_OpenedFinished.Text = openedFinished.TimeOfDay.ToString(@"hh\:mm\:ss\.fff");
 
-        if (_sample7OpenClicked.HasValue)
+        if (_sampleOpenClicked.HasValue)
         {
-            var diff = openedFinished - _sample7OpenClicked.Value;
-            Sample7_OpenTimeDifference.Text = ((long)diff.TotalMilliseconds).ToString() + " ms";
+            var diff = openedFinished - _sampleOpenClicked.Value;
+            Sample_OpenTimeDifference.Text = ((long)diff.TotalMilliseconds).ToString() + " ms";
         }
 
-        await Sample7DialogHost.WaitForClosed();
+        await SampleDialogHost.WaitForClosed();
         var closedFinished = DateTime.Now;
-        Sample7_ClosedFinished.Text = closedFinished.TimeOfDay.ToString(@"hh\:mm\:ss\.fff");
+        Sample_ClosedFinished.Text = closedFinished.TimeOfDay.ToString(@"hh\:mm\:ss\.fff");
 
-        if (_sample7CloseClicked.HasValue)
+        if (_sampleCloseClicked.HasValue)
         {
-            var closeDiff = closedFinished - _sample7CloseClicked.Value;
-            Sample7_CloseTimeDifference.Text = ((long)closeDiff.TotalMilliseconds).ToString() + " ms";
+            var closeDiff = closedFinished - _sampleCloseClicked.Value;
+            Sample_CloseTimeDifference.Text = ((long)closeDiff.TotalMilliseconds).ToString() + " ms";
         }
     }
 
-    private void Sample7_CloseButton_Click(object sender, RoutedEventArgs e)
+    private void Sample_CloseButton_Click(object sender, RoutedEventArgs e)
     {
-        _sample7CloseClicked = DateTime.Now;
-        Sample7_CloseClicked.Text = _sample7CloseClicked.Value.TimeOfDay.ToString(@"hh\:mm\:ss\.fff");
+        _sampleCloseClicked = DateTime.Now;
+        Sample_CloseClicked.Text = _sampleCloseClicked.Value.TimeOfDay.ToString(@"hh\:mm\:ss\.fff");
     }
 }

--- a/src/MaterialDesignDemo.Shared/IMaterialDesignDemoSharedAssemblyMarker.cs
+++ b/src/MaterialDesignDemo.Shared/IMaterialDesignDemoSharedAssemblyMarker.cs
@@ -1,0 +1,3 @@
+﻿namespace MaterialDesignDemo.Shared;
+
+public interface IMaterialDesignDemoSharedAssemblyMarker;

--- a/src/MaterialDesignDemo.Shared/MaterialDesignDemo.Shared.csproj
+++ b/src/MaterialDesignDemo.Shared/MaterialDesignDemo.Shared.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MaterialDesignDemo.Shared/MaterialDesignDemo.Shared.csproj
+++ b/src/MaterialDesignDemo.Shared/MaterialDesignDemo.Shared.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" />
+    <PackageReference Include="ShowMeTheXAML" />
+    <PackageReference Include="ShowMeTheXAML.MSBuild" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
adds an example to the demo apps showcasing the new `DialogHost.WaitFor*` methods to improve discoverability

https://github.com/user-attachments/assets/d0d35dd6-c592-4b74-8bfc-3ef6d4215933

